### PR TITLE
Multi gpu table potential

### DIFF
--- a/hoomd/md/TablePotential.h
+++ b/hoomd/md/TablePotential.h
@@ -7,7 +7,7 @@
 #include "hoomd/ForceCompute.h"
 #include "NeighborList.h"
 #include "hoomd/Index1D.h"
-#include "hoomd/GPUArray.h"
+#include "hoomd/GlobalArray.h"
 
 #include <memory>
 
@@ -88,8 +88,8 @@ class PYBIND11_EXPORT TablePotential : public ForceCompute
         std::shared_ptr<NeighborList> m_nlist;    //!< The neighborlist to use for the computation
         unsigned int m_table_width;                 //!< Width of the tables in memory
         unsigned int m_ntypes;                      //!< Store the number of particle types
-        GPUArray<Scalar2> m_tables;                  //!< Stored V and F tables
-        GPUArray<Scalar4> m_params;                 //!< Parameters stored for each table
+        GlobalArray<Scalar2> m_tables;                  //!< Stored V and F tables
+        GlobalArray<Scalar4> m_params;                 //!< Parameters stored for each table
         std::string m_log_name;                     //!< Cached log name
 
         //! Actually compute the forces

--- a/hoomd/md/TablePotentialGPU.cc
+++ b/hoomd/md/TablePotentialGPU.cc
@@ -76,6 +76,8 @@ void TablePotentialGPU::computeForces(unsigned int timestep)
     ArrayHandle<Scalar4> d_force(m_force,access_location::device,access_mode::overwrite);
     ArrayHandle<Scalar> d_virial(m_virial,access_location::device,access_mode::overwrite);
 
+    this->m_exec_conf->beginMultiGPU();
+
     // run the kernel on all GPUs in parallel
     m_tuner->begin();
     gpu_compute_table_forces(d_force.data,
@@ -95,11 +97,14 @@ void TablePotentialGPU::computeForces(unsigned int timestep)
                              m_table_width,
                              m_tuner->getParam(),
                              m_exec_conf->getComputeCapability(),
-                             m_exec_conf->dev_prop.maxTexture1DLinear);
+                             m_exec_conf->dev_prop.maxTexture1DLinear,
+                             m_pdata->getGPUPartition());
 
     if(m_exec_conf->isCUDAErrorCheckingEnabled())
         CHECK_CUDA_ERROR();
     m_tuner->end();
+
+    this->m_exec_conf->endMultiGPU();
 
     if (m_prof) m_prof->pop(m_exec_conf);
     }

--- a/hoomd/md/TablePotentialGPU.cu
+++ b/hoomd/md/TablePotentialGPU.cu
@@ -305,7 +305,7 @@ cudaError_t gpu_compute_table_forces(Scalar4* d_force,
             unsigned int run_block_size = min(block_size, max_block_size);
 
             // setup the grid to run the kernel
-            dim3 grid( N / run_block_size + 1, 1, 1);
+            dim3 grid( (range.second-range.first) / run_block_size + 1, 1, 1);
             dim3 threads(run_block_size, 1, 1);
 
             gpu_compute_table_forces_kernel<1><<< grid, threads, sizeof(Scalar4)*table_index.getNumElements() >>>(d_force,
@@ -340,7 +340,7 @@ cudaError_t gpu_compute_table_forces(Scalar4* d_force,
             Index2DUpperTriangular table_index(ntypes);
 
             // setup the grid to run the kernel
-            dim3 grid( N / run_block_size + 1, 1, 1);
+            dim3 grid( (range.second-range.first) / run_block_size + 1, 1, 1);
             dim3 threads(run_block_size, 1, 1);
 
             gpu_compute_table_forces_kernel<0><<< grid, threads, sizeof(Scalar4)*table_index.getNumElements() >>>(d_force,

--- a/hoomd/md/TablePotentialGPU.cu
+++ b/hoomd/md/TablePotentialGPU.cu
@@ -29,7 +29,7 @@ scalar2_tex_t tables_tex;
     \param d_force Device memory to write computed forces
     \param d_virial Device memory to write computed virials
     \param virial_pitch Pitch of 2D virial array
-    \param N number of particles in system
+    \param nwork number of particles this kernel processes
     \param d_pos device array of particle positions
     \param box Box dimensions used to implement periodic boundary conditions
     \param d_n_neigh Device memory array listing the number of neighbors for each particle
@@ -38,6 +38,7 @@ scalar2_tex_t tables_tex;
     \param d_params Parameters for each table associated with a type pair
     \param ntypes Number of particle types in the system
     \param table_width Number of points in each table
+    \param offset Offset in number of particles for this kernel
 
     See TablePotential for information on the memory layout.
 
@@ -52,7 +53,7 @@ template<unsigned char use_gmem_nlist>
 __global__ void gpu_compute_table_forces_kernel(Scalar4* d_force,
                                                 Scalar* d_virial,
                                                 const unsigned virial_pitch,
-                                                const unsigned int N,
+                                                const unsigned int nwork,
                                                 const Scalar4 *d_pos,
                                                 const BoxDim box,
                                                 const unsigned int *d_n_neigh,
@@ -61,7 +62,9 @@ __global__ void gpu_compute_table_forces_kernel(Scalar4* d_force,
                                                 const Scalar2 *d_tables,
                                                 const Scalar4 *d_params,
                                                 const unsigned int ntypes,
-                                                const unsigned int table_width)
+                                                const unsigned int table_width,
+                                                const unsigned int offset
+                                                )
     {
     // index calculation helpers
     Index2DUpperTriangular table_index(ntypes);
@@ -79,8 +82,10 @@ __global__ void gpu_compute_table_forces_kernel(Scalar4* d_force,
     // start by identifying which particle we are to handle
     unsigned int idx = blockIdx.x * blockDim.x + threadIdx.x;
 
-    if (idx >= N)
+    if (idx >= nwork)
         return;
+
+    idx += offset;
 
     // load in the length of the list
     unsigned int n_neigh = d_n_neigh[idx];
@@ -244,7 +249,8 @@ cudaError_t gpu_compute_table_forces(Scalar4* d_force,
                                      const unsigned int table_width,
                                      const unsigned int block_size,
                                      const unsigned int compute_capability,
-                                     const unsigned int max_tex1d_width)
+                                     const unsigned int max_tex1d_width,
+                                     const GPUPartition& gpu_partition)
     {
     assert(d_params);
     assert(d_tables);
@@ -254,97 +260,105 @@ cudaError_t gpu_compute_table_forces(Scalar4* d_force,
     // index calculation helper
     Index2DUpperTriangular table_index(ntypes);
 
-    // texture bind
-    if (compute_capability < 350)
+    // iterate over active GPUs in reverse, to end up on first GPU when returning from this function
+    for (int idev = gpu_partition.getNumActiveGPUs() - 1; idev >= 0; --idev)
         {
-        // bind the pdata position texture
-        pdata_pos_tex.normalized = false;
-        pdata_pos_tex.filterMode = cudaFilterModePoint;
-        cudaError_t error = cudaBindTexture(0, pdata_pos_tex, d_pos, sizeof(Scalar4) * (N+n_ghost));
-        if (error != cudaSuccess)
-            return error;
+        auto range = gpu_partition.getRangeAndSetGPU(idev);
 
-        if (size_nlist <= max_tex1d_width)
+        // texture bind
+        if (compute_capability < 350)
             {
-            nlist_tex.normalized = false;
-            nlist_tex.filterMode = cudaFilterModePoint;
-            error = cudaBindTexture(0, nlist_tex, d_nlist, sizeof(unsigned int)*size_nlist);
+            // bind the pdata position texture
+            pdata_pos_tex.normalized = false;
+            pdata_pos_tex.filterMode = cudaFilterModePoint;
+            cudaError_t error = cudaBindTexture(0, pdata_pos_tex, d_pos, sizeof(Scalar4) * (N+n_ghost));
+            if (error != cudaSuccess)
+                return error;
+
+            if (size_nlist <= max_tex1d_width)
+                {
+                nlist_tex.normalized = false;
+                nlist_tex.filterMode = cudaFilterModePoint;
+                error = cudaBindTexture(0, nlist_tex, d_nlist, sizeof(unsigned int)*size_nlist);
+                if (error != cudaSuccess)
+                    return error;
+                }
+
+            // bind the tables texture
+            tables_tex.normalized = false;
+            tables_tex.filterMode = cudaFilterModePoint;
+            error = cudaBindTexture(0, tables_tex, d_tables, sizeof(Scalar2) * table_width * table_index.getNumElements());
             if (error != cudaSuccess)
                 return error;
             }
 
-        // bind the tables texture
-        tables_tex.normalized = false;
-        tables_tex.filterMode = cudaFilterModePoint;
-        error = cudaBindTexture(0, tables_tex, d_tables, sizeof(Scalar2) * table_width * table_index.getNumElements());
-        if (error != cudaSuccess)
-            return error;
-        }
+        if (compute_capability < 350 && size_nlist > max_tex1d_width)
+            { // use global memory when the neighbor list must be texture bound, but exceeds the max size of a texture
+            static unsigned int max_block_size = UINT_MAX;
+            if (max_block_size == UINT_MAX)
+                {
+                cudaFuncAttributes attr;
+                cudaFuncGetAttributes(&attr, gpu_compute_table_forces_kernel<1>);
+                max_block_size = attr.maxThreadsPerBlock;
+                }
 
-    if (compute_capability < 350 && size_nlist > max_tex1d_width)
-        { // use global memory when the neighbor list must be texture bound, but exceeds the max size of a texture
-        static unsigned int max_block_size = UINT_MAX;
-        if (max_block_size == UINT_MAX)
-            {
-            cudaFuncAttributes attr;
-            cudaFuncGetAttributes(&attr, gpu_compute_table_forces_kernel<1>);
-            max_block_size = attr.maxThreadsPerBlock;
+            unsigned int run_block_size = min(block_size, max_block_size);
+
+            // setup the grid to run the kernel
+            dim3 grid( N / run_block_size + 1, 1, 1);
+            dim3 threads(run_block_size, 1, 1);
+
+            gpu_compute_table_forces_kernel<1><<< grid, threads, sizeof(Scalar4)*table_index.getNumElements() >>>(d_force,
+                                                                                                               d_virial,
+                                                                                                               virial_pitch,
+                                                                                                               range.second-range.first,
+                                                                                                               d_pos,
+                                                                                                               box,
+                                                                                                               d_n_neigh,
+                                                                                                               d_nlist,
+                                                                                                               d_head_list,
+                                                                                                               d_tables,
+                                                                                                               d_params,
+                                                                                                               ntypes,
+                                                                                                               table_width,
+                                                                                                               range.first
+                                                                                                               );
             }
-
-        unsigned int run_block_size = min(block_size, max_block_size);
-
-        // setup the grid to run the kernel
-        dim3 grid( N / run_block_size + 1, 1, 1);
-        dim3 threads(run_block_size, 1, 1);
-
-        gpu_compute_table_forces_kernel<1><<< grid, threads, sizeof(Scalar4)*table_index.getNumElements() >>>(d_force,
-                                                                                                           d_virial,
-                                                                                                           virial_pitch,
-                                                                                                           N,
-                                                                                                           d_pos,
-                                                                                                           box,
-                                                                                                           d_n_neigh,
-                                                                                                           d_nlist,
-                                                                                                           d_head_list,
-                                                                                                           d_tables,
-                                                                                                           d_params,
-                                                                                                           ntypes,
-                                                                                                           table_width);
-        }
-    else
-        {
-        static unsigned int max_block_size = UINT_MAX;
-        if (max_block_size == UINT_MAX)
+        else
             {
-            cudaFuncAttributes attr;
-            cudaFuncGetAttributes(&attr, gpu_compute_table_forces_kernel<0>);
-            max_block_size = attr.maxThreadsPerBlock;
+            static unsigned int max_block_size = UINT_MAX;
+            if (max_block_size == UINT_MAX)
+                {
+                cudaFuncAttributes attr;
+                cudaFuncGetAttributes(&attr, gpu_compute_table_forces_kernel<0>);
+                max_block_size = attr.maxThreadsPerBlock;
+                }
+
+            unsigned int run_block_size = min(block_size, max_block_size);
+
+            // index calculation helper
+            Index2DUpperTriangular table_index(ntypes);
+
+            // setup the grid to run the kernel
+            dim3 grid( N / run_block_size + 1, 1, 1);
+            dim3 threads(run_block_size, 1, 1);
+
+            gpu_compute_table_forces_kernel<0><<< grid, threads, sizeof(Scalar4)*table_index.getNumElements() >>>(d_force,
+                                                                                                               d_virial,
+                                                                                                               virial_pitch,
+                                                                                                               range.second-range.first,
+                                                                                                               d_pos,
+                                                                                                               box,
+                                                                                                               d_n_neigh,
+                                                                                                               d_nlist,
+                                                                                                               d_head_list,
+                                                                                                               d_tables,
+                                                                                                               d_params,
+                                                                                                               ntypes,
+                                                                                                               table_width,
+                                                                                                               range.first);
             }
-
-        unsigned int run_block_size = min(block_size, max_block_size);
-
-        // index calculation helper
-        Index2DUpperTriangular table_index(ntypes);
-
-        // setup the grid to run the kernel
-        dim3 grid( N / run_block_size + 1, 1, 1);
-        dim3 threads(run_block_size, 1, 1);
-
-        gpu_compute_table_forces_kernel<0><<< grid, threads, sizeof(Scalar4)*table_index.getNumElements() >>>(d_force,
-                                                                                                           d_virial,
-                                                                                                           virial_pitch,
-                                                                                                           N,
-                                                                                                           d_pos,
-                                                                                                           box,
-                                                                                                           d_n_neigh,
-                                                                                                           d_nlist,
-                                                                                                           d_head_list,
-                                                                                                           d_tables,
-                                                                                                           d_params,
-                                                                                                           ntypes,
-                                                                                                           table_width);
         }
-
     return cudaSuccess;
     }
 // vim:syntax=cpp

--- a/hoomd/md/TablePotentialGPU.cuh
+++ b/hoomd/md/TablePotentialGPU.cuh
@@ -11,6 +11,7 @@
 #include "hoomd/ParticleData.cuh"
 #include "hoomd/Index1D.h"
 #include "hoomd/HOOMDMath.h"
+#include "hoomd/GPUPartition.cuh"
 
 #ifndef __TABLEPOTENTIALGPU_CUH__
 #define __TABLEPOTENTIALGPU_CUH__
@@ -33,6 +34,7 @@ cudaError_t gpu_compute_table_forces(Scalar4* d_force,
                                      const unsigned int table_width,
                                      const unsigned int block_size,
                                      const unsigned int compute_capability,
-                                     const unsigned int max_tex1d_width);
+                                     const unsigned int max_tex1d_width,
+                                     const GPUPartition& gpu_partition);
 
 #endif

--- a/hoomd/md/test/test_dpd_integrator.cc
+++ b/hoomd/md/test/test_dpd_integrator.cc
@@ -63,8 +63,8 @@ void dpd_conservative_force_test(std::shared_ptr<ExecutionConfiguration> exec_co
     // compute the forces
     dpdc->compute(0);
 
-    GPUArray<Scalar4>& force_array_1 =  dpdc->getForceArray();
-    GPUArray<Scalar>& virial_array_1 =  dpdc->getVirialArray();
+    GlobalArray<Scalar4>& force_array_1 =  dpdc->getForceArray();
+    GlobalArray<Scalar>& virial_array_1 =  dpdc->getVirialArray();
     ArrayHandle<Scalar4> h_force_1(force_array_1,access_location::host,access_mode::read);
     ArrayHandle<Scalar> h_virial_1(virial_array_1,access_location::host,access_mode::read);
     MY_CHECK_CLOSE(h_force_1.data[0].x, -28.5, tol);


### PR DESCRIPTION
## Description

Enables unified memory and multi-GPU execution in TablePotentialGPU.

## Motivation and Context

I needed this to run simulations with `pair.table()` fast.

## How Has This Been Tested?

Currently only single GPU execution is unit-tested with the `test-py/test_pair_table.py` and `test/test_table_potential` unit test. The latter is only run with `-D HOOMD_SKIP_LONG_TESTS=OFF` which is not part of any build configuration. I fixed a compiler error for this configuration. Should we add this option to one of the unit tests or rather implement the same test as a python unit test?

## Change log

```
- pair.table() now takes advantage of multi-GPU execution with managed memory.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/hoomd-blue/blob/master/sphinx-doc/credits.rst).
