### PR TITLE
Update depletants for random123

### DIFF
--- a/hoomd/RNGIdentifiers.h
+++ b/hoomd/RNGIdentifiers.h
@@ -27,6 +27,7 @@ struct RNGIdentifier
     static const uint32_t HPMCMonoShuffle = 0xfa870af6;
     static const uint32_t HPMCMonoTrialMove = 0x754dea60;
     static const uint32_t HPMCMonoShift = 0xf4a3210e;
+    static const uint32_t HPMCDepletants = 0x6b71abc8;
     static const uint32_t UpdaterBoxMC= 0xf6a510ab;
     static const uint32_t UpdaterClusters =  0x09365bf5;
     static const uint32_t UpdaterClustersPairwise = 0x50060112;

--- a/hoomd/RandomNumbers.h
+++ b/hoomd/RandomNumbers.h
@@ -3,7 +3,7 @@
 
 /*!
    \file RandomNumbers.h
-   \brief Declaration of mpcd::RandomNumbers
+   \brief Declaration of hoomd::RandomNumbers
 
    This header includes templated generators for various types of random numbers required used throughout hoomd. These
    work with the RandomGenerator generator that wraps random123's Philox4x32 RNG with an API that handles streams of
@@ -602,6 +602,6 @@ class PoissonDistribution
           }
     };
 
-} // end namespace mpcd
+} // end namespace hoomd
 
 #endif // #define HOOMD_RANDOM_NUMBERS_H_

--- a/hoomd/hpmc/Moves.h
+++ b/hoomd/hpmc/Moves.h
@@ -229,9 +229,9 @@ DEVICE inline vec3<Scalar> generatePositionInAABB(RNG& rng, const detail::AABB& 
     vec3<Scalar> lower = aabb.getLower();
     vec3<Scalar> upper = aabb.getUpper();
 
-    p.x = rng.template s<Scalar>(lower.x, upper.x);
-    p.y = rng.template s<Scalar>(lower.y, upper.y);
-    p.z = rng.template s<Scalar>(lower.z, upper.z);
+    p.x = hoomd::UniformDistribution<Scalar>(lower.x, upper.x)(rng);
+    p.y = hoomd::UniformDistribution<Scalar>(lower.y, upper.y)(rng);
+    p.z = hoomd::UniformDistribution<Scalar>(lower.z, upper.z)(rng);
 
     return p;
     }


### PR DESCRIPTION
## Description

Update `IntegratorHPMCMonoImplicit` to the new random123 API. I left Saru in place for the common parts in the loop between `IntegratorHPMCMono` and `IntegratorHPMCMonoImplicit`, as I plan to unify those classes later.

## Motivation and Context

`random123` replaces `Saru`.

## How Has This Been Tested?

Existing unit and validation tests.

## Change log

```
- Update random number generation for depletants to use the random123 library
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/hoomd-blue/blob/master/sphinx-doc/credits.rst).
