### PR TITLE
fix initialization of NPT barostat velocity

### DIFF
--- a/hoomd/md/TwoStepNPTMTK.h
+++ b/hoomd/md/TwoStepNPTMTK.h
@@ -220,6 +220,8 @@ class PYBIND11_EXPORT TwoStepNPTMTK : public IntegrationMethodTwoStep
         //! Helper function to update the propagator elements
         void updatePropagator(Scalar nuxx, Scalar nuxy, Scalar nuxz, Scalar nuyy, Scalar nuyz, Scalar nuzz);
 
+        //! Get the relevant couplings for the active box degrees of freedom
+        couplingMode getRelevantCouplings();
         };
 
 //! Exports the TwoStepNPTMTK class to python

--- a/hoomd/md/test-py/test_randomize_velocities.py
+++ b/hoomd/md/test-py/test_randomize_velocities.py
@@ -54,7 +54,7 @@ class velocity_randomization_tests (unittest.TestCase):
         # Set one particle to be really massive for validation
         self.system.particles[0].mass = 10000
 
-        md.integrate.mode_standard(dt=0.)
+        self.mode_standard = md.integrate.mode_standard(dt=0.)
         self.all = group.all()
         self.aniso = False
         self.quantities = ['N',
@@ -122,14 +122,27 @@ class velocity_randomization_tests (unittest.TestCase):
         self.assertTrue(thermostat_energy == 0.0)
         self.assertTrue(barostat_energy == 0.0)
         self.kT = 1.0
-        integrator = md.integrate.npt(group=self.all, kT=self.kT, tau=0.5, tauP=1.0, P=2.0)
+        integrator = md.integrate.npt(group=self.all, kT=self.kT, tau=0.5, tauP=1.0, P=2.0, couple='xyz')
         integrator.randomize_velocities(seed=42)
+
+        box = self.system.box
+        ratio_xy = box.Lx/box.Ly
+        ratio_xz = box.Lx/box.Lz
+        ratio_yz = box.Ly/box.Lz
         run(1)
         thermostat_energy = self.log.query('npt_thermostat_energy')
         barostat_energy = self.log.query('npt_barostat_energy')
         self.assertTrue(thermostat_energy != 0.0)
         self.assertTrue(barostat_energy != 0.0)
         self.check_quantities()
+
+        # check that box degrees of freedom are correctly coupled
+        self.mode_standard.set_params(dt=0.005)
+        run(100)
+        box = self.system.box
+        self.assertAlmostEqual(box.Lx/box.Ly, ratio_xy, 5)
+        self.assertAlmostEqual(box.Lx/box.Lz, ratio_xz, 5)
+        self.assertAlmostEqual(box.Ly/box.Lz, ratio_yz, 5)
 
     def test_nph(self):
         thermostat_energy = self.log.query('npt_thermostat_energy')


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should based on *maint*. -->
<!-- New features should based on *master*. -->

## Description
The NPT barostat degrees of freedom were initialized independently for x,y,z with `randomize_velocities()`. However, couplings (such as xyz) should be respected. This PR fixes that.

## Motivation and Context
Resolves the issue that a cubic box can become non-cubic with `integrate.npt()` and `randomize_velocities()`.

## How Has This Been Tested?

extended unit test (fails on current maint)

## Change log

* Fix issue where an initially cubic box can become non-cubic with `integrate.npt()` and `randomize_velocities()`.
```

```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/hoomd-blue/blob/master/sphinx-doc/credits.rst).
