### PR TITLE
fix single GPU behavior when per-device cell list is not requested

### DIFF
--- a/hoomd/CellList.h
+++ b/hoomd/CellList.h
@@ -211,6 +211,7 @@ class PYBIND11_EXPORT CellList : public Compute
         virtual void setPerDevice(bool per_device)
             {
             // base class does nothing
+            throw std::runtime_error("Per-device cell list only supported with CellListGPU.");
             }
 
         //! Return true if we maintain a cell list per device

--- a/hoomd/CellList.h
+++ b/hoomd/CellList.h
@@ -211,7 +211,8 @@ class PYBIND11_EXPORT CellList : public Compute
         virtual void setPerDevice(bool per_device)
             {
             // base class does nothing
-            throw std::runtime_error("Per-device cell list only supported with CellListGPU.");
+            if (per_device)
+                throw std::runtime_error("Per-device cell list only supported with CellListGPU.");
             }
 
         //! Return true if we maintain a cell list per device

--- a/hoomd/CellList.h
+++ b/hoomd/CellList.h
@@ -211,8 +211,6 @@ class PYBIND11_EXPORT CellList : public Compute
         virtual void setPerDevice(bool per_device)
             {
             // base class does nothing
-            if (per_device)
-                throw std::runtime_error("Per-device cell list only supported with CellListGPU.");
             }
 
         //! Return true if we maintain a cell list per device

--- a/hoomd/CellListGPU.cc
+++ b/hoomd/CellListGPU.cc
@@ -158,6 +158,9 @@ void CellListGPU::computeCellList()
             }
         }
 
+    if (ngpu > 1 && !m_per_device)
+        combineCellLists();
+
     if (m_prof)
         m_prof->pop(m_exec_conf);
     }

--- a/hoomd/CellListGPU.cc
+++ b/hoomd/CellListGPU.cc
@@ -44,6 +44,8 @@ void CellListGPU::computeCellList()
     ArrayHandle<unsigned int> d_body(m_pdata->getBodies(), access_location::device, access_mode::read);
 
     BoxDim box = m_pdata->getBox();
+    unsigned int ngpu = m_exec_conf->getNumActiveGPUs();
+
 
         {
         // access the cell list data arrays
@@ -68,7 +70,7 @@ void CellListGPU::computeCellList()
         if (m_exec_conf->isCUDAErrorCheckingEnabled())
             CHECK_CUDA_ERROR();
 
-        if (m_per_device)
+        if (ngpu > 1 || m_per_device)
             {
             // reset temporary arrays
             cudaMemsetAsync(d_cell_size_scratch.data, 0, sizeof(unsigned int)*m_cell_size_scratch.getNumElements(),0);
@@ -82,11 +84,11 @@ void CellListGPU::computeCellList()
         m_tuner->begin();
 
         // compute cell list, and write to temporary arrays with multi-GPU
-        gpu_compute_cell_list(!m_per_device ? d_cell_size.data : d_cell_size_scratch.data,
-                              !m_per_device ? d_xyzf.data : d_xyzf_scratch.data,
-                              !m_per_device ? d_tdb.data : d_tdb_scratch.data,
-                              !m_per_device ? d_cell_orientation.data : d_cell_orientation_scratch.data,
-                              !m_per_device ? d_cell_idx.data : d_cell_idx_scratch.data,
+        gpu_compute_cell_list((ngpu == 1 && !m_per_device) ? d_cell_size.data : d_cell_size_scratch.data,
+                              (ngpu == 1 && !m_per_device) ? d_xyzf.data : d_xyzf_scratch.data,
+                              (ngpu == 1 && !m_per_device) ? d_tdb.data : d_tdb_scratch.data,
+                              (ngpu == 1 && !m_per_device) ? d_cell_orientation.data : d_cell_orientation_scratch.data,
+                              (ngpu == 1 && !m_per_device) ? d_cell_idx.data : d_cell_idx_scratch.data,
                               d_conditions.data,
                               d_pos.data,
                               d_orientation.data,
@@ -137,14 +139,14 @@ void CellListGPU::computeCellList()
             ScopedAllocation<Scalar4> d_cell_orientation_new(m_exec_conf->getCachedAllocator(), m_orientation.getNumElements());
             ScopedAllocation<Scalar4> d_tdb_new(m_exec_conf->getCachedAllocator(), m_tdb.getNumElements());
 
-            gpu_sort_cell_list(!m_per_device ? d_cell_size.data : d_cell_size_scratch.data + i*m_cell_indexer.getNumElements(),
-                               !m_per_device ? d_xyzf.data : d_xyzf_scratch.data + i*m_cell_list_indexer.getNumElements(),
+            gpu_sort_cell_list((ngpu == 1 && !m_per_device) ? d_cell_size.data : d_cell_size_scratch.data + i*m_cell_indexer.getNumElements(),
+                               (ngpu == 1 && !m_per_device) ? d_xyzf.data : d_xyzf_scratch.data + i*m_cell_list_indexer.getNumElements(),
                                d_xyzf_new.data,
-                               !m_per_device ? d_tdb.data : d_tdb_scratch.data + i*m_cell_list_indexer.getNumElements(),
+                               (ngpu == 1 && !m_per_device) ? d_tdb.data : d_tdb_scratch.data + i*m_cell_list_indexer.getNumElements(),
                                d_tdb_new.data,
-                               !m_per_device ? d_cell_orientation.data : d_cell_orientation_scratch.data + i*m_cell_list_indexer.getNumElements(),
+                               (ngpu == 1 && !m_per_device) ? d_cell_orientation.data : d_cell_orientation_scratch.data + i*m_cell_list_indexer.getNumElements(),
                                d_cell_orientation_new.data,
-                               !m_per_device ? d_cell_idx.data : d_cell_idx_scratch.data + i*m_cell_list_indexer.getNumElements(),
+                               (ngpu == 1 && !m_per_device) ? d_cell_idx.data : d_cell_idx_scratch.data + i*m_cell_list_indexer.getNumElements(),
                                d_cell_idx_new.data,
                                d_sort_idx.data,
                                d_sort_permutation.data,
@@ -213,7 +215,8 @@ void CellListGPU::initializeMemory()
 
     // only need to keep separate cell lists with more than one GPU
     unsigned int ngpu = m_exec_conf->getNumActiveGPUs();
-    if (! m_per_device)
+
+    if (ngpu == 1 && !m_per_device)
         return;
 
     m_exec_conf->msg->notice(10) << "CellListGPU initialize multiGPU memory" << endl;

--- a/hoomd/CellListGPU.h
+++ b/hoomd/CellListGPU.h
@@ -47,7 +47,7 @@ class PYBIND11_EXPORT CellListGPU : public CellList
         //! Request a multi-GPU cell list
         virtual void setPerDevice(bool per_device)
             {
-            if (! this->m_exec_conf->allConcurrentManagedAccess())
+            if (per_device && ! this->m_exec_conf->allConcurrentManagedAccess())
                 throw std::runtime_error("Per-device cell list only supported with unified memory.");
 
             m_per_device = per_device;

--- a/hoomd/CellListGPU.h
+++ b/hoomd/CellListGPU.h
@@ -47,6 +47,9 @@ class PYBIND11_EXPORT CellListGPU : public CellList
         //! Request a multi-GPU cell list
         virtual void setPerDevice(bool per_device)
             {
+            if (! this->m_exec_conf->allConcurrentManagedAccess())
+                throw std::runtime_error("Per-device cell list only supported with unified memory.");
+
             m_per_device = per_device;
             m_params_changed = true;
             }


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should based on *maint*. -->
<!-- New features should based on *master*. -->

## Description

This PR fixes a potential issue when the cell list is computed on the GPU with managed memory, but with only one GPU in the ExecutionConfiguration.

## Motivation and Context

The fix was motivated by an inspection of failing unit tests on the `quermass_ellipsoid` branch for [pull request 495 on bitbucket](https://bitbucket.org/glotzer/hoomd-blue/pull-requests/549), which seemed to be caused by an incomplete merge. This PR should fix those issues once and for all, even if they were already partly fixed in maint.

**EDIT** It turns out there was an incomplete fix in place in `quermass_ellipsoid` which didn't belong there.

## How Has This Been Tested?

The bug should have affected every unit test using CellListGPU with `-DMANAGED_MEMORY=ON`, in particular python unit tests on the GPU.

## Change log
```
* Fix illegal memory access in NeighborListGPU with `-DALWAYS_USE_MANAGED_MEMORY=ON` on single GPUs
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/hoomd-blue/blob/master/sphinx-doc/credits.rst).
