### PR TITLE
fix cell lists stats with unified memory on single GPU

### DIFF
--- a/hoomd/CellListGPU.h
+++ b/hoomd/CellListGPU.h
@@ -77,7 +77,7 @@ class PYBIND11_EXPORT CellListGPU : public CellList
         virtual void printStats()
             {
             // first reduce the cell size counter per device
-            if (m_exec_conf->getNumActiveGPUs() > 1)
+            if (m_per_device)
                 combineCellLists();
 
             CellList::printStats();


### PR DESCRIPTION
## Description

Fixes the statistics output for cell lists with `-DALWAYS_USE_MANAGED_MEMORY`.
 
## Motivation and Context

the current output with those compiler flags on a single GPU is wrong:

```
-- Cell list stats:
Dimension: 211, 211, 211
n_min    : 0 / n_max: 0 / n_avg: 0.01395
** run complete **
```

## How Has This Been Tested?

Not unit tested.

## Change log

```
Display correct cell list statistics with the `-DALWAYS_USE_MANAGED_MEMORY=ON` compile option.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/hoomd-blue/blob/master/sphinx-doc/credits.rst).
