### PR TITLE
Detect sys.stdout/err changes

### DIFF
--- a/hoomd/Messenger.cc
+++ b/hoomd/Messenger.cc
@@ -279,9 +279,9 @@ void Messenger::collectiveNoticeStr(unsigned int level, const std::string& msg)
                     int rank = notice_it - rank_notices.begin();
                     // output message for accumulated ranks
                     if (last_output_rank+1 == rank-1)
-                        notice(level) << "Rank " << last_output_rank + 1 << ": " << last_msg;
+                        notice(level) << "Rank " << last_output_rank + 1 << ": " << last_msg << std::flush;
                     else
-                        notice(level) << "Ranks " << last_output_rank + 1 << "-" << rank-1 << ": " << last_msg;
+                        notice(level) << "Ranks " << last_output_rank + 1 << "-" << rank-1 << ": " << last_msg << std::flush;
 
                     if (notice_it != rank_notices.end())
                         {
@@ -295,7 +295,7 @@ void Messenger::collectiveNoticeStr(unsigned int level, const std::string& msg)
     #endif
             {
             // output without prefix
-            notice(level) << rank_notices[0];
+            notice(level) << rank_notices[0] << std::flush;
             }
     #ifdef ENABLE_MPI
         }

--- a/hoomd/Messenger.cc
+++ b/hoomd/Messenger.cc
@@ -165,7 +165,7 @@ Messenger::~Messenger()
     \post If the error prefix is not the empty string, the message is preceded with
     "${error_prefix}: ".
 */
-std::ostream& Messenger::error() const
+std::ostream& Messenger::error()
     {
     assert(m_err_stream);
     #ifdef ENABLE_MPI
@@ -187,6 +187,7 @@ std::ostream& Messenger::error() const
         if (! m_has_lock) return *m_nullstream;
         }
     #endif
+    reopenPythonIfNeeded();
     if (m_err_prefix != string(""))
         *m_err_stream << m_err_prefix << ": ";
     if (m_nranks > 1)
@@ -197,7 +198,7 @@ std::ostream& Messenger::error() const
 /*! \param msg Message to print
     \sa error()
 */
-void Messenger::errorStr(const std::string& msg) const
+void Messenger::errorStr(const std::string& msg)
     {
     error() << msg << std::flush;
     }
@@ -206,11 +207,12 @@ void Messenger::errorStr(const std::string& msg) const
     \post If the warning prefix is not the empty string, the message is preceded with
     "${warning_prefix}: ".
 */
-std::ostream& Messenger::warning() const
+std::ostream& Messenger::warning()
     {
     if (m_rank != 0) return *m_nullstream;
 
     assert(m_warning_stream);
+    reopenPythonIfNeeded();
     if (m_warning_prefix != string(""))
         *m_warning_stream << m_warning_prefix << ": ";
     return *m_warning_stream;
@@ -219,7 +221,7 @@ std::ostream& Messenger::warning() const
 /*! \param msg Message to print
     \sa warning()
 */
-void Messenger::warningStr(const std::string& msg) const
+void Messenger::warningStr(const std::string& msg)
     {
     warning() << msg << std::flush;;
     }
@@ -230,11 +232,12 @@ void Messenger::warningStr(const std::string& msg) const
 
     If level is greater than the notice level, a null stream is returned so that the output is not printed.
 */
-std::ostream& Messenger::notice(unsigned int level) const
+std::ostream& Messenger::notice(unsigned int level)
     {
     assert(m_notice_stream);
     if (level <= m_notice_level)
         {
+        reopenPythonIfNeeded();
         if (m_notice_prefix != string("") && level > 1)
             *m_notice_stream << m_notice_prefix << "(" << level << "): ";
         return *m_notice_stream;
@@ -250,7 +253,7 @@ std::ostream& Messenger::notice(unsigned int level) const
  \param level The notice level
  \param msg Content of the notice
  */
-void Messenger::collectiveNoticeStr(unsigned int level, const std::string& msg) const
+void Messenger::collectiveNoticeStr(unsigned int level, const std::string& msg)
     {
     std::vector<std::string> rank_notices;
 
@@ -303,7 +306,7 @@ void Messenger::collectiveNoticeStr(unsigned int level, const std::string& msg) 
     \param msg Message to print
     \sa notice()
 */
-void Messenger::noticeStr(unsigned int level, const std::string& msg) const
+void Messenger::noticeStr(unsigned int level, const std::string& msg)
     {
     notice(level) << msg << std::flush;
     }
@@ -329,10 +332,15 @@ void Messenger::openFile(const std::string& fname)
 */
 void Messenger::openPython()
     {
-    pybind11::object pystdout = pybind11::module::import("sys").attr("stdout");
-    m_streambuf_out = std::shared_ptr<std::streambuf>(new pybind11::detail::pythonbuf(pystdout));
-    pybind11::object pystderr = pybind11::module::import("sys").attr("stderr");
-    m_streambuf_err = std::shared_ptr<std::streambuf>(new pybind11::detail::pythonbuf(pystderr));
+    // only import sys on first load
+    if (!m_python_open)
+        m_sys = pybind11::module::import("sys");
+
+    m_pystdout = m_sys.attr("stdout");
+    m_pystderr = m_sys.attr("stderr");
+
+    m_streambuf_out = std::shared_ptr<std::streambuf>(new pybind11::detail::pythonbuf(m_pystdout));
+    m_streambuf_err = std::shared_ptr<std::streambuf>(new pybind11::detail::pythonbuf(m_pystderr));
 
     // now update the error, warning, and notice streams
     m_file_out = std::shared_ptr<std::ostream>(new std::ostream(m_streambuf_out.get()));
@@ -341,6 +349,28 @@ void Messenger::openPython()
     m_err_stream = m_file_err.get();
     m_warning_stream = m_file_err.get();
     m_notice_stream = m_file_out.get();
+    m_python_open = true;
+    }
+
+/*! Some notebook operations swap out sys.stdout and sys.stderr. Check if these have been swapped and reopen
+    the output streams as necessary.
+*/
+void Messenger::reopenPythonIfNeeded()
+    {
+    // only attempt to reopen python streams if we previously opened them
+    // and python is initialized
+    if (m_python_open && Py_IsInitialized())
+        {
+        // flush and reopen the streams if sys.stdout or sys.stderr change
+        pybind11::object new_pystdout = m_sys.attr("stdout");
+        pybind11::object new_pystderr = m_sys.attr("stderr");
+        if (!new_pystdout.is(m_pystdout) || !new_pystderr.is(m_pystderr))
+            {
+            m_file_out->flush();
+            m_file_err->flush();
+            openPython();
+            }
+        }
     }
 
 #ifdef ENABLE_MPI

--- a/hoomd/Messenger.h
+++ b/hoomd/Messenger.h
@@ -117,25 +117,25 @@ class PYBIND11_EXPORT Messenger
         ~Messenger();
 
         //! Get the error stream
-        std::ostream& error() const;
+        std::ostream& error();
 
         //! Alternate method to print error strings
-        void errorStr(const std::string& msg) const;
+        void errorStr(const std::string& msg);
 
         //! Get the warning stream
-        std::ostream& warning() const;
+        std::ostream& warning();
 
         //! Alternate method to print warning strings
-        void warningStr(const std::string& msg) const;
+        void warningStr(const std::string& msg);
 
         //! Get a notice stream
-        std::ostream& notice(unsigned int level) const;
+        std::ostream& notice(unsigned int level);
 
         //! Print a notice message in rank-order
-        void collectiveNoticeStr(unsigned int level, const std::string& msg) const;
+        void collectiveNoticeStr(unsigned int level, const std::string& msg);
 
         //! Alternate method to print notice strings
-        void noticeStr(unsigned int level, const std::string& msg) const;
+        void noticeStr(unsigned int level, const std::string& msg);
 
         //! Set processor rank
         /*! Error and warning messages are prefixed with rank information.
@@ -304,6 +304,9 @@ class PYBIND11_EXPORT Messenger
         //! "Open" python sys.stdout and sys.stderr
         void openPython();
 
+        //! Reopen the python streams if sys.stdout/err changes
+        void reopenPythonIfNeeded();
+
 #ifdef ENABLE_MPI
         //! Request logging of notices, warning and errors into shared log file
         /*! \param fname The filenam
@@ -354,6 +357,11 @@ class PYBIND11_EXPORT Messenger
         unsigned int m_rank;            //!< The MPI rank (default 0)
         unsigned int m_partition;       //!< The MPI partition
         unsigned int m_nranks;          //!< Number of ranks in communicator
+
+        bool m_python_open=false;       //!< True when the python output stream is open
+        pybind11::module m_sys;         //!< sys module
+        pybind11::object m_pystdout;    //!< Currently bound python sys.stdout
+        pybind11::object m_pystderr;    //!< Currently bound python sys.stderr
 
 #ifdef ENABLE_MPI
         std::string m_shared_filename;  //!< Filename of shared log file


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should based on *maint*. -->
<!-- New features should based on *master*. -->

## Description

Send message output to new `sys.stdout` and/or `sys.stderr` when these objects change.

## Motivation and Context

This enables support for the `%%capture ` magic in *ipython* and *jupyter*. With this change in place, `%%capture` is capable of capturing HOOMD message output on a cell by cell basis. `%%capture` works by temporarily replacing `sys.stdout` and `sys.stderr`.

## How Has This Been Tested?

I tested this with a *jupyter* notebook. I also tested that command line scripts still function appropriately, with and without `mpirun`.

## Change log

<!-- Propose a change log entry. -->
```
* Send messages to replaced `sys.stdout` and `sys.stderr` streams.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/hoomd-blue/blob/master/sphinx-doc/credits.rst).
