### PR TITLE
Optimize rigid body multi gpu

### DIFF
--- a/hoomd/md/ForceCompositeGPU.cc
+++ b/hoomd/md/ForceCompositeGPU.cc
@@ -335,7 +335,7 @@ void ForceCompositeGPU::findRigidCenters()
     unsigned int old_size = m_lookup_center.getNumElements();
     m_lookup_center.resize(m_pdata->getN()+m_pdata->getNGhosts());
 
-    if (m_lookup_center.getNumElements() != old_size)
+    if (m_exec_conf->allConcurrentManagedAccess() && m_lookup_center.getNumElements() != old_size)
         {
         // set memory hints
         cudaMemAdvise(m_lookup_center.get(), sizeof(unsigned int)*m_lookup_center.getNumElements(), cudaMemAdviseSetReadMostly, 0);

--- a/hoomd/md/ForceCompositeGPU.cc
+++ b/hoomd/md/ForceCompositeGPU.cc
@@ -331,7 +331,16 @@ void ForceCompositeGPU::findRigidCenters()
     ArrayHandle<unsigned int> d_body(m_pdata->getBodies(), access_location::device, access_mode::read);
 
     m_rigid_center.resize(m_pdata->getN());
+
+    unsigned int old_size = m_lookup_center.getNumElements();
     m_lookup_center.resize(m_pdata->getN()+m_pdata->getNGhosts());
+
+    if (m_lookup_center.getNumElements() != old_size)
+        {
+        // set memory hints
+        cudaMemAdvise(m_lookup_center.get(), sizeof(unsigned int)*m_lookup_center.getNumElements(), cudaMemAdviseSetReadMostly, 0);
+        CHECK_CUDA_ERROR();
+        }
 
     ArrayHandle<unsigned int> d_rigid_center(m_rigid_center, access_location::device, access_mode::overwrite);
     ArrayHandle<unsigned int> d_lookup_center(m_lookup_center, access_location::device, access_mode::overwrite);


### PR DESCRIPTION
## Description

A minor optimization to speed up rigid body constraints with unified memory/NVLINK.

## Motivation and Context

Trying to benchmark SPC/E water.

## How Has This Been Tested?

Tested as part of the standard unit tests.

## Change log

```
Minor optimization of rigid bodies with unified memory/NVLINK.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/hoomd-blue/blob/master/sphinx-doc/credits.rst).
