### PR TITLE
fix bus error / synchronize GPU upon GlobalArray<T>::resize()

### DIFF
--- a/hoomd/GlobalArray.h
+++ b/hoomd/GlobalArray.h
@@ -519,18 +519,6 @@ class GlobalArray : public GPUArrayBase<T, GlobalArray<T> >
 
             checkAcquired(*this);
 
-            // store old data in temporary vector
-            std::vector<T> old(m_num_elements);
-            std::copy(m_data.get(), m_data.get()+m_num_elements, old.begin());
-
-            unsigned int num_copy_elements = m_num_elements > num_elements ? num_elements : m_num_elements;
-
-            m_num_elements = num_elements;
-
-            assert(m_num_elements > 0);
-
-            allocate();
-
             #ifdef ENABLE_CUDA
             if (this->m_exec_conf && this->m_exec_conf->isCUDAEnabled())
                 {
@@ -543,6 +531,18 @@ class GlobalArray : public GPUArrayBase<T, GlobalArray<T> >
                     }
                 }
             #endif
+
+            // store old data in temporary vector
+            std::vector<T> old(m_num_elements);
+            std::copy(m_data.get(), m_data.get()+m_num_elements, old.begin());
+
+            unsigned int num_copy_elements = m_num_elements > num_elements ? num_elements : m_num_elements;
+
+            m_num_elements = num_elements;
+
+            assert(m_num_elements > 0);
+
+            allocate();
 
             std::copy(old.begin(), old.begin() + num_copy_elements, m_data.get());
 
@@ -568,16 +568,6 @@ class GlobalArray : public GPUArrayBase<T, GlobalArray<T> >
             // make m_pitch the next multiple of 16 larger or equal to the given width
             unsigned int pitch = (width + (16 - (width & 15)));
 
-            // store old data in temporary vector
-            std::vector<T> old(m_num_elements);
-            std::copy(m_data.get(), m_data.get()+m_num_elements, old.begin());
-
-            m_num_elements = pitch * height;
-
-            assert(m_num_elements > 0);
-
-            allocate();
-
             #ifdef ENABLE_CUDA
             if (this->m_exec_conf->isCUDAEnabled())
                 {
@@ -590,6 +580,16 @@ class GlobalArray : public GPUArrayBase<T, GlobalArray<T> >
                     }
                 }
             #endif
+
+            // store old data in temporary vector
+            std::vector<T> old(m_num_elements);
+            std::copy(m_data.get(), m_data.get()+m_num_elements, old.begin());
+
+            m_num_elements = pitch * height;
+
+            assert(m_num_elements > 0);
+
+            allocate();
 
             // copy over data
             // every column is copied separately such as to align with the new pitch

--- a/hoomd/ParticleData.cu
+++ b/hoomd/ParticleData.cu
@@ -223,6 +223,10 @@ unsigned int gpu_pdata_remove(const unsigned int N,
         N, (unsigned int) 0, mgpu::plus<unsigned int>(),
         (unsigned int *)NULL, &n_out, d_tmp, *mgpu_context);
 
+    // NOTE: the call in the line above assumes that a cudaDeviceSynchronize() with the host is performed
+    // in mgpu.  If this call is ever replaced by a device-level primitive which does not synchronize, e.g. CUB,
+    // we will need to perform an explicit sync between devices in multi-GPU simulations here
+
     // Don't write past end of buffer
     if (n_out <= max_n_out)
         {


### PR DESCRIPTION
##

This PR should fix some bus errors that have been cropping up in the `*mng` (`-DALWAYS_USE_MANAGED_MEMORY=ON`) validation tests on K40 especially. It also adds a comment for what to be aware of regarding future changes from moderngpu to CUB.

## Motivation and Context

Fix validation tests. It is necessary to synchronize the GPU before accessing memory on the host.

## How Has This Been Tested?

Covered by existing MPI+ CUDA + managed memory validation tests, at least when they run on Kepler (which doesn't support concurrent managed access).  This bug *could* have affected simulations in which arrays are resized even with Pascal/Volta generation GPUs, in that it *may* have caused silent data corruption particularly in combination of managed memory and MPI.

## Change log

```
- Fix a sporadic data corruption / bus error issue when data structures are dynamically resized in simulations that use unified memory (multi-GPU, or with -DALWAYS_USE_MANAGED_MEMORY=ON compile time option)
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/hoomd-blue/blob/master/sphinx-doc/credits.rst).
