### PR TITLE
Feature/lattice field group

### DIFF
--- a/hoomd/hpmc/ExternalFieldLattice.h
+++ b/hoomd/hpmc/ExternalFieldLattice.h
@@ -12,6 +12,7 @@
 #include "hoomd/Saru.h"
 #include "hoomd/VectorMath.h"
 #include "hoomd/HOOMDMPI.h"
+#include "hoomd/ParticleGroup.h"
 
 #include "ExternalField.h"
 
@@ -27,41 +28,48 @@ the external field will take in a list of either positions or orientations that
 are the reference values. the i-th reference point will correspond to the particle
 with tag i.
 */
-inline void python_list_to_vector_scalar3(const pybind11::list& r0, std::vector<Scalar3>& ret, unsigned int ndim)
+inline void python_list_to_vector_scalar3(
+        const pybind11::list& r0,
+        std::vector<Scalar3>& ret,
+        unsigned int ndim)
     {
     // validate input type and rank
     pybind11::ssize_t n = pybind11::len(r0);
     ret.resize(n);
     for ( pybind11::ssize_t i=0; i<n; i++)
         {
+        // make sure dimensions of system and positions match
         pybind11::ssize_t d = pybind11::len(r0[i]);
         pybind11::list r0_tuple = pybind11::cast<pybind11::list >(r0[i]);
-        if( d < ndim )
+        if (d < ndim)
             {
-            throw std::runtime_error("dimension of the list does not match the dimension of the simulation.");
+            throw std::runtime_error(
+                    "dimension of the list does not match the dimension of the simulation.");
             }
-        Scalar x = pybind11::cast<Scalar>(r0_tuple[0]), y = pybind11::cast<Scalar>(r0_tuple[1]), z = 0.0;
-        if(d == 3)
+
+        Scalar x = pybind11::cast<Scalar>(r0_tuple[0]);
+        Scalar y = pybind11::cast<Scalar>(r0_tuple[1]);
+        Scalar z = 0.0;
+        if (d == 3)
             {
             z = pybind11::cast<Scalar>(r0_tuple[2]);
             }
         ret[i] = make_scalar3(x, y, z);
         }
-    }
+    }  // end python_list_to_vector_scalar3()
 
 inline void python_list_to_vector_scalar4(const pybind11::list& r0, std::vector<Scalar4>& ret)
     {
     // validate input type and rank
     pybind11::ssize_t n = pybind11::len(r0);
     ret.resize(n);
-    for ( pybind11::ssize_t i=0; i<n; i++)
+    for (pybind11::ssize_t i=0; i<n; i++)
         {
         pybind11::list r0_tuple = pybind11::cast<pybind11::list >(r0[i]);
-
-        ret[i] = make_scalar4(  pybind11::cast<Scalar>(r0_tuple[0]),
-                                pybind11::cast<Scalar>(r0_tuple[1]),
-                                pybind11::cast<Scalar>(r0_tuple[2]),
-                                pybind11::cast<Scalar>(r0_tuple[3]));
+        ret[i] = make_scalar4(pybind11::cast<Scalar>(r0_tuple[0]),
+                              pybind11::cast<Scalar>(r0_tuple[1]),
+                              pybind11::cast<Scalar>(r0_tuple[2]),
+                              pybind11::cast<Scalar>(r0_tuple[3]));
         }
     }
 
@@ -70,58 +78,94 @@ template< class ScalarType >
 class LatticeReferenceList
     {
     public:
+        /* Default constructor
+         *
+         **/
         LatticeReferenceList() : m_N(0) {}
 
+        /*  Constructor that sets the reference positions
+         *
+         **/
         template<class InputIterator >
-        LatticeReferenceList(InputIterator first, InputIterator last, const std::shared_ptr<ParticleData> pdata, std::shared_ptr<const ExecutionConfiguration> exec_conf)
+        LatticeReferenceList(
+                InputIterator first,
+                InputIterator last,
+                const std::shared_ptr<ParticleData> pdata,
+                std::shared_ptr<const ExecutionConfiguration> exec_conf)
             {
             initialize(first, last, pdata, exec_conf);
             }
 
+        /*  Default destructor
+         *
+         **/
         ~LatticeReferenceList() {}
 
         template <class InputIterator>
-        void initialize(InputIterator first, InputIterator last, const std::shared_ptr<ParticleData> pdata, std::shared_ptr<const ExecutionConfiguration> exec_conf)
+        void initialize(InputIterator first,
+                InputIterator last,
+                const std::shared_ptr<ParticleData> pdata,
+                std::shared_ptr<const ExecutionConfiguration> exec_conf)
             {
             m_N = std::distance(first, last);
-            if( m_N > 0 )
+            if (m_N > 0)
                 {
                 setReferences(first, last, pdata, exec_conf);
                 }
             }
 
-        const ScalarType& getReference( const unsigned int& tag ) { ArrayHandle<ScalarType> h_ref(m_reference, access_location::host, access_mode::read); return h_ref.data[tag]; }
+        const ScalarType& getReference(const unsigned int& tag)
+            {
+            ArrayHandle<ScalarType> h_ref(m_reference, access_location::host, access_mode::read);
+            return h_ref.data[tag];
+            }
 
-        const GPUArray< ScalarType >& getReferenceArray() { return m_reference; }
+        const GPUArray< ScalarType >& getReferenceArray()
+            {
+            return m_reference;
+            }
 
         template <class InputIterator>
-        void setReferences(InputIterator first, InputIterator last, const std::shared_ptr<ParticleData> pdata, std::shared_ptr<const ExecutionConfiguration> exec_conf)
-        {
+        void setReferences(
+                InputIterator first,
+                InputIterator last,
+                const std::shared_ptr<ParticleData> pdata,
+                std::shared_ptr<const ExecutionConfiguration> exec_conf)
+            {
             size_t numPoints = std::distance(first, last);
-            if(!numPoints)
+
+            // early exit if reference list is 0 elements in length
+            if (!numPoints)
                 {
                 clear();
                 return;
                 }
 
-            if(!exec_conf || !pdata || pdata->getNGlobal() != numPoints)
+            if (!exec_conf || !pdata || pdata->getNGlobal() != numPoints)
                 {
-                if(exec_conf) exec_conf->msg->error() << "Check pointers and initialization list" << std::endl;
+                if (exec_conf)
+                    {
+                    exec_conf->msg->error()
+                    << "Check pointers and initialization list"
+                    << std::endl;
+                    }
                 throw std::runtime_error("Error setting LatticeReferenceList");
                 }
+
             m_N = numPoints;
             GPUArray<ScalarType> temp(numPoints, exec_conf);
-            { // scope the copy.
+            { // scope the copy
             ArrayHandle<ScalarType> h_temp(temp, access_location::host, access_mode::overwrite);
             // now copy and swap the data.
             std::copy(first, last, h_temp.data);
             }
             m_reference.swap(temp);
-        }
+            }  // end LatticeReferenceList::setReferences()
 
         void scale(const Scalar& s)
             {
-            ArrayHandle<ScalarType> h_ref(m_reference, access_location::host, access_mode::readwrite);
+            ArrayHandle<ScalarType> h_ref(
+                    m_reference, access_location::host, access_mode::readwrite);
             for(unsigned int i = 0; i < m_N; i++)
                 {
                 h_ref.data[i].x *= s;
@@ -137,12 +181,15 @@ class LatticeReferenceList
             m_reference.swap(nullArray);
             }
 
-        bool isValid() { return m_N != 0 && !m_reference.isNull(); }
+        bool isValid()
+            {
+            return m_N != 0 && !m_reference.isNull();
+            }
 
     private:
         GPUArray<ScalarType> m_reference;
-        unsigned int         m_N;
-    };
+        unsigned int         m_N;  /// number of particles in the system (change for groups)
+    };  // end class LatticeReferenceList
 
 
 #define LATTICE_ENERGY_LOG_NAME                 "lattice_energy"
@@ -159,25 +206,35 @@ class ExternalFieldLattice : public ExternalFieldMono<Shape>
     using ExternalFieldMono<Shape>::m_exec_conf;
     using ExternalFieldMono<Shape>::m_sysdef;
     public:
-        ExternalFieldLattice(  std::shared_ptr<SystemDefinition> sysdef,
-                                        pybind11::list r0,
-                                        Scalar k,
-                                        pybind11::list q0,
-                                        Scalar q,
-                                        pybind11::list symRotations
-                                    ) : ExternalFieldMono<Shape>(sysdef), m_k(k), m_q(q), m_Energy(0)
+        ExternalFieldLattice(std::shared_ptr<SystemDefinition> sysdef,
+                             std::shared_ptr<ParticleGroup> group,
+                             pybind11::list r0,
+                             Scalar k,
+                             pybind11::list q0,
+                             Scalar q,
+                             pybind11::list symRotations)
+                             : ExternalFieldMono<Shape>(sysdef),
+                               m_k(k),
+                               m_q(q),
+                               m_Energy(0),
+                               m_group(group)
             {
+            // add to provided quantities
             m_ProvidedQuantities.push_back(LATTICE_ENERGY_LOG_NAME);
             m_ProvidedQuantities.push_back(LATTICE_ENERGY_AVG_LOG_NAME);
             m_ProvidedQuantities.push_back(LATTICE_ENERGY_SIGMA_LOG_NAME);
             m_ProvidedQuantities.push_back(LATTICE_TRANS_SPRING_CONSTANT_LOG_NAME);
             m_ProvidedQuantities.push_back(LATTICE_ROTAT_SPRING_CONSTANT_LOG_NAME);
             m_ProvidedQuantities.push_back(LATTICE_NUM_SAMPLES_LOG_NAME);
+
             // Connect to the BoxChange signal
             m_box = m_pdata->getBox();
-            m_pdata->getBoxChangeSignal().template connect<ExternalFieldLattice<Shape>, &ExternalFieldLattice<Shape>::scaleReferencePoints>(this);
+            m_pdata->getBoxChangeSignal().template connect<
+                ExternalFieldLattice<Shape>,
+                &ExternalFieldLattice<Shape>::scaleReferencePoints>(this);
             setReferences(r0, q0);
 
+            // build up list of equivalent orientations
             std::vector<Scalar4> rots;
             python_list_to_vector_scalar4(symRotations, rots);
             bool identityFound = false;
@@ -189,38 +246,54 @@ class ExternalFieldLattice : public ExternalFieldMono<Shape>
                 identityFound = !identityFound ? norm2(qi-identity) < tol : identityFound;
                 m_symmetry.push_back(qi);
                 }
-            if(!identityFound) // ensure that the identity rotation is provided.
+            if (!identityFound)  // ensure that the identity rotation is provided
                 {
                 m_symmetry.push_back(identity);
                 }
-            reset(0); // initializes all of the energy logging parameters.
-            }
+            reset(0);  // initializes all of the energy logging parameters
+            }  // end ExternalFieldLattice::ExternalFieldLattice()
 
         ~ExternalFieldLattice()
-        {
-            m_pdata->getBoxChangeSignal().template disconnect<ExternalFieldLattice<Shape>, &ExternalFieldLattice<Shape>::scaleReferencePoints>(this);
-        }
-
-        Scalar calculateBoltzmannWeight(unsigned int timestep) { return 0.0; }
-
-        double calculateDeltaE(const Scalar4 * const position_old_arg,
-                                        const Scalar4 * const orientation_old_arg,
-                                        const BoxDim * const box_old_arg
-                                        )
             {
-            // TODO: rethink the formatting a bit.
-            ArrayHandle<Scalar4> h_pos(m_pdata->getPositions(), access_location::host, access_mode::readwrite);
-            ArrayHandle<Scalar4> h_orient(m_pdata->getOrientationArray(), access_location::host, access_mode::readwrite);
+            // Disconnect from the BoxChange signal
+            m_pdata->getBoxChangeSignal().template disconnect<
+                ExternalFieldLattice<Shape>,
+                &ExternalFieldLattice<Shape>::scaleReferencePoints>(this);
+            }
+
+        // why is this zero? this feels wrong, esp. considering we have an energy
+        // associated with configurations with this external field
+        Scalar calculateBoltzmannWeight(unsigned int timestep)
+            {
+            return 0.0;
+            }
+
+        //! Calculate energy difference between new and old configurations
+        double calculateDeltaE(const Scalar4 * const position_old_arg,
+                               const Scalar4 * const orientation_old_arg,
+                               const BoxDim * const box_old_arg
+                               )
+            {
+            // TODO: rethink the formatting a bit
+            ArrayHandle<Scalar4> h_pos(
+                    m_pdata->getPositions(), access_location::host, access_mode::readwrite);
+            ArrayHandle<Scalar4> h_orient(
+                    m_pdata->getOrientationArray(), access_location::host, access_mode::readwrite);
             const Scalar4 * const position_new = h_pos.data;
             const Scalar4 * const orientation_new = h_orient.data;
             const BoxDim * const box_new = &m_pdata->getGlobalBox();
-            const Scalar4 * position_old=position_old_arg, * orientation_old=orientation_old_arg;
+
+            // copy arguments into new arrays
+            const Scalar4 * position_old = position_old_arg;
+            const Scalar4 * orientation_old = orientation_old_arg;
             const BoxDim * box_old = box_old_arg;
-            if( !position_old )
+
+            // if arrays are empty, fill with "new" ones
+            if (!position_old)
                 position_old = position_new;
-            if( !orientation_old )
+            if (!orientation_old)
                 orientation_old = orientation_new;
-            if( !box_old )
+            if (!box_old)
                 box_old = box_new;
 
             Scalar curVolume = m_box.getVolume();
@@ -230,35 +303,61 @@ class ExternalFieldLattice : public ExternalFieldMono<Shape>
             Scalar scaleNew = pow((newVolume/curVolume), Scalar(1.0/3.0));
 
             double dE = 0.0;
+            // TODO: only loop over particles in the group
             for(size_t i = 0; i < m_pdata->getN(); i++)
                 {
-                Scalar old_E = calcE(i, vec3<Scalar>(*(position_old+i)), quat<Scalar>(*(orientation_old+i)), scaleOld);
-                Scalar new_E = calcE(i, vec3<Scalar>(*(position_new+i)), quat<Scalar>(*(orientation_new+i)), scaleNew);
+                if (!m_group->isMember(i))
+                    continue;
+
+                Scalar old_E = calcE(
+                        i,
+                        vec3<Scalar>(*(position_old+i)),
+                        quat<Scalar>(*(orientation_old+i)),
+                        scaleOld);
+                Scalar new_E = calcE(
+                        i,
+                        vec3<Scalar>(*(position_new+i)),
+                        quat<Scalar>(*(orientation_new+i)),
+                        scaleNew);
                 dE += new_E - old_E;
                 }
 
             #ifdef ENABLE_MPI
             if (this->m_pdata->getDomainDecomposition())
                 {
-                MPI_Allreduce(MPI_IN_PLACE, &dE, 1, MPI_HOOMD_SCALAR, MPI_SUM, m_exec_conf->getMPICommunicator());
+                MPI_Allreduce(
+                        MPI_IN_PLACE,
+                        &dE,
+                        1,
+                        MPI_HOOMD_SCALAR,
+                        MPI_SUM,
+                        m_exec_conf->getMPICommunicator());
                 }
             #endif
 
             return dE;
-            }
+            }  // end ExternalFieldLattice::calculateDeltaE()
 
         void compute(unsigned int timestep)
             {
-            if(!this->shouldCompute(timestep))
+            // early exit if we don't need to calculate this at this timestep
+            if (!this->shouldCompute(timestep))
                 {
                 return;
                 }
+
             m_Energy = Scalar(0.0);
             // access particle data and system box
-            ArrayHandle<Scalar4> h_postype(m_pdata->getPositions(), access_location::host, access_mode::read);
-            ArrayHandle<Scalar4> h_orient(m_pdata->getOrientationArray(), access_location::host, access_mode::read);
+            ArrayHandle<Scalar4> h_postype(
+                    m_pdata->getPositions(), access_location::host, access_mode::read);
+            ArrayHandle<Scalar4> h_orient(
+                    m_pdata->getOrientationArray(), access_location::host, access_mode::read);
+            // TODO: only loop over particles in group
             for(size_t i = 0; i < m_pdata->getN(); i++)
                 {
+                if (!m_group->isMember(i))
+                    continue;
+
                 vec3<Scalar> position(h_postype.data[i]);
                 quat<Scalar> orientation(h_orient.data[i]);
                 m_Energy += calcE(i, position, orientation);
@@ -267,14 +366,23 @@ class ExternalFieldLattice : public ExternalFieldMono<Shape>
             #ifdef ENABLE_MPI
             if (this->m_pdata->getDomainDecomposition())
                 {
-                MPI_Allreduce(MPI_IN_PLACE, &m_Energy, 1, MPI_HOOMD_SCALAR, MPI_SUM, m_exec_conf->getMPICommunicator());
+                MPI_Allreduce(
+                        MPI_IN_PLACE,
+                        &m_Energy,
+                        1,
+                        MPI_HOOMD_SCALAR,
+                        MPI_SUM,
+                        m_exec_conf->getMPICommunicator());
                 }
             #endif
 
-            Scalar energy_per = m_Energy / Scalar(m_pdata->getNGlobal());
+            // Kahan/compensation summation of energy per particle and (energy per particle)**2
+            // See https://en.wikipedia.org/wiki/Kahan_summation_algorithm
+            // energy_per <--> input[i]
+            Scalar energy_per = m_Energy / Scalar(m_group->getNumMembersGlobal());
             m_EnergySum_y    = energy_per - m_EnergySum_c;
             m_EnergySum_t    = m_EnergySum + m_EnergySum_y;
-            m_EnergySum_c    = (m_EnergySum_t-m_EnergySum) - m_EnergySum_y;
+            m_EnergySum_c    = (m_EnergySum_t - m_EnergySum) - m_EnergySum_y;
             m_EnergySum      = m_EnergySum_t;
 
             Scalar energy_sq_per = energy_per*energy_per;
@@ -283,34 +391,44 @@ class ExternalFieldLattice : public ExternalFieldMono<Shape>
             m_EnergySqSum_c    = (m_EnergySqSum_t-m_EnergySqSum) - m_EnergySqSum_y;
             m_EnergySqSum      = m_EnergySqSum_t;
             m_num_samples++;
-            }
+            }  // end ExternalFieldLattice::compute()
 
-        double energydiff(const unsigned int& index, const vec3<Scalar>& position_old, const Shape& shape_old, const vec3<Scalar>& position_new, const Shape& shape_new)
+        double energydiff(
+                const unsigned int& index,
+                const vec3<Scalar>& position_old,
+                const Shape& shape_old,
+                const vec3<Scalar>& position_new,
+                const Shape& shape_new)
             {
-            double old_U = calcE(index, position_old, shape_old), new_U = calcE(index, position_new, shape_new);
+            if (!m_group->isMember(index))
+                return 0;
+
+            double old_U = calcE(index, position_old, shape_old);
+            double new_U = calcE(index, position_new, shape_new);
             return new_U - old_U;
-            }
+            }  // end ExternalFieldLattice::energydiff()
 
         void setReferences(const pybind11::list& r0, const pybind11::list& q0)
             {
+            // initialize some arrays to hold things
             unsigned int ndim = m_sysdef->getNDimensions();
             std::vector<Scalar3> lattice_positions;
             std::vector<Scalar> pbuffer;
             std::vector<Scalar4> lattice_orientations;
             std::vector<Scalar> qbuffer;
             #ifdef ENABLE_MPI
-            unsigned int psz = 0, qsz = 0;
-
-            if ( this->m_exec_conf->isRoot() )
+            unsigned int psz = 0, qsz = 0;  // length of particle and orientation lists
+            if (this->m_exec_conf->isRoot())
                 {
                 python_list_to_vector_scalar3(r0, lattice_positions, ndim);
                 python_list_to_vector_scalar4(q0, lattice_orientations);
                 psz = lattice_positions.size();
                 qsz = lattice_orientations.size();
                 }
-            if( this->m_pdata->getDomainDecomposition())
+            if (this->m_pdata->getDomainDecomposition())
                 {
-                if(psz)
+                // fill in the position and orientation buffers
+                if (psz)
                     {
                     pbuffer.resize(3*psz, 0.0);
                     for(size_t i = 0; i < psz; i++)
@@ -320,7 +438,7 @@ class ExternalFieldLattice : public ExternalFieldMono<Shape>
                         pbuffer[3*i+2] = lattice_positions[i].z;
                         }
                     }
-                if(qsz)
+                if (qsz)
                     {
                     qbuffer.resize(4*qsz, 0.0);
                     for(size_t i = 0; i < qsz; i++)
@@ -331,13 +449,21 @@ class ExternalFieldLattice : public ExternalFieldMono<Shape>
                         qbuffer[4*i+3] = lattice_orientations[i].w;
                         }
                     }
+
+                // broadcast particle array size to all ranks
                 MPI_Bcast(&psz, 1, MPI_UNSIGNED, 0, m_exec_conf->getMPICommunicator());
-                if(psz)
+                if (psz)
                     {
-                    if(!pbuffer.size())
+                    if (!pbuffer.size())
                         pbuffer.resize(3*psz, 0.0);
-                    MPI_Bcast(&pbuffer.front(), 3*psz, MPI_HOOMD_SCALAR, 0, m_exec_conf->getMPICommunicator());
-                    if(!lattice_positions.size())
+                    // broadcast particle position array to all ranks
+                    MPI_Bcast(
+                            &pbuffer.front(),
+                            3*psz,
+                            MPI_HOOMD_SCALAR,
+                            0,
+                            m_exec_conf->getMPICommunicator());
+                    if (!lattice_positions.size())
                         {
                         lattice_positions.resize(psz, make_scalar3(0.0, 0.0, 0.0));
                         for(size_t i = 0; i < psz; i++)
@@ -347,14 +473,21 @@ class ExternalFieldLattice : public ExternalFieldMono<Shape>
                             lattice_positions[i].z = pbuffer[3*i+2];
                             }
                         }
-                    }
+                    }  // end if (psz)
+
+                // broadcast particle orientation array size to all ranks
                 MPI_Bcast(&qsz, 1, MPI_UNSIGNED, 0, m_exec_conf->getMPICommunicator());
-                if(qsz)
+                if (qsz)
                     {
-                    if(!qbuffer.size())
+                    if (!qbuffer.size())
                         qbuffer.resize(4*qsz, 0.0);
-                    MPI_Bcast(&qbuffer.front(), 4*qsz, MPI_HOOMD_SCALAR, 0, m_exec_conf->getMPICommunicator());
-                    if(!lattice_orientations.size())
+                    // broadcast orientation array to all ranks
+                    MPI_Bcast(&qbuffer.front(),
+                            4*qsz,
+                            MPI_HOOMD_SCALAR,
+                            0,
+                            m_exec_conf->getMPICommunicator());
+                    if (!lattice_orientations.size())
                         {
                         lattice_orientations.resize(qsz, make_scalar4(0, 0, 0, 0));
                         for(size_t i = 0; i < qsz; i++)
@@ -366,19 +499,34 @@ class ExternalFieldLattice : public ExternalFieldMono<Shape>
                             }
                         }
                     }
-                }
+                }  // end if (this->m_pdata->getDomainDecomposition())
 
             #else
+            // if not using mpi, can just use these functions to set reference
+            // positions/orientations
             python_list_to_vector_scalar3(r0, lattice_positions, ndim);
             python_list_to_vector_scalar4(q0, lattice_orientations);
             #endif
 
-            if( lattice_positions.size() )
-                m_latticePositions.setReferences(lattice_positions.begin(), lattice_positions.end(), m_pdata, m_exec_conf);
+            // set reference positions for the lattice position/orientations
+            if (lattice_positions.size())
+                {
+                m_latticePositions.setReferences(
+                        lattice_positions.begin(),
+                        lattice_positions.end(),
+                        m_pdata,
+                        m_exec_conf);
+                }
 
-            if( lattice_orientations.size() )
-                m_latticeOrientations.setReferences(lattice_orientations.begin(), lattice_orientations.end(), m_pdata, m_exec_conf);
-            }
+            if (lattice_orientations.size())
+                {
+                m_latticeOrientations.setReferences(
+                        lattice_orientations.begin(),
+                        lattice_orientations.end(),
+                        m_pdata,
+                        m_exec_conf);
+                }
+            }  // end ExternalFieldLattice::setReferences()
 
         void clearPositions() { m_latticePositions.clear(); }
 
@@ -386,16 +534,14 @@ class ExternalFieldLattice : public ExternalFieldMono<Shape>
 
         void scaleReferencePoints()
             {
-                BoxDim newBox = m_pdata->getBox();
-                Scalar newVol = newBox.getVolume();
-                Scalar lastVol = m_box.getVolume();
-                Scalar scale;
-                if (this->m_sysdef->getNDimensions() == 2)
-                    scale = pow((newVol/lastVol), Scalar(1.0/2.0));
-                else
-                    scale = pow((newVol/lastVol), Scalar(1.0/3.0));
-                m_latticePositions.scale(scale);
-                m_box = newBox;
+            BoxDim newBox = m_pdata->getBox();
+            Scalar newVol = newBox.getVolume();
+            Scalar lastVol = m_box.getVolume();
+            Scalar scale;
+            Scalar ndim = Scalar(this->m_sysdef->getNDimensions());
+            scale = pow((newVol/lastVol), Scalar(1.0/ndim));
+            m_latticePositions.scale(scale);
+            m_box = newBox;
             }
 
         //! Returns a list of log quantities this compute calculates
@@ -409,42 +555,40 @@ class ExternalFieldLattice : public ExternalFieldMono<Shape>
             {
             compute(timestep);
 
-            if( quantity == LATTICE_ENERGY_LOG_NAME )
+            if (quantity == LATTICE_ENERGY_LOG_NAME)
                 {
                 return m_Energy;
                 }
-            else if( quantity == LATTICE_ENERGY_AVG_LOG_NAME )
+            else if (quantity == LATTICE_ENERGY_AVG_LOG_NAME)
                 {
-                if( !m_num_samples )
-                    return 0.0;
-                return m_EnergySum/double(m_num_samples);
+                return getAvgEnergy(timestep);
                 }
-            else if ( quantity == LATTICE_ENERGY_SIGMA_LOG_NAME )
+            else if (quantity == LATTICE_ENERGY_SIGMA_LOG_NAME)
                 {
-                if( !m_num_samples )
-                    return 0.0;
-                Scalar first_moment = m_EnergySum/double(m_num_samples);
-                Scalar second_moment = m_EnergySqSum/double(m_num_samples);
-                return sqrt(second_moment - (first_moment*first_moment));
+                return getSigma(timestep);
                 }
-            else if ( quantity == LATTICE_TRANS_SPRING_CONSTANT_LOG_NAME )
+            else if (quantity == LATTICE_TRANS_SPRING_CONSTANT_LOG_NAME)
                 {
                 return m_k;
                 }
-            else if ( quantity == LATTICE_ROTAT_SPRING_CONSTANT_LOG_NAME )
+            else if (quantity == LATTICE_ROTAT_SPRING_CONSTANT_LOG_NAME)
                 {
                 return m_q;
                 }
-            else if ( quantity == LATTICE_NUM_SAMPLES_LOG_NAME )
+            else if (quantity == LATTICE_NUM_SAMPLES_LOG_NAME)
                 {
                 return m_num_samples;
                 }
             else
                 {
-                m_exec_conf->msg->error() << "field.lattice_field: " << quantity << " is not a valid log quantity" << std::endl;
+                m_exec_conf->msg->error()
+                    << "field.lattice_field: "
+                    << quantity
+                    << " is not a valid log quantity"
+                    << std::endl;
                 throw std::runtime_error("Error getting log value");
                 }
-            }
+            }  // end ExternalFieldLattice::getLogValue()
 
         void setParams(Scalar k, Scalar q)
             {
@@ -462,7 +606,7 @@ class ExternalFieldLattice : public ExternalFieldMono<Shape>
             return m_latticeOrientations.getReferenceArray();
             }
 
-        void reset( unsigned int ) // TODO: remove the timestep
+        void reset(unsigned int)  // TODO: remove the timestep
             {
             m_EnergySum = m_EnergySum_y = m_EnergySum_t = m_EnergySum_c = Scalar(0.0);
             m_EnergySqSum = m_EnergySqSum_y = m_EnergySqSum_t = m_EnergySqSum_c = Scalar(0.0);
@@ -470,34 +614,44 @@ class ExternalFieldLattice : public ExternalFieldMono<Shape>
             }
 
         Scalar getEnergy(unsigned int timestep)
-        {
+            {
             compute(timestep);
             return m_Energy;
-        }
-        Scalar getAvgEnergy(unsigned int timestep)
-        {
-            compute(timestep);
-            if( !m_num_samples )
-                return 0.0;
-            return m_EnergySum/double(m_num_samples);
-        }
-        Scalar getSigma(unsigned int timestep)
-        {
-            compute(timestep);
-            if( !m_num_samples )
-                return 0.0;
-            Scalar first_moment = m_EnergySum/double(m_num_samples);
-            Scalar second_moment = m_EnergySqSum/double(m_num_samples);
-            return sqrt(second_moment - (first_moment*first_moment));
-        }
+            }
 
+        //! Energy per particle averaged over the number of computes()s called
+        Scalar getAvgEnergy(unsigned int timestep)
+            {
+            compute(timestep);
+            if (!m_num_samples)
+                return 0.0;
+            return m_EnergySum / double(m_num_samples);
+            }
+
+        //! Standard deviation of the energy per particle over the number of times compute() is
+        // called
+        Scalar getSigma(unsigned int timestep)
+            {
+            compute(timestep);
+            if (!m_num_samples)
+                return 0.0;
+            Scalar first_moment = m_EnergySum / double(m_num_samples);
+            Scalar second_moment = m_EnergySqSum / double(m_num_samples);
+            return sqrt(second_moment - (first_moment*first_moment));
+            }
 
     protected:
-
         // These could be a little redundant. think about this more later.
-        Scalar calcE_trans(const unsigned int& index, const vec3<Scalar>& position, const Scalar& scale = 1.0)
+        // They definetely _feel_ redundant
+        Scalar calcE_trans(
+                const unsigned int& index,
+                const vec3<Scalar>& position,
+                const Scalar& scale = 1.0)
             {
-            ArrayHandle<unsigned int> h_tags(m_pdata->getTags(), access_location::host, access_mode::read);
+            if (!m_group->isMember(index))
+                return 0.0;
+            ArrayHandle<unsigned int> h_tags(
+                    m_pdata->getTags(), access_location::host, access_mode::read);
             int3 dummy = make_int3(0,0,0);
             vec3<Scalar> origin(m_pdata->getOrigin());
             const BoxDim& box = this->m_pdata->getGlobalBox();
@@ -512,8 +666,11 @@ class ExternalFieldLattice : public ExternalFieldMono<Shape>
 
         Scalar calcE_rot(const unsigned int& index, const quat<Scalar>& orientation)
             {
+            if (!m_group->isMember(index))
+                return 0.0;
             assert(m_symmetry.size());
-            ArrayHandle<unsigned int> h_tags(m_pdata->getTags(), access_location::host, access_mode::read);
+            ArrayHandle<unsigned int> h_tags(
+                    m_pdata->getTags(), access_location::host, access_mode::read);
             quat<Scalar> q0(m_latticeOrientations.getReference(h_tags.data[index]));
             Scalar dqmin = 0.0;
             for(size_t i = 0; i < m_symmetry.size(); i++)
@@ -526,61 +683,94 @@ class ExternalFieldLattice : public ExternalFieldMono<Shape>
             }
         Scalar calcE_rot(const unsigned int& index, const Shape& shape)
             {
-            if(!shape.hasOrientation())
+            if (!m_group->isMember(index))
+                return 0.0;
+            if (!shape.hasOrientation())
                 return Scalar(0.0);
 
             return calcE_rot(index, shape.orientation);
             }
-        Scalar calcE(const unsigned int& index, const vec3<Scalar>& position, const quat<Scalar>& orientation, const Scalar& scale = 1.0)
+
+        //! Calculate the energy associated with the configuration
+        Scalar calcE(
+                const unsigned int& index,
+                const vec3<Scalar>& position,
+                const quat<Scalar>& orientation,
+                const Scalar& scale = 1.0)
             {
+            // exit early if particle not in group
+            if (!m_group->isMember(index))
+                return 0.0;
+
             Scalar energy = 0.0;
-            if(m_latticePositions.isValid())
+            if (m_latticePositions.isValid())
                 {
                 energy += calcE_trans(index, position, scale);
                 }
-            if(m_latticeOrientations.isValid())
+            if (m_latticeOrientations.isValid())
                 {
                 energy += calcE_rot(index, orientation);
                 }
             return energy;
-            }
-        Scalar calcE(const unsigned int& index, const vec3<Scalar>& position, const Shape& shape, const Scalar& scale = 1.0)
+            }  // end ExternalFieldLattice::calcE()
+
+        Scalar calcE(const unsigned int& index,
+                const vec3<Scalar>& position,
+                const Shape& shape,
+                const Scalar& scale = 1.0)
             {
             return calcE(index, position, shape.orientation, scale);
             }
+
     private:
-        LatticeReferenceList<Scalar3>   m_latticePositions;         // positions of the lattice.
-        Scalar                          m_k;                        // spring constant
+        Scalar  m_k;        // translational spring constant
+        Scalar  m_q;        // rotational spring constant
+        Scalar  m_Energy;   // total energy of the last computed timestep
 
-        LatticeReferenceList<Scalar4>   m_latticeOrientations;      // orientation of the lattice particles.
-        Scalar                          m_q;                        // spring constant
+        // group to apply external field to
+        std::shared_ptr<ParticleGroup> m_group;
 
-        std::vector< quat<Scalar> >     m_symmetry;       // quaternions in the symmetry group of the shape.
+        // positions of the lattice
+        LatticeReferenceList<Scalar3> m_latticePositions;
 
-        Scalar                          m_Energy;                   // Store the total energy of the last computed timestep
+        // orientation of the lattice particles
+        LatticeReferenceList<Scalar4> m_latticeOrientations;
 
-        // All of these are on a per particle basis
-        Scalar                          m_EnergySum;
-        Scalar                          m_EnergySum_y;
-        Scalar                          m_EnergySum_t;
-        Scalar                          m_EnergySum_c;
+        // quaternions in the symmetry group of the shape
+        std::vector< quat<Scalar> > m_symmetry;
 
-        Scalar                          m_EnergySqSum;
-        Scalar                          m_EnergySqSum_y;
-        Scalar                          m_EnergySqSum_t;
-        Scalar                          m_EnergySqSum_c;
+        // Terms for Kahan summation of energy; all are on a per-particle basis
+        Scalar  m_EnergySum;
+        Scalar  m_EnergySum_y;
+        Scalar  m_EnergySum_t;
+        Scalar  m_EnergySum_c;
+        Scalar  m_EnergySqSum;
+        Scalar  m_EnergySqSum_y;
+        Scalar  m_EnergySqSum_t;
+        Scalar  m_EnergySqSum_c;
 
-        unsigned int                    m_num_samples;
-
-        std::vector<std::string>        m_ProvidedQuantities;
-        BoxDim                          m_box;              //!< Save the last known box;
-    };
+        // other stuff
+        unsigned int              m_num_samples;   // no. times compute() has been called
+        std::vector<std::string>  m_ProvidedQuantities;
+        BoxDim                    m_box;
+    };  // end class ExternalFieldLattice
 
 template<class Shape>
 void export_LatticeField(pybind11::module& m, std::string name)
     {
-   pybind11::class_<ExternalFieldLattice<Shape>, std::shared_ptr< ExternalFieldLattice<Shape> > >(m, name.c_str(), pybind11::base< ExternalFieldMono<Shape> >())
-    .def(pybind11::init< std::shared_ptr<SystemDefinition>, pybind11::list, Scalar, pybind11::list, Scalar, pybind11::list>())
+   pybind11::class_<
+       ExternalFieldLattice<Shape>,
+       std::shared_ptr< ExternalFieldLattice<Shape> > >(
+               m,
+               name.c_str(),
+               pybind11::base< ExternalFieldMono<Shape> >())
+    .def(pybind11::init< std::shared_ptr<SystemDefinition>,
+         std::shared_ptr<ParticleGroup>,
+         pybind11::list,
+         Scalar,
+         pybind11::list,
+         Scalar,
+         pybind11::list>())
     .def("setReferences", &ExternalFieldLattice<Shape>::setReferences)
     .def("setParams", &ExternalFieldLattice<Shape>::setParams)
     .def("reset", &ExternalFieldLattice<Shape>::reset)

--- a/hoomd/hpmc/field.py
+++ b/hoomd/hpmc/field.py
@@ -1,7 +1,8 @@
-# Copyright (c) 2009-2019 The Regents of the University of Michigan
+/ Copyright (c) 2009-2019 The Regents of the University of Michigan
 # This file is part of the HOOMD-blue project, released under the BSD 3-Clause License.
 
 """ Apply external fields to HPMC simulations.
+
 """
 
 from hoomd import _hoomd
@@ -26,23 +27,25 @@ class _external(_compute):
     #
     # \post nothing is done here yet.
     def __init__(self):
-        _compute.__init__(self);
-        self.cpp_compute = None;
+        _compute.__init__(self)
+        self.cpp_compute = None
         # nothing else to do.
 
 class lattice_field(_external):
-    R""" Restrain particles on a lattice
+    R""" Restrain particles to defined positions/orientations
 
     Args:
         mc (:py:mod:`hoomd.hpmc.integrate`): MC integrator.
-        position (list): list of positions to restrain each particle (distance units).
-        orientation (list): list of orientations to restrain each particle (quaternions).
+        position (list): list of positions to which to restrain each particle (distance units).
+        orientation (list): list of orientations to which to restrain each particle (quaternions).
         k (float): translational spring constant.
         q (float): rotational spring constant.
         symmetry (list): list of equivalent quaternions for the shape.
         composite (bool): Set this to True when this field is part of a :py:class:`external_field_composite`.
+        group (:py:mod:`hoomd.group`): Group of particles on which to apply the restraints
 
-    :py:class:`lattice_field` specifies that a harmonic spring is added to every particle:
+    :py:class:`lattice_field` specifies that a harmonic spring is added to every particle in the
+    group. If no group is specified, the restraints are applied to every particle in the system.
 
     .. math::
 
@@ -68,58 +71,74 @@ class lattice_field(_external):
 
     Example::
 
-        mc = hpmc.integrate.sphere(seed=415236);
-        hpmc.field.lattice_field(mc=mc, position=fcc_lattice, k=1000.0);
-        log = analyze.log(quantities=['lattice_energy'], period=100, filename='log.dat', overwrite=True);
+        mc = hpmc.integrate.sphere(seed=415236)
+        hpmc.field.lattice_field(mc=mc, position=fcc_lattice, k=1000.0)
+        log = analyze.log(quantities=['lattice_energy'], period=100, filename='log.dat', overwrite=True)
+
+    Example with groups::
+
+        snapshot = system.take_snapshot()
+        mc = hpmc.integrate.sphere(seed=12345)
+        seed_particles = hoomd.group.cuboid('seed_particles, -2, 2, -2, 2, -2, 2)
+        springs = hpmc.field.lattice_field(mc=mc, position=snapshot.particles.position,
+                                           k=100.0, group=seed_particles)
 
     """
-    def __init__(self, mc, position = [], orientation = [], k = 0.0, q = 0.0, symmetry = [], composite=False):
+    def __init__(self, mc, position=[], orientation=[], k=0.0, q=0.0,
+            symmetry=[], composite=False, group=None):
         import numpy
-        hoomd.util.print_status_line();
-        _external.__init__(self);
-        cls = None;
+        hoomd.util.print_status_line()
+        _external.__init__(self)
+        cls = None
         if not hoomd.context.exec_conf.isCUDAEnabled():
             if isinstance(mc, integrate.sphere):
-                cls = _hpmc.ExternalFieldLatticeSphere;
+                cls = _hpmc.ExternalFieldLatticeSphere
             elif isinstance(mc, integrate.convex_polygon):
-                cls = _hpmc.ExternalFieldLatticeConvexPolygon;
+                cls = _hpmc.ExternalFieldLatticeConvexPolygon
             elif isinstance(mc, integrate.simple_polygon):
-                cls = _hpmc.ExternalFieldLatticeSimplePolygon;
+                cls = _hpmc.ExternalFieldLatticeSimplePolygon
             elif isinstance(mc, integrate.convex_polyhedron):
-                cls = _hpmc.ExternalFieldLatticeConvexPolyhedron;
+                cls = _hpmc.ExternalFieldLatticeConvexPolyhedron
             elif isinstance(mc, integrate.convex_spheropolyhedron):
-                cls = _hpmc.ExternalFieldLatticeSpheropolyhedron;
+                cls = _hpmc.ExternalFieldLatticeSpheropolyhedron
             elif isinstance(mc, integrate.ellipsoid):
-                cls = _hpmc.ExternalFieldLatticeEllipsoid;
+                cls = _hpmc.ExternalFieldLatticeEllipsoid
             elif isinstance(mc, integrate.convex_spheropolygon):
-                cls =_hpmc.ExternalFieldLatticeSpheropolygon;
+                cls =_hpmc.ExternalFieldLatticeSpheropolygon
             elif isinstance(mc, integrate.faceted_ellipsoid):
-                cls =_hpmc.ExternalFieldLatticeFacetedEllipsoid;
+                cls =_hpmc.ExternalFieldLatticeFacetedEllipsoid
             elif isinstance(mc, integrate.polyhedron):
-                cls =_hpmc.ExternalFieldLatticePolyhedron;
+                cls =_hpmc.ExternalFieldLatticePolyhedron
             elif isinstance(mc, integrate.sphinx):
-                cls =_hpmc.ExternalFieldLatticeSphinx;
+                cls =_hpmc.ExternalFieldLatticeSphinx
             elif isinstance(mc, integrate.sphere_union):
-                cls = _hpmc.ExternalFieldLatticeSphereUnion;
+                cls = _hpmc.ExternalFieldLatticeSphereUnion
             elif isinstance(mc, integrate.faceted_ellipsoid_union):
-                cls = _hpmc.ExternalFieldlatticeFacetedEllipsoidUnion;
+                cls = _hpmc.ExternalFieldlatticeFacetedEllipsoidUnion
             elif isinstance(mc, integrate.convex_polyhedron_union):
-                cls = _hpmc.ExternalFieldLatticeConvexPolyhedronUnion;
+                cls = _hpmc.ExternalFieldLatticeConvexPolyhedronUnion
             else:
-                hoomd.context.msg.error("compute.position_lattice_field: Unsupported integrator.\n");
-                raise RuntimeError("Error initializing compute.position_lattice_field");
+                hoomd.context.msg.error("compute.position_lattice_field: Unsupported integrator.\n")
+                raise RuntimeError("Error initializing compute.position_lattice_field")
         else:
             hoomd.context.msg.error("GPU not supported yet")
-            raise RuntimeError("Error initializing compute.position_lattice_field");
+            raise RuntimeError("Error initializing compute.position_lattice_field")
+
+        if group is None:
+            self.group = hoomd.context.current.group_all
+        else:
+            self.group = group
 
         self.compute_name = "lattice_field"
-        enlist = hoomd.hpmc.data._param.ensure_list;
-        self.cpp_compute = cls(hoomd.context.current.system_definition, enlist(position), float(k), enlist(orientation), float(q), enlist(symmetry));
+        enlist = hoomd.hpmc.data._param.ensure_list
+        self.cpp_compute = cls(hoomd.context.current.system_definition,
+                self.group.cpp_group, enlist(position), float(k), enlist(orientation),
+                float(q), enlist(symmetry))
         hoomd.context.current.system.addCompute(self.cpp_compute, self.compute_name)
         if not composite:
-            mc.set_external(self);
+            mc.set_external(self)
 
-    def set_references(self, position = [], orientation = []):
+    def set_references(self, position=[], orientation=[]):
         R""" Reset the reference positions or reference orientations.
 
         Args:
@@ -128,15 +147,15 @@ class lattice_field(_external):
 
         Example::
 
-            mc = hpmc.integrate.sphere(seed=415236);
-            lattice = hpmc.field.lattice_field(mc=mc, position=fcc_lattice, k=1000.0);
+            mc = hpmc.integrate.sphere(seed=415236)
+            lattice = hpmc.field.lattice_field(mc=mc, position=fcc_lattice, k=1000.0)
             lattice.set_references(position=bcc_lattice)
 
         """
         import numpy
-        hoomd.util.print_status_line();
-        enlist = hoomd.hpmc.data._param.ensure_list;
-        self.cpp_compute.setReferences(enlist(position), enlist(orientation));
+        hoomd.util.print_status_line()
+        enlist = hoomd.hpmc.data._param.ensure_list
+        self.cpp_compute.setReferences(enlist(position), enlist(orientation))
 
     def set_params(self, k, q):
         R""" Set the translational and rotational spring constants.
@@ -147,16 +166,16 @@ class lattice_field(_external):
 
         Example::
 
-            mc = hpmc.integrate.sphere(seed=415236);
-            lattice = hpmc.field.lattice_field(mc=mc, position=fcc_lattice, k=1000.0);
-            ks = np.linspace(1000, 0.01, 100);
+            mc = hpmc.integrate.sphere(seed=415236)
+            lattice = hpmc.field.lattice_field(mc=mc, position=fcc_lattice, k=1000.0)
+            ks = np.linspace(1000, 0.01, 100)
             for k in ks:
-              lattice.set_params(k=k, q=0.0);
+              lattice.set_params(k=k, q=0.0)
               run(1000)
 
         """
-        hoomd.util.print_status_line();
-        self.cpp_compute.setParams(float(k), float(q));
+        hoomd.util.print_status_line()
+        self.cpp_compute.setParams(float(k), float(q))
 
     def reset(self, timestep = None):
         R""" Reset the statistics counters.
@@ -166,62 +185,62 @@ class lattice_field(_external):
 
         Example::
 
-            mc = hpmc.integrate.sphere(seed=415236);
-            lattice = hpmc.field.lattice_field(mc=mc, position=fcc_lattice, k=1000.0);
-            ks = np.linspace(1000, 0.01, 100);
+            mc = hpmc.integrate.sphere(seed=415236)
+            lattice = hpmc.field.lattice_field(mc=mc, position=fcc_lattice, k=1000.0)
+            ks = np.linspace(1000, 0.01, 100)
             for k in ks:
-              lattice.set_params(k=k, q=0.0);
-              lattice.reset();
+              lattice.set_params(k=k, q=0.0)
+              lattice.reset()
               run(1000)
 
         """
-        hoomd.util.print_status_line();
+        hoomd.util.print_status_line()
         if timestep == None:
-            timestep = hoomd.context.current.system.getCurrentTimeStep();
-        self.cpp_compute.reset(timestep);
+            timestep = hoomd.context.current.system.getCurrentTimeStep()
+        self.cpp_compute.reset(timestep)
 
     def get_energy(self):
         R"""    Get the current energy of the lattice field.
                 This is a collective call and must be called on all ranks.
         Example::
-            mc = hpmc.integrate.sphere(seed=415236);
-            lattice = hpmc.field.lattice_field(mc=mc, position=fcc_lattice, k=1000.0);
+            mc = hpmc.integrate.sphere(seed=415236)
+            lattice = hpmc.field.lattice_field(mc=mc, position=fcc_lattice, k=1000.0)
             run(20000)
             eng = lattice.get_energy()
         """
-        hoomd.util.print_status_line();
-        timestep = hoomd.context.current.system.getCurrentTimeStep();
-        return self.cpp_compute.getEnergy(timestep);
+        hoomd.util.print_status_line()
+        timestep = hoomd.context.current.system.getCurrentTimeStep()
+        return self.cpp_compute.getEnergy(timestep)
 
     def get_average_energy(self):
         R"""    Get the average energy per particle of the lattice field.
                 This is a collective call and must be called on all ranks.
 
         Example::
-            mc = hpmc.integrate.sphere(seed=415236);
-            lattice = hpmc.field.lattice_field(mc=mc, position=fcc_lattice, k=exp(15));
+            mc = hpmc.integrate.sphere(seed=415236)
+            lattice = hpmc.field.lattice_field(mc=mc, position=fcc_lattice, k=exp(15))
             run(20000)
-            avg_eng = lattice.get_average_energy() //  should be about 1.5kT
+            avg_eng = lattice.get_average_energy()  // should be about 1.5kT
 
         """
-        hoomd.util.print_status_line();
-        timestep = hoomd.context.current.system.getCurrentTimeStep();
-        return self.cpp_compute.getAvgEnergy(timestep);
+        hoomd.util.print_status_line()
+        timestep = hoomd.context.current.system.getCurrentTimeStep()
+        return self.cpp_compute.getAvgEnergy(timestep)
 
     def get_sigma_energy(self):
         R"""    Gives the standard deviation of the average energy per particle of the lattice field.
                 This is a collective call and must be called on all ranks.
 
         Example::
-            mc = hpmc.integrate.sphere(seed=415236);
-            lattice = hpmc.field.lattice_field(mc=mc, position=fcc_lattice, k=exp(15));
+            mc = hpmc.integrate.sphere(seed=415236)
+            lattice = hpmc.field.lattice_field(mc=mc, position=fcc_lattice, k=exp(15))
             run(20000)
             sig_eng = lattice.get_sigma_energy()
 
         """
-        hoomd.util.print_status_line();
-        timestep = hoomd.context.current.system.getCurrentTimeStep();
-        return self.cpp_compute.getSigma(timestep);
+        hoomd.util.print_status_line()
+        timestep = hoomd.context.current.system.getCurrentTimeStep()
+        return self.cpp_compute.getSigma(timestep)
 
 class external_field_composite(_external):
     R""" Manage multiple external fields.
@@ -238,57 +257,57 @@ class external_field_composite(_external):
 
     Examples::
 
-        mc = hpmc.integrate.shape(...);
+        mc = hpmc.integrate.shape(...)
         walls = hpmc.field.walls(...)
         lattice = hpmc.field.lattice(...)
         composite_field = hpmc.field.external_field_composite(mc, fields=[walls, lattice])
 
     """
     def __init__(self, mc, fields = None):
-        _external.__init__(self);
-        cls = None;
+        _external.__init__(self)
+        cls = None
         if not hoomd.context.exec_conf.isCUDAEnabled():
             if isinstance(mc, integrate.sphere):
-                cls = _hpmc.ExternalFieldCompositeSphere;
+                cls = _hpmc.ExternalFieldCompositeSphere
             elif isinstance(mc, integrate.convex_polygon):
-                cls = _hpmc.ExternalFieldCompositeConvexPolygon;
+                cls = _hpmc.ExternalFieldCompositeConvexPolygon
             elif isinstance(mc, integrate.simple_polygon):
-                cls = _hpmc.ExternalFieldCompositeSimplePolygon;
+                cls = _hpmc.ExternalFieldCompositeSimplePolygon
             elif isinstance(mc, integrate.convex_polyhedron):
-                cls = _hpmc.ExternalFieldCompositeConvexPolyhedron;
+                cls = _hpmc.ExternalFieldCompositeConvexPolyhedron
             elif isinstance(mc, integrate.convex_spheropolyhedron):
-                cls = _hpmc.ExternalFieldCompositeSpheropolyhedron;
+                cls = _hpmc.ExternalFieldCompositeSpheropolyhedron
             elif isinstance(mc, integrate.ellipsoid):
-                cls = _hpmc.ExternalFieldCompositeEllipsoid;
+                cls = _hpmc.ExternalFieldCompositeEllipsoid
             elif isinstance(mc, integrate.convex_spheropolygon):
-                cls =_hpmc.ExternalFieldCompositeSpheropolygon;
+                cls =_hpmc.ExternalFieldCompositeSpheropolygon
             elif isinstance(mc, integrate.faceted_ellipsoid):
-                cls =_hpmc.ExternalFieldCompositeFacetedEllipsoid;
+                cls =_hpmc.ExternalFieldCompositeFacetedEllipsoid
             elif isinstance(mc, integrate.polyhedron):
-                cls =_hpmc.ExternalFieldCompositePolyhedron;
+                cls =_hpmc.ExternalFieldCompositePolyhedron
             elif isinstance(mc, integrate.sphinx):
-                cls =_hpmc.ExternalFieldCompositeSphinx;
+                cls =_hpmc.ExternalFieldCompositeSphinx
             elif isinstance(mc, integrate.sphere_union):
-                cls = _hpmc.ExternalFieldCompositeSphereUnion;
+                cls = _hpmc.ExternalFieldCompositeSphereUnion
             elif isinstance(mc, integrate.faceted_ellipsoid_union):
-                cls = _hpmc.ExternalFieldCompositeFacetedEllipsoidUnion;
+                cls = _hpmc.ExternalFieldCompositeFacetedEllipsoidUnion
             elif isinstance(mc, integrate.convex_polyhedron_union):
-                cls = _hpmc.ExternalFieldCompositeConvexPolyhedronUnion;
+                cls = _hpmc.ExternalFieldCompositeConvexPolyhedronUnion
             else:
-                hoomd.context.msg.error("compute.position_lattice_field: Unsupported integrator.\n");
-                raise RuntimeError("Error initializing compute.position_lattice_field");
+                hoomd.context.msg.error("compute.position_lattice_field: Unsupported integrator.\n")
+                raise RuntimeError("Error initializing compute.position_lattice_field")
         else:
             hoomd.context.msg.error("GPU not supported yet")
-            raise RuntimeError("Error initializing compute.position_lattice_field");
+            raise RuntimeError("Error initializing compute.position_lattice_field")
 
         self.compute_name = "composite_field"
-        self.cpp_compute = cls(hoomd.context.current.system_definition);
-        hoomd.context.current.system.addCompute(self.cpp_compute, self.compute_name);
+        self.cpp_compute = cls(hoomd.context.current.system_definition)
+        hoomd.context.current.system.addCompute(self.cpp_compute, self.compute_name)
 
-        mc.set_external(self);
+        mc.set_external(self)
 
         if not fields is None:
-            self.add_field(fields=fields);
+            self.add_field(fields=fields)
 
     def add_field(self, fields):
         R""" Add an external field to the ensemble.
@@ -298,7 +317,7 @@ class external_field_composite(_external):
 
         Example::
 
-            mc = hpmc.integrate.shape(...);
+            mc = hpmc.integrate.shape(...)
             composite_field = hpmc.compute.external_field_composite(mc)
             walls = hpmc.compute.walls(..., setup=False)
             lattice = hpmc.compute.lattice(..., setup=False)
@@ -306,9 +325,9 @@ class external_field_composite(_external):
 
         """
         if not type(fields) == list:
-            fields = list(fields);
+            fields = list(fields)
         for field in fields:
-            self.cpp_compute.addExternal(field.cpp_compute);
+            self.cpp_compute.addExternal(field.cpp_compute)
 
 class wall(_external):
     R""" Manage walls (an external field type).
@@ -342,42 +361,43 @@ class wall(_external):
 
     Example::
 
-        mc = hpmc.integrate.sphere(seed = 415236);
-        ext_wall = hpmc.compute.wall(mc);
-        ext_wall.add_sphere_wall(radius = 1.0, origin = [0, 0, 0], inside = True);
-        ext_wall.set_volume(4./3.*np.pi);
-        log = analyze.log(quantities=['hpmc_wall_volume','hpmc_wall_sph_rsq-0'], period=100, filename='log.dat', overwrite=True);
+        mc = hpmc.integrate.sphere(seed=415236)
+        ext_wall = hpmc.compute.wall(mc)
+        ext_wall.add_sphere_wall(radius=1.0, origin=[0, 0, 0], inside=True)
+        ext_wall.set_volume(4./3.*np.pi)
+        log = analyze.log(quantities=['hpmc_wall_volume','hpmc_wall_sph_rsq-0'],
+                          period=100, filename='log.dat', overwrite=True)
 
     """
 
-    index=0;
+    index = 0
 
     def __init__(self, mc, composite=False):
-        hoomd.util.print_status_line();
-        _external.__init__(self);
+        hoomd.util.print_status_line()
+        _external.__init__(self)
         # create the c++ mirror class
-        cls = None;
+        cls = None
         self.compute_name = "wall-"+str(wall.index)
         wall.index+=1
         if not hoomd.context.exec_conf.isCUDAEnabled():
             if isinstance(mc, integrate.sphere):
-                cls = _hpmc.WallSphere;
+                cls = _hpmc.WallSphere
             elif isinstance(mc, integrate.convex_polyhedron):
-                cls = _hpmc.WallConvexPolyhedron;
+                cls = _hpmc.WallConvexPolyhedron
             elif isinstance(mc, integrate.convex_spheropolyhedron):
-                cls = _hpmc.WallSpheropolyhedron;
+                cls = _hpmc.WallSpheropolyhedron
             else:
-                hoomd.context.msg.error("compute.wall: Unsupported integrator.\n");
-                raise RuntimeError("Error initializing compute.wall");
+                hoomd.context.msg.error("compute.wall: Unsupported integrator.\n")
+                raise RuntimeError("Error initializing compute.wall")
         else:
             hoomd.context.msg.error("GPU not supported yet")
-            raise RuntimeError("Error initializing compute.wall");
+            raise RuntimeError("Error initializing compute.wall")
 
-        self.cpp_compute = cls(hoomd.context.current.system_definition, mc.cpp_integrator);
-        hoomd.context.current.system.addCompute(self.cpp_compute, self.compute_name);
+        self.cpp_compute = cls(hoomd.context.current.system_definition, mc.cpp_integrator)
+        hoomd.context.current.system.addCompute(self.cpp_compute, self.compute_name)
 
         if not composite:
-            mc.set_external(self);
+            mc.set_external(self)
 
     def count_overlaps(self, exit_early=False):
         R""" Count the overlaps associated with the walls.
@@ -392,15 +412,15 @@ class wall(_external):
 
         Example:
 
-            mc = hpmc.integrate.sphere(seed = 415236);
-            ext_wall = hpmc.compute.wall(mc);
-            ext_wall.add_sphere_wall(radius = 1.0, origin = [0, 0, 0], inside = True);
+            mc = hpmc.integrate.sphere(seed=415236)
+            ext_wall = hpmc.compute.wall(mc)
+            ext_wall.add_sphere_wall(radius=1.0, origin=[0, 0, 0], inside=True)
             run(100)
-            num_overlaps = ext_wall.count_overlaps();
+            num_overlaps = ext_wall.count_overlaps()
 
         """
-        hoomd.util.print_status_line();
-        return self.cpp_compute.countOverlaps(hoomd.context.current.system.getCurrentTimeStep(), exit_early);
+        hoomd.util.print_status_line()
+        return self.cpp_compute.countOverlaps(hoomd.context.current.system.getCurrentTimeStep(), exit_early)
 
     def add_sphere_wall(self, radius, origin, inside = True):
         R""" Add a spherical wall to the simulation.
@@ -413,13 +433,13 @@ class wall(_external):
 
         Quick Example::
 
-            mc = hpmc.integrate.sphere(seed = 415236);
-            ext_wall = hpmc.compute.wall(mc);
-            ext_wall.add_sphere_wall(radius = 1.0, origin = [0, 0, 0], inside = True);
+            mc = hpmc.integrate.sphere(seed=415236)
+            ext_wall = hpmc.compute.wall(mc)
+            ext_wall.add_sphere_wall(radius=1.0, origin=[0, 0, 0], inside=True)
 
         """
-        hoomd.util.print_status_line();
-        self.cpp_compute.AddSphereWall(_hpmc.make_sphere_wall(radius, origin, inside));
+        hoomd.util.print_status_line()
+        self.cpp_compute.AddSphereWall(_hpmc.make_sphere_wall(radius, origin, inside))
 
     def set_sphere_wall(self, index, radius, origin, inside = True):
         R""" Change the parameters associated with a particular sphere wall.
@@ -433,14 +453,14 @@ class wall(_external):
 
         Example::
 
-            mc = hpmc.integrate.sphere(seed = 415236);
-            ext_wall = hpmc.compute.wall(mc);
-            ext_wall.add_sphere_wall(radius = 1.0, origin = [0, 0, 0], inside = True);
-            ext_wall.set_sphere_wall(index = 0, radius = 3.0, origin = [0, 0, 0], inside = True);
+            mc = hpmc.integrate.sphere(seed=415236)
+            ext_wall = hpmc.compute.wall(mc)
+            ext_wall.add_sphere_wall(radius=1.0, origin=[0, 0, 0], inside=True)
+            ext_wall.set_sphere_wall(index=0, radius=3.0, origin=[0, 0, 0], inside=True)
 
         """
-        hoomd.util.print_status_line();
-        self.cpp_compute.SetSphereWallParameter(index, _hpmc.make_sphere_wall(radius, origin, inside));
+        hoomd.util.print_status_line()
+        self.cpp_compute.SetSphereWallParameter(index, _hpmc.make_sphere_wall(radius, origin, inside))
 
     def get_sphere_wall_param(self, index, param):
         R""" Access a parameter associated with a particular sphere wall.
@@ -454,23 +474,23 @@ class wall(_external):
 
         Example::
 
-            mc = hpmc.integrate.sphere(seed = 415236);
-            ext_wall = hpmc.compute.wall(mc);
-            ext_wall.add_sphere_wall(radius = 1.0, origin = [0, 0, 0], inside = True);
-            rsq = ext_wall.get_sphere_wall_param(index = 0, param = "rsq");
+            mc = hpmc.integrate.sphere(seed=415236)
+            ext_wall = hpmc.compute.wall(mc)
+            ext_wall.add_sphere_wall(radius=1.0, origin=[0, 0, 0], inside=True)
+            rsq = ext_wall.get_sphere_wall_param(index=0, param="rsq")
 
         """
-        hoomd.util.print_status_line();
-        t = self.cpp_compute.GetSphereWallParametersPy(index);
+        hoomd.util.print_status_line()
+        t = self.cpp_compute.GetSphereWallParametersPy(index)
         if param == "rsq":
-            return t[0];
+            return t[0]
         elif param == "origin":
-            return t[1];
+            return t[1]
         elif param == "inside":
-            return t[2];
+            return t[2]
         else:
-            hoomd.context.msg.error("compute.wall.get_sphere_wall_param: Parameter type is not valid. Choose from rsq, origin, inside.");
-            raise RuntimeError("Error: compute.wall");
+            hoomd.context.msg.error("compute.wall.get_sphere_wall_param: Parameter type is not valid. Choose from rsq, origin, inside.")
+            raise RuntimeError("Error: compute.wall")
 
     def remove_sphere_wall(self, index):
         R""" Remove a particular sphere wall from the simulation.
@@ -480,14 +500,14 @@ class wall(_external):
 
         Quick Example::
 
-            mc = hpmc.integrate.sphere(seed = 415236);
-            ext_wall = hpmc.compute.wall(mc);
-            ext_wall.add_sphere_wall(radius = 1.0, origin = [0, 0, 0], inside = True);
-            ext_wall.remove_sphere_wall(index = 0);
+            mc = hpmc.integrate.sphere(seed=415236)
+            ext_wall = hpmc.compute.wall(mc)
+            ext_wall.add_sphere_wall(radius=1.0, origin=[0, 0, 0], inside=True)
+            ext_wall.remove_sphere_wall(index=0)
 
         """
-        hoomd.util.print_status_line();
-        self.cpp_compute.RemoveSphereWall(index);
+        hoomd.util.print_status_line()
+        self.cpp_compute.RemoveSphereWall(index)
 
     def get_num_sphere_walls(self):
         R""" Get the current number of sphere walls in the simulation.
@@ -496,14 +516,14 @@ class wall(_external):
 
         Example::
 
-            mc = hpmc.integrate.sphere(seed = 415236);
-            ext_wall = hpmc.compute.wall(mc);
-            ext_wall.add_sphere_wall(radius = 1.0, origin = [0, 0, 0], inside = True);
-            num_sph_walls = ext_wall.get_num_sphere_walls();
+            mc = hpmc.integrate.sphere(seed=415236)
+            ext_wall = hpmc.compute.wall(mc)
+            ext_wall.add_sphere_wall(radius=1.0, origin=[0, 0, 0], inside=True)
+            num_sph_walls = ext_wall.get_num_sphere_walls()
 
         """
-        hoomd.util.print_status_line();
-        return self.cpp_compute.getNumSphereWalls();
+        hoomd.util.print_status_line()
+        return self.cpp_compute.getNumSphereWalls()
 
     def add_cylinder_wall(self, radius, origin, orientation, inside = True):
         R""" Add a cylindrical wall to the simulation.
@@ -517,15 +537,15 @@ class wall(_external):
 
         Example::
 
-            mc = hpmc.integrate.sphere(seed = 415236);
-            ext_wall = hpmc.compute.wall(mc);
-            ext_wall.add_cylinder_wall(radius = 1.0, origin = [0, 0, 0], orientation = [0, 0, 1], inside = True);
+            mc = hpmc.integrate.sphere(seed=415236)
+            ext_wall = hpmc.compute.wall(mc)
+            ext_wall.add_cylinder_wall(radius=1.0, origin=[0, 0, 0], orientation=[0, 0, 1], inside=True)
 
         """
 
-        hoomd.util.print_status_line();
-        param = _hpmc.make_cylinder_wall(radius, origin, orientation, inside);
-        self.cpp_compute.AddCylinderWall(param);
+        hoomd.util.print_status_line()
+        param = _hpmc.make_cylinder_wall(radius, origin, orientation, inside)
+        self.cpp_compute.AddCylinderWall(param)
 
     def set_cylinder_wall(self, index, radius, origin, orientation, inside = True):
         R""" Change the parameters associated with a particular cylinder wall.
@@ -541,15 +561,15 @@ class wall(_external):
 
         Example::
 
-            mc = hpmc.integrate.sphere(seed = 415236);
-            ext_wall = hpmc.compute.wall(mc);
-            ext_wall.add_cylinder_wall(radius = 1.0, origin = [0, 0, 0], orientation = [0, 0, 1], inside = True);
-            ext_wall.set_cylinder_wall(index = 0, radius = 3.0, origin = [0, 0, 0], orientation = [0, 0, 1], inside = True);
+            mc = hpmc.integrate.sphere(seed=415236)
+            ext_wall = hpmc.compute.wall(mc)
+            ext_wall.add_cylinder_wall(radius=1.0, origin=[0, 0, 0], orientation=[0, 0, 1], inside=True)
+            ext_wall.set_cylinder_wall(index=0, radius=3.0, origin=[0, 0, 0], orientation=[0, 0, 1], inside=True)
 
         """
-        hoomd.util.print_status_line();
+        hoomd.util.print_status_line()
         param = _hpmc.make_cylinder_wall(radius, origin, orientation, inside)
-        self.cpp_compute.SetCylinderWallParameter(index, param);
+        self.cpp_compute.SetCylinderWallParameter(index, param)
 
     def get_cylinder_wall_param(self, index, param):
         R""" Access a parameter associated with a particular cylinder wall.
@@ -564,25 +584,25 @@ class wall(_external):
 
         Example::
 
-            mc = hpmc.integrate.sphere(seed = 415236);
-            ext_wall = hpmc.compute.wall(mc);
-            ext_wall.add_cylinder_wall(radius = 1.0, origin = [0, 0, 0], orientation = [0, 0, 1], inside = True);
-            rsq = ext_wall.get_cylinder_wall_param(index = 0, param = "rsq");
+            mc = hpmc.integrate.sphere(seed=415236)
+            ext_wall = hpmc.compute.wall(mc)
+            ext_wall.add_cylinder_wall(radius=1.0, origin=[0, 0, 0], orientation=[0, 0, 1], inside=True)
+            rsq = ext_wall.get_cylinder_wall_param(index=0, param="rsq")
 
         """
-        hoomd.util.print_status_line();
-        t = self.cpp_compute.GetCylinderWallParametersPy(index);
+        hoomd.util.print_status_line()
+        t = self.cpp_compute.GetCylinderWallParametersPy(index)
         if param == "rsq":
-            return t[0];
+            return t[0]
         elif param == "origin":
-            return t[1];
+            return t[1]
         elif param == "orientation":
-            return t[2];
+            return t[2]
         elif param == "inside":
-            return t[3];
+            return t[3]
         else:
-            hoomd.context.msg.error("compute.wall.get_cylinder_wall_param: Parameter type is not valid. Choose from rsq, origin, orientation, inside.");
-            raise RuntimeError("Error: compute.wall");
+            hoomd.context.msg.error("compute.wall.get_cylinder_wall_param: Parameter type is not valid. Choose from rsq, origin, orientation, inside.")
+            raise RuntimeError("Error: compute.wall")
 
     def remove_cylinder_wall(self, index):
         R""" Remove a particular cylinder wall from the simulation.
@@ -592,14 +612,14 @@ class wall(_external):
 
         Example::
 
-            mc = hpmc.integrate.sphere(seed = 415236);
-            ext_wall = hpmc.compute.wall(mc);
-            ext_wall.add_cylinder_wall(radius = 1.0, origin = [0, 0, 0], orientation = [0, 0, 1], inside = True);
-            ext_wall.remove_cylinder_wall(index = 0);
+            mc = hpmc.integrate.sphere(seed=415236)
+            ext_wall = hpmc.compute.wall(mc)
+            ext_wall.add_cylinder_wall(radius=1.0, origin=[0, 0, 0], orientation=[0, 0, 1], inside=True)
+            ext_wall.remove_cylinder_wall(index=0)
 
         """
-        hoomd.util.print_status_line();
-        self.cpp_compute.RemoveCylinderWall(index);
+        hoomd.util.print_status_line()
+        self.cpp_compute.RemoveCylinderWall(index)
 
     def get_num_cylinder_walls(self):
         R""" Get the current number of cylinder walls in the simulation.
@@ -609,14 +629,14 @@ class wall(_external):
 
         Example::
 
-            mc = hpmc.integrate.sphere(seed = 415236);
-            ext_wall = hpmc.compute.wall(mc);
-            ext_wall.add_cylinder_wall(radius = 1.0, origin = [0, 0, 0], orientation = [0, 0, 1], inside = True);
-            num_cyl_walls = ext_wall.get_num_cylinder_walls();
+            mc = hpmc.integrate.sphere(seed=415236)
+            ext_wall = hpmc.compute.wall(mc)
+            ext_wall.add_cylinder_wall(radius=1.0, origin=[0, 0, 0], orientation=[0, 0, 1], inside=True)
+            num_cyl_walls = ext_wall.get_num_cylinder_walls()
 
         """
-        hoomd.util.print_status_line();
-        return self.cpp_compute.getNumCylinderWalls();
+        hoomd.util.print_status_line()
+        return self.cpp_compute.getNumCylinderWalls()
 
     def add_plane_wall(self, normal, origin):
         R""" Add a plane wall to the simulation.
@@ -628,13 +648,13 @@ class wall(_external):
 
         Example::
 
-            mc = hpmc.integrate.sphere(seed = 415236);
-            ext_wall = hpmc.compute.wall(mc);
-            ext_wall.add_plane_wall(normal = [0, 0, 1], origin = [0, 0, 0]);
+            mc = hpmc.integrate.sphere(seed=415236)
+            ext_wall = hpmc.compute.wall(mc)
+            ext_wall.add_plane_wall(normal=[0, 0, 1], origin=[0, 0, 0])
 
         """
-        hoomd.util.print_status_line();
-        self.cpp_compute.AddPlaneWall(_hpmc.make_plane_wall(normal, origin, True));
+        hoomd.util.print_status_line()
+        self.cpp_compute.AddPlaneWall(_hpmc.make_plane_wall(normal, origin, True))
 
     def set_plane_wall(self, index, normal, origin):
         R""" Change the parameters associated with a particular plane wall.
@@ -647,14 +667,14 @@ class wall(_external):
 
         Example::
 
-            mc = hpmc.integrate.sphere(seed = 415236);
-            ext_wall = hpmc.compute.wall(mc);
-            ext_wall.add_plane_wall(normal = [0, 0, 1], origin = [0, 0, 0]);
-            ext_wall.set_plane_wall(index = 0, normal = [0, 0, 1], origin = [0, 0, 1]);
+            mc = hpmc.integrate.sphere(seed=415236)
+            ext_wall = hpmc.compute.wall(mc)
+            ext_wall.add_plane_wall(normal=[0, 0, 1], origin=[0, 0, 0])
+            ext_wall.set_plane_wall(index=0, normal=[0, 0, 1], origin=[0, 0, 1])
 
         """
-        hoomd.util.print_status_line();
-        self.cpp_compute.SetPlaneWallParameter(index, _hpmc.make_plane_wall(normal, origin, True));
+        hoomd.util.print_status_line()
+        self.cpp_compute.SetPlaneWallParameter(index, _hpmc.make_plane_wall(normal, origin, True))
 
     def get_plane_wall_param(self, index, param):
         R""" Access a parameter associated with a particular plane wall.
@@ -668,21 +688,21 @@ class wall(_external):
 
         Example::
 
-            mc = hpmc.integrate.sphere(seed = 415236);
-            ext_wall = hpmc.compute.wall(mc);
-            ext_wall.add_plane_wall(normal = [0, 0, 1], origin = [0, 0, 0]);
-            n = ext_wall.get_plane_wall_param(index = 0, param = "normal");
+            mc = hpmc.integrate.sphere(seed=415236)
+            ext_wall = hpmc.compute.wall(mc)
+            ext_wall.add_plane_wall(normal=[0, 0, 1], origin=[0, 0, 0])
+            n = ext_wall.get_plane_wall_param(index=0, param="normal")
 
         """
-        hoomd.util.print_status_line();
-        t = self.cpp_compute.GetPlaneWallParametersPy(index);
+        hoomd.util.print_status_line()
+        t = self.cpp_compute.GetPlaneWallParametersPy(index)
         if param == "normal":
-            return t[0];
+            return t[0]
         elif param == "origin":
-            return t[1];
+            return t[1]
         else:
-            hoomd.context.msg.error("compute.wall.get_plane_wall_param: Parameter type is not valid. Choose from normal, origin.");
-            raise RuntimeError("Error: compute.wall");
+            hoomd.context.msg.error("compute.wall.get_plane_wall_param: Parameter type is not valid. Choose from normal, origin.")
+            raise RuntimeError("Error: compute.wall")
 
     def remove_plane_wall(self, index):
         R""" Remove a particular plane wall from the simulation.
@@ -692,14 +712,14 @@ class wall(_external):
 
         Example::
 
-            mc = hpmc.integrate.sphere(seed = 415236);
-            ext_wall = hpmc.compute.wall(mc);
-            ext_wall.add_plane_wall(normal = [0, 0, 1], origin = [0, 0, 0]);
-            ext_wall.remove_plane_wall(index = 0);
+            mc = hpmc.integrate.sphere(seed=415236)
+            ext_wall = hpmc.compute.wall(mc)
+            ext_wall.add_plane_wall(normal=[0, 0, 1], origin=[0, 0, 0])
+            ext_wall.remove_plane_wall(index=0)
 
         """
-        hoomd.util.print_status_line();
-        self.cpp_compute.RemovePlaneWall(index);
+        hoomd.util.print_status_line()
+        self.cpp_compute.RemovePlaneWall(index)
 
     def get_num_plane_walls(self):
         R""" Get the current number of plane walls in the simulation.
@@ -709,14 +729,14 @@ class wall(_external):
 
         Example::
 
-            mc = hpmc.integrate.sphere(seed = 415236);
-            ext_wall = hpmc.compute.wall(mc);
-            ext_wall.add_plane_wall(normal = [0, 0, 1], origin = [0, 0, 0]);
-            num_plane_walls = ext_wall.get_num_plane_walls();
+            mc = hpmc.integrate.sphere(seed=415236)
+            ext_wall = hpmc.compute.wall(mc)
+            ext_wall.add_plane_wall(normal=[0, 0, 1], origin=[0, 0, 0])
+            num_plane_walls = ext_wall.get_num_plane_walls()
 
         """
-        hoomd.util.print_status_line();
-        return self.cpp_compute.getNumPlaneWalls();
+        hoomd.util.print_status_line()
+        return self.cpp_compute.getNumPlaneWalls()
 
     def set_volume(self, volume):
         R""" Set the volume associated with the intersection of all walls in the system.
@@ -725,14 +745,14 @@ class wall(_external):
 
         Example::
 
-            mc = hpmc.integrate.sphere(seed = 415236);
-            ext_wall = hpmc.compute.wall(mc);
-            ext_wall.add_sphere_wall(radius = 1.0, origin = [0, 0, 0], inside = True);
-            ext_wall.set_volume(4./3.*np.pi);
+            mc = hpmc.integrate.sphere(seed=415236)
+            ext_wall = hpmc.compute.wall(mc)
+            ext_wall.add_sphere_wall(radius=1.0, origin=[0, 0, 0], inside=True)
+            ext_wall.set_volume(4./3.*np.pi)
 
         """
-        hoomd.util.print_status_line();
-        self.cpp_compute.setVolume(volume);
+        hoomd.util.print_status_line()
+        self.cpp_compute.setVolume(volume)
 
     def get_volume(self):
         R""" Get the current volume associated with the intersection of all walls in the system.
@@ -744,16 +764,16 @@ class wall(_external):
 
         Example::
 
-            mc = hpmc.integrate.sphere(seed = 415236);
-            ext_wall = hpmc.compute.wall(mc);
-            ext_wall.add_sphere_wall(radius = 1.0, origin = [0, 0, 0], inside = True);
-            ext_wall.set_volume(4./3.*np.pi);
+            mc = hpmc.integrate.sphere(seed=415236)
+            ext_wall = hpmc.compute.wall(mc)
+            ext_wall.add_sphere_wall(radius=1.0, origin=[0, 0, 0], inside=True)
+            ext_wall.set_volume(4./3.*np.pi)
             run(100)
-            curr_vol = ext_wall.get_volume();
+            curr_vol = ext_wall.get_volume()
 
         """
-        hoomd.util.print_status_line();
-        return self.cpp_compute.getVolume();
+        hoomd.util.print_status_line()
+        return self.cpp_compute.getVolume()
 
     def get_curr_box(self):
         R""" Get the simulation box that the wall class is currently storing.
@@ -763,23 +783,23 @@ class wall(_external):
 
         Example::
 
-            mc = hpmc.integrate.sphere(seed = 415236);
-            ext_wall = hpmc.compute.wall(mc);
-            ext_wall.add_sphere_wall(radius = 1.0, origin = [0, 0, 0], inside = True);
-            ext_wall.set_volume(4./3.*np.pi);
+            mc = hpmc.integrate.sphere(seed=415236)
+            ext_wall = hpmc.compute.wall(mc)
+            ext_wall.add_sphere_wall(radius=1.0, origin=[0, 0, 0], inside=True)
+            ext_wall.set_volume(4./3.*np.pi)
             run(100)
-            curr_box = ext_wall.get_curr_box();
+            curr_box = ext_wall.get_curr_box()
 
         """
-        hoomd.util.print_status_line();
+        hoomd.util.print_status_line()
         return hoomd.data.boxdim(Lx=self.cpp_compute.GetCurrBoxLx(),
                            Ly=self.cpp_compute.GetCurrBoxLy(),
                            Lz=self.cpp_compute.GetCurrBoxLz(),
                            xy=self.cpp_compute.GetCurrBoxTiltFactorXY(),
                            xz=self.cpp_compute.GetCurrBoxTiltFactorXZ(),
-                           yz=self.cpp_compute.GetCurrBoxTiltFactorYZ());
+                           yz=self.cpp_compute.GetCurrBoxTiltFactorYZ())
 
-    def set_curr_box(self, Lx = None, Ly = None, Lz = None, xy = None, xz = None, yz = None):
+    def set_curr_box(self, Lx=None, Ly=None, Lz=None, xy=None, xz=None, yz=None):
         R""" Set the simulation box that the wall class is currently storing.
 
         You may want to set this independently so that you can cleverly control whether or not the walls actually scale in case you manually resize your simulation box.
@@ -789,41 +809,41 @@ class wall(_external):
 
         Example::
 
-            init_box = hoomd.data.boxdim(L=10, dimensions=3);
-            snap = hoomd.data.make_snapshot(N=1, box=init_box, particle_types=['A']);
-            system = hoomd.init.read_snapshot(snap);
-            system.particles[0].position = [0,0,0];
-            system.particles[0].type = 'A';
-            mc = hpmc.integrate.sphere(seed = 415236);
-            mc.shape_param.set('A', diameter = 2.0);
-            ext_wall = hpmc.compute.wall(mc);
-            ext_wall.add_sphere_wall(radius = 3.0, origin = [0, 0, 0], inside = True);
-            ext_wall.set_curr_box(Lx=2.0*init_box.Lx, Ly=2.0*init_box.Ly, Lz=2.0*init_box.Lz, xy=init_box.xy, xz=init_box.xz, yz=init_box.yz);
+            init_box = hoomd.data.boxdim(L=10, dimensions=3)
+            snap = hoomd.data.make_snapshot(N=1, box=init_box, particle_types=['A'])
+            system = hoomd.init.read_snapshot(snap)
+            system.particles[0].position = [0,0,0]
+            system.particles[0].type = 'A'
+            mc = hpmc.integrate.sphere(seed=415236)
+            mc.shape_param.set('A', diameter=2.0)
+            ext_wall = hpmc.compute.wall(mc)
+            ext_wall.add_sphere_wall(radius=3.0, origin=[0, 0, 0], inside=True)
+            ext_wall.set_curr_box(Lx=2.0*init_box.Lx, Ly=2.0*init_box.Ly, Lz=2.0*init_box.Lz, xy=init_box.xy, xz=init_box.xz, yz=init_box.yz)
             system.sysdef.getParticleData().setGlobalBox(ext_wall.get_curr_box()._getBoxDim())
 
         """
         # much of this is from hoomd's update.py box_resize class
-        hoomd.util.print_status_line();
+        hoomd.util.print_status_line()
         if Lx is None and Ly is None and Lz is None and xy is None and xz is None and yz is None:
             hoomd.context.msg.warning("compute.wall.set_curr_box: Ignoring request to set the wall's box without parameters\n")
             return
 
         # setup arguments
         if Lx is None:
-            Lx = self.cpp_compute.GetCurrBoxLx();
+            Lx = self.cpp_compute.GetCurrBoxLx()
         if Ly is None:
-            Ly = self.cpp_compute.GetCurrBoxLy();
+            Ly = self.cpp_compute.GetCurrBoxLy()
         if Lz is None:
-            Lz = self.cpp_compute.GetCurrBoxLz();
+            Lz = self.cpp_compute.GetCurrBoxLz()
 
         if xy is None:
-            xy = self.cpp_compute.GetCurrBoxTiltFactorXY();
+            xy = self.cpp_compute.GetCurrBoxTiltFactorXY()
         if xz is None:
-            xz = self.cpp_compute.GetCurrBoxTiltFactorXZ();
+            xz = self.cpp_compute.GetCurrBoxTiltFactorXZ()
         if yz is None:
-            yz = self.cpp_compute.GetCurrBoxTiltFactorYZ();
+            yz = self.cpp_compute.GetCurrBoxTiltFactorYZ()
 
-        self.cpp_compute.SetCurrBox(Lx, Ly, Lz, xy, xz, yz);
+        self.cpp_compute.SetCurrBox(Lx, Ly, Lz, xy, xz, yz)
 
 class frenkel_ladd_energy(_compute):
     R""" Compute the Frenkel-Ladd Energy of a crystal.
@@ -842,7 +862,7 @@ class frenkel_ladd_energy(_compute):
 
     Example::
 
-        mc = hpmc.integrate.convex_polyhedron(seed=seed);
+        mc = hpmc.integrate.convex_polyhedron(seed=seed)
         mc.shape_param.set("A", vertices=verts)
         mc.set_params(d=0.005, a=0.005)
         #set the FL parameters
@@ -860,49 +880,49 @@ class frenkel_ladd_energy(_compute):
                 ):
         import math
         import numpy
-        hoomd.util.print_status_line();
+        hoomd.util.print_status_line()
         # initialize base class
-        _compute.__init__(self);
+        _compute.__init__(self)
 
         if type(r0) == numpy.ndarray:
-            self.lattice_positions = r0.tolist();
+            self.lattice_positions = r0.tolist()
         else:
-            self.lattice_positions = list(r0);
+            self.lattice_positions = list(r0)
 
         if type(q0) == numpy.ndarray:
-            self.lattice_orientations = q0.tolist();
+            self.lattice_orientations = q0.tolist()
         else:
-            self.lattice_orientations = list(q0);
+            self.lattice_orientations = list(q0)
 
 
-        self.mc = mc;
-        self.q_factor = q_factor;
-        self.trans_spring_const = math.exp(ln_gamma);
-        self.rotat_spring_const = self.q_factor*self.trans_spring_const;
+        self.mc = mc
+        self.q_factor = q_factor
+        self.trans_spring_const = math.exp(ln_gamma)
+        self.rotat_spring_const = self.q_factor*self.trans_spring_const
         self.lattice = lattice_field(   self.mc,
                                         position = self.lattice_positions,
                                         orientation = self.lattice_orientations,
                                         k = self.trans_spring_const,
                                         q = self.rotat_spring_const,
-                                        symmetry=symmetry);
-        self.remove_drift = hoomd.hpmc.update.remove_drift(self.mc, self.lattice, period=drift_period);
+                                        symmetry=symmetry)
+        self.remove_drift = hoomd.hpmc.update.remove_drift(self.mc, self.lattice, period=drift_period)
 
     def reset_statistics(self):
         R""" Reset the statistics counters.
 
         Example::
 
-            mc = hpmc.integrate.sphere(seed=415236);
+            mc = hpmc.integrate.sphere(seed=415236)
             fl = hpmc.compute.frenkel_ladd_energy(mc=mc, ln_gamma=0.0, q_factor=10.0, r0=rs, q0=qs, drift_period=1000)
-            ks = np.linspace(1000, 0.01, 100);
+            ks = np.linspace(1000, 0.01, 100)
             for k in ks:
-              fl.set_params(ln_gamma=math.log(k), q_factor=10.0);
-              fl.reset_statistics();
+              fl.set_params(ln_gamma=math.log(k), q_factor=10.0)
+              fl.reset_statistics()
               run(1000)
 
         """
-        hoomd.util.print_status_line();
-        self.lattice.reset(0);
+        hoomd.util.print_status_line()
+        self.lattice.reset(0)
 
     def set_params(self, ln_gamma = None, q_factor = None):
         R""" Set the Frenkel-Ladd parameters.
@@ -913,23 +933,23 @@ class frenkel_ladd_energy(_compute):
 
         Example::
 
-            mc = hpmc.integrate.sphere(seed=415236);
+            mc = hpmc.integrate.sphere(seed=415236)
             fl = hpmc.compute.frenkel_ladd_energy(mc=mc, ln_gamma=0.0, q_factor=10.0, r0=rs, q0=qs, drift_period=1000)
-            ks = np.linspace(1000, 0.01, 100);
+            ks = np.linspace(1000, 0.01, 100)
             for k in ks:
-              fl.set_params(ln_gamma=math.log(k), q_factor=10.0);
-              fl.reset_statistics();
+              fl.set_params(ln_gamma=math.log(k), q_factor=10.0)
+              fl.reset_statistics()
               run(1000)
 
         """
         import math
-        hoomd.util.print_status_line();
+        hoomd.util.print_status_line()
         if not q_factor is None:
-            self.q_factor = q_factor;
+            self.q_factor = q_factor
         if not ln_gamma is None:
-            self.trans_spring_const = math.exp(ln_gamma);
-        self.rotat_spring_const = self.q_factor*self.trans_spring_const;
-        self.lattice.set_params(self.trans_spring_const, self.rotat_spring_const);
+            self.trans_spring_const = math.exp(ln_gamma)
+        self.rotat_spring_const = self.q_factor*self.trans_spring_const
+        self.lattice.set_params(self.trans_spring_const, self.rotat_spring_const)
 
 class callback(_external):
     R""" Use a python-defined energy function in MC integration
@@ -950,51 +970,51 @@ class callback(_external):
                   e -= numpy.dot(gradient,p)
               return e
 
-          mc = hpmc.integrate.sphere(seed=415236);
+          mc = hpmc.integrate.sphere(seed=415236)
           mc.shape_param.set('A',diameter=1.0)
-          hpmc.field.callback(mc=mc, energy_function=energy);
+          hpmc.field.callback(mc=mc, energy_function=energy)
           run(100)
     """
     def __init__(self, mc, energy_function, composite=False):
-        hoomd.util.print_status_line();
-        _external.__init__(self);
-        cls = None;
+        hoomd.util.print_status_line()
+        _external.__init__(self)
+        cls = None
         if not hoomd.context.exec_conf.isCUDAEnabled():
             if isinstance(mc, integrate.sphere):
-                cls = _hpmc.ExternalCallbackSphere;
+                cls = _hpmc.ExternalCallbackSphere
             elif isinstance(mc, integrate.convex_polygon):
-                cls = _hpmc.ExternalCallbackConvexPolygon;
+                cls = _hpmc.ExternalCallbackConvexPolygon
             elif isinstance(mc, integrate.simple_polygon):
-                cls = _hpmc.ExternalCallbackSimplePolygon;
+                cls = _hpmc.ExternalCallbackSimplePolygon
             elif isinstance(mc, integrate.convex_polyhedron):
-                cls = _hpmc.ExternalCallbackConvexPolyhedron;
+                cls = _hpmc.ExternalCallbackConvexPolyhedron
             elif isinstance(mc, integrate.convex_spheropolyhedron):
-                cls = _hpmc.ExternalCallbackSpheropolyhedron;
+                cls = _hpmc.ExternalCallbackSpheropolyhedron
             elif isinstance(mc, integrate.ellipsoid):
-                cls = _hpmc.ExternalCallbackEllipsoid;
+                cls = _hpmc.ExternalCallbackEllipsoid
             elif isinstance(mc, integrate.convex_spheropolygon):
-                cls =_hpmc.ExternalCallbackSpheropolygon;
+                cls =_hpmc.ExternalCallbackSpheropolygon
             elif isinstance(mc, integrate.faceted_ellipsoid):
-                cls =_hpmc.ExternalCallbackFacetedEllipsoid;
+                cls =_hpmc.ExternalCallbackFacetedEllipsoid
             elif isinstance(mc, integrate.polyhedron):
-                cls =_hpmc.ExternalCallbackPolyhedron;
+                cls =_hpmc.ExternalCallbackPolyhedron
             elif isinstance(mc, integrate.sphinx):
-                cls =_hpmc.ExternalCallbackSphinx;
+                cls =_hpmc.ExternalCallbackSphinx
             elif isinstance(mc, integrate.sphere_union):
-                cls = _hpmc.ExternalCallbackSphereUnion;
+                cls = _hpmc.ExternalCallbackSphereUnion
             elif isinstance(mc, integrate.faceted_ellipsoid_union):
-                cls = _hpmc.ExternalCallbackFacetedEllipsoidUnion;
+                cls = _hpmc.ExternalCallbackFacetedEllipsoidUnion
             elif isinstance(mc, integrate.convex_spheropolyhedron_union):
-                cls = _hpmc.ExternalCallbackConvexPolyhedronUnion;
+                cls = _hpmc.ExternalCallbackConvexPolyhedronUnion
             else:
-                hoomd.context.msg.error("hpmc.field.callback: Unsupported integrator.\n");
-                raise RuntimeError("Error initializing python callback");
+                hoomd.context.msg.error("hpmc.field.callback: Unsupported integrator.\n")
+                raise RuntimeError("Error initializing python callback")
         else:
             hoomd.context.msg.error("GPU not supported")
-            raise RuntimeError("Error initializing hpmc.field.callback");
+            raise RuntimeError("Error initializing hpmc.field.callback")
 
         self.compute_name = "callback"
         self.cpp_compute = cls(hoomd.context.current.system_definition, energy_function)
         hoomd.context.current.system.addCompute(self.cpp_compute, self.compute_name)
         if not composite:
-            mc.set_external(self);
+            mc.set_external(self)

--- a/hoomd/hpmc/field.py
+++ b/hoomd/hpmc/field.py
@@ -1,4 +1,4 @@
-/ Copyright (c) 2009-2019 The Regents of the University of Michigan
+# Copyright (c) 2009-2019 The Regents of the University of Michigan
 # This file is part of the HOOMD-blue project, released under the BSD 3-Clause License.
 
 """ Apply external fields to HPMC simulations.

--- a/sphinx-doc/credits.rst
+++ b/sphinx-doc/credits.rst
@@ -314,6 +314,9 @@ William Zygmunt, Luis Rivera-Rivera, University of Michigan
  * Patchy interaction support in HPMC CPU integrators
  * GSD state bug fixes
 
+Tim Moore, University of Michigan
+ * Apply external lattice field to particle groups
+
 DEM developers
 --------------
 


### PR DESCRIPTION
## Description

This PR adds the ability to apply an external lattice field to a group of particles, instead of the whole system. This was done by modifying the `ExternalFieldLattice` to accept a group in its constructor, and test for group membership when calculating the energy associated with a trial configuration. 

## Motivation and Context

This could be useful for people simulating self-assembly with HPMC and want to add a nucleation site to do seeded simulations. This would allow the seed particles to move around their equilibrium positions instead of setting their move sizes to 0. 

## How Has This Been Tested?

I haven't written the required tests yet.

## Change log

<!-- Propose a change log entry. -->
```
Add ability to apply external lattice fields to groups of particles.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/hoomd-blue/blob/master/sphinx-doc/credits.rst).
