### PR TITLE
Fixed docs for hpmc.update.clusters

### DIFF
--- a/sphinx-doc/module-hpmc-update.rst
+++ b/sphinx-doc/module-hpmc-update.rst
@@ -9,6 +9,7 @@ hpmc.update
     :nosignatures:
 
     hpmc.update.boxmc
+    hpmc.update.clusters
     hpmc.update.muvt
     hpmc.update.remove_drift
     hpmc.update.wall


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should based on *maint*. -->
<!-- New features should based on *master*. -->

## Description

<!-- Describe your changes in detail. -->

Fixed readthedocs summary on page for hpmc.update

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

readthedocs summary on page for hpmc.update was missing hpmc.update.clusters

<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves: #???

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

N/A

## Change log

<!-- Propose a change log entry. -->
```
Added line to fix readthedocs summary on page for hpmc.update
```

## Checklist:

- [ x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [ x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x ] My name is on the [list of contributors](https://github.com/glotzerlab/hoomd-blue/blob/master/sphinx-doc/credits.rst).
