### PR TITLE
fix bounding volume calculation for faceted ellipsoid

### DIFF
--- a/hoomd/hpmc/ShapeFacetedEllipsoid.h
+++ b/hoomd/hpmc/ShapeFacetedEllipsoid.h
@@ -301,7 +301,7 @@ struct ShapeFacetedEllipsoid
     //! Return a tight fitting OBB
     DEVICE detail::OBB getOBB(const vec3<Scalar>& pos) const
         {
-        detail::SupportFuncFacetedEllipsoid sfunc(params, 0.0);
+        detail::SupportFuncFacetedEllipsoid sfunc(params);
         vec3<OverlapReal> e_x(1,0,0);
         vec3<OverlapReal> e_y(0,1,0);
         vec3<OverlapReal> e_z(0,0,1);

--- a/hoomd/hpmc/ShapeFacetedEllipsoid.h
+++ b/hoomd/hpmc/ShapeFacetedEllipsoid.h
@@ -257,7 +257,8 @@ struct ShapeFacetedEllipsoid
         { }
 
     //! Does this shape have an orientation
-    DEVICE bool hasOrientation() { return params.N > 0; }
+    DEVICE bool hasOrientation() { return (params.N > 0) ||
+        (params.a != params.b) || (params.a != params.c) || (params.b != params.c); }
 
     //!Ignore flag for acceptance statistics
     DEVICE bool ignoreStatistics() const { return params.ignore; }


### PR DESCRIPTION
## Description

This PR fixes the calculation of the bounding volumes for `ShapeFacetedEllipsoid`. The asymmetry of the shape with facets wasn't correctly taken into account.

## Motivation and Context

I noticed that unions of faceted ellipsoids, which use OBBs internally, were overlapping, but no overlaps were reported. The tricky thing was they did this only when the leaf node capacity was small, so N^2 overlap checks were not active (the union was small enough that this was not visible with the default capacity setting). Also depletants in the `quermass_ellipsoid` branch used OBBs, so those were wrong, too.

## How Has This Been Tested?

Currently only offline.

## Change log

Since the changes have only made it into master thus far, no change log required.
## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/hoomd-blue/blob/master/sphinx-doc/credits.rst).