### PR TITLE
fix handling of non-MPI_COMM_WORLD communicator in Messenger

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,7 @@ executors:
       PYTHONPATH: /home/ci/project/build
       PYTHON: "/usr/bin/python<< parameters.python-version >>"
       PYTEST: "/usr/bin/python<< parameters.python-version >> -m pytest"
+      OMPI_MCA_btl: "tcp,self"
     working_directory: /home/ci/project
 
 commands:

--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -18,6 +18,7 @@ pipeline
                         CC = '/usr/bin/gcc'
                         CXX = '/usr/bin/g++'
                         OMP_NUM_THREADS = '1'
+                        OMPI_MCA_btl = 'tcp,self'
                         }
 
                     steps
@@ -72,6 +73,7 @@ pipeline
                         CC = '/usr/bin/gcc-7'
                         CXX = '/usr/bin/g++-7'
                         OMP_NUM_THREADS = '1'
+                        OMPI_MCA_btl = 'tcp,self'
                         }
 
                     steps
@@ -126,6 +128,7 @@ pipeline
                         CC = '/usr/bin/gcc-7'
                         CXX = '/usr/bin/g++-7'
                         OMP_NUM_THREADS = '1'
+                        OMPI_MCA_btl = 'tcp,self'
                         }
 
                     steps
@@ -188,6 +191,7 @@ pipeline
                         CC = '/usr/bin/gcc-6'
                         CXX = '/usr/bin/g++-6'
                         OMP_NUM_THREADS = '1'
+                        OMPI_MCA_btl = 'tcp,self'
                         }
 
                     steps
@@ -242,6 +246,7 @@ pipeline
                         CC = '/usr/bin/gcc-7'
                         CXX = '/usr/bin/g++-7'
                         OMP_NUM_THREADS = '1'
+                        OMPI_MCA_btl = 'tcp,self'
                         }
 
                     steps
@@ -296,6 +301,7 @@ pipeline
                         CC = '/usr/bin/gcc-8'
                         CXX = '/usr/bin/g++-8'
                         OMP_NUM_THREADS = '3'
+                        OMPI_MCA_btl = 'tcp,self'
                         }
 
                     steps
@@ -350,6 +356,7 @@ pipeline
                         CC = '/usr/bin/gcc-7'
                         CXX = '/usr/bin/g++-7'
                         OMP_NUM_THREADS = '1'
+                        OMPI_MCA_btl = 'tcp,self'
                         }
 
                     steps

--- a/.jenkins/Jenkinsfile.jinja
+++ b/.jenkins/Jenkinsfile.jinja
@@ -18,6 +18,7 @@ pipeline
                         CC = '{{ test.CC }}'
                         CXX = '{{ test.CXX }}'
                         OMP_NUM_THREADS = '{{ test.OMP_NUM_THREADS }}'
+                        OMPI_MCA_btl = 'tcp,self'
                         }
 
                     steps
@@ -80,6 +81,7 @@ pipeline
                         CC = '{{ test.CC }}'
                         CXX = '{{ test.CXX }}'
                         OMP_NUM_THREADS = '{{ test.OMP_NUM_THREADS }}'
+                        OMPI_MCA_btl = 'tcp,self'
                         }
 
                     steps

--- a/hoomd/CMakeLists.txt
+++ b/hoomd/CMakeLists.txt
@@ -44,6 +44,7 @@ set(_hoomd_sources Analyzer.cc
                    LogHDF5.cc
                    Messenger.cc
                    MemoryTraceback.cc
+                   MPIConfiguration.cc
                    ParticleData.cc
                    ParticleGroup.cc
                    Profiler.cc
@@ -124,6 +125,7 @@ set(_hoomd_headers
     ManagedArray.h
     MemoryTraceback.h
     Messenger.h
+    MPIConfiguration.h
     ParticleData.cuh
     ParticleData.h
     ParticleGroup.cuh

--- a/hoomd/ExecutionConfiguration.h
+++ b/hoomd/ExecutionConfiguration.h
@@ -80,11 +80,11 @@ struct PYBIND11_EXPORT ExecutionConfiguration
                            std::vector<int> gpu_id = std::vector<int>(),
                            bool min_cpu=false,
                            bool ignore_display=false,
-                           std::shared_ptr<Messenger> _msg=std::shared_ptr<Messenger>(),
-                           unsigned int n_ranks = 0
+                           unsigned int n_ranks = 0,
                            #ifdef ENABLE_MPI
-                           , MPI_Comm hoomd_world=MPI_COMM_WORLD
+                           MPI_Comm hoomd_world=MPI_COMM_WORLD,
                            #endif
+                           std::shared_ptr<Messenger> _msg=std::shared_ptr<Messenger>()
                            );
 
     ~ExecutionConfiguration();

--- a/hoomd/ExecutionConfiguration.h
+++ b/hoomd/ExecutionConfiguration.h
@@ -13,6 +13,8 @@
 #include <mpi.h>
 #endif
 
+#include "MPIConfiguration.h"
+
 #include <vector>
 #include <string>
 #include <memory>
@@ -80,38 +82,40 @@ struct PYBIND11_EXPORT ExecutionConfiguration
                            std::vector<int> gpu_id = std::vector<int>(),
                            bool min_cpu=false,
                            bool ignore_display=false,
-                           unsigned int n_ranks = 0,
-                           #ifdef ENABLE_MPI
-                           MPI_Comm hoomd_world=MPI_COMM_WORLD,
-                           #endif
+                           std::shared_ptr<MPIConfiguration> mpi_config=std::shared_ptr<MPIConfiguration>(),
                            std::shared_ptr<Messenger> _msg=std::shared_ptr<Messenger>()
                            );
 
     ~ExecutionConfiguration();
 
+    //! Returns the MPI Configuration
+    std::shared_ptr<MPIConfiguration> getMPIConfig() const
+        {
+        assert(m_mpi_config);
+        return m_mpi_config;
+        }
+
 #ifdef ENABLE_MPI
     //! Returns the MPI communicator
     MPI_Comm getMPICommunicator() const
         {
-        return m_mpi_comm;
+        assert(m_mpi_config);
+        return m_mpi_config->getCommunicator();
         }
+
     //! Returns the HOOMD World MPI communicator
     MPI_Comm getHOOMDWorldMPICommunicator() const
         {
-        return m_hoomd_world;
+        assert(m_mpi_config);
+        return m_mpi_config->getHOOMDWorldCommunicator();
         }
 #endif
-
-    //! Guess local rank of this processor, used for GPU initialization
-    /*! \returns Local rank guessed from common environment variables
-                 or falls back to the global rank if no information is available
-        \param found [output] True if a local rank was found, false otherwise
-     */
-    int guessLocalRank(bool &found);
 
     executionMode exec_mode;    //!< Execution mode specified in the constructor
     unsigned int n_cpu;         //!< Number of CPUS hoomd is executing on
     bool m_cuda_error_checking;                //!< Set to true if GPU error checking is enabled
+
+    std::shared_ptr<MPIConfiguration> m_mpi_config; //!< The MPI object holding the MPI communicator
     std::shared_ptr<Messenger> msg;          //!< Messenger for use in printing messages to the screen / log file
 
     //! Returns true if CUDA is enabled
@@ -215,74 +219,45 @@ struct PYBIND11_EXPORT ExecutionConfiguration
     void handleCUDAError(cudaError_t err, const char *file, unsigned int line) const;
 #endif
 
+    /*
+     * The following MPI related methods only wrap those of the MPIConfiguration object,
+       which can obtained with getMPIConfig(), and are provided as a legacy API.
+    */
+
     //! Return the rank of this processor in the partition
     unsigned int getRank() const
         {
-        return m_rank;
-        }
-
-    #ifdef ENABLE_MPI
-    //! Return the global rank of this processor
-    static unsigned int getRankGlobal()
-        {
-        int rank;
-        // get rank on world communicator
-        MPI_Comm_rank(MPI_COMM_WORLD, &rank);
-        return rank;
-        }
-
-    //! Return the global communicator size
-    static unsigned int getNRanksGlobal()
-        {
-        int size;
-        MPI_Comm_size(MPI_COMM_WORLD, &size);
-        return size;
+        assert(m_mpi_config);
+        return m_mpi_config->getRank();
         }
 
     //! Returns the partition number of this processor
     unsigned int getPartition() const
         {
-        return m_n_rank ? getRankGlobal()/m_n_rank : 0;
+        assert(m_mpi_config);
+        return m_mpi_config->getPartition();
         }
 
     //! Returns the number of partitions
     unsigned int getNPartitions() const
         {
-        return m_n_rank ? getNRanksGlobal()/m_n_rank : 1;
+        assert(m_mpi_config);
+        return m_mpi_config->getNPartitions();
         }
 
     //! Return the number of ranks in this partition
-    unsigned int getNRanks() const;
+    unsigned int getNRanks() const
+        {
+        assert(m_mpi_config);
+        return m_mpi_config->getNRanks();
+        }
 
     //! Returns true if this is the root processor
     bool isRoot() const
         {
-        return getRank() == 0;
+        assert(m_mpi_config);
+        return m_mpi_config->isRoot();
         }
-
-    //! Set the MPI communicator
-    void setMPICommunicator(const MPI_Comm mpi_comm)
-        {
-        m_mpi_comm = mpi_comm;
-        }
-
-    //! Set the HOOMD world MPI communicator
-    void setHOOMDWorldMPICommunicator(const MPI_Comm mpi_comm)
-        {
-        m_hoomd_world = mpi_comm;
-        }
-
-    //! Perform a job-wide MPI barrier
-    void barrier()
-        {
-        MPI_Barrier(m_mpi_comm);
-        }
-    #else
-    bool isRoot() const
-        {
-        return true;
-        }
-    #endif
 
     #ifdef ENABLE_TBB
     //! set number of TBB threads
@@ -340,6 +315,13 @@ struct PYBIND11_EXPORT ExecutionConfiguration
         }
 
 private:
+    //! Guess local rank of this processor, used for GPU initialization
+    /*! \returns Local rank guessed from common environment variables
+                 or falls back to the global rank if no information is available
+        \param found [output] True if a local rank was found, false otherwise
+     */
+    int guessLocalRank(bool &found);
+
 #ifdef ENABLE_CUDA
     //! Initialize the GPU with the given id
     void initializeGPU(int gpu_id, bool min_cpu);
@@ -370,16 +352,6 @@ private:
     bool m_concurrent;                      //!< True if all GPUs have concurrentManagedAccess flag
 
     mutable bool m_in_multigpu_block;       //!< Tracks whether we are in a multi-GPU block
-
-#ifdef ENABLE_MPI
-    void splitPartitions(const MPI_Comm mpi_comm); //!< Create partitioned communicators
-
-    MPI_Comm m_mpi_comm;                   //!< The MPI communicator
-    MPI_Comm m_hoomd_world;                //!< The HOOMD world communicator
-    unsigned int m_n_rank;                 //!< Ranks per partition
-#endif
-
-    unsigned int m_rank;                   //!< Rank of this processor (0 if running in single-processor mode)
 
     #ifdef ENABLE_CUDA
     std::unique_ptr<CachedAllocator> m_cached_alloc;       //!< Cached allocator for temporary allocations

--- a/hoomd/MPIConfiguration.cc
+++ b/hoomd/MPIConfiguration.cc
@@ -1,0 +1,105 @@
+// Copyright (c) 2009-2019 The Regents of the University of Michigan
+// This file is part of the HOOMD-blue project, released under the BSD 3-Clause License.
+
+// Maintainer: joaander
+
+#include "MPIConfiguration.h"
+
+#ifdef ENABLE_MPI
+#include "HOOMDMPI.h"
+#endif
+
+#include <stdexcept>
+#include <iostream>
+#include <sstream>
+
+/*! \file MPIConfiguration.cc
+    \brief Defines MPIConfiguration and related classes
+*/
+
+//! Default constructor
+MPIConfiguration::MPIConfiguration(
+    #ifdef ENABLE_MPI
+    MPI_Comm hoomd_world
+    #endif
+    )
+    : m_rank(0), m_n_rank(1)
+    {
+    #ifdef ENABLE_MPI
+    m_mpi_comm = m_hoomd_world = hoomd_world;
+
+    // use all ranks in a single partition
+    int size;
+    MPI_Comm_size(m_hoomd_world, &size);
+    m_n_rank = size;
+
+    int rank;
+    MPI_Comm_rank(m_mpi_comm, &rank);
+    m_rank = rank;
+    #endif
+    }
+
+
+void MPIConfiguration::splitPartitions(unsigned int nrank)
+    {
+#ifdef ENABLE_MPI
+    int num_total_ranks;
+    MPI_Comm_size(m_mpi_comm, &num_total_ranks);
+
+    unsigned int partition = 0;
+
+    if  (m_n_rank != 0)
+        {
+        int rank;
+        MPI_Comm_rank(m_mpi_comm, &rank);
+
+        if (num_total_ranks % m_n_rank != 0)
+            throw(std::runtime_error("Invalid setting --nrank."));
+
+        partition = rank / m_n_rank;
+
+        // Split the communicator
+        MPI_Comm new_comm;
+        MPI_Comm_split(m_mpi_comm, partition, rank, &new_comm);
+
+        // update communicator
+        m_mpi_comm = new_comm;
+        }
+
+    int rank;
+    MPI_Comm_rank(m_mpi_comm, &rank);
+    m_rank = rank;
+#endif
+    }
+
+unsigned int MPIConfiguration::getNRanks() const
+    {
+    #ifdef ENABLE_MPI
+    int size;
+    MPI_Comm_size(m_mpi_comm, &size);
+    return size;
+    #else
+    return 1;
+    #endif
+    }
+
+void export_MPIConfiguration(pybind11::module& m)
+    {
+    pybind11::class_<MPIConfiguration, std::shared_ptr<MPIConfiguration> > mpiconfiguration(m,"MPIConfiguration");
+    mpiconfiguration.def(pybind11::init< >())
+        .def("splitPartitions", &MPIConfiguration::splitPartitions)
+        .def("getPartition", &MPIConfiguration::getPartition)
+        .def("getNRanks", &MPIConfiguration::getNRanks)
+        .def("getRank", &MPIConfiguration::getRank)
+        .def("barrier", &MPIConfiguration::barrier)
+        .def("getNRanksGlobal", &MPIConfiguration::getNRanksGlobal)
+        .def("getRankGlobal", &MPIConfiguration::getRankGlobal)
+#ifdef ENABLE_MPI
+        .def_static("_make_mpi_conf_mpi_comm",  [](pybind11::object mpi_comm) -> std::shared_ptr<MPIConfiguration>
+            {
+            MPI_Comm *comm = (MPI_Comm*)PyLong_AsVoidPtr(mpi_comm.ptr());
+            return std::make_shared<MPIConfiguration>(*comm);
+            })
+#endif
+    ;
+    }

--- a/hoomd/MPIConfiguration.cc
+++ b/hoomd/MPIConfiguration.cc
@@ -47,26 +47,26 @@ void MPIConfiguration::splitPartitions(unsigned int nrank)
     MPI_Comm_size(m_mpi_comm, &num_total_ranks);
 
     unsigned int partition = 0;
+    m_n_rank = nrank;
 
-    if  (m_n_rank != 0)
-        {
-        int rank;
-        MPI_Comm_rank(m_mpi_comm, &rank);
-
-        if (num_total_ranks % m_n_rank != 0)
-            throw(std::runtime_error("Invalid setting --nrank."));
-
-        partition = rank / m_n_rank;
-
-        // Split the communicator
-        MPI_Comm new_comm;
-        MPI_Comm_split(m_mpi_comm, partition, rank, &new_comm);
-
-        // update communicator
-        m_mpi_comm = new_comm;
-        }
+    if (m_n_rank == 0)
+        throw std::runtime_error("--nrank setting has to be > 0");
 
     int rank;
+    MPI_Comm_rank(m_mpi_comm, &rank);
+
+    if (num_total_ranks % m_n_rank != 0)
+        throw std::runtime_error("Invalid setting --nrank.");
+
+    partition = rank / m_n_rank;
+
+    // Split the communicator
+    MPI_Comm new_comm;
+    MPI_Comm_split(m_mpi_comm, partition, rank, &new_comm);
+
+    // update communicator
+    m_mpi_comm = new_comm;
+
     MPI_Comm_rank(m_mpi_comm, &rank);
     m_rank = rank;
 #endif

--- a/hoomd/MPIConfiguration.h
+++ b/hoomd/MPIConfiguration.h
@@ -1,0 +1,138 @@
+// Copyright (c) 2009-2019 The Regents of the University of Michigan
+// This file is part of the HOOMD-blue project, released under the BSD 3-Clause License.
+
+// Maintainer: jglaser
+
+#pragma once
+
+// ensure that HOOMDMath.h is the first thing included
+#include "HOOMDMath.h"
+
+#ifdef ENABLE_MPI
+#include <mpi.h>
+#endif
+
+/*! \file MPIConfiguration.h
+    \brief Declares MPIConfiguration, which initializes the MPI environment
+*/
+
+#ifdef NVCC
+#error This header cannot be compiled by nvcc
+#endif
+
+#include <hoomd/extern/pybind/include/pybind11/pybind11.h>
+
+//! Defines the MPI configuration for the simulation
+/*! \ingroup data_structs
+    MPIConfiguration is class that stores the MPI communicator and splits it into partitions if needed.
+
+    It is constructed *before* ExecutionConfiguration and other classes (Messenger) that need the MPI
+    world communicator.
+*/
+class PYBIND11_EXPORT MPIConfiguration
+    {
+    public:
+        //! Constructor with externally provided MPI communicator (only in MPI enabled builds)
+        /*! \param mpi_comm world MPI communicator
+         */
+        MPIConfiguration(
+            #ifdef ENABLE_MPI
+            MPI_Comm hoomd_world = MPI_COMM_WORLD
+            #endif
+            );
+
+        //! Destructor
+        virtual ~MPIConfiguration() {};
+
+#ifdef ENABLE_MPI
+        //! Returns the MPI communicator
+        MPI_Comm getCommunicator() const
+            {
+            return m_mpi_comm;
+            }
+        //! Returns the World MPI communicator
+        MPI_Comm getHOOMDWorldCommunicator() const
+            {
+            return m_hoomd_world;
+            }
+#endif
+
+        //!< Partition the communicator
+        /*! \param nrank Number of ranks per partition
+        */
+        void splitPartitions(unsigned int nrank);
+
+        //! Return the rank of this processor in the partition
+        unsigned int getRank() const
+            {
+            return m_rank;
+            }
+
+        //! Return the global rank of this processor
+        unsigned int getRankGlobal() const
+            {
+            #ifdef ENABLE_MPI
+            // get rank on world communicator
+            int rank;
+            MPI_Comm_rank(m_hoomd_world, &rank);
+            return rank;
+            #else
+            return 0;
+            #endif
+            }
+
+        //! Return the global communicator size
+        unsigned int getNRanksGlobal() const
+            {
+            #ifdef ENABLE_MPI
+            int size;
+            MPI_Comm_size(m_hoomd_world, &size);
+            return size;
+            #else
+            return 1;
+            #endif
+            }
+
+        //! Returns the partition number of this processor
+        unsigned int getPartition() const
+            {
+            return getRankGlobal()/m_n_rank;
+            }
+
+        //! Returns the number of partitions
+        unsigned int getNPartitions() const
+            {
+            return getNRanksGlobal()/m_n_rank;
+            }
+
+        //! Return the number of ranks in this partition
+        unsigned int getNRanks() const;
+
+        //! Returns true if this is the root processor
+        bool isRoot() const
+            {
+            return getRank() == 0;
+            }
+
+        //! Perform a job-wide MPI barrier
+        void barrier()
+            {
+            #ifdef ENABLE_MPI
+            MPI_Barrier(m_mpi_comm);
+            #endif
+            }
+
+    protected:
+#ifdef ENABLE_MPI
+        MPI_Comm m_mpi_comm;                   //!< The MPI communicator
+        MPI_Comm m_hoomd_world;                //!< The HOOMD world communicator
+#endif
+        unsigned int m_rank;                   //!< Rank of this processor (0 if running in single-processor mode)
+        unsigned int m_n_rank;                 //!< Ranks per partition
+    };
+
+
+//! Exports MPIConfiguration to python
+#ifndef NVCC
+void export_MPIConfiguration(pybind11::module& m);
+#endif

--- a/hoomd/Messenger.cc
+++ b/hoomd/Messenger.cc
@@ -58,7 +58,11 @@ class mpi_io : public std::streambuf
     \post The notice level is set to 2
     \post prefixes are "error!!!!" , "warning!!" and "notice"
 */
+#ifdef ENABLE_MPI
+Messenger::Messenger(MPI_Comm hoomd_world)
+#else
 Messenger::Messenger()
+#endif
     {
     m_err_stream = &cerr;
     m_warning_stream = &cerr;
@@ -72,7 +76,8 @@ Messenger::Messenger()
 
 #ifdef ENABLE_MPI
     // initial value
-    m_mpi_comm = MPI_COMM_WORLD;
+    m_hoomd_world = hoomd_world;
+    m_mpi_comm = hoomd_world;
     m_error_flag = NULL;
     m_has_lock = false;
     initializeSharedMem();
@@ -467,7 +472,6 @@ void Messenger::releaseSharedMem()
 void export_Messenger(py::module& m)
     {
     py::class_<Messenger, std::shared_ptr<Messenger> >(m,"Messenger")
-        .def(py::init< >())
         .def("error", &Messenger::errorStr)
         .def("warning", &Messenger::warningStr)
         .def("notice", &Messenger::noticeStr)

--- a/hoomd/Messenger.cc
+++ b/hoomd/Messenger.cc
@@ -117,7 +117,6 @@ Messenger::Messenger()
         {
         if ((env = getenv(it->c_str())) != NULL)
             {
-            msg->notice(3) << "Found rank in: " << *it << ", not using sys.stdout/stderr" << std::endl;
             mpi_job = true;
             }
         }

--- a/hoomd/Messenger.cc
+++ b/hoomd/Messenger.cc
@@ -90,6 +90,15 @@ Messenger::Messenger()
     #else
     setRank(0,0);
     #endif
+
+    int nranks = 1;
+    #ifdef ENABLE_MPI
+    MPI_Comm_size(m_hoomd_world, &nranks);
+    #endif
+
+    // only open python stdout/stderr in non-MPI runs
+    if (nranks == 1)
+        openPython();
     }
 
 Messenger::Messenger(const Messenger& msg)

--- a/hoomd/Messenger.cc
+++ b/hoomd/Messenger.cc
@@ -61,11 +61,8 @@ class mpi_io : public std::streambuf
     \post The notice level is set to 2
     \post prefixes are "error!!!!" , "warning!!" and "notice"
 */
-#ifdef ENABLE_MPI
-Messenger::Messenger(MPI_Comm hoomd_world)
-#else
-Messenger::Messenger()
-#endif
+Messenger::Messenger(std::shared_ptr<MPIConfiguration> mpi_config)
+    : m_mpi_config(mpi_config)
     {
     m_err_stream = &cerr;
     m_warning_stream = &cerr;
@@ -77,53 +74,23 @@ Messenger::Messenger()
     m_warning_prefix = "*Warning*";
     m_notice_prefix  = "notice";
 
+    if (! m_mpi_config)
+        {
+        // create one on the fly
+        m_mpi_config = std::shared_ptr<MPIConfiguration>(new MPIConfiguration());
+        }
+
+    // silence output on non-zero ranks
+    assert(m_mpi_config);
+    if (m_mpi_config->getRank() != 0)
+        m_notice_level = 0;
+
 #ifdef ENABLE_MPI
-    // initial value
-    m_hoomd_world = hoomd_world;
-    m_mpi_comm = hoomd_world;
     m_error_flag = NULL;
     m_has_lock = false;
     initializeSharedMem();
     m_shared_filename = "";
 #endif
-
-    // preliminarily initialize rank and partition
-    #ifdef ENABLE_MPI
-    setRank(ExecutionConfiguration::getRankGlobal(),0);
-    #else
-    setRank(0,0);
-    #endif
-
-    // try to detect if we're running inside an MPI job
-    bool mpi_job = false;
-    #ifdef ENABLE_MPI
-    int nranks = 1;
-    MPI_Comm_size(m_hoomd_world, &nranks);
-    mpi_job = nranks > 1;
-    #endif
-
-    std::vector<std::string> env_vars;
-    char *env;
-
-    // add environment variables here as needed
-    env_vars.push_back("MV2_COMM_WORLD_LOCAL_RANK");
-    env_vars.push_back("OMPI_COMM_WORLD_RANK");
-    env_vars.push_back("PMI_RANK");
-    env_vars.push_back("ALPS_APP_PE");
-
-    std::vector<std::string>::iterator it;
-
-    for (it = env_vars.begin(); it != env_vars.end(); it++)
-        {
-        if ((env = getenv(it->c_str())) != NULL)
-            {
-            mpi_job = true;
-            }
-        }
-
-    // only open python stdout/stderr in non-MPI runs
-    if (!mpi_job)
-        openPython();
     }
 
 Messenger::Messenger(const Messenger& msg)
@@ -141,13 +108,10 @@ Messenger::Messenger(const Messenger& msg)
     m_notice_prefix = msg.m_notice_prefix;
     m_notice_level = msg.m_notice_level;
 
-    m_rank = msg.m_rank;
-    m_partition = msg.m_partition;
-    m_nranks = msg.m_nranks;
+    m_mpi_config = msg.m_mpi_config;
 
     #ifdef ENABLE_MPI
     m_shared_filename = msg.m_shared_filename;
-    m_mpi_comm = msg.m_mpi_comm;
     m_error_flag = NULL;
     m_has_lock = false;
     initializeSharedMem();
@@ -173,13 +137,10 @@ Messenger& Messenger::operator=(Messenger& msg)
     m_notice_prefix = msg.m_notice_prefix;
     m_notice_level = msg.m_notice_level;
 
-    m_rank = msg.m_rank;
-    m_partition = msg.m_partition;
-    m_nranks = msg.m_nranks;
+    m_mpi_config = msg.m_mpi_config;
 
     #ifdef ENABLE_MPI
     m_shared_filename = msg.m_shared_filename;
-    m_mpi_comm = msg.m_mpi_comm;
     m_error_flag = NULL;
     m_has_lock = false;
     initializeSharedMem();
@@ -209,7 +170,7 @@ std::ostream& Messenger::error()
     assert(m_err_stream);
     #ifdef ENABLE_MPI
     assert(m_error_flag);
-    if (m_nranks > 1)
+    if (m_mpi_config->getNRanks() > 1)
         {
         int one = 1;
         int flag;
@@ -229,8 +190,8 @@ std::ostream& Messenger::error()
     reopenPythonIfNeeded();
     if (m_err_prefix != string(""))
         *m_err_stream << m_err_prefix << ": ";
-    if (m_nranks > 1)
-        *m_err_stream << " (Rank " << m_rank << "): ";
+    if (m_mpi_config->getNRanks() > 1)
+        *m_err_stream << " (Rank " << m_mpi_config->getRank() << "): ";
     return *m_err_stream;
     }
 
@@ -248,7 +209,7 @@ void Messenger::errorStr(const std::string& msg)
 */
 std::ostream& Messenger::warning()
     {
-    if (m_rank != 0) return *m_nullstream;
+    if (m_mpi_config->getRank() != 0) return *m_nullstream;
 
     assert(m_warning_stream);
     reopenPythonIfNeeded();
@@ -297,13 +258,13 @@ void Messenger::collectiveNoticeStr(unsigned int level, const std::string& msg)
     std::vector<std::string> rank_notices;
 
     #ifdef ENABLE_MPI
-    gather_v(msg, rank_notices, 0, m_mpi_comm);
+    gather_v(msg, rank_notices, 0, m_mpi_config->getCommunicator());
     #else
     rank_notices.push_back(msg);
     #endif
 
     #ifdef ENABLE_MPI
-    if (m_rank == 0)
+    if (m_mpi_config->getRank() == 0)
         {
         if (rank_notices.size() > 1)
             {
@@ -421,8 +382,8 @@ void Messenger::reopenPythonIfNeeded()
 void Messenger::openSharedFile()
     {
     std::ostringstream oss;
-    oss << m_shared_filename << "." << m_partition;
-    m_streambuf_out = std::shared_ptr< std::streambuf >(new mpi_io((const MPI_Comm&) m_mpi_comm, oss.str()));
+    oss << m_shared_filename << "." << m_mpi_config->getPartition();
+    m_streambuf_out = std::shared_ptr< std::streambuf >(new mpi_io((const MPI_Comm&) m_mpi_config->getCommunicator(), oss.str()));
 
     // now update the error, warning, and notice streams
     m_file_out = std::shared_ptr<std::ostream>(new std::ostream(m_streambuf_out.get()));
@@ -492,7 +453,7 @@ void Messenger::initializeSharedMem()
     *m_error_flag = 0;
 
     // create window for exclusive access to the error stream
-    MPI_Win_create(m_error_flag, sizeof(int), sizeof(int), MPI_INFO_NULL, m_mpi_comm, &m_mpi_win);
+    MPI_Win_create(m_error_flag, sizeof(int), sizeof(int), MPI_INFO_NULL, m_mpi_config->getCommunicator(), &m_mpi_win);
     }
 
 void Messenger::releaseSharedMem()
@@ -506,6 +467,7 @@ void Messenger::releaseSharedMem()
 void export_Messenger(py::module& m)
     {
     py::class_<Messenger, std::shared_ptr<Messenger> >(m,"Messenger")
+        .def(py::init< std::shared_ptr<MPIConfiguration> >())
         .def("error", &Messenger::errorStr)
         .def("warning", &Messenger::warningStr)
         .def("notice", &Messenger::noticeStr)

--- a/hoomd/Messenger.h
+++ b/hoomd/Messenger.h
@@ -13,9 +13,7 @@
 #include <string>
 #include <memory>
 
-#ifdef ENABLE_MPI
-#include "HOOMDMPI.h"
-#endif
+#include "MPIConfiguration.h"
 
 #ifdef NVCC
 #error This header cannot be compiled by nvcc
@@ -105,11 +103,7 @@ class PYBIND11_EXPORT Messenger
     {
     public:
         //! Construct a messenger
-        #ifdef ENABLE_MPI
-        Messenger(MPI_Comm hoomd_world=MPI_COMM_WORLD);
-        #else
-        Messenger();
-        #endif
+        Messenger(std::shared_ptr<MPIConfiguration> mpi_conf = std::shared_ptr<MPIConfiguration>());
 
         //! Copy constructor
         Messenger(const Messenger& msg);
@@ -118,7 +112,7 @@ class PYBIND11_EXPORT Messenger
         Messenger& operator=(Messenger& msg);
 
         //! Destructor
-        ~Messenger();
+        virtual ~Messenger();
 
         //! Get the error stream
         std::ostream& error();
@@ -141,66 +135,6 @@ class PYBIND11_EXPORT Messenger
         //! Alternate method to print notice strings
         void noticeStr(unsigned int level, const std::string& msg);
 
-        //! Set processor rank
-        /*! Error and warning messages are prefixed with rank information.
-
-            Notice messages are only output on processor with rank 0.
-
-            \param rank This processor's rank
-
-         */
-        void setRank(unsigned int rank, unsigned int partition)
-            {
-            // prefix all messages with rank information
-            m_rank = rank;
-            m_nranks = 1;
-            #ifdef ENABLE_MPI
-            bcast(m_notice_level,0,m_mpi_comm);
-
-            // get communicator size
-            int nranks;
-            if (m_rank != 0) m_notice_level = 0;
-            MPI_Comm_size(m_mpi_comm, &nranks);
-            m_nranks = nranks;
-            #endif
-            m_partition = partition;
-            }
-
-
-#ifdef ENABLE_MPI
-        //! Set MPI communicator
-        /*! \param mpi_comm The MPI communicator to use
-         */
-        void setMPICommunicator(const MPI_Comm mpi_comm)
-            {
-            // clean up data associated with old communicator
-            releaseSharedMem();
-
-            m_mpi_comm = mpi_comm;
-
-            // open shared log file if necessary
-            if (m_shared_filename != "")
-                openSharedFile();
-
-            // initialize RMA memory for error messages
-            initializeSharedMem();
-            }
-
-        //! Revert to MPI_COMM_WORLD communicator
-        void unsetMPICommunicator()
-            {
-            if (m_shared_filename != "")
-                openStd();
-
-            releaseSharedMem();
-
-            m_mpi_comm = m_hoomd_world;
-
-            // initialize RMA memory for error messages
-            initializeSharedMem();
-            }
-#endif
-
         //! Get the notice level
         /*! \returns Current notice level
         */
@@ -214,7 +148,7 @@ class PYBIND11_EXPORT Messenger
         */
         void setNoticeLevel(unsigned int level)
             {
-            m_notice_level = (m_rank == 0) ? level : 0;
+            m_notice_level = (m_mpi_config->getRank() == 0) ? level : 0;
             }
 
         //! Set the error stream
@@ -341,7 +275,10 @@ class PYBIND11_EXPORT Messenger
 
         //! Open stdout and stderr again, closing any open file
         void openStd();
+
     private:
+        std::shared_ptr<MPIConfiguration> m_mpi_config; //!< The MPI configuration
+
         std::ostream *m_err_stream;     //!< error stream
         std::ostream *m_warning_stream; //!< warning stream
         std::ostream *m_notice_stream;  //!< notice stream
@@ -358,10 +295,6 @@ class PYBIND11_EXPORT Messenger
 
         unsigned int m_notice_level;    //!< Notice level
 
-        unsigned int m_rank;            //!< The MPI rank (default 0)
-        unsigned int m_partition;       //!< The MPI partition
-        unsigned int m_nranks;          //!< Number of ranks in communicator
-
         bool m_python_open=false;       //!< True when the python output stream is open
         pybind11::module m_sys;         //!< sys module
         pybind11::object m_pystdout;    //!< Currently bound python sys.stdout
@@ -369,9 +302,6 @@ class PYBIND11_EXPORT Messenger
 
 #ifdef ENABLE_MPI
         std::string m_shared_filename;  //!< Filename of shared log file
-        MPI_Comm m_mpi_comm;            //!< The MPI communicator
-        MPI_Comm m_hoomd_world;         //!< The world communicator
-
         MPI_Win m_mpi_win;              //!< MPI Window for atomic printing of error messages
         int *m_error_flag;              //!< Flag on (on processor 0) to lock stdout
         mutable bool m_has_lock;        //!< True if this rank has exclusive access to stdout

--- a/hoomd/Messenger.h
+++ b/hoomd/Messenger.h
@@ -105,7 +105,11 @@ class PYBIND11_EXPORT Messenger
     {
     public:
         //! Construct a messenger
+        #ifdef ENABLE_MPI
+        Messenger(MPI_Comm hoomd_world=MPI_COMM_WORLD);
+        #else
         Messenger();
+        #endif
 
         //! Copy constructor
         Messenger(const Messenger& msg);
@@ -190,7 +194,7 @@ class PYBIND11_EXPORT Messenger
 
             releaseSharedMem();
 
-            m_mpi_comm = MPI_COMM_WORLD;
+            m_mpi_comm = m_hoomd_world;
 
             // initialize RMA memory for error messages
             initializeSharedMem();
@@ -366,6 +370,7 @@ class PYBIND11_EXPORT Messenger
 #ifdef ENABLE_MPI
         std::string m_shared_filename;  //!< Filename of shared log file
         MPI_Comm m_mpi_comm;            //!< The MPI communicator
+        MPI_Comm m_hoomd_world;         //!< The world communicator
 
         MPI_Win m_mpi_win;              //!< MPI Window for atomic printing of error messages
         int *m_error_flag;              //!< Flag on (on processor 0) to lock stdout

--- a/hoomd/comm.py
+++ b/hoomd/comm.py
@@ -145,15 +145,14 @@ class decomposition(object):
     def __init__(self, x=None, y=None, z=None, nx=None, ny=None, nz=None):
         hoomd.util.print_status_line()
 
+        # check that the context has been initialized though
+        if hoomd.context.exec_conf is None:
+            raise RuntimeError("Cannot initialize decomposition without context.initialize() first")
+
         # check that system is not initialized
         if hoomd.context.current.system is not None:
             hoomd.context.msg.error("comm.decomposition: cannot modify decomposition after system is initialized. Call before init.*\n")
             raise RuntimeError("Cannot create decomposition after system is initialized. Call before init.*")
-
-        # check that the context has been initialized though
-        if hoomd.context.exec_conf is None:
-            hoomd.context.msg.error("comm.decomposition: call context.initialize() before decomposition can be set\n")
-            raise RuntimeError("Cannot initialize decomposition without context.initialize() first")
 
         # check that there are ranks available for decomposition
         if get_num_ranks() == 1:

--- a/hoomd/comm.py
+++ b/hoomd/comm.py
@@ -25,7 +25,7 @@ def get_num_ranks():
 
     hoomd.context._verify_init();
     if _hoomd.is_MPI_available():
-        return hoomd.context.exec_conf.getNRanks();
+        return hoomd.context.mpi_conf.getNRanks();
     else:
         return 1;
 
@@ -42,7 +42,7 @@ def get_rank():
     hoomd.context._verify_init();
 
     if _hoomd.is_MPI_available():
-        return hoomd.context.exec_conf.getRank()
+        return hoomd.context.mpi_conf.getRank()
     else:
         return 0;
 
@@ -58,7 +58,7 @@ def get_partition():
     hoomd.context._verify_init();
 
     if _hoomd.is_MPI_available():
-        return hoomd.context.exec_conf.getPartition()
+        return hoomd.context.mpi_conf.getPartition()
     else:
         return 0;
 
@@ -80,7 +80,7 @@ def barrier():
     hoomd.context._verify_init();
 
     if _hoomd.is_MPI_available():
-        hoomd.context.exec_conf.barrier()
+        hoomd.context.mpi_conf.barrier()
 
 class decomposition(object):
     """ Set the domain decomposition.
@@ -182,7 +182,7 @@ class decomposition(object):
                 self.uniform_y = True
             if not self.z and self.nz == 0:
                 if hoomd.context.options.linear is True:
-                    self.nz = hoomd.context.exec_conf.getNRanks()
+                    self.nz = hoomd.context.mpi_conf.getNRanks()
                     self.uniform_z = True
                 elif hoomd.context.options.nz is not None:
                     self.nz = hoomd.context.options.nz

--- a/hoomd/context.py
+++ b/hoomd/context.py
@@ -31,6 +31,9 @@ bib = None;
 ## Global options
 options = None;
 
+## Global variable that holds the MPI configuration
+mpi_conf = None;
+
 ## Global variable that holds the execution configuration for reference by the python API
 exec_conf = None;
 
@@ -205,9 +208,9 @@ def initialize(args=None, memory_traceback=False, mpi_comm=None):
         hoomd.context.initialize(mpi_comm=comm)
 
     """
-    global exec_conf, msg, options, current, _prev_args
+    global mpi_conf, exec_conf, msg, options, current, _prev_args
 
-    if exec_conf is not None:
+    if mpi_conf is not None or exec_conf is not None:
         if args != _prev_args:
             msg.warning("Ignoring new options, cannot change execution mode after initialization.\n");
         current = SimulationContext();
@@ -229,13 +232,20 @@ def initialize(args=None, memory_traceback=False, mpi_comm=None):
         print('exiting now to prevent many sequential jobs from starting');
         raise RuntimeError('Error launching hoomd')
 
-    exec_conf = _create_exec_conf(mpi_comm);
+    # create the MPI configuration
+    mpi_conf = _create_mpi_conf(mpi_comm, options)
+
+    # set options on messenger object
+    msg = _create_messenger(mpi_conf, options)
+
+    # output the version info on initialization
+    msg.notice(1, _hoomd.output_version_info())
 
     # ensure creation of global bibliography to print HOOMD base citations
     cite._ensure_global_bib()
 
-    # output the version info on initialization
-    msg.notice(1, _hoomd.output_version_info())
+    # create the parallel execution configuration
+    exec_conf = _create_exec_conf(mpi_conf, msg, options);
 
     # set memory tracing option
     exec_conf.setMemoryTracing(memory_traceback)
@@ -243,17 +253,90 @@ def initialize(args=None, memory_traceback=False, mpi_comm=None):
     current = SimulationContext();
     return current
 
+## Initializes the MPI configuration
+#
+# \internal
+def _create_mpi_conf(mpi_comm, options):
+    global mpi_conf
+
+    mpi_available = _hoomd.is_MPI_available();
+
+    # create the specified configuration
+    if mpi_comm is None:
+        mpi_conf = _hoomd.MPIConfiguration();
+    else:
+        if not mpi_available:
+            raise RuntimeError("mpi_comm is not supported in serial builds");
+
+        handled = False;
+
+        # pass in pointer to MPI_Comm object provided by mpi4py
+        try:
+            import mpi4py
+            if isinstance(mpi_comm, mpi4py.MPI.Comm):
+                addr = mpi4py.MPI._addressof(mpi_comm);
+                mpi_conf = _hoomd.MPIConfiguration._make_mpi_conf_mpi_comm(addr);
+                handled = True
+        except ImportError:
+            # silently ignore when mpi4py is missing
+            pass
+
+        # undocumented case: handle plain integers as pointers to MPI_Comm objects
+        if not handled and isinstance(mpi_comm, int):
+            mpi_conf = _hoomd.MPIConfiguration._make_mpi_conf_mpi_comm(mpi_comm);
+            handled = True
+
+        if not handled:
+            raise RuntimeError("Invalid mpi_comm object: {}".format(mpi_comm));
+
+    if options.nrank is not None:
+         # split the communicator into partitions
+         mpi_conf.splitPartitions(options.nrank)
+
+    return mpi_conf
+
+## Initializes the Messenger
+# \internal
+def _create_messenger(mpi_config, options):
+    global msg
+
+    msg = _hoomd.Messenger(mpi_config)
+
+    # try to detect if we're running inside an MPI job
+    inside_mpi_job = mpi_config.getNRanksGlobal() > 1
+    if ('OMPI_COMM_WORLD_RANK' in os.environ or
+        'MV2_COMM_WORLD_LOCAL_RANK' in os.environ or
+        'PMI_RANK' in os.environ or
+        'ALPS_APP_PE' in os.environ):
+        inside_mpi_job = True
+
+    # only open python stdout/stderr in non-MPI runs
+    if not inside_mpi_job:
+        msg.openPython();
+
+    if options.notice_level is not None:
+        msg.setNoticeLevel(options.notice_level);
+
+    if options.msg_file is not None:
+        msg.openFile(options.msg_file);
+
+    if options.shared_msg_file is not None:
+        if not _hoomd.is_MPI_available():
+            hoomd.context.msg.error("Shared log files are only available in MPI builds.\n");
+            raise RuntimeError('Error setting option');
+        msg.setSharedFile(options.shared_msg_file);
+
+    return msg
+
 ## Initializes the execution configuration
 #
 # \internal
-def _create_exec_conf(mpi_comm):
-    global exec_conf, options, msg
+def _create_exec_conf(mpi_config, msg, options):
+    global exec_conf
 
     # use a cached execution configuration if available
     if exec_conf is not None:
         return exec_conf
-
-    mpi_available = _hoomd.is_MPI_available();
 
     if options.mode == 'auto':
         exec_mode = _hoomd.ExecutionConfiguration.executionMode.AUTO;
@@ -270,46 +353,12 @@ def _create_exec_conf(mpi_comm):
     else:
         gpu_id = options.gpu;
 
-    if options.nrank is None:
-        nrank = 0;
-    else:
-        nrank = int(options.nrank);
-
     gpu_vec = _hoomd.std_vector_int()
     for gpuid in gpu_id:
         gpu_vec.append(gpuid)
 
     # create the specified configuration
-    if mpi_comm is None:
-        exec_conf = _hoomd.ExecutionConfiguration(exec_mode, gpu_vec, options.min_cpu, options.ignore_display, nrank);
-        msg = exec_conf.msg
-    else:
-        if not mpi_available:
-            raise RuntimeError("mpi_comm is not supported in serial builds");
-
-        handled = False;
-
-        # pass in pointer to MPI_Comm object provided by mpi4py
-        try:
-            import mpi4py
-            if isinstance(mpi_comm, mpi4py.MPI.Comm):
-                addr = mpi4py.MPI._addressof(mpi_comm);
-                exec_conf = _hoomd.ExecutionConfiguration._make_exec_conf_mpi_comm(exec_mode, gpu_vec, options.min_cpu, options.ignore_display, nrank, addr);
-                msg = exec_conf.msg
-                handled = True
-        except ImportError:
-            # silently ignore when mpi4py is missing
-            pass
-
-        # undocumented case: handle plain integers as pointers to MPI_Comm objects
-        if not handled and isinstance(mpi_comm, int):
-            exec_conf = _hoomd.ExecutionConfiguration._make_exec_conf_mpi_comm(exec_mode, gpu_vec, options.min_cpu, options.ignore_display, nrank, mpi_comm);
-            msg = exec_conf.msg
-            handled = True
-
-        if not handled:
-            msg.error("unknown mpi_comm object: {}.\n".format(mpi_comm));
-            raise RuntimeError("Invalid mpi_comm object");
+    exec_conf = _hoomd.ExecutionConfiguration(exec_mode, gpu_vec, options.min_cpu, options.ignore_display, mpi_conf, msg);
 
     # if gpu_error_checking is set, enable it on the GPU
     if options.gpu_error_checking:

--- a/hoomd/context.py
+++ b/hoomd/context.py
@@ -290,8 +290,13 @@ def _create_mpi_conf(mpi_comm, options):
             raise RuntimeError("Invalid mpi_comm object: {}".format(mpi_comm));
 
     if options.nrank is not None:
-         # split the communicator into partitions
-         mpi_conf.splitPartitions(options.nrank)
+        # check validity
+        nrank = options.nrank
+        if (mpi_conf.getNRanksGlobal() % nrank):
+            raise RuntimeError('Total number of ranks is not a multiple of --nrank');
+
+        # split the communicator into partitions
+        mpi_conf.splitPartitions(nrank)
 
     return mpi_conf
 

--- a/hoomd/context.py
+++ b/hoomd/context.py
@@ -337,8 +337,7 @@ def _verify_init():
     global exec_conf, msg, current
 
     if exec_conf is None:
-        msg.error("call context.initialize() before any other method in hoomd.")
-        raise RuntimeError("hoomd execution context is not available")
+        raise RuntimeError("Call context.initialize() before any method")
 
 ## \internal
 # \brief Gather context from the environment

--- a/hoomd/context.py
+++ b/hoomd/context.py
@@ -259,6 +259,10 @@ def initialize(args=None, memory_traceback=False, mpi_comm=None):
 def _create_mpi_conf(mpi_comm, options):
     global mpi_conf
 
+    # use a cached MPI configuration if available
+    if mpi_conf is not None:
+        return mpi_conf
+
     mpi_available = _hoomd.is_MPI_available();
 
     # create the specified configuration
@@ -304,6 +308,10 @@ def _create_mpi_conf(mpi_comm, options):
 # \internal
 def _create_messenger(mpi_config, options):
     global msg
+
+    # use a cached messenger if available
+    if msg is not None:
+        return msg
 
     msg = _hoomd.Messenger(mpi_config)
 

--- a/hoomd/context.py
+++ b/hoomd/context.py
@@ -311,13 +311,6 @@ def _create_exec_conf(mpi_comm):
             msg.error("unknown mpi_comm object: {}.\n".format(mpi_comm));
             raise RuntimeError("Invalid mpi_comm object");
 
-    # only use python stdout/stderr in non-mpi runs
-    if not (  'OMPI_COMM_WORLD_RANK' in os.environ
-            or 'MV2_COMM_WORLD_LOCAL_RANK' in os.environ
-            or 'PMI_RANK' in os.environ
-            or 'ALPS_APP_PE' in os.environ):
-        msg.openPython();
-
     # if gpu_error_checking is set, enable it on the GPU
     if options.gpu_error_checking:
        exec_conf.setCUDAErrorChecking(True);

--- a/hoomd/data.py
+++ b/hoomd/data.py
@@ -2210,16 +2210,16 @@ def set_snapshot_box(snapshot, box):
 ## \internal
 # \brief Broadcast snapshot to all ranks
 def broadcast_snapshot(cpp_snapshot):
-    hoomd.util.print_status_line();
     hoomd.context._verify_init();
+    hoomd.util.print_status_line();
     # broadcast from rank 0
     cpp_snapshot._broadcast(0, hoomd.context.exec_conf);
 
 ## \internal
 # \brief Broadcast snapshot to all ranks
 def broadcast_snapshot_all(cpp_snapshot):
-    hoomd.util.print_status_line();
     hoomd.context._verify_init();
+    hoomd.util.print_status_line();
     # broadcast from rank 0
     cpp_snapshot._broadcast_all(0, hoomd.context.exec_conf);
 

--- a/hoomd/deprecated/init.py
+++ b/hoomd/deprecated/init.py
@@ -50,9 +50,8 @@ def read_xml(filename, restart = None, time_step = None, wrap_coordinates = Fals
     coordinates will result in an error.
 
     """
-    hoomd.util.print_status_line();
-
     hoomd.context._verify_init();
+    hoomd.util.print_status_line();
 
     # check if initialization has already occurred
     if hoomd.init.is_initialized():
@@ -116,9 +115,8 @@ def create_random(N, phi_p=None, name="A", min_dist=0.7, box=None, seed=1, dimen
     and/or change particle properties later in the script. See :py:mod:`hoomd.data` for more information.
 
     """
-    hoomd.util.print_status_line();
-
     hoomd.context._verify_init();
+    hoomd.util.print_status_line();
 
     # check if initialization has already occurred
     if hoomd.init.is_initialized():
@@ -279,9 +277,8 @@ def create_random_polymers(box, polymers, separation, seed=1):
         bonds (bond.fene).
 
     """
-    hoomd.util.print_status_line();
-
     hoomd.context._verify_init();
+    hoomd.util.print_status_line();
 
     # check if initialization has already occurred
     if hoomd.init.is_initialized():

--- a/hoomd/init.py
+++ b/hoomd/init.py
@@ -60,9 +60,8 @@ def create_lattice(unitcell, n):
         hoomd.init.create_lattice(unitcell=hoomd.lattice.hex(a=1.0),
                                   n=[100,58]);
     """
-    hoomd.util.print_status_line();
-
     hoomd.context._verify_init();
+    hoomd.util.print_status_line();
 
     # check if initialization has already occurred
     if is_initialized():
@@ -167,9 +166,8 @@ def read_getar(filename, modes={'any': 'any'}):
        "velocity", "float", "(N, 3)", "velocity of each particle in the system"
 
     """
-    hoomd.util.print_status_line();
-
     hoomd.context._verify_init();
+    hoomd.util.print_status_line();
 
     # check if initialization has already occurred
     if is_initialized():
@@ -229,9 +227,8 @@ def read_snapshot(snapshot):
     See Also:
         :py:mod:`hoomd.data`
     """
-    hoomd.util.print_status_line();
-
     hoomd.context._verify_init();
+    hoomd.util.print_status_line();
 
     # check if initialization has already occurred
     if is_initialized():
@@ -279,9 +276,8 @@ def read_gsd(filename, restart = None, frame = 0, time_step = None):
     See Also:
         :py:class:`hoomd.dump.gsd`
     """
-    hoomd.util.print_status_line();
-
     hoomd.context._verify_init();
+    hoomd.util.print_status_line();
 
     # check if initialization has already occurred
     if is_initialized():

--- a/hoomd/jit/patch.py
+++ b/hoomd/jit/patch.py
@@ -107,8 +107,7 @@ class user(object):
 
         # check if initialization has occurred
         if hoomd.context.exec_conf is None:
-            hoomd.context.msg.error("Cannot create patch energy before context initialization\n");
-            raise RuntimeError('Error creating patch energy');
+            raise RuntimeError('Error creating patch energy, call context.initialize() first');
 
         # raise an error if this run is on the GPU
         if hoomd.context.exec_conf.isCUDAEnabled():
@@ -278,8 +277,7 @@ class user_union(user):
 
         # check if initialization has occurred
         if hoomd.context.exec_conf is None:
-            hoomd.context.msg.error("Cannot create patch energy before context initialization\n");
-            raise RuntimeError('Error creating patch energy');
+            raise RuntimeError('Error creating patch energy, call context.initialize() first');
 
         if clang_exec is not None:
             clang = clang_exec;

--- a/hoomd/module.cc
+++ b/hoomd/module.cc
@@ -250,7 +250,7 @@ void finalize_mpi()
 void abort_mpi(std::shared_ptr<ExecutionConfiguration> exec_conf)
     {
     #ifdef ENABLE_MPI
-    if(exec_conf->getNRanksGlobal() > 1)
+    if(exec_conf->getMPIConfig()->getNRanksGlobal() > 1)
         {
         MPI_Abort(exec_conf->getMPICommunicator(), MPI_ERR_OTHER);
         }
@@ -328,6 +328,7 @@ PYBIND11_MODULE(_hoomd, m)
     export_BoxDim(m);
     export_ParticleData(m);
     export_SnapshotParticleData(m);
+    export_MPIConfiguration(m);
     export_ExecutionConfiguration(m);
     export_SystemDefinition(m);
     export_SnapshotSystemData(m);

--- a/hoomd/mpcd/test/cell_communicator_mpi_test.cc
+++ b/hoomd/mpcd/test/cell_communicator_mpi_test.cc
@@ -196,8 +196,8 @@ UP_TEST( mpcd_cell_communicator )
         std::shared_ptr<ExecutionConfiguration> exec_conf(new ExecutionConfiguration(ExecutionConfiguration::CPU,
                                                                                      std::vector<int>(),
                                                                                      false,
-                                                                                     false,
-                                                                                     2));
+                                                                                     false));
+        exec_conf->getMPIConfig()->splitPartitions(2);
         cell_communicator_reduce_test(exec_conf, true, false, false);
         cell_communicator_reduce_test(exec_conf, false, true, false);
         cell_communicator_reduce_test(exec_conf, false, false, true);
@@ -207,8 +207,8 @@ UP_TEST( mpcd_cell_communicator )
         std::shared_ptr<ExecutionConfiguration> exec_conf(new ExecutionConfiguration(ExecutionConfiguration::CPU,
                                                                                      std::vector<int>(),
                                                                                      false,
-                                                                                     false,
-                                                                                     4));
+                                                                                     false));
+        exec_conf->getMPIConfig()->splitPartitions(4);
         cell_communicator_reduce_test(exec_conf, true, true, false);
         cell_communicator_reduce_test(exec_conf, true, false, true);
         cell_communicator_reduce_test(exec_conf, false, true, true);
@@ -216,10 +216,8 @@ UP_TEST( mpcd_cell_communicator )
     // mpi in 3d
         {
         std::shared_ptr<ExecutionConfiguration> exec_conf(new ExecutionConfiguration(ExecutionConfiguration::CPU,
-                                                                                     std::vector<int>(),
-                                                                                     false,
-                                                                                     false,
-                                                                                     8));
+                                                                                     std::vector<int>()));
+        exec_conf->getMPIConfig()->splitPartitions(8);
         cell_communicator_reduce_test(exec_conf, true, true, true);
         }
     }
@@ -240,8 +238,8 @@ UP_TEST( mpcd_cell_communicator_gpu )
         std::shared_ptr<ExecutionConfiguration> exec_conf(new ExecutionConfiguration(ExecutionConfiguration::GPU,
                                                                                      std::vector<int>(),
                                                                                      false,
-                                                                                     false,
-                                                                                     2));
+                                                                                     false));
+        exec_conf->getMPIConfig()->splitPartitions(2);
         cell_communicator_reduce_test(exec_conf, true, false, false);
         cell_communicator_reduce_test(exec_conf, false, true, false);
         cell_communicator_reduce_test(exec_conf, false, false, true);
@@ -251,8 +249,8 @@ UP_TEST( mpcd_cell_communicator_gpu )
         std::shared_ptr<ExecutionConfiguration> exec_conf(new ExecutionConfiguration(ExecutionConfiguration::GPU,
                                                                                      std::vector<int>(),
                                                                                      false,
-                                                                                     false,
-                                                                                     4));
+                                                                                     false));
+        exec_conf->getMPIConfig()->splitPartitions(4);
         cell_communicator_reduce_test(exec_conf, true, true, false);
         cell_communicator_reduce_test(exec_conf, true, false, true);
         cell_communicator_reduce_test(exec_conf, false, true, true);
@@ -262,8 +260,8 @@ UP_TEST( mpcd_cell_communicator_gpu )
         std::shared_ptr<ExecutionConfiguration> exec_conf(new ExecutionConfiguration(ExecutionConfiguration::GPU,
                                                                                      std::vector<int>(),
                                                                                      false,
-                                                                                     false,
-                                                                                     8));
+                                                                                     false));
+        exec_conf->getMPIConfig()->splitPartitions(8);
         cell_communicator_reduce_test(exec_conf, true, true, true);
         }
     }

--- a/hoomd/mpcd/test/cell_communicator_mpi_test.cc
+++ b/hoomd/mpcd/test/cell_communicator_mpi_test.cc
@@ -197,7 +197,6 @@ UP_TEST( mpcd_cell_communicator )
                                                                                      std::vector<int>(),
                                                                                      false,
                                                                                      false,
-                                                                                     std::shared_ptr<Messenger>(),
                                                                                      2));
         cell_communicator_reduce_test(exec_conf, true, false, false);
         cell_communicator_reduce_test(exec_conf, false, true, false);
@@ -209,7 +208,6 @@ UP_TEST( mpcd_cell_communicator )
                                                                                      std::vector<int>(),
                                                                                      false,
                                                                                      false,
-                                                                                     std::shared_ptr<Messenger>(),
                                                                                      4));
         cell_communicator_reduce_test(exec_conf, true, true, false);
         cell_communicator_reduce_test(exec_conf, true, false, true);
@@ -221,7 +219,6 @@ UP_TEST( mpcd_cell_communicator )
                                                                                      std::vector<int>(),
                                                                                      false,
                                                                                      false,
-                                                                                     std::shared_ptr<Messenger>(),
                                                                                      8));
         cell_communicator_reduce_test(exec_conf, true, true, true);
         }
@@ -244,7 +241,6 @@ UP_TEST( mpcd_cell_communicator_gpu )
                                                                                      std::vector<int>(),
                                                                                      false,
                                                                                      false,
-                                                                                     std::shared_ptr<Messenger>(),
                                                                                      2));
         cell_communicator_reduce_test(exec_conf, true, false, false);
         cell_communicator_reduce_test(exec_conf, false, true, false);
@@ -256,7 +252,6 @@ UP_TEST( mpcd_cell_communicator_gpu )
                                                                                      std::vector<int>(),
                                                                                      false,
                                                                                      false,
-                                                                                     std::shared_ptr<Messenger>(),
                                                                                      4));
         cell_communicator_reduce_test(exec_conf, true, true, false);
         cell_communicator_reduce_test(exec_conf, true, false, true);
@@ -268,7 +263,6 @@ UP_TEST( mpcd_cell_communicator_gpu )
                                                                                      std::vector<int>(),
                                                                                      false,
                                                                                      false,
-                                                                                     std::shared_ptr<Messenger>(),
                                                                                      8));
         cell_communicator_reduce_test(exec_conf, true, true, true);
         }

--- a/hoomd/mpcd/test/cell_list_mpi_test.cc
+++ b/hoomd/mpcd/test/cell_list_mpi_test.cc
@@ -1365,8 +1365,8 @@ UP_TEST( mpcd_cell_list_dimensions )
         std::shared_ptr<ExecutionConfiguration> exec_conf(new ExecutionConfiguration(ExecutionConfiguration::CPU,
                                                                                      std::vector<int>(),
                                                                                      false,
-                                                                                     false,
-                                                                                     2));
+                                                                                     false));
+        exec_conf->getMPIConfig()->splitPartitions(2);
         celllist_dimension_test<mpcd::CellList>(exec_conf, true, false, false);
         celllist_dimension_test<mpcd::CellList>(exec_conf, false, true, false);
         celllist_dimension_test<mpcd::CellList>(exec_conf, false, false, true);
@@ -1376,8 +1376,8 @@ UP_TEST( mpcd_cell_list_dimensions )
         std::shared_ptr<ExecutionConfiguration> exec_conf(new ExecutionConfiguration(ExecutionConfiguration::CPU,
                                                                                      std::vector<int>(),
                                                                                      false,
-                                                                                     false,
-                                                                                     4));
+                                                                                     false));
+        exec_conf->getMPIConfig()->splitPartitions(4);
         celllist_dimension_test<mpcd::CellList>(exec_conf, true, true, false);
         celllist_dimension_test<mpcd::CellList>(exec_conf, true, false, true);
         celllist_dimension_test<mpcd::CellList>(exec_conf, false, true, true);
@@ -1387,8 +1387,8 @@ UP_TEST( mpcd_cell_list_dimensions )
         std::shared_ptr<ExecutionConfiguration> exec_conf(new ExecutionConfiguration(ExecutionConfiguration::CPU,
                                                                                      std::vector<int>(),
                                                                                      false,
-                                                                                     false,
-                                                                                     8));
+                                                                                     false));
+        exec_conf->getMPIConfig()->splitPartitions(8);
         celllist_dimension_test<mpcd::CellList>(exec_conf, true, true, true);
         }
     }
@@ -1414,8 +1414,8 @@ UP_TEST( mpcd_cell_list_gpu_dimensions )
         std::shared_ptr<ExecutionConfiguration> exec_conf(new ExecutionConfiguration(ExecutionConfiguration::GPU,
                                                                                      std::vector<int>(),
                                                                                      false,
-                                                                                     false,
-                                                                                     2));
+                                                                                     false));
+        exec_conf->getMPIConfig()->splitPartitions(2);
         celllist_dimension_test<mpcd::CellListGPU>(exec_conf, true, false, false);
         celllist_dimension_test<mpcd::CellListGPU>(exec_conf, false, true, false);
         celllist_dimension_test<mpcd::CellListGPU>(exec_conf, false, false, true);
@@ -1425,8 +1425,8 @@ UP_TEST( mpcd_cell_list_gpu_dimensions )
         std::shared_ptr<ExecutionConfiguration> exec_conf(new ExecutionConfiguration(ExecutionConfiguration::GPU,
                                                                                      std::vector<int>(),
                                                                                      false,
-                                                                                     false,
-                                                                                     4));
+                                                                                     false));
+        exec_conf->getMPIConfig()->splitPartitions(4);
         celllist_dimension_test<mpcd::CellListGPU>(exec_conf, true, true, false);
         celllist_dimension_test<mpcd::CellListGPU>(exec_conf, true, false, true);
         celllist_dimension_test<mpcd::CellListGPU>(exec_conf, false, true, true);
@@ -1436,8 +1436,8 @@ UP_TEST( mpcd_cell_list_gpu_dimensions )
         std::shared_ptr<ExecutionConfiguration> exec_conf(new ExecutionConfiguration(ExecutionConfiguration::GPU,
                                                                                      std::vector<int>(),
                                                                                      false,
-                                                                                     false,
-                                                                                     8));
+                                                                                     false));
+        exec_conf->getMPIConfig()->splitPartitions(8);
         celllist_dimension_test<mpcd::CellListGPU>(exec_conf, true, true, true);
         }
     }

--- a/hoomd/mpcd/test/cell_list_mpi_test.cc
+++ b/hoomd/mpcd/test/cell_list_mpi_test.cc
@@ -1366,7 +1366,6 @@ UP_TEST( mpcd_cell_list_dimensions )
                                                                                      std::vector<int>(),
                                                                                      false,
                                                                                      false,
-                                                                                     std::shared_ptr<Messenger>(),
                                                                                      2));
         celllist_dimension_test<mpcd::CellList>(exec_conf, true, false, false);
         celllist_dimension_test<mpcd::CellList>(exec_conf, false, true, false);
@@ -1378,7 +1377,6 @@ UP_TEST( mpcd_cell_list_dimensions )
                                                                                      std::vector<int>(),
                                                                                      false,
                                                                                      false,
-                                                                                     std::shared_ptr<Messenger>(),
                                                                                      4));
         celllist_dimension_test<mpcd::CellList>(exec_conf, true, true, false);
         celllist_dimension_test<mpcd::CellList>(exec_conf, true, false, true);
@@ -1390,7 +1388,6 @@ UP_TEST( mpcd_cell_list_dimensions )
                                                                                      std::vector<int>(),
                                                                                      false,
                                                                                      false,
-                                                                                     std::shared_ptr<Messenger>(),
                                                                                      8));
         celllist_dimension_test<mpcd::CellList>(exec_conf, true, true, true);
         }
@@ -1418,7 +1415,6 @@ UP_TEST( mpcd_cell_list_gpu_dimensions )
                                                                                      std::vector<int>(),
                                                                                      false,
                                                                                      false,
-                                                                                     std::shared_ptr<Messenger>(),
                                                                                      2));
         celllist_dimension_test<mpcd::CellListGPU>(exec_conf, true, false, false);
         celllist_dimension_test<mpcd::CellListGPU>(exec_conf, false, true, false);
@@ -1430,7 +1426,6 @@ UP_TEST( mpcd_cell_list_gpu_dimensions )
                                                                                      std::vector<int>(),
                                                                                      false,
                                                                                      false,
-                                                                                     std::shared_ptr<Messenger>(),
                                                                                      4));
         celllist_dimension_test<mpcd::CellListGPU>(exec_conf, true, true, false);
         celllist_dimension_test<mpcd::CellListGPU>(exec_conf, true, false, true);
@@ -1442,7 +1437,6 @@ UP_TEST( mpcd_cell_list_gpu_dimensions )
                                                                                      std::vector<int>(),
                                                                                      false,
                                                                                      false,
-                                                                                     std::shared_ptr<Messenger>(),
                                                                                      8));
         celllist_dimension_test<mpcd::CellListGPU>(exec_conf, true, true, true);
         }

--- a/hoomd/mpcd/test/communicator_mpi_test.cc
+++ b/hoomd/mpcd/test/communicator_mpi_test.cc
@@ -777,7 +777,6 @@ UP_TEST( mpcd_communicator_overdecompose_test )
                                                                   std::vector<int>(),
                                                                   false,
                                                                   false,
-                                                                  std::shared_ptr<Messenger>(),
                                                                   2);
         test_communicator_overdecompose(exec_conf, 2, 1, 1, false);
         test_communicator_overdecompose(exec_conf, 1, 2, 1, false);
@@ -789,7 +788,6 @@ UP_TEST( mpcd_communicator_overdecompose_test )
                                                                   std::vector<int>(),
                                                                   false,
                                                                   false,
-                                                                  std::shared_ptr<Messenger>(),
                                                                   4);
         test_communicator_overdecompose(exec_conf, 4, 1, 1, false);
         test_communicator_overdecompose(exec_conf, 1, 4, 1, false);
@@ -801,7 +799,6 @@ UP_TEST( mpcd_communicator_overdecompose_test )
                                                                   std::vector<int>(),
                                                                   false,
                                                                   false,
-                                                                  std::shared_ptr<Messenger>(),
                                                                   8);
         test_communicator_overdecompose(exec_conf, 8, 1, 1, true);
         test_communicator_overdecompose(exec_conf, 1, 8, 1, true);

--- a/hoomd/mpcd/test/communicator_mpi_test.cc
+++ b/hoomd/mpcd/test/communicator_mpi_test.cc
@@ -776,8 +776,8 @@ UP_TEST( mpcd_communicator_overdecompose_test )
         auto exec_conf = std::make_shared<ExecutionConfiguration>(ExecutionConfiguration::CPU,
                                                                   std::vector<int>(),
                                                                   false,
-                                                                  false,
-                                                                  2);
+                                                                  false);
+        exec_conf->getMPIConfig()->splitPartitions(2);
         test_communicator_overdecompose(exec_conf, 2, 1, 1, false);
         test_communicator_overdecompose(exec_conf, 1, 2, 1, false);
         test_communicator_overdecompose(exec_conf, 1, 1, 2, false);
@@ -787,8 +787,8 @@ UP_TEST( mpcd_communicator_overdecompose_test )
         auto exec_conf = std::make_shared<ExecutionConfiguration>(ExecutionConfiguration::CPU,
                                                                   std::vector<int>(),
                                                                   false,
-                                                                  false,
-                                                                  4);
+                                                                  false);
+        exec_conf->getMPIConfig()->splitPartitions(4);
         test_communicator_overdecompose(exec_conf, 4, 1, 1, false);
         test_communicator_overdecompose(exec_conf, 1, 4, 1, false);
         test_communicator_overdecompose(exec_conf, 1, 1, 4, false);
@@ -798,8 +798,8 @@ UP_TEST( mpcd_communicator_overdecompose_test )
         auto exec_conf = std::make_shared<ExecutionConfiguration>(ExecutionConfiguration::CPU,
                                                                   std::vector<int>(),
                                                                   false,
-                                                                  false,
-                                                                  8);
+                                                                  false);
+        exec_conf->getMPIConfig()->splitPartitions(8);
         test_communicator_overdecompose(exec_conf, 8, 1, 1, true);
         test_communicator_overdecompose(exec_conf, 1, 8, 1, true);
         test_communicator_overdecompose(exec_conf, 1, 1, 8, true);

--- a/hoomd/option.py
+++ b/hoomd/option.py
@@ -191,12 +191,7 @@ def _parse_command_line(arg_string=None):
         if not _hoomd.is_MPI_available():
             hoomd.context.msg.error("The --nrank option is only available in MPI builds.\n");
             raise RuntimeError('Error setting option');
-        # check validity
-        nrank = int(cmd_options.nrank)
-        if (_hoomd.ExecutionConfiguration.getNRanksGlobal() % nrank):
-            hoomd.context.msg.error("Total number of ranks is not a multiple of --nrank\n");
-            raise RuntimeError('Error checking option');
-        hoomd.context.options.nrank = nrank
+        hoomd.context.options.nrank = int(cmd_options.nrank)
 
     if cmd_options.user is not None:
         hoomd.context.options.user = shlex.split(cmd_options.user);

--- a/hoomd/option.py
+++ b/hoomd/option.py
@@ -125,7 +125,7 @@ def _parse_command_line(arg_string=None):
     # Convert nx to an integer
     if cmd_options.nx is not None:
         if not _hoomd.is_MPI_available():
-            hoomd.context.msg.error("The --nx option is only available in MPI builds.\n");
+            parser.error("The --nx option is only available in MPI builds.\n");
             raise RuntimeError('Error setting option');
         try:
             cmd_options.nx = int(cmd_options.nx);
@@ -135,7 +135,7 @@ def _parse_command_line(arg_string=None):
     # Convert ny to an integer
     if cmd_options.ny is not None:
         if not _hoomd.is_MPI_available():
-            hoomd.context.msg.error("The --ny option is only available in MPI builds.\n");
+            parser.error("The --ny option is only available in MPI builds.\n");
             raise RuntimeError('Error setting option');
         try:
             cmd_options.ny = int(cmd_options.ny);
@@ -145,7 +145,7 @@ def _parse_command_line(arg_string=None):
     # Convert nz to an integer
     if cmd_options.nz is not None:
        if not _hoomd.is_MPI_available():
-            hoomd.context.msg.error("The --nz option is only available in MPI builds.\n");
+            parser.error("The --nz option is only available in MPI builds.\n");
             raise RuntimeError('Error setting option');
        try:
             cmd_options.nz = int(cmd_options.nz);
@@ -155,7 +155,7 @@ def _parse_command_line(arg_string=None):
     # Convert nthreads to an integer
     if cmd_options.nthreads is not None:
        if not _hoomd.is_TBB_available():
-            hoomd.context.msg.error("The --nthreads option is only available in TBB-enabled builds.\n");
+            parser.error("The --nthreads option is only available in TBB-enabled builds.\n");
             raise RuntimeError('Error setting option');
        try:
             cmd_options.nthreads = int(cmd_options.nthreads);
@@ -178,20 +178,14 @@ def _parse_command_line(arg_string=None):
     hoomd.context.options.single_mpi = cmd_options.single_mpi
     hoomd.context.options.nthreads = cmd_options.nthreads
 
-    if cmd_options.notice_level is not None:
-        hoomd.context.options.notice_level = cmd_options.notice_level;
-        hoomd.context.msg.setNoticeLevel(hoomd.context.options.notice_level);
-
-    if cmd_options.msg_file is not None:
-        hoomd.context.options.msg_file = cmd_options.msg_file;
-        hoomd.context.msg.openFile(hoomd.context.options.msg_file);
+    hoomd.context.options.notice_level = cmd_options.notice_level;
+    hoomd.context.options.msg_file = cmd_options.msg_file;
 
     if cmd_options.shared_msg_file is not None:
         if not _hoomd.is_MPI_available():
-            hoomd.context.msg.error("Shared log files are only available in MPI builds.\n");
+            parser.error("Shared log files are only available in MPI builds.\n");
             raise RuntimeError('Error setting option');
         hoomd.context.options.shared_msg_file = cmd_options.shared_msg_file;
-        hoomd.context.msg.setSharedFile(hoomd.context.options.shared_msg_file);
 
     if cmd_options.nrank is not None:
         if not _hoomd.is_MPI_available():


### PR DESCRIPTION
## Description

Fix the usage of `MPI_COMM_WORLD` in Messenger.cc by passing it the `hoomd_world` communicator.

**EDIT** I refactored the MPI configuration as we discussed. There is now an `MPIConfiguration` class that handles the communicator handle and splits it as necessary. The three important data structures are created inside `context.py` in this order:

1. MPIConfiguration (MPI related tasks)
2. Messenger (Messaging I/O)
3. ExecutionConfiguration (per-rank parallel execution configuration)

Some MPI related routines that pertain specifically to GPUs (`guessLocalRank()`) were left in `ExecutionConfiguration`

## Motivation and Context

In `mpi4py` jobs with custom communicator arguments to `context.initialize()` we need to honor these options, otherwise the MPI RMA calls in `Messenger` will cause hangs.

## How Has This Been Tested?

Standard unit tests. I confirmed that `--msg-file` and `--shared-msg-file` work as advertised. Setting up unit tests for command line options would be good, but I'd like to defer that to the future. Also, possibly a mpi4py unit test would be good.

## Change log
```
- Fix a problem where HOOMD could not be imported in `mpi4py` jobs
- Refactor handling of MPI_Comm inside library (for developers)
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/hoomd-blue/blob/master/sphinx-doc/credits.rst).
