### PR TITLE
Install new RNG API headers

### DIFF
--- a/hoomd/CMakeLists.txt
+++ b/hoomd/CMakeLists.txt
@@ -129,6 +129,7 @@ set(_hoomd_headers
     ParticleGroup.cuh
     ParticleGroup.h
     Profiler.h
+    RandomNumbers.h
     Saru.h
     SFCPackUpdaterGPU.cuh
     SFCPackUpdaterGPU.h

--- a/hoomd/CMakeLists.txt
+++ b/hoomd/CMakeLists.txt
@@ -130,6 +130,7 @@ set(_hoomd_headers
     ParticleGroup.h
     Profiler.h
     RandomNumbers.h
+    RNGIdentifiers.h
     Saru.h
     SFCPackUpdaterGPU.cuh
     SFCPackUpdaterGPU.h


### PR DESCRIPTION

## Description

Fix plugins that use the RNG API, by installing the relevant headers.

## Motivation and Context

This came up in the context of porting the new HPMC GPU integrator from the plugin to the main repository.

## How Has This Been Tested?

by compiling a plugin (offline)

## Change log

none needed, as this is against master

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/hoomd-blue/blob/master/sphinx-doc/credits.rst).
