### PR TITLE
Support LLVM 8

### DIFF
--- a/hoomd/jit/KaleidoscopeJIT.h
+++ b/hoomd/jit/KaleidoscopeJIT.h
@@ -37,8 +37,8 @@
 
 #include <memory>
 
-// use legacy interfaces in LLVM 9
-#if defined LLVM_VERSION_MAJOR && LLVM_VERSION_MAJOR >= 9
+// use legacy interfaces in LLVM 8 and 9
+#if defined LLVM_VERSION_MAJOR && LLVM_VERSION_MAJOR >= 8
 
 #define RTDYLDOBJECTLINKINGLAYER LegacyRTDyldObjectLinkingLayer
 #define IRCOMPILELAYER LegacyIRCompileLayer


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should based on *maint*. -->
<!-- New features should based on *master*. -->

## Description

Add support for LLVM 8

## Motivation and Context

Compilation currently fails with LLVM8.

## How Has This Been Tested?

Tested locally on a system with llvm 8 installed. CI containers do not yet have llvm 8 available.

## Change log

<!-- Propose a change log entry. -->
```
* Fix compile errors with LLVM 8 and ``-DBUILD_JIT=on``
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/hoomd-blue/blob/master/sphinx-doc/credits.rst).
