### PR TITLE
Restore state snapshot fixes

### DIFF
--- a/hoomd/hpmc/GSDHPMCSchema.h
+++ b/hoomd/hpmc/GSDHPMCSchema.h
@@ -118,7 +118,7 @@ struct gsd_shape_schema<hpmc::sph_params>: public gsd_schema_hpmc_base
         std::string path = name + "radius";
         std::vector<float> data;
         if(m_exec_conf->isRoot())
-	        {
+            {
             data.resize(Ntypes, 0.0);
             if(!reader->readChunk((void *) &data[0], frame, path.c_str(), Ntypes*gsd_sizeof_type(GSD_TYPE_FLOAT), Ntypes))
                 throw std::runtime_error("Error occurred while attempting to restore from gsd file.");
@@ -130,14 +130,14 @@ struct gsd_shape_schema<hpmc::sph_params>: public gsd_schema_hpmc_base
             bcast(data, 0, m_exec_conf->getMPICommunicator()); // broadcast the data
             }
         #endif
-  
-	    for(unsigned int i = 0; i < Ntypes; i++)
+
+        for(unsigned int i = 0; i < Ntypes; i++)
             {
             shape[i].radius = data[i];
             shape[i].isOriented = false;
             shape[i].ignore = 0;
             }
-	    }
+        }
     };
 
 template<>

--- a/hoomd/hpmc/GSDHPMCSchema.h
+++ b/hoomd/hpmc/GSDHPMCSchema.h
@@ -117,19 +117,24 @@ struct gsd_shape_schema<hpmc::sph_params>: public gsd_schema_hpmc_base
 
         std::string path = name + "radius";
         std::vector<float> data;
+        bool state_read = true;
         if(m_exec_conf->isRoot())
             {
             data.resize(Ntypes, 0.0);
             if(!reader->readChunk((void *) &data[0], frame, path.c_str(), Ntypes*gsd_sizeof_type(GSD_TYPE_FLOAT), Ntypes))
-                throw std::runtime_error("Error occurred while attempting to restore from gsd file.");
+                state_read = false;
             }
 
         #ifdef ENABLE_MPI
             if(m_mpi)
             {
+            bcast(state_read, 0, m_exec_conf->getMPICommunicator());
             bcast(data, 0, m_exec_conf->getMPICommunicator()); // broadcast the data
             }
         #endif
+
+        if (!state_read)
+            throw std::runtime_error("Error occurred while attempting to restore from gsd file.");
 
         for(unsigned int i = 0; i < Ntypes; i++)
             {
@@ -172,29 +177,34 @@ struct gsd_shape_schema<hpmc::ell_params>: public gsd_schema_hpmc_base
             )
         {
 
+        bool state_read = true;
         std::vector<float> a,b,c;
         if(m_exec_conf->isRoot())
             {
             a.resize(Ntypes),b.resize(Ntypes),c.resize(Ntypes);
             std::string path = name + "a";
             if (!reader->readChunk((void *)&a[0], frame, path.c_str(), Ntypes*gsd_sizeof_type(GSD_TYPE_FLOAT), Ntypes))
-                throw std::runtime_error("Error occurred while attempting to restore from gsd file.");
+                state_read = false;
             path = name + "b";
             if (!reader->readChunk((void *)&b[0], frame, path.c_str(), Ntypes*gsd_sizeof_type(GSD_TYPE_FLOAT), Ntypes))
-                throw std::runtime_error("Error occurred while attempting to restore from gsd file.");
+                state_read = false;
             path = name + "c";
             if (!reader->readChunk((void *)&c[0], frame, path.c_str(), Ntypes*gsd_sizeof_type(GSD_TYPE_FLOAT), Ntypes))
-                throw std::runtime_error("Error occurred while attempting to restore from gsd file.");
+                state_read = false;
             }
 
         #ifdef ENABLE_MPI
             if(m_mpi)
                 {
+                bcast(state_read, 0, m_exec_conf->getMPICommunicator());
                 bcast(a, 0, m_exec_conf->getMPICommunicator()); // broadcast the data
                 bcast(b, 0, m_exec_conf->getMPICommunicator()); // broadcast the data
                 bcast(c, 0, m_exec_conf->getMPICommunicator()); // broadcast the data
                 }
         #endif
+
+        if (!state_read)
+            throw std::runtime_error("Error occurred while attempting to restore from gsd file.");
 
         for(unsigned int i = 0; i < Ntypes; i++)
             {
@@ -251,6 +261,7 @@ struct gsd_shape_schema< hpmc::detail::poly3d_verts > : public gsd_schema_hpmc_b
             )
         {
 
+        bool state_read = true;
         std::vector<float> vertices,sweep_radius;
         std::vector<uint32_t> N;
         uint32_t count = 0;
@@ -262,24 +273,28 @@ struct gsd_shape_schema< hpmc::detail::poly3d_verts > : public gsd_schema_hpmc_b
             sweep_radius.resize(Ntypes);
             path = name + "N";
             if(!reader->readChunk((void *)&N[0], frame, path.c_str(),  Ntypes*gsd_sizeof_type(GSD_TYPE_UINT32), Ntypes))
-                throw std::runtime_error("Error occurred while attempting to restore from gsd file.");
+                state_read = false;
             count = std::accumulate(N.begin(), N.end(), 0);
             vertices.resize(count*Ntypes*3);
             path = name + "vertices";
             if(!reader->readChunk((void *)&vertices[0], frame, path.c_str(), 3*count*gsd_sizeof_type(GSD_TYPE_FLOAT), count))
-                throw std::runtime_error("Error occurred while attempting to restore from gsd file.");
+                state_read = false;
             path = name + "sweep_radius";
             if(!reader->readChunk((void *)&sweep_radius[0], frame, path.c_str(), Ntypes*gsd_sizeof_type(GSD_TYPE_FLOAT), Ntypes))
-                throw std::runtime_error("Error occurred while attempting to restore from gsd file.");
+                state_read = false;
             }
     #ifdef ENABLE_MPI
         if(m_mpi)
             {
+            bcast(state_read, 0, m_exec_conf->getMPICommunicator());
             bcast(N, 0, m_exec_conf->getMPICommunicator()); // broadcast the data
             bcast(vertices, 0, m_exec_conf->getMPICommunicator()); // broadcast the data
             bcast(sweep_radius, 0, m_exec_conf->getMPICommunicator()); // broadcast the data
             }
     #endif
+
+        if (!state_read)
+            throw std::runtime_error("Error occurred while attempting to restore from gsd file.");
 
         count = 0;
         for (unsigned int i = 0; i < Ntypes; i++)
@@ -345,7 +360,8 @@ struct gsd_shape_schema< hpmc::detail::poly2d_verts >: public gsd_schema_hpmc_ba
                 param_array<hpmc::detail::poly2d_verts>& shape
             )
         {
- 
+
+        bool state_read = true;
         std::vector<float> vertices,sweep_radius;
         std::vector<uint32_t> N;
         uint32_t count = 0;
@@ -357,23 +373,27 @@ struct gsd_shape_schema< hpmc::detail::poly2d_verts >: public gsd_schema_hpmc_ba
             sweep_radius.resize(Ntypes);
             path = name + "N";
             if(!reader->readChunk((void *)&N[0], frame, path.c_str(),  Ntypes*gsd_sizeof_type(GSD_TYPE_UINT32), Ntypes))
-                throw std::runtime_error("Error occurred while attempting to restore from gsd file.");
+                state_read = false;
             count = std::accumulate(N.begin(), N.end(), 0);
             path = name + "vertices";
             if(!reader->readChunk((void *)&vertices[0], frame, path.c_str(), 2*count*gsd_sizeof_type(GSD_TYPE_FLOAT), count))
-                throw std::runtime_error("Error occurred while attempting to restore from gsd file.");
+                state_read = false;
             path = name + "sweep_radius";
             if(!reader->readChunk((void *)&sweep_radius[0], frame, path.c_str(), Ntypes*gsd_sizeof_type(GSD_TYPE_FLOAT), Ntypes))
-                throw std::runtime_error("Error occurred while attempting to restore from gsd file.");
+                state_read = false;
             }
         #ifdef ENABLE_MPI
             if(m_mpi)
                 {
+                bcast(state_read, 0, m_exec_conf->getMPICommunicator());
                 bcast(N, 0, m_exec_conf->getMPICommunicator()); // broadcast the data
                 bcast(vertices, 0, m_exec_conf->getMPICommunicator()); // broadcast the data
                 bcast(sweep_radius, 0, m_exec_conf->getMPICommunicator()); // broadcast the data
                 }
         #endif
+
+        if (!state_read)
+            throw std::runtime_error("Error occurred while attempting to restore from gsd file.");
 
         count = 0;
         for (unsigned int i = 0; i < Ntypes; i++)

--- a/hoomd/hpmc/GSDHPMCSchema.h
+++ b/hoomd/hpmc/GSDHPMCSchema.h
@@ -114,13 +114,14 @@ struct gsd_shape_schema<hpmc::sph_params>: public gsd_schema_hpmc_base
                 param_array<hpmc::sph_params>& shape
             )
         {
-        bool success = true;
+        bool success;
         std::string path = name + "radius";
         std::vector<float> data;
-        if(m_exec_conf->isRoot()){
+        if(m_exec_conf->isRoot())
+	    {
             data.resize(Ntypes, 0.0);
-            success = reader->readChunk((void *) &data[0], frame, path.c_str(), Ntypes*gsd_sizeof_type(GSD_TYPE_FLOAT), Ntypes) && success;
-        }
+            success = reader->readChunk((void *) &data[0], frame, path.c_str(), Ntypes*gsd_sizeof_type(GSD_TYPE_FLOAT), Ntypes);
+            }
 
     #ifdef ENABLE_MPI
         if(m_mpi)
@@ -128,16 +129,21 @@ struct gsd_shape_schema<hpmc::sph_params>: public gsd_schema_hpmc_base
             bcast(data, 0, m_exec_conf->getMPICommunicator()); // broadcast the data
             }
     #endif
-        if(!data.size()) // adding this sanity check but can remove.
+        if(!success) // adding this sanity check but can remove.
+	    {
             throw std::runtime_error("Error occurred while attempting to restore from gsd file.");
-        for(unsigned int i = 0; i < Ntypes; i++)
-            {
-            shape[i].radius = data[i];
-            shape[i].isOriented = false;
-            shape[i].ignore = 0;
-            }
-        return success;
-        }
+	    }
+	else
+     	    {
+	    for(unsigned int i = 0; i < Ntypes; i++)
+                {
+                shape[i].radius = data[i];
+                shape[i].isOriented = false;
+                shape[i].ignore = 0;
+                }
+             }
+	return success;
+	}
     };
 
 template<>

--- a/hoomd/hpmc/test-py/hpmc_gsd_state.py
+++ b/hoomd/hpmc/test-py/hpmc_gsd_state.py
@@ -323,30 +323,49 @@ class hpmc_gsd_check_restore_state(unittest.TestCase):
         self.lattice = hoomd.lattice.sc(a=1.5, type_name='A');
         self.system = hoomd.init.create_lattice(self.lattice, n=3);
 
-        self.mc = hpmc.integrate.sphere(seed=1, d=0.3);
-        self.mc.shape_param.set('A', diameter=1.0);
-
         self.gsd = hoomd.dump.gsd('init.gsd', period=100, group=hoomd.group.all(), overwrite=True);
-        self.gsd.dump_state(self.mc);
         self.gsd.write_restart();
         
     def tearDown(self):
         del self.lattice
         del self.gsd
-        del self.mc
         del self.system
         filename = "init.gsd"
         if hoomd.comm.get_rank() == 0 and os.path.exists(filename):
             os.remove(filename);    
         context.initialize()
 
-    def test_spheres(self):
+    def test_sphere(self):
 
         context.initialize()
         self.system = hoomd.init.read_gsd(filename='init.gsd')
 
         with self.assertRaises(RuntimeError):
-            self.mc = hpmc.integrate.sphere(seed=1, d=0.3, restore_state=True);
+            self.mc = hpmc.integrate.sphere(seed=2234, d=0.3, restore_state=True);
+
+    def test_ellipsoid(self):
+
+        context.initialize()
+        self.system = hoomd.init.read_gsd(filename='init.gsd')
+
+        with self.assertRaises(RuntimeError):
+            self.mc = hpmc.integrate.ellipsoid(seed=2234, d=0.3, a=0.4, restore_state=True);
+
+    def test_convex_polygon(self):
+
+        context.initialize()
+        self.system = hoomd.init.read_gsd(filename='init.gsd')
+
+        with self.assertRaises(RuntimeError):
+            self.mc = hpmc.integrate.convex_polygon(seed=2234, d=0.3, a=0.4, restore_state=True);
+
+    def test_convex_polyhedron(self):
+
+        context.initialize()
+        self.system = hoomd.init.read_gsd(filename='init.gsd')
+
+        with self.assertRaises(RuntimeError):
+            self.mc = hpmc.integrate.convex_polyhedron(seed=2234, d=0.3, a=0.4, restore_state=True);
 
 if __name__ == '__main__':
     unittest.main(argv = ['test.py', '-v'])

--- a/hoomd/hpmc/test-py/hpmc_gsd_state.py
+++ b/hoomd/hpmc/test-py/hpmc_gsd_state.py
@@ -325,14 +325,14 @@ class hpmc_gsd_check_restore_state(unittest.TestCase):
 
         self.gsd = hoomd.dump.gsd('init.gsd', period=100, group=hoomd.group.all(), overwrite=True);
         self.gsd.write_restart();
-        
+
     def tearDown(self):
         del self.lattice
         del self.gsd
         del self.system
         filename = "init.gsd"
         if hoomd.comm.get_rank() == 0 and os.path.exists(filename):
-            os.remove(filename);    
+            os.remove(filename);
         context.initialize()
 
     def test_sphere(self):

--- a/sphinx-doc/credits.rst
+++ b/sphinx-doc/credits.rst
@@ -312,6 +312,7 @@ Vyas Ramasubramani, University of Michigan
 
 William Zygmunt, Luis Rivera-Rivera, University of Michigan
  * Patchy interaction support in HPMC CPU integrators
+ * GSD state bug fixes
 
 DEM developers
 --------------


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should based on *maint*. -->
<!-- New features should based on *master*. -->

## Description

<!-- Describe your changes in detail. -->
Fixed HPMC so that when state information is missing from a GSD file an error gets thrown. Added tests for sphere, ellipsoid, 2D/3D shapes

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Bug fix. Needed to get appropriate state info

<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves: #326 

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
Tests in test-py verify that when state info not passed in, error gets thrown

## Change log

<!-- Propose a change log entry. -->
```
Added error statements for missing state information in GSD files. Backed up with tests on various shape classes
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/hoomd-blue/blob/master/sphinx-doc/credits.rst).
