### PR TITLE
Fix formatting and improve docstrings for get_type_shapes.

### DIFF
--- a/hoomd/dem/pair.py
+++ b/hoomd/dem/pair.py
@@ -103,9 +103,12 @@ class _DEMBase:
         self.cpp_force.setParams(itype, vertices, faces);
 
     def get_type_shapes(self):
-        """Returns a list of shape descriptions with one element for each
-        unique particle type in the system. Currently assumes that all
-        3D shapes are convex.
+        """Get all the types of shapes in the current simulation.
+
+        Assumes all 3D shapes are convex.
+
+        Returns:
+            A list of dictionaries, one for each particle type in the system.
         """
         result = []
 

--- a/hoomd/dem/pair.py
+++ b/hoomd/dem/pair.py
@@ -105,7 +105,22 @@ class _DEMBase:
     def get_type_shapes(self):
         """Get all the types of shapes in the current simulation.
 
-        Assumes all 3D shapes are convex.
+        This assumes all 3D shapes are convex.
+
+        Examples:
+            Types depend on the number of shape vertices and system dimensionality. One vertex will yield a Disk (2D) or Sphere (3D), while multiple vertices will give a Polygon (2D) or ConvexPolyhedron (3D).
+
+            >>> mc.get_type_shapes()  # one vertex in 3D
+            [{'type': 'Sphere', 'diameter': 1.0}]
+            >>> mc.get_type_shapes()  # one vertex in 2D
+            [{'type': 'Disk', 'diameter': 1.0}]
+            >>> mc.get_type_shapes()  # multiple vertices in 3D
+            [{'type': 'ConvexPolyhedron', 'rounding_radius': 0.1,
+              'vertices': [[0.5, 0.5, 0.5], [0.5, -0.5, -0.5],
+                           [-0.5, 0.5, -0.5], [-0.5, -0.5, 0.5]]}]
+            >>> mc.get_type_shapes()  # multiple vertices in 2D
+            [{'type': 'Polygon', 'rounding_radius': 0.1,
+              'vertices': [[-0.5, -0.5], [0.5, -0.5], [0.5, 0.5], [-0.5, 0.5]]}]
 
         Returns:
             A list of dictionaries, one for each particle type in the system.

--- a/hoomd/hpmc/integrate.py
+++ b/hoomd/hpmc/integrate.py
@@ -371,11 +371,16 @@ class mode_hpmc(_integrator):
             pos.set_def(type_list[i], shapedef + ' ' + color)
 
     def get_type_shapes(self):
-        """ Get all the types of shapes in the current simulation
+        """Get all the types of shapes in the current simulation.
 
-        Since this behaves differently for different types of shapes, the default behavior just raises an exception. Subclasses can override this to properly return
+        Since this behaves differently for different types of shapes, the
+        default behavior just raises an exception. Subclasses can override this
+        to properly return.
         """
-        raise NotImplementedError("You are using a shape type that is not implemented! If you want it, please modify the hoomd.hpmc.integrate.mode_hpmc.get_type_shapes function")
+        raise NotImplementedError(
+            "You are using a shape type that is not implemented! "
+            "If you want it, please modify the "
+            "hoomd.hpmc.integrate.mode_hpmc.get_type_shapes function.")
 
     def initialize_shape_params(self):
         shape_param_type = data.__dict__[self.__class__.__name__ + "_params"]; # using the naming convention for convenience.
@@ -851,9 +856,12 @@ class sphere(mode_hpmc):
         return 'sphere {0}'.format(d);
 
     def get_type_shapes(self):
-        """ Get all the types of shapes in the current simulation
+        """Get all the types of shapes in the current simulation.
+
+        Currently assumes that all 3D shapes are convex.
+
         Returns:
-            A list of dictionaries, one for each particle type in the system. Currently assumes that all 3D shapes are convex.
+            A list of dictionaries, one for each particle type in the system.
         """
         result = []
 
@@ -863,12 +871,11 @@ class sphere(mode_hpmc):
         for i in range(ntypes):
             typename = hoomd.context.current.system_definition.getParticleData().getNameByType(i);
             shape = self.shape_param.get(typename)
-            # Need to add logic to figure out whether this is 2D or not
             if dim == 3:
-                result.append(dict(type='Sphere',diameter=shape.diameter,
+                result.append(dict(type='Sphere', diameter=shape.diameter,
                                    orientable=shape.orientable));
             else:
-                result.append(dict(type='Disk',diameter=shape.diameter,
+                result.append(dict(type='Disk', diameter=shape.diameter,
                                    orientable=shape.orientable));
 
         return result
@@ -957,9 +964,12 @@ class convex_polygon(mode_hpmc):
         return shape_def
 
     def get_type_shapes(self):
-        """ Get all the types of shapes in the current simulation
+        """Get all the types of shapes in the current simulation.
+
+        Currently assumes that all 3D shapes are convex.
+
         Returns:
-            A list of dictionaries, one for each particle type in the system. Currently assumes that all 3D shapes are convex.
+            A list of dictionaries, one for each particle type in the system.
         """
         result = []
 
@@ -1066,9 +1076,12 @@ class convex_spheropolygon(mode_hpmc):
         return shape_def
 
     def get_type_shapes(self):
-        """ Get all the types of shapes in the current simulation
+        """Get all the types of shapes in the current simulation.
+
+        Currently assumes that all 3D shapes are convex.
+
         Returns:
-            A list of dictionaries, one for each particle type in the system. Currently assumes that all 3D shapes are convex.
+            A list of dictionaries, one for each particle type in the system.
         """
         result = []
 
@@ -1166,9 +1179,12 @@ class simple_polygon(mode_hpmc):
         return shape_def
 
     def get_type_shapes(self):
-        """ Get all the types of shapes in the current simulation
+        """Get all the types of shapes in the current simulation.
+
+        Currently assumes that all 3D shapes are convex.
+
         Returns:
-            A list of dictionaries, one for each particle type in the system. Currently assumes that all 3D shapes are convex.
+            A list of dictionaries, one for each particle type in the system.
         """
         result = []
 
@@ -1428,9 +1444,12 @@ class convex_polyhedron(mode_hpmc):
         return shape_def
 
     def get_type_shapes(self):
-        """ Get all the types of shapes in the current simulation
+        """Get all the types of shapes in the current simulation.
+
+        Currently assumes that all 3D shapes are convex.
+
         Returns:
-            A list of dictionaries, one for each particle type in the system. Currently assumes that all 3D shapes are convex.
+            A list of dictionaries, one for each particle type in the system.
         """
         result = []
 
@@ -1791,9 +1810,12 @@ class convex_spheropolyhedron(mode_hpmc):
         return shape_def
 
     def get_type_shapes(self):
-        """ Get all the types of shapes in the current simulation
+        """Get all the types of shapes in the current simulation.
+
+        Currently assumes that all 3D shapes are convex.
+
         Returns:
-            A list of dictionaries, one for each particle type in the system. Currently assumes that all 3D shapes are convex.
+            A list of dictionaries, one for each particle type in the system.
         """
         result = []
 

--- a/hoomd/hpmc/integrate.py
+++ b/hoomd/hpmc/integrate.py
@@ -858,6 +858,14 @@ class sphere(mode_hpmc):
     def get_type_shapes(self):
         """Get all the types of shapes in the current simulation.
 
+        Examples:
+            The types will be either Sphere or Disk, depending on system dimensionality.
+
+            >>> mc.get_type_shapes()  # in 3D
+            [{'type': 'Sphere', 'diameter': 1.0, 'orientable': False}]
+            >>> mc.get_type_shapes()  # in 2D
+            [{'type': 'Disk', 'diameter': 1.0, 'orientable': False}]
+
         Returns:
             A list of dictionaries, one for each particle type in the system.
         """
@@ -963,6 +971,11 @@ class convex_polygon(mode_hpmc):
 
     def get_type_shapes(self):
         """Get all the types of shapes in the current simulation.
+
+        Example:
+            >>> mc.get_type_shapes()
+            [{'type': 'Polygon', 'rounding_radius': 0,
+              'vertices': [[-0.5, -0.5], [0.5, -0.5], [0.5, 0.5], [-0.5, 0.5]]}]
 
         Returns:
             A list of dictionaries, one for each particle type in the system.
@@ -1074,6 +1087,11 @@ class convex_spheropolygon(mode_hpmc):
     def get_type_shapes(self):
         """Get all the types of shapes in the current simulation.
 
+        Example:
+            >>> mc.get_type_shapes()
+            [{'type': 'Polygon', 'rounding_radius': 0.1,
+              'vertices': [[-0.5, -0.5], [0.5, -0.5], [0.5, 0.5], [-0.5, 0.5]]}]
+
         Returns:
             A list of dictionaries, one for each particle type in the system.
         """
@@ -1174,6 +1192,11 @@ class simple_polygon(mode_hpmc):
 
     def get_type_shapes(self):
         """Get all the types of shapes in the current simulation.
+
+        Example:
+            >>> mc.get_type_shapes()
+            [{'type': 'Polygon', 'rounding_radius': 0,
+              'vertices': [[-0.5, -0.5], [0.5, -0.5], [0.5, 0.5], [-0.5, 0.5]]}]
 
         Returns:
             A list of dictionaries, one for each particle type in the system.
@@ -1437,6 +1460,12 @@ class convex_polyhedron(mode_hpmc):
 
     def get_type_shapes(self):
         """Get all the types of shapes in the current simulation.
+
+        Example:
+            >>> mc.get_type_shapes()
+            [{'type': 'ConvexPolyhedron', 'rounding_radius': 0,
+              'vertices': [[0.5, 0.5, 0.5], [0.5, -0.5, -0.5],
+                           [-0.5, 0.5, -0.5], [-0.5, -0.5, 0.5]]}]
 
         Returns:
             A list of dictionaries, one for each particle type in the system.
@@ -1801,6 +1830,12 @@ class convex_spheropolyhedron(mode_hpmc):
 
     def get_type_shapes(self):
         """Get all the types of shapes in the current simulation.
+
+        Example:
+            >>> mc.get_type_shapes()
+            [{'type': 'ConvexPolyhedron', 'rounding_radius': 0.1,
+              'vertices': [[0.5, 0.5, 0.5], [0.5, -0.5, -0.5],
+                           [-0.5, 0.5, -0.5], [-0.5, -0.5, 0.5]]}]
 
         Returns:
             A list of dictionaries, one for each particle type in the system.

--- a/hoomd/hpmc/integrate.py
+++ b/hoomd/hpmc/integrate.py
@@ -858,8 +858,6 @@ class sphere(mode_hpmc):
     def get_type_shapes(self):
         """Get all the types of shapes in the current simulation.
 
-        Currently assumes that all 3D shapes are convex.
-
         Returns:
             A list of dictionaries, one for each particle type in the system.
         """
@@ -965,8 +963,6 @@ class convex_polygon(mode_hpmc):
 
     def get_type_shapes(self):
         """Get all the types of shapes in the current simulation.
-
-        Currently assumes that all 3D shapes are convex.
 
         Returns:
             A list of dictionaries, one for each particle type in the system.
@@ -1078,8 +1074,6 @@ class convex_spheropolygon(mode_hpmc):
     def get_type_shapes(self):
         """Get all the types of shapes in the current simulation.
 
-        Currently assumes that all 3D shapes are convex.
-
         Returns:
             A list of dictionaries, one for each particle type in the system.
         """
@@ -1180,8 +1174,6 @@ class simple_polygon(mode_hpmc):
 
     def get_type_shapes(self):
         """Get all the types of shapes in the current simulation.
-
-        Currently assumes that all 3D shapes are convex.
 
         Returns:
             A list of dictionaries, one for each particle type in the system.
@@ -1445,8 +1437,6 @@ class convex_polyhedron(mode_hpmc):
 
     def get_type_shapes(self):
         """Get all the types of shapes in the current simulation.
-
-        Currently assumes that all 3D shapes are convex.
 
         Returns:
             A list of dictionaries, one for each particle type in the system.
@@ -1811,8 +1801,6 @@ class convex_spheropolyhedron(mode_hpmc):
 
     def get_type_shapes(self):
         """Get all the types of shapes in the current simulation.
-
-        Currently assumes that all 3D shapes are convex.
 
         Returns:
             A list of dictionaries, one for each particle type in the system.


### PR DESCRIPTION
This PR corrects the formatting for `get_type_shapes` docstrings in `hpmc.integrate`.

The current formatting can be seen here: https://hoomd-blue.readthedocs.io/en/stable/module-hpmc-integrate.html#hoomd.hpmc.integrate.convex_polygon.get_type_shapes