### PR TITLE
Remove compute 3.0

### DIFF
--- a/CMake/hoomd/HOOMDCUDASetup.cmake
+++ b/CMake/hoomd/HOOMDCUDASetup.cmake
@@ -53,9 +53,9 @@ if (ENABLE_CUDA)
 
     # setup nvcc to build for all CUDA architectures. Allow user to modify the list if desired
     if (CUDA_VERSION VERSION_GREATER 8.99)
-        set(CUDA_ARCH_LIST 30 35 50 60 70 CACHE STRING "List of target sm_ architectures to compile CUDA code for. Separate with semicolons.")
+        set(CUDA_ARCH_LIST 35 50 60 70 CACHE STRING "List of target sm_ architectures to compile CUDA code for. Separate with semicolons.")
     elseif (CUDA_VERSION VERSION_GREATER 7.99)
-        set(CUDA_ARCH_LIST 30 35 50 60 CACHE STRING "List of target sm_ architectures to compile CUDA code for. Separate with semicolons.")
+        set(CUDA_ARCH_LIST 35 50 60 CACHE STRING "List of target sm_ architectures to compile CUDA code for. Separate with semicolons.")
     endif()
 
     foreach(_cuda_arch ${CUDA_ARCH_LIST})
@@ -69,8 +69,8 @@ if (ENABLE_CUDA)
     list(GET _cuda_arch_list_sorted -1 _cuda_max_arch)
     add_definitions(-DCUDA_ARCH=${_cuda_min_arch})
 
-    if (_cuda_min_arch LESS 30)
-        message(SEND_ERROR "HOOMD requires compute 3.0 or newer")
+    if (_cuda_min_arch LESS 35)
+        message(SEND_ERROR "HOOMD requires compute 3.5 or newer")
     endif ()
 
     # only generate ptx code for the maximum supported CUDA_ARCH (saves on file size)

--- a/hoomd/TextureTools.h
+++ b/hoomd/TextureTools.h
@@ -10,70 +10,30 @@
 /*! \file TextureTools.h
     \brief Utilities for working with textures
 
-    TextureTools.h exists to aid in defining Scalar textures which may be either float or double. It aims to simplify
-    code that reads from these textures so that the amount of conditional code is simplified to be entirely within
-    this header.
+    TextureTools.h previously existed to aid in defining Scalar textures which may be either float or double.
 
-    Planning for the future (__ldg), the fetch methods will also take in a pointer to the memory. That way, the initial
-    work done to convert the texture loads over to the single/double will also make it easy to change over to __ldg
-    in a single spot.
+    Now, it only provides a __ldg() overload for double4.
 */
 
 #include "HOOMDMath.h"
 
 #ifdef NVCC
 
-//! Fetch an unsigned int from texture memory.
+//! Fetch a double4 value from texture memory.
 /*! This function should be called whenever a CUDA kernel wants to retrieve a
-    unsigned int value from texture memory.
+    double4 value from read only memory.
 
-    \param ptr Pointer to bound memory
-    \param tex_ref Texture in which the desired values are stored.
-    \param ii Index at which to look.
+    \param ptr Pointer to read
 */
-__device__ inline unsigned int texFetchUint(const unsigned int *ptr, texture<unsigned int, 1> tex_ref, unsigned int ii)
+__device__ inline double4 __ldg(const double4 *ptr)
     {
-    #if __CUDA_ARCH__ >= 350
-    return __ldg(ptr+ii);
-    #else
-    return tex1Dfetch(tex_ref, ii);
-    #endif
-    }
-
-#ifdef SINGLE_PRECISION
-
-//! Fetch a Scalar4 value from texture memory.
-/*! This function should called whenever a CUDA kernel wants to retrieve a
-    Scalar4 value from texture memory.
-
-    \param ptr Pointer to bound memory
-    \param ii Index at which to look.
-*/
-__device__ inline Scalar4 texFetchScalar4(const Scalar4 *ptr, unsigned int ii)
-    {
-    return __ldg(ptr+ii);
-    }
-
-#else
-
-//! Fetch a Scalar4 value from texture memory.
-/*! This function should be called whenever a CUDA kernel wants to retrieve a
-    Scalar4 value from texture memory.
-
-    \param ptr Pointer to bound memory
-    \param ii Index at which to look.
-*/
-__device__ inline Scalar4 texFetchScalar4(const Scalar4 *ptr, unsigned int ii)
-    {
-    unsigned int idx = 2*ii;
-    int4 part1 = __ldg(((int4 *)ptr)+idx);;
-    int4 part2 = __ldg(((int4 *)ptr)+idx+1);;
-    return make_scalar4(__hiloint2double(part1.y, part1.x),
+    int4 part1 = __ldg(((int4 *)ptr));;
+    int4 part2 = __ldg(((int4 *)ptr)+1);;
+    return make_double4(__hiloint2double(part1.y, part1.x),
                         __hiloint2double(part1.w, part1.z),
                         __hiloint2double(part2.y, part2.x),
                         __hiloint2double(part2.w, part2.z));
     }
-#endif
 #endif
 
 #endif // __HOOMD_MATH_H__

--- a/hoomd/TextureTools.h
+++ b/hoomd/TextureTools.h
@@ -42,46 +42,32 @@ __device__ inline unsigned int texFetchUint(const unsigned int *ptr, texture<uns
 
 #ifdef SINGLE_PRECISION
 
-typedef texture<Scalar4, 1, cudaReadModeElementType> scalar4_tex_t;
-
 //! Fetch a Scalar4 value from texture memory.
 /*! This function should called whenever a CUDA kernel wants to retrieve a
     Scalar4 value from texture memory.
 
     \param ptr Pointer to bound memory
-    \param tex_ref Texture in which the desired values are stored.
     \param ii Index at which to look.
 */
-__device__ inline Scalar4 texFetchScalar4(const Scalar4 *ptr, texture<Scalar4, 1> tex_ref, unsigned int ii)
+__device__ inline Scalar4 texFetchScalar4(const Scalar4 *ptr, unsigned int ii)
     {
-    #if __CUDA_ARCH__ >= 350
     return __ldg(ptr+ii);
-    #else
-    return tex1Dfetch(tex_ref, ii);
-    #endif
     }
 
 #else
-typedef texture<int4, 1, cudaReadModeElementType> scalar4_tex_t;
 
 //! Fetch a Scalar4 value from texture memory.
 /*! This function should be called whenever a CUDA kernel wants to retrieve a
     Scalar4 value from texture memory.
 
     \param ptr Pointer to bound memory
-    \param tex_ref Texture in which the desired values are stored.
     \param ii Index at which to look.
 */
-__device__ inline Scalar4 texFetchScalar4(const Scalar4 *ptr, texture<int4, 1> tex_ref, unsigned int ii)
+__device__ inline Scalar4 texFetchScalar4(const Scalar4 *ptr, unsigned int ii)
     {
     unsigned int idx = 2*ii;
-    #if __CUDA_ARCH__ >= 350
     int4 part1 = __ldg(((int4 *)ptr)+idx);;
     int4 part2 = __ldg(((int4 *)ptr)+idx+1);;
-    #else
-    int4 part1 = tex1Dfetch(tex_ref, idx);
-    int4 part2 = tex1Dfetch(tex_ref, idx+1);
-    #endif
     return make_scalar4(__hiloint2double(part1.y, part1.x),
                         __hiloint2double(part1.w, part1.z),
                         __hiloint2double(part2.y, part2.x),
@@ -89,7 +75,5 @@ __device__ inline Scalar4 texFetchScalar4(const Scalar4 *ptr, texture<int4, 1> t
     }
 #endif
 #endif
-
-
 
 #endif // __HOOMD_MATH_H__

--- a/hoomd/TextureTools.h
+++ b/hoomd/TextureTools.h
@@ -42,26 +42,8 @@ __device__ inline unsigned int texFetchUint(const unsigned int *ptr, texture<uns
 
 #ifdef SINGLE_PRECISION
 
-typedef texture<Scalar, 1, cudaReadModeElementType> scalar_tex_t;
 typedef texture<Scalar2, 1, cudaReadModeElementType> scalar2_tex_t;
 typedef texture<Scalar4, 1, cudaReadModeElementType> scalar4_tex_t;
-
-//! Fetch a Scalar value from texture memory.
-/*! This function should be called whenever a CUDA kernel wants to retrieve a
-    Scalar value from texture memory.
-
-    \param ptr Pointer to bound memory
-    \param tex_ref Texture in which the desired values are stored.
-    \param ii Index at which to look.
-*/
-__device__ inline Scalar texFetchScalar(const Scalar *ptr, texture<Scalar, 1> tex_ref, unsigned int ii)
-    {
-    #if __CUDA_ARCH__ >= 350
-    return __ldg(ptr+ii);
-    #else
-    return tex1Dfetch(tex_ref, ii);
-    #endif
-    }
 
 //! Fetch a Scalar2 value from texture memory.
 /*! This function should be called whenever a CUDA kernel wants to retrieve a
@@ -98,27 +80,8 @@ __device__ inline Scalar4 texFetchScalar4(const Scalar4 *ptr, texture<Scalar4, 1
     }
 
 #else
-typedef texture<int2, 1, cudaReadModeElementType> scalar_tex_t;
 typedef texture<int4, 1, cudaReadModeElementType> scalar2_tex_t;
 typedef texture<int4, 1, cudaReadModeElementType> scalar4_tex_t;
-
-//! Fetch a Scalar value from texture memory.
-/*! This function should be called whenever a CUDA kernel wants to retrieve a
-    Scalar value from texture memory.
-
-    \param ptr Pointer to bound memory
-    \param tex_ref Texture in which the desired values are stored.
-    \param ii Index at which to look.
-*/
-__device__ inline Scalar texFetchScalar(const Scalar *ptr, texture<int2, 1> tex_ref, unsigned int ii)
-    {
-    #if __CUDA_ARCH__ >= 350
-    return __ldg(ptr+ii);
-    #else
-    int2 val = tex1Dfetch(tex_ref, ii);
-    return Scalar(__hiloint2double(val.y, val.x));
-    #endif
-    }
 
 //! Fetch a Scalar2 value from texture memory.
 /*! This function should be called whenever a CUDA kernel wants to retrieve a

--- a/hoomd/TextureTools.h
+++ b/hoomd/TextureTools.h
@@ -42,25 +42,7 @@ __device__ inline unsigned int texFetchUint(const unsigned int *ptr, texture<uns
 
 #ifdef SINGLE_PRECISION
 
-typedef texture<Scalar2, 1, cudaReadModeElementType> scalar2_tex_t;
 typedef texture<Scalar4, 1, cudaReadModeElementType> scalar4_tex_t;
-
-//! Fetch a Scalar2 value from texture memory.
-/*! This function should be called whenever a CUDA kernel wants to retrieve a
-    Scalar2 value from texture memory.
-
-    \param ptr Pointer to bound memory
-    \param tex_ref Texture in which the desired values are stored.
-    \param ii Index at which to look.
-*/
-__device__ inline Scalar2 texFetchScalar2(const Scalar2 *ptr, texture<Scalar2, 1> tex_ref, unsigned int ii)
-    {
-    #if __CUDA_ARCH__ >= 350
-    return __ldg(ptr+ii);
-    #else
-    return tex1Dfetch(tex_ref, ii);
-    #endif
-    }
 
 //! Fetch a Scalar4 value from texture memory.
 /*! This function should called whenever a CUDA kernel wants to retrieve a
@@ -80,27 +62,7 @@ __device__ inline Scalar4 texFetchScalar4(const Scalar4 *ptr, texture<Scalar4, 1
     }
 
 #else
-typedef texture<int4, 1, cudaReadModeElementType> scalar2_tex_t;
 typedef texture<int4, 1, cudaReadModeElementType> scalar4_tex_t;
-
-//! Fetch a Scalar2 value from texture memory.
-/*! This function should be called whenever a CUDA kernel wants to retrieve a
-    Scalar2 value from texture memory.
-
-    \param ptr Pointer to bound memory
-    \param tex_ref Texture in which the desired values are stored.
-    \param ii Index at which to look.
-*/
-__device__ inline Scalar2 texFetchScalar2(const Scalar2* ptr, texture<int4, 1> tex_ref, unsigned int ii)
-    {
-    #if __CUDA_ARCH__ >= 350
-    return __ldg(ptr+ii);
-    #else
-    int4 val = tex1Dfetch(tex_ref, ii);
-    return make_scalar2(__hiloint2double(val.y, val.x),
-                        __hiloint2double(val.w, val.z));
-    #endif
-    }
 
 //! Fetch a Scalar4 value from texture memory.
 /*! This function should be called whenever a CUDA kernel wants to retrieve a

--- a/hoomd/cgcmm/CGCMMAngleForceComputeGPU.cc
+++ b/hoomd/cgcmm/CGCMMAngleForceComputeGPU.cc
@@ -133,8 +133,7 @@ void CGCMMAngleForceComputeGPU::computeForces(unsigned int timestep)
                                    d_CGCMMsr.data,
                                    d_CGCMMepow.data,
                                    m_CGCMMAngle_data->getNTypes(),
-                                   m_tuner->getParam(),
-                                   m_exec_conf->getComputeCapability());
+                                   m_tuner->getParam());
 
     if(m_exec_conf->isCUDAErrorCheckingEnabled())
         CHECK_CUDA_ERROR();

--- a/hoomd/cgcmm/CGCMMAngleForceGPU.cu
+++ b/hoomd/cgcmm/CGCMMAngleForceGPU.cu
@@ -16,9 +16,6 @@
     \brief Defines GPU kernel code for calculating the CGCMM angle forces. Used by CGCMMAngleForceComputeGPU.
 */
 
-//! Texture for reading angle CGCMM Epsilon-pow/pref parameters
-scalar4_tex_t angle_CGCMMepow_tex; // now with EPSILON=.x, pow1=.y, pow2=.z, pref=.w
-
 //! Kernel for calculating CGCMM angle forces on the GPU
 /*! \param d_force Device memory to write computed forces
     \param d_virial Device memory to write computed virials
@@ -155,7 +152,7 @@ extern "C" __global__ void gpu_compute_CGCMM_angle_forces_kernel(Scalar4* d_forc
 
         if (rac < cgrcut)
             {
-            const Scalar4 cgEPOW = texFetchScalar4(d_CGCMMepow, angle_CGCMMepow_tex, cur_angle_type);
+            const Scalar4 cgEPOW = texFetchScalar4(d_CGCMMepow, cur_angle_type);
 
             // get the angle pow/pref parameters (MEM TRANSFER: 12 bytes)
             Scalar cgeps = cgEPOW.x;
@@ -276,8 +273,7 @@ cudaError_t gpu_compute_CGCMM_angle_forces(Scalar4* d_force,
                                            Scalar2 *d_CGCMMsr,
                                            Scalar4 *d_CGCMMepow,
                                            unsigned int n_angle_types,
-                                           int block_size,
-                                           const unsigned int compute_capability)
+                                           int block_size)
     {
     assert(d_params);
     assert(d_CGCMMsr);
@@ -299,14 +295,6 @@ cudaError_t gpu_compute_CGCMM_angle_forces(Scalar4* d_force,
     // setup the grid to run the kernel
     dim3 grid( (int)ceil((double)N / (double)run_block_size), 1, 1);
     dim3 threads(run_block_size, 1, 1);
-
-    // bind the textures on pre sm 35 arches
-    if (compute_capability < 350)
-        {
-        cudaError_t error = cudaBindTexture(0, angle_CGCMMepow_tex, d_CGCMMepow, sizeof(Scalar4) * n_angle_types);
-        if (error != cudaSuccess)
-            return error;
-        }
 
     // run the kernel
     gpu_compute_CGCMM_angle_forces_kernel<<< grid, threads>>>(d_force,

--- a/hoomd/cgcmm/CGCMMAngleForceGPU.cu
+++ b/hoomd/cgcmm/CGCMMAngleForceGPU.cu
@@ -152,7 +152,7 @@ extern "C" __global__ void gpu_compute_CGCMM_angle_forces_kernel(Scalar4* d_forc
 
         if (rac < cgrcut)
             {
-            const Scalar4 cgEPOW = texFetchScalar4(d_CGCMMepow, cur_angle_type);
+            const Scalar4 cgEPOW = __ldg(d_CGCMMepow + cur_angle_type);
 
             // get the angle pow/pref parameters (MEM TRANSFER: 12 bytes)
             Scalar cgeps = cgEPOW.x;

--- a/hoomd/cgcmm/CGCMMAngleForceGPU.cuh
+++ b/hoomd/cgcmm/CGCMMAngleForceGPU.cuh
@@ -30,7 +30,6 @@ cudaError_t gpu_compute_CGCMM_angle_forces(Scalar4* d_force,
                                            Scalar2 *d_CGCMMsr,
                                            Scalar4 *d_CGCMMepow,
                                            unsigned int n_angle_types,
-                                           int block_size,
-                                           const unsigned int compute_capability);
+                                           int block_size);
 
 #endif

--- a/hoomd/cgcmm/CGCMMForceComputeGPU.cc
+++ b/hoomd/cgcmm/CGCMMForceComputeGPU.cc
@@ -165,9 +165,7 @@ void CGCMMForceComputeGPU::computeForces(unsigned int timestep)
                              this->m_nlist->getNListArray().getPitch(),
                              m_pdata->getNTypes(),
                              m_r_cut * m_r_cut,
-                             m_block_size,
-                             m_exec_conf->getComputeCapability()/10,
-                             m_exec_conf->dev_prop.maxTexture1DLinear);
+                             m_block_size);
     if (m_exec_conf->isCUDAErrorCheckingEnabled())
         CHECK_CUDA_ERROR();
 

--- a/hoomd/cgcmm/CGCMMForceGPU.cu
+++ b/hoomd/cgcmm/CGCMMForceGPU.cu
@@ -13,9 +13,6 @@
     \brief Defines GPU kernel code for calculating the Lennard-Jones pair forces. Used by CGCMMForceComputeGPU.
 */
 
-//! Texture for reading the neighbor list
-texture<unsigned int, 1, cudaReadModeElementType> nlist_tex;
-
 //! Kernel for calculating CG-CMM Lennard-Jones forces
 /*! This kernel is called to calculate the Lennard-Jones forces on all N particles for the CG-CMM model potential.
 
@@ -43,7 +40,6 @@ texture<unsigned int, 1, cudaReadModeElementType> nlist_tex;
     Each thread will calculate the total force on one particle.
     The neighborlist is arranged in columns so that reads are fully coalesced when doing this.
 */
-template<unsigned char use_gmem_nlist>
 __global__ void gpu_compute_cgcmm_forces_kernel(Scalar4* d_force,
                                                 Scalar* d_virial,
                                                 const unsigned int virial_pitch,
@@ -78,7 +74,7 @@ __global__ void gpu_compute_cgcmm_forces_kernel(Scalar4* d_force,
 
     // read in the position of our particle.
     // (MEM TRANSFER: 16 bytes)
-    Scalar4 postype = texFetchScalar4(d_pos, idx);
+    Scalar4 postype = __ldg(d_pos + idx);
     Scalar3 pos = make_scalar3(postype.x, postype.y, postype.z);
 
     // initialize the force to 0
@@ -90,14 +86,7 @@ __global__ void gpu_compute_cgcmm_forces_kernel(Scalar4* d_force,
     // prefetch neighbor index
     unsigned int cur_neigh = 0;
     unsigned int next_neigh(0);
-    if (use_gmem_nlist)
-        {
-        next_neigh = d_nlist[head_idx];
-        }
-    else
-        {
-        next_neigh = texFetchUint(d_nlist, nlist_tex, head_idx);
-        }
+    next_neigh = __ldg(d_nlist + head_idx);
 
     // loop over neighbors
     for (int neigh_idx = 0; neigh_idx < n_neigh; neigh_idx++)
@@ -105,17 +94,10 @@ __global__ void gpu_compute_cgcmm_forces_kernel(Scalar4* d_force,
         // read the current neighbor index (MEM TRANSFER: 4 bytes)
         // prefetch the next value and set the current one
         cur_neigh = next_neigh;
-        if (use_gmem_nlist)
-            {
-            next_neigh = d_nlist[head_idx + neigh_idx + 1];
-            }
-        else
-            {
-            next_neigh = texFetchUint(d_nlist, nlist_tex, head_idx + neigh_idx+1);
-            }
+        next_neigh = __ldg(d_nlist + head_idx + neigh_idx+1);
 
         // get the neighbor's position (MEM TRANSFER: 16 bytes)
-        Scalar4 neigh_postype = texFetchScalar4(d_pos, cur_neigh);
+        Scalar4 neigh_postype = __ldg(d_pos + cur_neigh);
         Scalar3 neigh_pos = make_scalar3(neigh_postype.x, neigh_postype.y, neigh_postype.z);
 
         // calculate dr (with periodic boundary conditions)
@@ -210,9 +192,7 @@ cudaError_t gpu_compute_cgcmm_forces(Scalar4* d_force,
                                      const unsigned int size_nlist,
                                      const unsigned int coeff_width,
                                      const Scalar r_cutsq,
-                                     const unsigned int block_size,
-                                     const unsigned int compute_capability,
-                                     const unsigned int max_tex1d_width)
+                                     const unsigned int block_size)
     {
     assert(d_coeffs);
     assert(coeff_width > 0);
@@ -221,50 +201,18 @@ cudaError_t gpu_compute_cgcmm_forces(Scalar4* d_force,
     dim3 grid( (int)ceil((double)N / (double)block_size), 1, 1);
     dim3 threads(block_size, 1, 1);
 
-    // bind the texture
-    if (compute_capability < 35)
-        {
-        if (size_nlist <= max_tex1d_width)
-            {
-            nlist_tex.normalized = false;
-            nlist_tex.filterMode = cudaFilterModePoint;
-            cudaError_t error = cudaBindTexture(0, nlist_tex, d_nlist, sizeof(unsigned int)*size_nlist);
-            if (error != cudaSuccess)
-                return error;
-            }
-        }
-
-    // run the kernel
-    if (compute_capability < 35 && size_nlist > max_tex1d_width)
-        { // fall back to slow global loads when the neighbor list is too big for texture memory
-        gpu_compute_cgcmm_forces_kernel<1><<< grid, threads, sizeof(Scalar4)*coeff_width*coeff_width >>>(d_force,
-                                                                                                      d_virial,
-                                                                                                      virial_pitch,
-                                                                                                      N,
-                                                                                                      d_pos,
-                                                                                                      box,
-                                                                                                      d_n_neigh,
-                                                                                                      d_nlist,
-                                                                                                      d_head_list,
-                                                                                                      d_coeffs,
-                                                                                                      coeff_width,
-                                                                                                      r_cutsq);
-        }
-    else
-        {
-        gpu_compute_cgcmm_forces_kernel<0><<< grid, threads, sizeof(Scalar4)*coeff_width*coeff_width >>>(d_force,
-                                                                                                      d_virial,
-                                                                                                      virial_pitch,
-                                                                                                      N,
-                                                                                                      d_pos,
-                                                                                                      box,
-                                                                                                      d_n_neigh,
-                                                                                                      d_nlist,
-                                                                                                      d_head_list,
-                                                                                                      d_coeffs,
-                                                                                                      coeff_width,
-                                                                                                      r_cutsq);
-        }
+    gpu_compute_cgcmm_forces_kernel<<< grid, threads, sizeof(Scalar4)*coeff_width*coeff_width >>>(d_force,
+                                                                                                  d_virial,
+                                                                                                  virial_pitch,
+                                                                                                  N,
+                                                                                                  d_pos,
+                                                                                                  box,
+                                                                                                  d_n_neigh,
+                                                                                                  d_nlist,
+                                                                                                  d_head_list,
+                                                                                                  d_coeffs,
+                                                                                                  coeff_width,
+                                                                                                  r_cutsq);
 
     return cudaSuccess;
     }

--- a/hoomd/cgcmm/CGCMMForceGPU.cuh
+++ b/hoomd/cgcmm/CGCMMForceGPU.cuh
@@ -29,8 +29,6 @@ cudaError_t gpu_compute_cgcmm_forces(Scalar4* d_force,
                                      const unsigned int size_nlist,
                                      const unsigned int coeff_width,
                                      const Scalar r_cutsq,
-                                     const unsigned int block_size,
-                                     const unsigned int compute_capability,
-                                     const unsigned int max_tex1d_width);
+                                     const unsigned int block_size);
 
 #endif

--- a/hoomd/dem/DEM2DForceGPU.cu
+++ b/hoomd/dem/DEM2DForceGPU.cu
@@ -165,10 +165,10 @@ __global__ void gpu_compute_dem2d_forces_kernel(const Scalar4 *d_pos,
         const unsigned int myHead(d_head_list[partIdx]);
 
         // fetch position and orientation of this particle
-        const Scalar4 postype(texFetchScalar4(d_pos, partIdx));
+        const Scalar4 postype(__ldg(d_pos + partIdx));
         const vec3<Scalar> pos_i(postype.x, postype.y, 0);
         const unsigned int type_i(__scalar_as_int(postype.w));
-        const Scalar4 quati(texFetchScalar4(d_quat, partIdx));
+        const Scalar4 quati(__ldg(d_quat + partIdx));
         const quat<Real> quat_i(quati.x, vec3<Real>(quati.y, quati.z, quati.w));
 
         Scalar di = 0.0f;
@@ -180,7 +180,7 @@ __global__ void gpu_compute_dem2d_forces_kernel(const Scalar4 *d_pos,
         vec3<Scalar> vi;
         if (Evaluator::needsVelocity())
             vi = vec3<Scalar>(
-                texFetchScalar4(d_velocity, partIdx));
+                __ldg(d_velocity + partIdx));
 
         for(unsigned int featureEpoch(0);
             featureEpoch < (numShapeVerts[type_i] + blockDim.x - 1)/blockDim.x; ++featureEpoch)
@@ -208,7 +208,7 @@ __global__ void gpu_compute_dem2d_forces_kernel(const Scalar4 *d_pos,
                     next_neigh = d_nlist[myHead + neigh_idx + 1];
 
                     // grab the position and type of the neighbor
-                    const Scalar4 neigh_postype(texFetchScalar4(d_pos, cur_neigh));
+                    const Scalar4 neigh_postype(__ldg(d_pos + cur_neigh));
                     const unsigned int neigh_type(__scalar_as_int(neigh_postype.w));
                     const vec3<Scalar> neigh_pos(neigh_postype.x, neigh_postype.y, 0);
 
@@ -231,13 +231,13 @@ __global__ void gpu_compute_dem2d_forces_kernel(const Scalar4 *d_pos,
                     if(evaluator.withinCutoff(rsq,r_cutsq))
                         {
                         // fetch neighbor's orientation
-                        const Scalar4 neighQuatF(texFetchScalar4(d_quat, cur_neigh));
+                        const Scalar4 neighQuatF(__ldg(d_quat + cur_neigh));
                         const quat<Real> neighQuat(
                             neighQuatF.x, vec3<Real>(neighQuatF.y, neighQuatF.z, neighQuatF.w));
 
                         if (Evaluator::needsVelocity())
                             {
-                            Scalar4 vj(texFetchScalar4(d_velocity, cur_neigh));
+                            Scalar4 vj(__ldg(d_velocity + cur_neigh));
                             evaluator.setVelocity(vi - vec3<Scalar>(vj));
                             }
 

--- a/hoomd/dem/DEM2DForceGPU.cu
+++ b/hoomd/dem/DEM2DForceGPU.cu
@@ -29,7 +29,6 @@
 //! Texture for reading particle positions
 scalar4_tex_t pdata_pos_tex;
 scalar4_tex_t pdata_quat_tex;
-scalar_tex_t pdata_diam_tex;
 scalar4_tex_t pdata_velocity_tex;
 
 //! Kernel for calculating 2D DEM forces
@@ -179,7 +178,7 @@ __global__ void gpu_compute_dem2d_forces_kernel(const Scalar4 *d_pos,
 
         Scalar di = 0.0f;
         if (Evaluator::needsDiameter())
-            di = texFetchScalar(d_diam, pdata_diam_tex, partIdx);
+            di = __ldg(d_diam + partIdx);
         else
             di += 1.0f; //shut up compiler warning. Vestigial from HOOMD
 
@@ -230,7 +229,7 @@ __global__ void gpu_compute_dem2d_forces_kernel(const Scalar4 *d_pos,
                     if (Evaluator::needsDiameter())
                         {
                         Scalar dj(0);
-                        dj = texFetchScalar(d_diam, pdata_diam_tex, cur_neigh);
+                        dj = __ldg(d_diam + cur_neigh);
                         evaluator.setDiameter(di, dj);
                         }
 
@@ -426,11 +425,6 @@ cudaError_t gpu_compute_dem2d_forces(Scalar4* d_force,
     pdata_quat_tex.normalized = false;
     pdata_quat_tex.filterMode = cudaFilterModePoint;
     error = cudaBindTexture(0, pdata_quat_tex, d_quat, sizeof(Scalar4)*(N+n_ghosts));
-    if (error != cudaSuccess)
-        return error;
-    pdata_diam_tex.normalized = false;
-    pdata_diam_tex.filterMode = cudaFilterModePoint;
-    error = cudaBindTexture(0, pdata_diam_tex, d_diam, sizeof(Scalar)*(N+n_ghosts));
     if (error != cudaSuccess)
         return error;
     pdata_velocity_tex.normalized = false;

--- a/hoomd/dem/DEM3DForceGPU.cu
+++ b/hoomd/dem/DEM3DForceGPU.cu
@@ -27,11 +27,6 @@
   \brief Defines GPU kernel code for calculating conservative DEM pair forces. Used by DEM3DForceComputeGPU.
 */
 
-//! Texture for reading particle positions
-scalar4_tex_t pdata_pos_tex;
-scalar4_tex_t pdata_quat_tex;
-scalar4_tex_t pdata_velocity_tex;
-
 //! Kernel for calculating 3D DEM forces
 /*! This kernel is called to calculate the DEM forces for all N particles.
 
@@ -233,10 +228,10 @@ __global__ void gpu_compute_dem3d_forces_kernel(
         const unsigned int myHead(d_head_list[partIdx]);
 
         // fetch position and orientation of this particle
-        const Scalar4 postype(texFetchScalar4(d_pos,pdata_pos_tex, partIdx));
+        const Scalar4 postype(texFetchScalar4(d_pos, partIdx));
         const vec3<Scalar> pos_i(postype.x, postype.y, postype.z);
         const unsigned int type_i(__scalar_as_int(postype.w));
-        const Scalar4 quati(texFetchScalar4(d_quat, pdata_quat_tex, partIdx));
+        const Scalar4 quati(texFetchScalar4(d_quat, partIdx));
         const quat<Real> quat_i(quati.x, vec3<Real>(quati.y, quati.z, quati.w));
 
         Scalar di = 0.0f;
@@ -248,7 +243,7 @@ __global__ void gpu_compute_dem3d_forces_kernel(
         vec3<Scalar> vi;
         if (Evaluator::needsVelocity())
             vi = vec3<Scalar>(
-                texFetchScalar4(d_velocity, pdata_velocity_tex, partIdx));
+                texFetchScalar4(d_velocity, partIdx));
 
         for(unsigned int featureEpoch(0);
             featureEpoch < (maxFeatures + blockDim.y - 1)/blockDim.y; ++featureEpoch)
@@ -282,7 +277,7 @@ __global__ void gpu_compute_dem3d_forces_kernel(
                 next_neigh = d_nlist[myHead + neigh_idx + 1];
 
                 // grab the position and type of the neighbor
-                const Scalar4 neigh_postype(texFetchScalar4(d_pos, pdata_pos_tex, cur_neigh));
+                const Scalar4 neigh_postype(texFetchScalar4(d_pos, cur_neigh));
                 const unsigned int type_j(__scalar_as_int(neigh_postype.w));
                 const vec3<Scalar> neigh_pos(neigh_postype.x, neigh_postype.y, neigh_postype.z);
 
@@ -307,13 +302,13 @@ __global__ void gpu_compute_dem3d_forces_kernel(
                 if(evaluator.withinCutoff(rsq, r_cutsq))
                     {
                     // fetch neighbor's orientation
-                    const Scalar4 neighQuatF(texFetchScalar4(d_quat, pdata_quat_tex, cur_neigh));
+                    const Scalar4 neighQuatF(texFetchScalar4(d_quat, cur_neigh));
                     const quat<Real> neighQuat(
                         neighQuatF.x, vec3<Real>(neighQuatF.y, neighQuatF.z, neighQuatF.w));
 
                     if (Evaluator::needsVelocity())
                         {
-                        Scalar4 vj(texFetchScalar4(d_velocity, pdata_velocity_tex, cur_neigh));
+                        Scalar4 vj(texFetchScalar4(d_velocity, cur_neigh));
                         evaluator.setVelocity(vi - vec3<Scalar>(vj));
                         }
 
@@ -513,23 +508,6 @@ cudaError_t gpu_compute_dem3d_forces(
     assert(numFeatures);
 
     dim3 threads(particlesPerBlock, numFeatures, 1);
-
-    // bind the textures for position and orientation
-    pdata_pos_tex.normalized = false;
-    pdata_pos_tex.filterMode = cudaFilterModePoint;
-    cudaError_t error = cudaBindTexture(0, pdata_pos_tex, d_pos, sizeof(Scalar4)*(N+n_ghosts));
-    if (error != cudaSuccess)
-        return error;
-    pdata_quat_tex.normalized = false;
-    pdata_quat_tex.filterMode = cudaFilterModePoint;
-    error = cudaBindTexture(0, pdata_quat_tex, d_quat, sizeof(Scalar4)*(N+n_ghosts));
-    if (error != cudaSuccess)
-        return error;
-    pdata_velocity_tex.normalized = false;
-    pdata_velocity_tex.filterMode = cudaFilterModePoint;
-    error = cudaBindTexture(0, pdata_velocity_tex, d_velocity, sizeof(Scalar4)*(N+n_ghosts));
-    if (error != cudaSuccess)
-        return error;
 
     // Calculate the amount of shared memory required
     const size_t shmSize(2*particlesPerBlock*sizeof(Real4) + 6*particlesPerBlock*sizeof(Real) + // forces, torques, virials per-particle

--- a/hoomd/dem/DEM3DForceGPU.cu
+++ b/hoomd/dem/DEM3DForceGPU.cu
@@ -228,10 +228,10 @@ __global__ void gpu_compute_dem3d_forces_kernel(
         const unsigned int myHead(d_head_list[partIdx]);
 
         // fetch position and orientation of this particle
-        const Scalar4 postype(texFetchScalar4(d_pos, partIdx));
+        const Scalar4 postype(__ldg(d_pos + partIdx));
         const vec3<Scalar> pos_i(postype.x, postype.y, postype.z);
         const unsigned int type_i(__scalar_as_int(postype.w));
-        const Scalar4 quati(texFetchScalar4(d_quat, partIdx));
+        const Scalar4 quati(__ldg(d_quat + partIdx));
         const quat<Real> quat_i(quati.x, vec3<Real>(quati.y, quati.z, quati.w));
 
         Scalar di = 0.0f;
@@ -243,7 +243,7 @@ __global__ void gpu_compute_dem3d_forces_kernel(
         vec3<Scalar> vi;
         if (Evaluator::needsVelocity())
             vi = vec3<Scalar>(
-                texFetchScalar4(d_velocity, partIdx));
+                __ldg(d_velocity + partIdx));
 
         for(unsigned int featureEpoch(0);
             featureEpoch < (maxFeatures + blockDim.y - 1)/blockDim.y; ++featureEpoch)
@@ -277,7 +277,7 @@ __global__ void gpu_compute_dem3d_forces_kernel(
                 next_neigh = d_nlist[myHead + neigh_idx + 1];
 
                 // grab the position and type of the neighbor
-                const Scalar4 neigh_postype(texFetchScalar4(d_pos, cur_neigh));
+                const Scalar4 neigh_postype(__ldg(d_pos + cur_neigh));
                 const unsigned int type_j(__scalar_as_int(neigh_postype.w));
                 const vec3<Scalar> neigh_pos(neigh_postype.x, neigh_postype.y, neigh_postype.z);
 
@@ -302,13 +302,13 @@ __global__ void gpu_compute_dem3d_forces_kernel(
                 if(evaluator.withinCutoff(rsq, r_cutsq))
                     {
                     // fetch neighbor's orientation
-                    const Scalar4 neighQuatF(texFetchScalar4(d_quat, cur_neigh));
+                    const Scalar4 neighQuatF(__ldg(d_quat + cur_neigh));
                     const quat<Real> neighQuat(
                         neighQuatF.x, vec3<Real>(neighQuatF.y, neighQuatF.z, neighQuatF.w));
 
                     if (Evaluator::needsVelocity())
                         {
-                        Scalar4 vj(texFetchScalar4(d_velocity, cur_neigh));
+                        Scalar4 vj(__ldg(d_velocity + cur_neigh));
                         evaluator.setVelocity(vi - vec3<Scalar>(vj));
                         }
 

--- a/hoomd/hpmc/ComputeFreeVolumeGPU.cuh
+++ b/hoomd/hpmc/ComputeFreeVolumeGPU.cuh
@@ -329,11 +329,7 @@ __global__ void gpu_hpmc_free_volume_kernel(unsigned int n_sample,
             if (local_k < excell_size)
                 {
                 // read in position, and orientation of neighboring particle
-                #if ( __CUDA_ARCH__ > 300)
                 unsigned int j = __ldg(&d_excell_idx[excli(local_k, my_cell)]);
-                #else
-                unsigned int j = d_excell_idx[excli(local_k, my_cell)];
-                #endif
 
                 Scalar4 postype_j = texFetchScalar4(d_postype, free_volume_postype_tex, j);
                 Scalar4 orientation_j = make_scalar4(1,0,0,0);

--- a/hoomd/hpmc/ComputeFreeVolumeGPU.cuh
+++ b/hoomd/hpmc/ComputeFreeVolumeGPU.cuh
@@ -136,10 +136,6 @@ template< class Shape >
 cudaError_t gpu_hpmc_free_volume(const hpmc_free_volume_args_t &args, const typename Shape::param_type *d_params);
 
 #ifdef NVCC
-//! Texture for reading postype
-scalar4_tex_t free_volume_postype_tex;
-//! Texture for reading orientation
-scalar4_tex_t free_volume_orientation_tex;
 
 //! Compute the cell that a particle sits in
 __device__ inline unsigned int compute_cell_idx(const Scalar3 p,
@@ -331,12 +327,12 @@ __global__ void gpu_hpmc_free_volume_kernel(unsigned int n_sample,
                 // read in position, and orientation of neighboring particle
                 unsigned int j = __ldg(&d_excell_idx[excli(local_k, my_cell)]);
 
-                Scalar4 postype_j = texFetchScalar4(d_postype, free_volume_postype_tex, j);
+                Scalar4 postype_j = texFetchScalar4(d_postype, j);
                 Scalar4 orientation_j = make_scalar4(1,0,0,0);
                 unsigned int typ_j = __scalar_as_int(postype_j.w);
                 Shape shape_j(quat<Scalar>(orientation_j), s_params[typ_j]);
                 if (shape_j.hasOrientation())
-                    shape_j.orientation = quat<Scalar>(texFetchScalar4(d_orientation, free_volume_orientation_tex, j));
+                    shape_j.orientation = quat<Scalar>(texFetchScalar4(d_orientation, j));
 
                 // put particle j into the coordinate system of particle i
                 vec3<Scalar> r_ij = vec3<Scalar>(postype_j) - pos_i;
@@ -401,20 +397,6 @@ cudaError_t gpu_hpmc_free_volume(const hpmc_free_volume_args_t& args, const type
     assert(args.group_size >= 1);
     assert(args.group_size <= 32);  // note, really should be warp size of the device
     assert(args.block_size%(args.stride*args.group_size)==0);
-
-
-    // bind the textures
-    free_volume_postype_tex.normalized = false;
-    free_volume_postype_tex.filterMode = cudaFilterModePoint;
-    cudaError_t error = cudaBindTexture(0, free_volume_postype_tex, args.d_postype, sizeof(Scalar4)*args.max_n);
-    if (error != cudaSuccess)
-        return error;
-
-    free_volume_orientation_tex.normalized = false;
-    free_volume_orientation_tex.filterMode = cudaFilterModePoint;
-    error = cudaBindTexture(0, free_volume_orientation_tex, args.d_orientation, sizeof(Scalar4)*args.max_n);
-    if (error != cudaSuccess)
-        return error;
 
     // reset counters
     cudaMemsetAsync(args.d_n_overlap_all,0, sizeof(unsigned int), args.stream);

--- a/hoomd/hpmc/ComputeFreeVolumeGPU.cuh
+++ b/hoomd/hpmc/ComputeFreeVolumeGPU.cuh
@@ -327,12 +327,12 @@ __global__ void gpu_hpmc_free_volume_kernel(unsigned int n_sample,
                 // read in position, and orientation of neighboring particle
                 unsigned int j = __ldg(&d_excell_idx[excli(local_k, my_cell)]);
 
-                Scalar4 postype_j = texFetchScalar4(d_postype, j);
+                Scalar4 postype_j = __ldg(d_postype + j);
                 Scalar4 orientation_j = make_scalar4(1,0,0,0);
                 unsigned int typ_j = __scalar_as_int(postype_j.w);
                 Shape shape_j(quat<Scalar>(orientation_j), s_params[typ_j]);
                 if (shape_j.hasOrientation())
-                    shape_j.orientation = quat<Scalar>(texFetchScalar4(d_orientation, j));
+                    shape_j.orientation = quat<Scalar>(__ldg(d_orientation + j));
 
                 // put particle j into the coordinate system of particle i
                 vec3<Scalar> r_ij = vec3<Scalar>(postype_j) - pos_i;

--- a/hoomd/hpmc/IntegratorHPMCMonoGPU.cuh
+++ b/hoomd/hpmc/IntegratorHPMCMonoGPU.cuh
@@ -184,10 +184,6 @@ cudaError_t gpu_hpmc_shift(Scalar4 *d_postype,
  * Definition of function templates and templated GPU kernels
  */
 
-//! Texture for reading postype
-scalar4_tex_t postype_tex;
-//! Texture for reading orientation
-scalar4_tex_t orientation_tex;
 //! Texture for reading cell index data
 texture<unsigned int, 1, cudaReadModeElementType> cell_idx_tex;
 
@@ -474,14 +470,14 @@ __global__ void gpu_hpmc_mpmc_kernel(Scalar4 *d_postype,
         i = tex1Dfetch(cell_idx_tex, cli(my_cell_offset, my_cell));
 
         // read in the position and orientation of our particle.
-        Scalar4 postype_i = texFetchScalar4(d_postype, postype_tex, i);
+        Scalar4 postype_i = texFetchScalar4(d_postype, i);
         Scalar4 orientation_i = make_scalar4(1,0,0,0);
 
         unsigned int typ_i = __scalar_as_int(postype_i.w);
         Shape shape_i(quat<Scalar>(orientation_i), s_params[typ_i]);
 
         if (shape_i.hasOrientation())
-            orientation_i = texFetchScalar4(d_orientation, orientation_tex, i);
+            orientation_i = texFetchScalar4(d_orientation, i);
 
         shape_i.orientation = quat<Scalar>(orientation_i);
 
@@ -577,7 +573,7 @@ __global__ void gpu_hpmc_mpmc_kernel(Scalar4 *d_postype,
                         }
 
                     // read in position, and orientation of neighboring particle
-                    postype_j = texFetchScalar4(d_postype, postype_tex, j);
+                    postype_j = texFetchScalar4(d_postype, j);
                     Shape shape_j(quat<Scalar>(orientation_j), s_params[__scalar_as_int(postype_j.w)]);
 
                     // put particle j into the coordinate system of particle i
@@ -637,12 +633,12 @@ __global__ void gpu_hpmc_mpmc_kernel(Scalar4 *d_postype,
             Shape shape_i(quat<Scalar>(s_orientation_group[check_group]), s_params[type_i]);
 
             // build shape j from global memory
-            postype_j = texFetchScalar4(d_postype, postype_tex, check_j);
+            postype_j = texFetchScalar4(d_postype, check_j);
             orientation_j = make_scalar4(1,0,0,0);
             unsigned int type_j = __scalar_as_int(postype_j.w);
             Shape shape_j(quat<Scalar>(orientation_j), s_params[type_j]);
             if (shape_j.hasOrientation())
-                shape_j.orientation = quat<Scalar>(texFetchScalar4(d_orientation, orientation_tex, check_j));
+                shape_j.orientation = quat<Scalar>(texFetchScalar4(d_orientation, check_j));
 
             // put particle j into the coordinate system of particle i
             r_ij = vec3<Scalar>(postype_j) - vec3<Scalar>(pos_i);
@@ -873,25 +869,9 @@ cudaError_t gpu_hpmc_update(const hpmc_args_t& args, const typename Shape::param
 
     dim3 grid( args.n_active_cells / n_groups + 1, 1, 1);
 
-    // bind the textures
-    postype_tex.normalized = false;
-    postype_tex.filterMode = cudaFilterModePoint;
-    cudaError_t error = cudaBindTexture(0, postype_tex, args.d_postype, sizeof(Scalar4)*args.max_n);
-    if (error != cudaSuccess)
-        return error;
-
-    if (args.has_orientation)
-        {
-        orientation_tex.normalized = false;
-        orientation_tex.filterMode = cudaFilterModePoint;
-        error = cudaBindTexture(0, orientation_tex, args.d_orientation, sizeof(Scalar4)*args.max_n);
-        if (error != cudaSuccess)
-            return error;
-        }
-
     cell_idx_tex.normalized = false;
     cell_idx_tex.filterMode = cudaFilterModePoint;
-    error = cudaBindTexture(0, cell_idx_tex, args.d_cell_idx, sizeof(Scalar4)*args.cli.getNumElements());
+    cudaError_t error = cudaBindTexture(0, cell_idx_tex, args.d_cell_idx, sizeof(Scalar4)*args.cli.getNumElements());
     if (error != cudaSuccess)
         return error;
 

--- a/hoomd/hpmc/IntegratorHPMCMonoGPU.cuh
+++ b/hoomd/hpmc/IntegratorHPMCMonoGPU.cuh
@@ -184,9 +184,6 @@ cudaError_t gpu_hpmc_shift(Scalar4 *d_postype,
  * Definition of function templates and templated GPU kernels
  */
 
-//! Texture for reading cell index data
-texture<unsigned int, 1, cudaReadModeElementType> cell_idx_tex;
-
 //! Device function to compute the cell that a particle sits in
 __device__ inline unsigned int computeParticleCell(const Scalar3& p,
                                                    const BoxDim& box,
@@ -274,9 +271,6 @@ __device__ inline unsigned int computeParticleCell(const Scalar3& p,
         - threadIdx.y indexes the current group in the block
         - threadIdx.x is the offset within the current group
         - blockIdx.x runs enough blocks so that all active cells are covered
-
-    **Possible enhancements**
-        - Use __ldg and not tex1Dfetch on sm35
 
     \ingroup hpmc_kernels
 */
@@ -467,17 +461,17 @@ __global__ void gpu_hpmc_mpmc_kernel(Scalar4 *d_postype,
 
         // select one of the particles randomly from the cell
         unsigned int my_cell_offset = hoomd::UniformIntDistribution(my_cell_size-1)(rng);
-        i = tex1Dfetch(cell_idx_tex, cli(my_cell_offset, my_cell));
+        i = __ldg(d_cell_idx + cli(my_cell_offset, my_cell));
 
         // read in the position and orientation of our particle.
-        Scalar4 postype_i = texFetchScalar4(d_postype, i);
+        Scalar4 postype_i = __ldg(d_postype + i);
         Scalar4 orientation_i = make_scalar4(1,0,0,0);
 
         unsigned int typ_i = __scalar_as_int(postype_i.w);
         Shape shape_i(quat<Scalar>(orientation_i), s_params[typ_i]);
 
         if (shape_i.hasOrientation())
-            orientation_i = texFetchScalar4(d_orientation, i);
+            orientation_i = __ldg(d_orientation + i);
 
         shape_i.orientation = quat<Scalar>(orientation_i);
 
@@ -573,7 +567,7 @@ __global__ void gpu_hpmc_mpmc_kernel(Scalar4 *d_postype,
                         }
 
                     // read in position, and orientation of neighboring particle
-                    postype_j = texFetchScalar4(d_postype, j);
+                    postype_j = __ldg(d_postype + j);
                     Shape shape_j(quat<Scalar>(orientation_j), s_params[__scalar_as_int(postype_j.w)]);
 
                     // put particle j into the coordinate system of particle i
@@ -633,12 +627,12 @@ __global__ void gpu_hpmc_mpmc_kernel(Scalar4 *d_postype,
             Shape shape_i(quat<Scalar>(s_orientation_group[check_group]), s_params[type_i]);
 
             // build shape j from global memory
-            postype_j = texFetchScalar4(d_postype, check_j);
+            postype_j = __ldg(d_postype + check_j);
             orientation_j = make_scalar4(1,0,0,0);
             unsigned int type_j = __scalar_as_int(postype_j.w);
             Shape shape_j(quat<Scalar>(orientation_j), s_params[type_j]);
             if (shape_j.hasOrientation())
-                shape_j.orientation = quat<Scalar>(texFetchScalar4(d_orientation, check_j));
+                shape_j.orientation = quat<Scalar>(__ldg(d_orientation + check_j));
 
             // put particle j into the coordinate system of particle i
             r_ij = vec3<Scalar>(postype_j) - vec3<Scalar>(pos_i);
@@ -868,12 +862,6 @@ cudaError_t gpu_hpmc_update(const hpmc_args_t& args, const typename Shape::param
         }
 
     dim3 grid( args.n_active_cells / n_groups + 1, 1, 1);
-
-    cell_idx_tex.normalized = false;
-    cell_idx_tex.filterMode = cudaFilterModePoint;
-    cudaError_t error = cudaBindTexture(0, cell_idx_tex, args.d_cell_idx, sizeof(Scalar4)*args.cli.getNumElements());
-    if (error != cudaSuccess)
-        return error;
 
     gpu_hpmc_mpmc_kernel<Shape><<<grid, threads, shared_bytes, args.stream>>>(args.d_postype,
                                                                  args.d_orientation,

--- a/hoomd/hpmc/IntegratorHPMCMonoGPU.cuh
+++ b/hoomd/hpmc/IntegratorHPMCMonoGPU.cuh
@@ -549,11 +549,7 @@ __global__ void gpu_hpmc_mpmc_kernel(Scalar4 *d_postype,
             unsigned int j, next_j = 0;
             if (k < excell_size)
                 {
-                #if (__CUDA_ARCH__ > 300)
                 next_j = __ldg(&d_excell_idx[excli(k, my_cell)]);
-                #else
-                next_j = d_excell_idx[excli(k, my_cell)];
-                #endif
                 }
 
             // add to the queue as long as the queue is not full, and we have not yet reached the end of our own list
@@ -577,11 +573,7 @@ __global__ void gpu_hpmc_mpmc_kernel(Scalar4 *d_postype,
 
                     if (k < excell_size)
                         {
-                        #if (__CUDA_ARCH__ > 300)
                         next_j = __ldg(&d_excell_idx[excli(k, my_cell)]);
-                        #else
-                        next_j = d_excell_idx[excli(k, my_cell)];
-                        #endif
                         }
 
                     // read in position, and orientation of neighboring particle

--- a/hoomd/hpmc/IntegratorHPMCMonoImplicitGPU.cuh
+++ b/hoomd/hpmc/IntegratorHPMCMonoImplicitGPU.cuh
@@ -528,11 +528,7 @@ __global__ void gpu_hpmc_implicit_count_overlaps_kernel(Scalar4 *d_postype,
                     Scalar4 postype_j;
                     do {
                         // read in position, and orientation of neighboring particle
-                        #if (__CUDA_ARCH__ > 300)
                         j = __ldg(&d_excell_idx[excli(local_k, my_cell)]);
-                        #else
-                        j = d_excell_idx[excli(local_k, my_cell)];
-                        #endif
 
                         // check against neighbor
                         postype_j = texFetchScalar4(d_postype_old, implicit_postype_old_tex, j);
@@ -1056,11 +1052,7 @@ __global__ void gpu_hpmc_implicit_reinsert_kernel(Scalar4 *d_postype,
             unsigned int j, next_j = 0;
             if (k < excell_size)
                 {
-                #if (__CUDA_ARCH__ > 300)
                 next_j = __ldg(&d_excell_idx[excli(k, my_cell)]);
-                #else
-                next_j = d_excell_idx[excli(k, my_cell)];
-                #endif
                 }
 
             // add to the queue as long as the queue is not full, and we have not yet reached the end of our own list
@@ -1082,11 +1074,7 @@ __global__ void gpu_hpmc_implicit_reinsert_kernel(Scalar4 *d_postype,
 
                     if (k < excell_size)
                         {
-                        #if (__CUDA_ARCH__ > 300)
                         next_j = __ldg(&d_excell_idx[excli(k, my_cell)]);
-                        #else
-                        next_j = d_excell_idx[excli(k, my_cell)];
-                        #endif
                         }
 
                     // read in position, and orientation of neighboring particle

--- a/hoomd/hpmc/IntegratorHPMCMonoImplicitGPU.cuh
+++ b/hoomd/hpmc/IntegratorHPMCMonoImplicitGPU.cuh
@@ -231,15 +231,6 @@ cudaError_t gpu_hpmc_implicit_accept_reject(const hpmc_implicit_args_t &args, co
  * Definition of function templates and templated GPU kernels
  */
 
-//! Texture for reading postype
-scalar4_tex_t implicit_postype_tex;
-//! Texture for reading orientation
-scalar4_tex_t implicit_orientation_tex;
-//! Texture for reading postype
-scalar4_tex_t implicit_postype_old_tex;
-//! Texture for reading orientation
-scalar4_tex_t implicit_orientation_old_tex;
-
 //! Texture for reading cell index data
 texture<unsigned int, 1, cudaReadModeElementType> implicit_cell_idx_tex;
 
@@ -425,7 +416,7 @@ __global__ void gpu_hpmc_implicit_count_overlaps_kernel(Scalar4 *d_postype,
     if (active)
         {
         // load updated particle position
-        postype_i = texFetchScalar4(d_postype, implicit_postype_tex, idx_i);
+        postype_i = texFetchScalar4(d_postype, idx_i);
         type_i = __scalar_as_int(postype_i.w);
         pos_i = vec3<Scalar>(postype_i);
         }
@@ -458,7 +449,7 @@ __global__ void gpu_hpmc_implicit_count_overlaps_kernel(Scalar4 *d_postype,
     Shape shape_i(quat<Scalar>(orientation_i), s_params[__scalar_as_int(postype_i.w)]);
     if (shape_i.hasOrientation())
         {
-        orientation_i = texFetchScalar4(d_orientation, implicit_orientation_tex, idx_i);
+        orientation_i = texFetchScalar4(d_orientation, idx_i);
         shape_i.orientation = quat<Scalar>(orientation_i);
         }
 
@@ -531,11 +522,11 @@ __global__ void gpu_hpmc_implicit_count_overlaps_kernel(Scalar4 *d_postype,
                         j = __ldg(&d_excell_idx[excli(local_k, my_cell)]);
 
                         // check against neighbor
-                        postype_j = texFetchScalar4(d_postype_old, implicit_postype_old_tex, j);
+                        postype_j = texFetchScalar4(d_postype_old, j);
                         Shape shape_j(quat<Scalar>(), s_params[__scalar_as_int(postype_j.w)]);
                         if (shape_j.hasOrientation())
                             {
-                            shape_j.orientation = quat<Scalar>(texFetchScalar4(d_orientation_old, implicit_orientation_old_tex, j));
+                            shape_j.orientation = quat<Scalar>(texFetchScalar4(d_orientation_old, j));
                             }
 
                         // test depletant in sphere around new particle position
@@ -561,7 +552,7 @@ __global__ void gpu_hpmc_implicit_count_overlaps_kernel(Scalar4 *d_postype,
                         Shape shape_j(quat<Scalar>(), s_params[typ_j]);
                         if (shape_j.hasOrientation())
                             {
-                            shape_j.orientation = quat<Scalar>(texFetchScalar4(d_orientation_old, implicit_orientation_old_tex, j));
+                            shape_j.orientation = quat<Scalar>(texFetchScalar4(d_orientation_old, j));
                             }
 
                         if (s_check_overlaps[overlap_idx(depletant_type, typ_j)]
@@ -829,12 +820,12 @@ __global__ void gpu_hpmc_implicit_reinsert_kernel(Scalar4 *d_postype,
     if (active)
         {
         // load updated particle position
-        postype_i = texFetchScalar4(d_postype, implicit_postype_tex, idx_i);
+        postype_i = texFetchScalar4(d_postype, idx_i);
 
         Shape shape_i(quat<Scalar>(), s_params[__scalar_as_int(postype_i.w)]);
         if (shape_i.hasOrientation())
             {
-            orientation_i = texFetchScalar4(d_orientation, implicit_orientation_tex, idx_i);
+            orientation_i = texFetchScalar4(d_orientation, idx_i);
             }
         }
 
@@ -847,7 +838,7 @@ __global__ void gpu_hpmc_implicit_reinsert_kernel(Scalar4 *d_postype,
     vec3<Scalar> pos_i_old;
     if (active)
         {
-        pos_i_old = vec3<Scalar>(texFetchScalar4(d_postype_old, implicit_postype_old_tex, idx_i));
+        pos_i_old = vec3<Scalar>(texFetchScalar4(d_postype_old, idx_i));
         }
 
     unsigned int excell_size;
@@ -980,7 +971,7 @@ __global__ void gpu_hpmc_implicit_reinsert_kernel(Scalar4 *d_postype,
         vec3<Scalar> r_ij = pos_i_old - pos_test;
         if (shape_i.hasOrientation())
             {
-            shape_i.orientation = quat<Scalar>(texFetchScalar4(d_orientation_old, implicit_orientation_old_tex, idx_i));
+            shape_i.orientation = quat<Scalar>(texFetchScalar4(d_orientation_old, idx_i));
             }
 
         // if depletant can be inserted in excluded volume at old (new) position, success
@@ -1078,7 +1069,7 @@ __global__ void gpu_hpmc_implicit_reinsert_kernel(Scalar4 *d_postype,
                         }
 
                     // read in position, and orientation of neighboring particle
-                    postype_j = texFetchScalar4(d_postype_old, implicit_postype_old_tex, j);
+                    postype_j = texFetchScalar4(d_postype_old, j);
                     Shape shape_j(quat<Scalar>(), s_params[__scalar_as_int(postype_j.w)]);
 
                     // put particle j into the coordinate system of depletant
@@ -1136,12 +1127,12 @@ __global__ void gpu_hpmc_implicit_reinsert_kernel(Scalar4 *d_postype,
             Shape shape_i(quat<Scalar>(s_orientation_group[check_group]), s_params[depletant_type]);
 
             // build shape j from global memory
-            postype_j = texFetchScalar4(d_postype_old, implicit_postype_old_tex, check_j);
+            postype_j = texFetchScalar4(d_postype_old, check_j);
             orientation_j = make_scalar4(1,0,0,0);
             unsigned int typ_j = __scalar_as_int(postype_j.w);
             Shape shape_j(quat<Scalar>(orientation_j), s_params[typ_j]);
             if (shape_j.hasOrientation())
-                shape_j.orientation = quat<Scalar>(texFetchScalar4(d_orientation_old, implicit_orientation_old_tex, check_j));
+                shape_j.orientation = quat<Scalar>(texFetchScalar4(d_orientation_old, check_j));
 
             // put particle j into the coordinate system of particle i
             r_ij = vec3<Scalar>(postype_j) - vec3<Scalar>(pos_i);
@@ -1397,37 +1388,9 @@ struct CountOverlapsKernelLauncher
                 n_active_cells = args.n_active_cells;
                 }
 
-            // bind the textures
-            implicit_postype_tex.normalized = false;
-            implicit_postype_tex.filterMode = cudaFilterModePoint;
-            cudaError_t error = cudaBindTexture(0, implicit_postype_tex, args.d_postype, sizeof(Scalar4)*args.max_n);
-            if (error != cudaSuccess)
-                return error;
-
-            implicit_postype_old_tex.normalized = false;
-            implicit_postype_old_tex.filterMode = cudaFilterModePoint;
-            error = cudaBindTexture(0, implicit_postype_old_tex, args.d_postype_old, sizeof(Scalar4)*args.max_n);
-            if (error != cudaSuccess)
-                return error;
-
-            if (args.has_orientation)
-                {
-                implicit_orientation_tex.normalized = false;
-                implicit_orientation_tex.filterMode = cudaFilterModePoint;
-                error = cudaBindTexture(0, implicit_orientation_tex, args.d_orientation, sizeof(Scalar4)*args.max_n);
-                if (error != cudaSuccess)
-                    return error;
-
-                implicit_orientation_old_tex.normalized = false;
-                implicit_orientation_old_tex.filterMode = cudaFilterModePoint;
-                error = cudaBindTexture(0, implicit_orientation_old_tex, args.d_orientation_old, sizeof(Scalar4)*args.max_n);
-                if (error != cudaSuccess)
-                    return error;
-                }
-
             implicit_cell_idx_tex.normalized = false;
             implicit_cell_idx_tex.filterMode = cudaFilterModePoint;
-            error = cudaBindTexture(0, implicit_cell_idx_tex, args.d_cell_idx, sizeof(unsigned int)*args.cli.getNumElements());
+            cudaError_t error = cudaBindTexture(0, implicit_cell_idx_tex, args.d_cell_idx, sizeof(unsigned int)*args.cli.getNumElements());
             if (error != cudaSuccess)
                 return error;
 

--- a/hoomd/hpmc/IntegratorHPMCMonoImplicitGPU.cuh
+++ b/hoomd/hpmc/IntegratorHPMCMonoImplicitGPU.cuh
@@ -231,9 +231,6 @@ cudaError_t gpu_hpmc_implicit_accept_reject(const hpmc_implicit_args_t &args, co
  * Definition of function templates and templated GPU kernels
  */
 
-//! Texture for reading cell index data
-texture<unsigned int, 1, cudaReadModeElementType> implicit_cell_idx_tex;
-
 //! HPMC implicit count overlaps kernel
 /*! \param d_postype Particle positions and types by index
     \param d_orientation Particle orientation
@@ -416,7 +413,7 @@ __global__ void gpu_hpmc_implicit_count_overlaps_kernel(Scalar4 *d_postype,
     if (active)
         {
         // load updated particle position
-        postype_i = texFetchScalar4(d_postype, idx_i);
+        postype_i = __ldg(d_postype + idx_i);
         type_i = __scalar_as_int(postype_i.w);
         pos_i = vec3<Scalar>(postype_i);
         }
@@ -449,7 +446,7 @@ __global__ void gpu_hpmc_implicit_count_overlaps_kernel(Scalar4 *d_postype,
     Shape shape_i(quat<Scalar>(orientation_i), s_params[__scalar_as_int(postype_i.w)]);
     if (shape_i.hasOrientation())
         {
-        orientation_i = texFetchScalar4(d_orientation, idx_i);
+        orientation_i = __ldg(d_orientation + idx_i);
         shape_i.orientation = quat<Scalar>(orientation_i);
         }
 
@@ -522,11 +519,11 @@ __global__ void gpu_hpmc_implicit_count_overlaps_kernel(Scalar4 *d_postype,
                         j = __ldg(&d_excell_idx[excli(local_k, my_cell)]);
 
                         // check against neighbor
-                        postype_j = texFetchScalar4(d_postype_old, j);
+                        postype_j = __ldg(d_postype_old + j);
                         Shape shape_j(quat<Scalar>(), s_params[__scalar_as_int(postype_j.w)]);
                         if (shape_j.hasOrientation())
                             {
-                            shape_j.orientation = quat<Scalar>(texFetchScalar4(d_orientation_old, j));
+                            shape_j.orientation = quat<Scalar>(__ldg(d_orientation_old + j));
                             }
 
                         // test depletant in sphere around new particle position
@@ -552,7 +549,7 @@ __global__ void gpu_hpmc_implicit_count_overlaps_kernel(Scalar4 *d_postype,
                         Shape shape_j(quat<Scalar>(), s_params[typ_j]);
                         if (shape_j.hasOrientation())
                             {
-                            shape_j.orientation = quat<Scalar>(texFetchScalar4(d_orientation_old, j));
+                            shape_j.orientation = quat<Scalar>(__ldg(d_orientation_old + j));
                             }
 
                         if (s_check_overlaps[overlap_idx(depletant_type, typ_j)]
@@ -820,12 +817,12 @@ __global__ void gpu_hpmc_implicit_reinsert_kernel(Scalar4 *d_postype,
     if (active)
         {
         // load updated particle position
-        postype_i = texFetchScalar4(d_postype, idx_i);
+        postype_i = __ldg(d_postype + idx_i);
 
         Shape shape_i(quat<Scalar>(), s_params[__scalar_as_int(postype_i.w)]);
         if (shape_i.hasOrientation())
             {
-            orientation_i = texFetchScalar4(d_orientation, idx_i);
+            orientation_i = __ldg(d_orientation + idx_i);
             }
         }
 
@@ -838,7 +835,7 @@ __global__ void gpu_hpmc_implicit_reinsert_kernel(Scalar4 *d_postype,
     vec3<Scalar> pos_i_old;
     if (active)
         {
-        pos_i_old = vec3<Scalar>(texFetchScalar4(d_postype_old, idx_i));
+        pos_i_old = vec3<Scalar>(__ldg(d_postype_old + idx_i));
         }
 
     unsigned int excell_size;
@@ -971,7 +968,7 @@ __global__ void gpu_hpmc_implicit_reinsert_kernel(Scalar4 *d_postype,
         vec3<Scalar> r_ij = pos_i_old - pos_test;
         if (shape_i.hasOrientation())
             {
-            shape_i.orientation = quat<Scalar>(texFetchScalar4(d_orientation_old, idx_i));
+            shape_i.orientation = quat<Scalar>(__ldg(d_orientation_old + idx_i));
             }
 
         // if depletant can be inserted in excluded volume at old (new) position, success
@@ -1069,7 +1066,7 @@ __global__ void gpu_hpmc_implicit_reinsert_kernel(Scalar4 *d_postype,
                         }
 
                     // read in position, and orientation of neighboring particle
-                    postype_j = texFetchScalar4(d_postype_old, j);
+                    postype_j = __ldg(d_postype_old + j);
                     Shape shape_j(quat<Scalar>(), s_params[__scalar_as_int(postype_j.w)]);
 
                     // put particle j into the coordinate system of depletant
@@ -1127,12 +1124,12 @@ __global__ void gpu_hpmc_implicit_reinsert_kernel(Scalar4 *d_postype,
             Shape shape_i(quat<Scalar>(s_orientation_group[check_group]), s_params[depletant_type]);
 
             // build shape j from global memory
-            postype_j = texFetchScalar4(d_postype_old, check_j);
+            postype_j = __ldg(d_postype_old + check_j);
             orientation_j = make_scalar4(1,0,0,0);
             unsigned int typ_j = __scalar_as_int(postype_j.w);
             Shape shape_j(quat<Scalar>(orientation_j), s_params[typ_j]);
             if (shape_j.hasOrientation())
-                shape_j.orientation = quat<Scalar>(texFetchScalar4(d_orientation_old, check_j));
+                shape_j.orientation = quat<Scalar>(__ldg(d_orientation_old + check_j));
 
             // put particle j into the coordinate system of particle i
             r_ij = vec3<Scalar>(postype_j) - vec3<Scalar>(pos_i);
@@ -1387,12 +1384,6 @@ struct CountOverlapsKernelLauncher
                                                   args.d_state_cell);
                 n_active_cells = args.n_active_cells;
                 }
-
-            implicit_cell_idx_tex.normalized = false;
-            implicit_cell_idx_tex.filterMode = cudaFilterModePoint;
-            cudaError_t error = cudaBindTexture(0, implicit_cell_idx_tex, args.d_cell_idx, sizeof(unsigned int)*args.cli.getNumElements());
-            if (error != cudaSuccess)
-                return error;
 
             unsigned int shared_bytes = args.num_types * (sizeof(typename Shape::param_type))
                 + args.overlap_idx.getNumElements() * sizeof(unsigned int);

--- a/hoomd/hpmc/IntegratorHPMCMonoImplicitNewGPU.cuh
+++ b/hoomd/hpmc/IntegratorHPMCMonoImplicitNewGPU.cuh
@@ -508,11 +508,7 @@ __global__ void gpu_hpmc_insert_depletants_queue_kernel(Scalar4 *d_postype,
                 unsigned int j, next_j = 0;
                 if (k < excell_size)
                     {
-                    #if (__CUDA_ARCH__ > 300)
                     next_j = __ldg(&d_excell_idx[excli(k, my_cell)]);
-                    #else
-                    next_j = d_excell_idx[excli(k, my_cell)];
-                    #endif
                     }
 
                 // add to the queue as long as the queue is not full, and we have not yet reached the end of our own list
@@ -536,11 +532,7 @@ __global__ void gpu_hpmc_insert_depletants_queue_kernel(Scalar4 *d_postype,
 
                         if (k < excell_size)
                             {
-                            #if (__CUDA_ARCH__ > 300)
                             next_j = __ldg(&d_excell_idx[excli(k, my_cell)]);
-                            #else
-                            next_j = d_excell_idx[excli(k, my_cell)];
-                            #endif
                             }
 
                         // read in position, and orientation of neighboring particle

--- a/hoomd/md/AnisoPotentialPairGPU.cuh
+++ b/hoomd/md/AnisoPotentialPairGPU.cuh
@@ -118,11 +118,6 @@ struct a_pair_args_t
     };
 
 #ifdef NVCC
-//! Texture for reading particle positions
-scalar4_tex_t aniso_pdata_pos_tex;
-
-//! Texture for reading particle quaternions
-scalar4_tex_t aniso_pdata_quat_tex;
 
 //! Kernel for calculating pair forces
 /*! This kernel is called to calculate the pair forces on all N particles. Actual evaluation of the potentials and
@@ -217,9 +212,9 @@ __global__ void gpu_compute_pair_aniso_forces_kernel(Scalar4 *d_force,
 
     // read in the position of our particle. Texture reads of Scalar4's are faster than global reads on compute 1.0 hardware
     // (MEM TRANSFER: 16 bytes)
-    Scalar4 postypei = texFetchScalar4(d_pos, aniso_pdata_pos_tex, idx);
+    Scalar4 postypei = texFetchScalar4(d_pos, idx);
     Scalar3 posi = make_scalar3(postypei.x, postypei.y, postypei.z);
-    Scalar4 quati = texFetchScalar4(d_orientation,aniso_pdata_quat_tex, idx);
+    Scalar4 quati = texFetchScalar4(d_orientation, idx);
 
     Scalar di;
     if (evaluator::needsDiameter())
@@ -259,9 +254,9 @@ __global__ void gpu_compute_pair_aniso_forces_kernel(Scalar4 *d_force,
                 next_j = d_nlist[myHead + neigh_idx + tpp];
 
             // get the neighbor's position (MEM TRANSFER: 16 bytes)
-            Scalar4 postypej = texFetchScalar4(d_pos, aniso_pdata_pos_tex, cur_j);
+            Scalar4 postypej = texFetchScalar4(d_pos, cur_j);
             Scalar3 posj = make_scalar3(postypej.x, postypej.y, postypej.z);
-            Scalar4 quatj = texFetchScalar4(d_orientation, aniso_pdata_quat_tex, cur_j);
+            Scalar4 quatj = texFetchScalar4(d_orientation, cur_j);
 
             Scalar dj = 0.0f;
             if (evaluator::needsDiameter())
@@ -407,19 +402,6 @@ int aniso_get_compute_capability(T func)
     return attr.binaryVersion;
     }
 
-void gpu_pair_aniso_force_bind_textures(const a_pair_args_t pair_args)
-    {
-    // bind the position texture
-    aniso_pdata_pos_tex.normalized = false;
-    aniso_pdata_pos_tex.filterMode = cudaFilterModePoint;
-    cudaBindTexture(0, aniso_pdata_pos_tex, pair_args.d_pos, sizeof(Scalar4)*pair_args.n_max);
-
-    // bind the position texture
-    aniso_pdata_quat_tex.normalized = false;
-    aniso_pdata_quat_tex.filterMode = cudaFilterModePoint;
-    cudaBindTexture(0, aniso_pdata_quat_tex, pair_args.d_orientation, sizeof(Scalar4)*pair_args.n_max);
-    }
-
 //! Kernel driver that computes lj forces on the GPU for LJForceComputeGPU
 /*! \param pair_args Other arguments to pass onto the kernel
     \param d_params Parameters for the potential, stored per type pair
@@ -455,13 +437,8 @@ cudaError_t gpu_compute_pair_aniso_forces(const a_pair_args_t& pair_args,
                 case 0:
                     {
                     static unsigned int max_block_size = UINT_MAX;
-                    static unsigned int sm = UINT_MAX;
                     if (max_block_size == UINT_MAX)
                         max_block_size = aniso_get_max_block_size(gpu_compute_pair_aniso_forces_kernel<evaluator, 0, 1>);
-                    if (sm == UINT_MAX)
-                        sm = aniso_get_compute_capability(gpu_compute_pair_aniso_forces_kernel<evaluator, 0, 1>);
-
-                    if (sm < 35) gpu_pair_aniso_force_bind_textures(pair_args);
 
                     block_size = block_size < max_block_size ? block_size : max_block_size;
                     dim3 grid(nwork / (block_size/tpp) + 1, 1, 1);
@@ -492,13 +469,8 @@ cudaError_t gpu_compute_pair_aniso_forces(const a_pair_args_t& pair_args,
                 case 1:
                     {
                     static unsigned int max_block_size = UINT_MAX;
-                    static unsigned int sm = UINT_MAX;
                     if (max_block_size == UINT_MAX)
                         max_block_size = aniso_get_max_block_size(gpu_compute_pair_aniso_forces_kernel<evaluator, 1, 1>);
-                    if (sm == UINT_MAX)
-                        sm = aniso_get_compute_capability(gpu_compute_pair_aniso_forces_kernel<evaluator, 1, 1>);
-
-                    if (sm < 35) gpu_pair_aniso_force_bind_textures(pair_args);
 
                     block_size = block_size < max_block_size ? block_size : max_block_size;
                     dim3 grid(nwork / (block_size/tpp) + 1, 1, 1);
@@ -537,13 +509,9 @@ cudaError_t gpu_compute_pair_aniso_forces(const a_pair_args_t& pair_args,
                 case 0:
                     {
                     static unsigned int max_block_size = UINT_MAX;
-                    static unsigned int sm = UINT_MAX;
                     if (max_block_size == UINT_MAX)
                         max_block_size = aniso_get_max_block_size(gpu_compute_pair_aniso_forces_kernel<evaluator, 0, 0>);
-                    if (sm == UINT_MAX)
-                        sm = aniso_get_compute_capability(gpu_compute_pair_aniso_forces_kernel<evaluator, 0, 0>);
 
-                    if (sm < 35) gpu_pair_aniso_force_bind_textures(pair_args);
 
                     block_size = block_size < max_block_size ? block_size : max_block_size;
                     dim3 grid(nwork / (block_size/tpp) + 1, 1, 1);
@@ -574,21 +542,11 @@ cudaError_t gpu_compute_pair_aniso_forces(const a_pair_args_t& pair_args,
                 case 1:
                     {
                     static unsigned int max_block_size = UINT_MAX;
-                    static unsigned int sm = UINT_MAX;
                     if (max_block_size == UINT_MAX)
                         max_block_size = aniso_get_max_block_size(gpu_compute_pair_aniso_forces_kernel<evaluator, 1, 0>);
-                    if (sm == UINT_MAX)
-                        sm = aniso_get_compute_capability(gpu_compute_pair_aniso_forces_kernel<evaluator, 1, 0>);
-
-                    if (sm < 35) gpu_pair_aniso_force_bind_textures(pair_args);
 
                     block_size = block_size < max_block_size ? block_size : max_block_size;
                     dim3 grid(nwork / (block_size/tpp) + 1, 1, 1);
-                    if (sm < 30 && grid.x > 65535)
-                        {
-                        grid.y = grid.x/65535 + 1;
-                        grid.x = 65535;
-                        }
 
                     shared_bytes += sizeof(Scalar)*block_size;
 

--- a/hoomd/md/AnisoPotentialPairGPU.cuh
+++ b/hoomd/md/AnisoPotentialPairGPU.cuh
@@ -212,9 +212,9 @@ __global__ void gpu_compute_pair_aniso_forces_kernel(Scalar4 *d_force,
 
     // read in the position of our particle. Texture reads of Scalar4's are faster than global reads on compute 1.0 hardware
     // (MEM TRANSFER: 16 bytes)
-    Scalar4 postypei = texFetchScalar4(d_pos, idx);
+    Scalar4 postypei = __ldg(d_pos + idx);
     Scalar3 posi = make_scalar3(postypei.x, postypei.y, postypei.z);
-    Scalar4 quati = texFetchScalar4(d_orientation, idx);
+    Scalar4 quati = __ldg(d_orientation + idx);
 
     Scalar di;
     if (evaluator::needsDiameter())
@@ -254,9 +254,9 @@ __global__ void gpu_compute_pair_aniso_forces_kernel(Scalar4 *d_force,
                 next_j = d_nlist[myHead + neigh_idx + tpp];
 
             // get the neighbor's position (MEM TRANSFER: 16 bytes)
-            Scalar4 postypej = texFetchScalar4(d_pos, cur_j);
+            Scalar4 postypej = __ldg(d_pos + cur_j);
             Scalar3 posj = make_scalar3(postypej.x, postypej.y, postypej.z);
-            Scalar4 quatj = texFetchScalar4(d_orientation, cur_j);
+            Scalar4 quatj = __ldg(d_orientation + cur_j);
 
             Scalar dj = 0.0f;
             if (evaluator::needsDiameter())

--- a/hoomd/md/BondTablePotentialGPU.cc
+++ b/hoomd/md/BondTablePotentialGPU.cc
@@ -93,8 +93,7 @@ void BondTablePotentialGPU::computeForces(unsigned int timestep)
                              m_table_width,
                              m_table_value,
                              d_flags.data,
-                             m_tuner->getParam(),
-                             m_exec_conf->getComputeCapability());
+                             m_tuner->getParam());
         }
 
 

--- a/hoomd/md/BondTablePotentialGPU.cuh
+++ b/hoomd/md/BondTablePotentialGPU.cuh
@@ -32,7 +32,6 @@ cudaError_t gpu_compute_bondtable_forces(Scalar4* d_force,
                                      const unsigned int table_width,
                                      const Index2D &table_value,
                                      unsigned int *d_flags,
-                                     const unsigned int block_size,
-                                     const unsigned int compute_capability);
+                                     const unsigned int block_size);
 
 #endif

--- a/hoomd/md/CosineSqAngleForceComputeGPU.cc
+++ b/hoomd/md/CosineSqAngleForceComputeGPU.cc
@@ -92,8 +92,7 @@ void CosineSqAngleForceComputeGPU::computeForces(unsigned int timestep)
                                       d_gpu_n_angles.data,
                                       d_params.data,
                                       m_angle_data->getNTypes(),
-                                      m_tuner->getParam(),
-                                      m_exec_conf->getComputeCapability());
+                                      m_tuner->getParam());
 
     if(m_exec_conf->isCUDAErrorCheckingEnabled())
         CHECK_CUDA_ERROR();

--- a/hoomd/md/CosineSqAngleForceGPU.cu
+++ b/hoomd/md/CosineSqAngleForceGPU.cu
@@ -16,9 +16,6 @@
     CosineSqAngleForceComputeGPU.
 */
 
-//! Texture for reading angle parameters
-scalar2_tex_t angle_params_tex;
-
 //! Kernel for calculating cosine squared angle forces on the GPU
 /*! \param d_force Device memory to write computed forces
     \param d_virial Device memory to write computed virials
@@ -115,7 +112,7 @@ extern "C" __global__ void gpu_compute_cosinesq_angle_forces_kernel(Scalar4* d_f
         dac = box.minImage(dac);
 
         // get the angle parameters (MEM TRANSFER: 8 bytes)
-        Scalar2 params = texFetchScalar2(d_params, angle_params_tex, cur_angle_type);
+        Scalar2 params = __ldg(d_params + cur_angle_type);
         Scalar K = params.x;
         Scalar t_0 = params.y;
 
@@ -205,7 +202,6 @@ extern "C" __global__ void gpu_compute_cosinesq_angle_forces_kernel(Scalar4* d_f
     \param d_params K and t_0 params packed as Scalar2 variables
     \param n_angle_types Number of angle types in d_params
     \param block_size Block size to use when performing calculations
-    \param compute_capability Device compute capability (200, 300, 350, ...)
 
     \returns Any error code resulting from the kernel launch
     \note Always returns cudaSuccess in release builds to avoid the cudaThreadSynchronize()
@@ -225,8 +221,7 @@ cudaError_t gpu_compute_cosinesq_angle_forces(Scalar4* d_force,
                                               const unsigned int *n_angles_list,
                                               Scalar2 *d_params,
                                               unsigned int n_angle_types,
-                                              int block_size,
-                                              const unsigned int compute_capability)
+                                              int block_size)
     {
     assert(d_params);
 
@@ -243,14 +238,6 @@ cudaError_t gpu_compute_cosinesq_angle_forces(Scalar4* d_force,
     // setup the grid to run the kernel
     dim3 grid( N / run_block_size + 1, 1, 1);
     dim3 threads(run_block_size, 1, 1);
-
-    // bind the texture on pre sm 35 arches
-    if (compute_capability < 350)
-        {
-        cudaError_t error = cudaBindTexture(0, angle_params_tex, d_params, sizeof(Scalar2) * n_angle_types);
-        if (error != cudaSuccess)
-            return error;
-        }
 
     // run the kernel
     gpu_compute_cosinesq_angle_forces_kernel<<< grid, threads>>>(

--- a/hoomd/md/CosineSqAngleForceGPU.cuh
+++ b/hoomd/md/CosineSqAngleForceGPU.cuh
@@ -28,7 +28,6 @@ cudaError_t gpu_compute_cosinesq_angle_forces(Scalar4* d_force,
                                               const unsigned int *n_angles_list,
                                               Scalar2 *d_params,
                                               unsigned int n_angle_types,
-                                              int block_size,
-                                              const unsigned int compute_capability);
+                                              int block_size);
 
 #endif

--- a/hoomd/md/HarmonicAngleForceComputeGPU.cc
+++ b/hoomd/md/HarmonicAngleForceComputeGPU.cc
@@ -94,8 +94,7 @@ void HarmonicAngleForceComputeGPU::computeForces(unsigned int timestep)
                                       d_gpu_n_angles.data,
                                       d_params.data,
                                       m_angle_data->getNTypes(),
-                                      m_tuner->getParam(),
-                                      m_exec_conf->getComputeCapability());
+                                      m_tuner->getParam());
 
     if(m_exec_conf->isCUDAErrorCheckingEnabled())
         CHECK_CUDA_ERROR();

--- a/hoomd/md/HarmonicAngleForceGPU.cu
+++ b/hoomd/md/HarmonicAngleForceGPU.cu
@@ -16,9 +16,6 @@
     \brief Defines GPU kernel code for calculating the harmonic angle forces. Used by HarmonicAngleForceComputeGPU.
 */
 
-//! Texture for reading angle parameters
-scalar2_tex_t angle_params_tex;
-
 //! Kernel for calculating harmonic angle forces on the GPU
 /*! \param d_force Device memory to write computed forces
     \param d_virial Device memory to write computed virials
@@ -115,7 +112,7 @@ extern "C" __global__ void gpu_compute_harmonic_angle_forces_kernel(Scalar4* d_f
         dac = box.minImage(dac);
 
         // get the angle parameters (MEM TRANSFER: 8 bytes)
-        Scalar2 params = texFetchScalar2(d_params, angle_params_tex, cur_angle_type);
+        Scalar2 params = __ldg(d_params + cur_angle_type);
         Scalar K = params.x;
         Scalar t_0 = params.y;
 
@@ -227,8 +224,7 @@ cudaError_t gpu_compute_harmonic_angle_forces(Scalar4* d_force,
                                               const unsigned int *n_angles_list,
                                               Scalar2 *d_params,
                                               unsigned int n_angle_types,
-                                              int block_size,
-                                              const unsigned int compute_capability)
+                                              int block_size)
     {
     assert(d_params);
 
@@ -245,14 +241,6 @@ cudaError_t gpu_compute_harmonic_angle_forces(Scalar4* d_force,
     // setup the grid to run the kernel
     dim3 grid( N / run_block_size + 1, 1, 1);
     dim3 threads(run_block_size, 1, 1);
-
-    // bind the texture on pre sm 35 arches
-    if (compute_capability < 350)
-        {
-        cudaError_t error = cudaBindTexture(0, angle_params_tex, d_params, sizeof(Scalar2) * n_angle_types);
-        if (error != cudaSuccess)
-            return error;
-        }
 
     // run the kernel
     gpu_compute_harmonic_angle_forces_kernel<<< grid, threads>>>(d_force, d_virial, virial_pitch, N, d_pos, d_params, box,

--- a/hoomd/md/HarmonicAngleForceGPU.cuh
+++ b/hoomd/md/HarmonicAngleForceGPU.cuh
@@ -28,7 +28,6 @@ cudaError_t gpu_compute_harmonic_angle_forces(Scalar4* d_force,
                                               const unsigned int *n_angles_list,
                                               Scalar2 *d_params,
                                               unsigned int n_angle_types,
-                                              int block_size,
-                                              const unsigned int compute_capability);
+                                              int block_size);
 
 #endif

--- a/hoomd/md/HarmonicDihedralForceComputeGPU.cc
+++ b/hoomd/md/HarmonicDihedralForceComputeGPU.cc
@@ -93,8 +93,7 @@ void HarmonicDihedralForceComputeGPU::computeForces(unsigned int timestep)
                                          d_n_dihedrals.data,
                                          d_params.data,
                                          m_dihedral_data->getNTypes(),
-                                         this->m_tuner->getParam(),
-                                         m_exec_conf->getComputeCapability());
+                                         this->m_tuner->getParam());
     if(m_exec_conf->isCUDAErrorCheckingEnabled())
         CHECK_CUDA_ERROR();
     this->m_tuner->end();

--- a/hoomd/md/HarmonicDihedralForceGPU.cu
+++ b/hoomd/md/HarmonicDihedralForceGPU.cu
@@ -134,7 +134,7 @@ void gpu_compute_harmonic_dihedral_forces_kernel(Scalar4* d_force,
         dcbm = box.minImage(dcbm);
 
         // get the dihedral parameters (MEM TRANSFER: 12 bytes)
-        Scalar4 params = texFetchScalar4(d_params, cur_dihedral_type);
+        Scalar4 params = __ldg(d_params + cur_dihedral_type);
         Scalar K = params.x;
         Scalar sign = params.y;
         Scalar multi = params.z;

--- a/hoomd/md/HarmonicDihedralForceGPU.cu
+++ b/hoomd/md/HarmonicDihedralForceGPU.cu
@@ -22,9 +22,6 @@
     \brief Defines GPU kernel code for calculating the harmonic dihedral forces. Used by HarmonicDihedralForceComputeGPU.
 */
 
-//! Texture for reading dihedral parameters
-scalar4_tex_t dihedral_params_tex;
-
 //! Kernel for calculating harmonic dihedral forces on the GPU
 /*! \param d_force Device memory to write computed forces
     \param d_virial Device memory to write computed virials
@@ -137,7 +134,7 @@ void gpu_compute_harmonic_dihedral_forces_kernel(Scalar4* d_force,
         dcbm = box.minImage(dcbm);
 
         // get the dihedral parameters (MEM TRANSFER: 12 bytes)
-        Scalar4 params = texFetchScalar4(d_params, dihedral_params_tex, cur_dihedral_type);
+        Scalar4 params = texFetchScalar4(d_params, cur_dihedral_type);
         Scalar K = params.x;
         Scalar sign = params.y;
         Scalar multi = params.z;
@@ -319,8 +316,7 @@ cudaError_t gpu_compute_harmonic_dihedral_forces(Scalar4* d_force,
                                                  const unsigned int *n_dihedrals_list,
                                                  Scalar4 *d_params,
                                                  unsigned int n_dihedral_types,
-                                                 int block_size,
-                                                 const unsigned int compute_capability)
+                                                 int block_size)
     {
     assert(d_params);
 
@@ -337,14 +333,6 @@ cudaError_t gpu_compute_harmonic_dihedral_forces(Scalar4* d_force,
     // setup the grid to run the kernel
     dim3 grid( N / run_block_size + 1, 1, 1);
     dim3 threads(run_block_size, 1, 1);
-
-    // bind the texture on pre sm35 devices
-    if (compute_capability < 350)
-        {
-        cudaError_t error = cudaBindTexture(0, dihedral_params_tex, d_params, sizeof(Scalar4) * n_dihedral_types);
-        if (error != cudaSuccess)
-            return error;
-        }
 
     // run the kernel
     gpu_compute_harmonic_dihedral_forces_kernel<<< grid, threads>>>(d_force, d_virial, virial_pitch, N, d_pos, d_params, box, tlist, dihedral_ABCD, pitch, n_dihedrals_list);

--- a/hoomd/md/HarmonicDihedralForceGPU.cuh
+++ b/hoomd/md/HarmonicDihedralForceGPU.cuh
@@ -28,7 +28,6 @@ cudaError_t gpu_compute_harmonic_dihedral_forces(Scalar4* d_force,
                                                  const unsigned int *n_dihedrals_list,
                                                  Scalar4 *d_params,
                                                  unsigned int n_dihedral_types,
-                                                 int block_size,
-                                                 const unsigned int compute_capability);
+                                                 int block_size);
 
 #endif

--- a/hoomd/md/HarmonicImproperForceComputeGPU.cc
+++ b/hoomd/md/HarmonicImproperForceComputeGPU.cc
@@ -91,8 +91,7 @@ void HarmonicImproperForceComputeGPU::computeForces(unsigned int timestep)
                                          d_n_dihedrals.data,
                                          d_params.data,
                                          m_improper_data->getNTypes(),
-                                         m_tuner->getParam(),
-                                         m_exec_conf->getComputeCapability());
+                                         m_tuner->getParam());
     if(m_exec_conf->isCUDAErrorCheckingEnabled())
         CHECK_CUDA_ERROR();
     m_tuner->end();

--- a/hoomd/md/HarmonicImproperForceGPU.cuh
+++ b/hoomd/md/HarmonicImproperForceGPU.cuh
@@ -28,7 +28,6 @@ cudaError_t gpu_compute_harmonic_improper_forces(Scalar4* d_force,
                                                  const unsigned int *n_dihedrals_list,
                                                  Scalar2 *d_params,
                                                  unsigned int n_improper_types,
-                                                 int block_size,
-                                                 const unsigned int compute_capability);
+                                                 int block_size);
 
 #endif

--- a/hoomd/md/NeighborListGPUBinned.cu
+++ b/hoomd/md/NeighborListGPUBinned.cu
@@ -193,7 +193,7 @@ __global__ void gpu_compute_nlist_binned_kernel(unsigned int *d_nlist,
             unsigned int j;
             Scalar4 postype_j;
             if (!use_index)
-                cur_xyzf = texFetchScalar4(d_cell_xyzf, cli(cur_offset, neigh_cell));
+                cur_xyzf = __ldg(d_cell_xyzf + cli(cur_offset, neigh_cell));
             else
                 {
                 j = d_cell_idx[cli(cur_offset, neigh_cell)+igpu*cli.getNumElements()];

--- a/hoomd/md/NeighborListGPUBinned.cu
+++ b/hoomd/md/NeighborListGPUBinned.cu
@@ -12,9 +12,6 @@
     \brief Defines GPU kernel code for O(N) neighbor list generation on the GPU
 */
 
-//! Texture for reading d_cell_xyzf
-scalar4_tex_t cell_xyzf_1d_tex;
-
 //! Kernel call for generating neighbor list on the GPU (Kepler optimized version)
 /*! \tparam flags Set bit 1 to enable body filtering. Set bit 2 to enable diameter filtering.
     \param d_nlist Neighbor list data structure to write
@@ -196,7 +193,7 @@ __global__ void gpu_compute_nlist_binned_kernel(unsigned int *d_nlist,
             unsigned int j;
             Scalar4 postype_j;
             if (!use_index)
-                cur_xyzf = texFetchScalar4(d_cell_xyzf, cell_xyzf_1d_tex, cli(cur_offset, neigh_cell));
+                cur_xyzf = texFetchScalar4(d_cell_xyzf, cli(cur_offset, neigh_cell));
             else
                 {
                 j = d_cell_idx[cli(cur_offset, neigh_cell)+igpu*cli.getNumElements()];
@@ -300,14 +297,6 @@ int get_max_block_size(T func)
     return max_threads;
     }
 
-void gpu_nlist_binned_bind_texture(const Scalar4 *d_cell_xyzf, unsigned int n_elements)
-    {
-    // bind the position texture
-    cell_xyzf_1d_tex.normalized = false;
-    cell_xyzf_1d_tex.filterMode = cudaFilterModePoint;
-    cudaBindTexture(0, cell_xyzf_1d_tex, d_cell_xyzf, sizeof(Scalar4)*n_elements);
-    }
-
 //! recursive template to launch neighborlist with given template parameters
 /* \tparam cur_tpp Number of threads per particle (assumed to be power of two) */
 template<int cur_tpp>
@@ -359,7 +348,6 @@ inline void launcher(unsigned int *d_nlist,
                 static unsigned int max_block_size = UINT_MAX;
                 if (max_block_size == UINT_MAX)
                     max_block_size = get_max_block_size(gpu_compute_nlist_binned_kernel<0,0,cur_tpp>);
-                if (compute_capability < 35) gpu_nlist_binned_bind_texture(d_cell_xyzf, cli.getNumElements());
 
                 block_size = block_size < max_block_size ? block_size : max_block_size;
                 dim3 grid(nwork / (block_size/tpp) + 1);
@@ -396,7 +384,6 @@ inline void launcher(unsigned int *d_nlist,
                 static unsigned int max_block_size = UINT_MAX;
                 if (max_block_size == UINT_MAX)
                     max_block_size = get_max_block_size(gpu_compute_nlist_binned_kernel<1,0,cur_tpp>);
-                if (compute_capability < 35) gpu_nlist_binned_bind_texture(d_cell_xyzf, cli.getNumElements());
 
                 block_size = block_size < max_block_size ? block_size : max_block_size;
                 dim3 grid(nwork / (block_size/tpp) + 1);
@@ -433,7 +420,6 @@ inline void launcher(unsigned int *d_nlist,
                 static unsigned int max_block_size = UINT_MAX;
                 if (max_block_size == UINT_MAX)
                     max_block_size = get_max_block_size(gpu_compute_nlist_binned_kernel<2,0,cur_tpp>);
-                if (compute_capability < 35) gpu_nlist_binned_bind_texture(d_cell_xyzf, cli.getNumElements());
 
                 block_size = block_size < max_block_size ? block_size : max_block_size;
                 dim3 grid(nwork / (block_size/tpp) + 1);
@@ -470,7 +456,6 @@ inline void launcher(unsigned int *d_nlist,
                 static unsigned int max_block_size = UINT_MAX;
                 if (max_block_size == UINT_MAX)
                     max_block_size = get_max_block_size(gpu_compute_nlist_binned_kernel<3,0,cur_tpp>);
-                if (compute_capability < 35) gpu_nlist_binned_bind_texture(d_cell_xyzf, cli.getNumElements());
 
                 block_size = block_size < max_block_size ? block_size : max_block_size;
                 dim3 grid(nwork / (block_size/tpp) + 1);
@@ -510,7 +495,6 @@ inline void launcher(unsigned int *d_nlist,
                 static unsigned int max_block_size = UINT_MAX;
                 if (max_block_size == UINT_MAX)
                     max_block_size = get_max_block_size(gpu_compute_nlist_binned_kernel<0,1,cur_tpp>);
-                if (compute_capability < 35) gpu_nlist_binned_bind_texture(d_cell_xyzf, cli.getNumElements());
 
                 block_size = block_size < max_block_size ? block_size : max_block_size;
                 dim3 grid(nwork / (block_size/tpp) + 1);
@@ -547,7 +531,6 @@ inline void launcher(unsigned int *d_nlist,
                 static unsigned int max_block_size = UINT_MAX;
                 if (max_block_size == UINT_MAX)
                     max_block_size = get_max_block_size(gpu_compute_nlist_binned_kernel<1,1,cur_tpp>);
-                if (compute_capability < 35) gpu_nlist_binned_bind_texture(d_cell_xyzf, cli.getNumElements());
 
                 block_size = block_size < max_block_size ? block_size : max_block_size;
                 dim3 grid(nwork / (block_size/tpp) + 1);
@@ -584,7 +567,6 @@ inline void launcher(unsigned int *d_nlist,
                 static unsigned int max_block_size = UINT_MAX;
                 if (max_block_size == UINT_MAX)
                     max_block_size = get_max_block_size(gpu_compute_nlist_binned_kernel<2,1,cur_tpp>);
-                if (compute_capability < 35) gpu_nlist_binned_bind_texture(d_cell_xyzf, cli.getNumElements());
 
                 block_size = block_size < max_block_size ? block_size : max_block_size;
                 dim3 grid(nwork / (block_size/tpp) + 1);
@@ -621,7 +603,6 @@ inline void launcher(unsigned int *d_nlist,
                 static unsigned int max_block_size = UINT_MAX;
                 if (max_block_size == UINT_MAX)
                     max_block_size = get_max_block_size(gpu_compute_nlist_binned_kernel<3,1,cur_tpp>);
-                if (compute_capability < 35) gpu_nlist_binned_bind_texture(d_cell_xyzf, cli.getNumElements());
 
                 block_size = block_size < max_block_size ? block_size : max_block_size;
                 dim3 grid(nwork / (block_size/tpp) + 1);

--- a/hoomd/md/NeighborListGPUStencil.cc
+++ b/hoomd/md/NeighborListGPUStencil.cc
@@ -312,8 +312,7 @@ void NeighborListGPUStencil::buildNlist(unsigned int timestep)
                               m_filter_body,
                               m_diameter_shift,
                               threads_per_particle,
-                              block_size,
-                              m_exec_conf->getComputeCapability()/10);
+                              block_size);
 
     if(m_exec_conf->isCUDAErrorCheckingEnabled()) CHECK_CUDA_ERROR();
     if (tune) this->m_tuner->end();

--- a/hoomd/md/NeighborListGPUStencil.cu
+++ b/hoomd/md/NeighborListGPUStencil.cu
@@ -170,7 +170,7 @@ __global__ void gpu_compute_nlist_stencil_kernel(unsigned int *d_nlist,
             if (cur_adj < n_stencil)
                 {
                 // compute the stenciled cell cartesian coordinates
-                Scalar4 stencil = texFetchScalar4(d_stencil, stencil_idx(cur_adj, my_type));
+                Scalar4 stencil = __ldg(d_stencil + stencil_idx(cur_adj, my_type));
                 int sib = ib + __scalar_as_int(stencil.x);
                 int sjb = jb + __scalar_as_int(stencil.y);
                 int skb = kb + __scalar_as_int(stencil.z);
@@ -203,7 +203,7 @@ __global__ void gpu_compute_nlist_stencil_kernel(unsigned int *d_nlist,
             do
                 {
                 // read in the particle type (diameter and body as well while we've got the Scalar4 in)
-                const Scalar4 neigh_tdb = texFetchScalar4(d_cell_tdb, cli(cur_offset, neigh_cell));
+                const Scalar4 neigh_tdb = __ldg(d_cell_tdb + cli(cur_offset, neigh_cell));
                 const unsigned int type_j = __scalar_as_int(neigh_tdb.x);
                 const Scalar diam_j = neigh_tdb.y;
                 const unsigned int body_j = __scalar_as_int(neigh_tdb.z);
@@ -228,7 +228,7 @@ __global__ void gpu_compute_nlist_stencil_kernel(unsigned int *d_nlist,
                 if (cell_dist2 > r_listsq) break;
 
                 // only load in the particle position and id if distance check is required
-                const Scalar4 neigh_xyzf = texFetchScalar4(d_cell_xyzf, cli(cur_offset, neigh_cell));
+                const Scalar4 neigh_xyzf = __ldg(d_cell_xyzf + cli(cur_offset, neigh_cell));
                 const Scalar3 neigh_pos = make_scalar3(neigh_xyzf.x, neigh_xyzf.y, neigh_xyzf.z);
                 unsigned int cur_neigh = __scalar_as_int(neigh_xyzf.w);
 

--- a/hoomd/md/NeighborListGPUStencil.cuh
+++ b/hoomd/md/NeighborListGPUStencil.cuh
@@ -49,8 +49,7 @@ cudaError_t gpu_compute_nlist_stencil(unsigned int *d_nlist,
                                       bool filter_body,
                                       bool diameter_shift,
                                       const unsigned int threads_per_particle,
-                                      const unsigned int block_size,
-                                      const unsigned int compute_capability);
+                                      const unsigned int block_size);
 
 //! Kernel driver for filling the particle types for sorting
 cudaError_t gpu_compute_nlist_stencil_fill_types(unsigned int *d_pids,

--- a/hoomd/md/NeighborListGPUTree.cc
+++ b/hoomd/md/NeighborListGPUTree.cc
@@ -809,7 +809,6 @@ void NeighborListGPUTree::traverseTree()
                             m_pdata->getNTypes(),
                             m_filter_body,
                             m_diameter_shift,
-                            m_exec_conf->getComputeCapability()/10,
                             m_tuner_traverse->getParam());
     if (m_exec_conf->isCUDAErrorCheckingEnabled())
         CHECK_CUDA_ERROR();

--- a/hoomd/md/NeighborListGPUTree.cuh
+++ b/hoomd/md/NeighborListGPUTree.cuh
@@ -120,7 +120,6 @@ cudaError_t gpu_nlist_traverse_tree(unsigned int *d_nlist,
                                     const unsigned int ntypes,
                                     bool filter_body,
                                     bool diameter_shift,
-                                    const unsigned int compute_capability,
                                     const unsigned int block_size);
 
 //! Kernel driver to initialize counting for types and nodes

--- a/hoomd/md/OPLSDihedralForceComputeGPU.cc
+++ b/hoomd/md/OPLSDihedralForceComputeGPU.cc
@@ -69,8 +69,7 @@ void OPLSDihedralForceComputeGPU::computeForces(unsigned int timestep)
                                          d_n_dihedrals.data,
                                          d_params.data,
                                          m_dihedral_data->getNTypes(),
-                                         this->m_tuner->getParam(),
-                                         m_exec_conf->getComputeCapability());
+                                         this->m_tuner->getParam());
     if(m_exec_conf->isCUDAErrorCheckingEnabled())
         CHECK_CUDA_ERROR();
     this->m_tuner->end();

--- a/hoomd/md/OPLSDihedralForceGPU.cu
+++ b/hoomd/md/OPLSDihedralForceGPU.cu
@@ -13,9 +13,6 @@
     \brief Defines GPU kernel code for calculating OPLS dihedral forces. Used by OPLSDihedralForceComputeGPU.
 */
 
-//! Texture for reading dihedral parameters
-scalar4_tex_t dihedral_params_tex;
-
 //! Kernel for calculating OPLS dihedral forces on the GPU
 /*! \param d_force Device memory to write computed forces
     \param d_virial Device memory to write computed virials
@@ -159,7 +156,7 @@ void gpu_compute_opls_dihedral_forces_kernel(Scalar4* d_force,
 
         // get values for k1/2 through k4/2 (MEM TRANSFER: 16 bytes)
         // ----- The 1/2 factor is already stored in the parameters --------
-        Scalar4 params = texFetchScalar4(d_params, dihedral_params_tex, cur_dihedral_type);
+        Scalar4 params = texFetchScalar4(d_params, cur_dihedral_type);
         Scalar k1 = params.x;
         Scalar k2 = params.y;
         Scalar k3 = params.z;
@@ -321,8 +318,7 @@ cudaError_t gpu_compute_opls_dihedral_forces(Scalar4* d_force,
                                                 const unsigned int *n_dihedrals_list,
                                                 const Scalar4 *d_params,
                                                 const unsigned int n_dihedral_types,
-                                                const int block_size,
-                                                const unsigned int compute_capability)
+                                                const int block_size)
     {
     assert(d_params);
 
@@ -339,14 +335,6 @@ cudaError_t gpu_compute_opls_dihedral_forces(Scalar4* d_force,
     // setup the grid to run the kernel
     dim3 grid( N / run_block_size + 1, 1, 1);
     dim3 threads(run_block_size, 1, 1);
-
-    // bind the texture on pre sm35 devices
-    if (compute_capability < 350)
-        {
-        cudaError_t error = cudaBindTexture(0, dihedral_params_tex, d_params, sizeof(Scalar4) * n_dihedral_types);
-        if (error != cudaSuccess)
-            return error;
-        }
 
     // run the kernel
     gpu_compute_opls_dihedral_forces_kernel<<< grid, threads>>>(d_force, d_virial, virial_pitch, N, d_pos, d_params,

--- a/hoomd/md/OPLSDihedralForceGPU.cu
+++ b/hoomd/md/OPLSDihedralForceGPU.cu
@@ -156,7 +156,7 @@ void gpu_compute_opls_dihedral_forces_kernel(Scalar4* d_force,
 
         // get values for k1/2 through k4/2 (MEM TRANSFER: 16 bytes)
         // ----- The 1/2 factor is already stored in the parameters --------
-        Scalar4 params = texFetchScalar4(d_params, cur_dihedral_type);
+        Scalar4 params = __ldg(d_params + cur_dihedral_type);
         Scalar k1 = params.x;
         Scalar k2 = params.y;
         Scalar k3 = params.z;

--- a/hoomd/md/OPLSDihedralForceGPU.cuh
+++ b/hoomd/md/OPLSDihedralForceGPU.cuh
@@ -28,7 +28,6 @@ cudaError_t gpu_compute_opls_dihedral_forces(Scalar4* d_force,
                                                 const unsigned int *n_dihedrals_list,
                                                 const Scalar4 *d_params,
                                                 const unsigned int n_dihedral_types,
-                                                const int block_size,
-                                                const unsigned int compute_capability);
+                                                const int block_size);
 
 #endif

--- a/hoomd/md/PPPMForceComputeGPU.cc
+++ b/hoomd/md/PPPMForceComputeGPU.cc
@@ -186,7 +186,7 @@ void PPPMForceComputeGPU::initializeFFT()
         cudaMemPrefetchAsync(m_fourier_mesh_G_z.get(), m_n_inner_cells*sizeof(cufftComplex), gpu_map[0]);
         cudaMemAdvise(m_fourier_mesh_G_z.get(), m_n_inner_cells*sizeof(cufftComplex), cudaMemAdviseSetPreferredLocation, gpu_map[0]);
         cudaMemPrefetchAsync(m_fourier_mesh_G_y.get(), m_n_inner_cells*sizeof(cufftComplex), gpu_map[0]);
-        } 
+        }
 
     unsigned int n_blocks = (m_mesh_points.x*m_mesh_points.y*m_mesh_points.z)/m_block_size+1;
     GlobalArray<Scalar> sum_partial(n_blocks,m_exec_conf);
@@ -686,8 +686,7 @@ void PPPMForceComputeGPU::fixExclusions()
                    m_alpha,
                    d_index_array.data,
                    group_size,
-                   m_block_size,
-                   m_exec_conf->getComputeCapability());
+                   m_block_size);
 
     if(m_exec_conf->isCUDAErrorCheckingEnabled())
         CHECK_CUDA_ERROR();

--- a/hoomd/md/PPPMForceComputeGPU.cu
+++ b/hoomd/md/PPPMForceComputeGPU.cu
@@ -1235,7 +1235,7 @@ __global__ void gpu_fix_exclusions_kernel(Scalar4 *d_force,
         unsigned int idx = d_group_members[group_idx];
         const Scalar sqrtpi = sqrtf(M_PI);
         unsigned int n_neigh = d_n_neigh[idx];
-        Scalar4 postypei =  texFetchScalar4(d_pos, idx);
+        Scalar4 postypei =  __ldg(d_pos + idx);
         Scalar3 posi = make_scalar3(postypei.x, postypei.y, postypei.z);
 
         Scalar qi = __ldg(d_charge + idx);
@@ -1258,7 +1258,7 @@ __global__ void gpu_fix_exclusions_kernel(Scalar4 *d_force,
                         next_j = d_nlist[nli(idx, neigh_idx+1)];
 
                     // get the neighbor's position (MEM TRANSFER: 16 bytes)
-                    Scalar4 postypej = texFetchScalar4(d_pos, cur_j);
+                    Scalar4 postypej = __ldg(d_pos + cur_j);
                     Scalar3 posj = make_scalar3(postypej.x, postypej.y, postypej.z);
 
                     Scalar qj = __ldg(d_charge + cur_j);

--- a/hoomd/md/PPPMForceComputeGPU.cuh
+++ b/hoomd/md/PPPMForceComputeGPU.cuh
@@ -30,7 +30,7 @@ void gpu_reduce_meshes(const unsigned int mesh_elements,
     cufftComplex *d_mesh,
     const unsigned int ngpu,
     const unsigned int block_size);
- 
+
 void gpu_compute_mesh_virial(const unsigned int n_wave_vectors,
                              cufftComplex *d_fourier_mesh,
                              Scalar *d_inf_f,
@@ -111,8 +111,7 @@ cudaError_t gpu_fix_exclusions(Scalar4 *d_force,
                            Scalar alpha,
                            unsigned int *d_group_members,
                            unsigned int group_size,
-                           int block_size,
-                           const unsigned int compute_capability);
+                           int block_size);
 
 void gpu_initialize_coeff(
     Scalar *CPU_rho_coeff,

--- a/hoomd/md/PotentialBondGPU.cuh
+++ b/hoomd/md/PotentialBondGPU.cuh
@@ -139,7 +139,7 @@ __global__ void gpu_compute_bond_forces_kernel(Scalar4 *d_force,
     int n_bonds =n_bonds_list[idx];
 
     // read in the position of our particle. (MEM TRANSFER: 16 bytes)
-    Scalar4 postype = texFetchScalar4(d_pos, idx);
+    Scalar4 postype = __ldg(d_pos + idx);
     Scalar3 pos = make_scalar3(postype.x, postype.y, postype.z);
 
     // read in the diameter of our particle if needed
@@ -175,7 +175,7 @@ __global__ void gpu_compute_bond_forces_kernel(Scalar4 *d_force,
         int cur_bond_type = cur_bond.idx[1];
 
         // get the bonded particle's position (MEM_TRANSFER: 16 bytes)
-        Scalar4 neigh_postypej = texFetchScalar4(d_pos, cur_bond_idx);
+        Scalar4 neigh_postypej = __ldg(d_pos + cur_bond_idx);
         Scalar3 neigh_pos= make_scalar3(neigh_postypej.x, neigh_postypej.y, neigh_postypej.z);
 
         // calculate dr (FLOPS: 3)

--- a/hoomd/md/PotentialBondGPU.cuh
+++ b/hoomd/md/PotentialBondGPU.cuh
@@ -37,8 +37,7 @@ struct bond_args_t
               const Index2D & _gpu_table_indexer,
               const unsigned int *_d_gpu_n_bonds,
               const unsigned int _n_bond_types,
-              const unsigned int _block_size,
-              const unsigned int _compute_capability)
+              const unsigned int _block_size)
                 : d_force(_d_force),
                   d_virial(_d_virial),
                   virial_pitch(_virial_pitch),
@@ -52,8 +51,7 @@ struct bond_args_t
                   gpu_table_indexer(_gpu_table_indexer),
                   d_gpu_n_bonds(_d_gpu_n_bonds),
                   n_bond_types(_n_bond_types),
-                  block_size(_block_size),
-                  compute_capability(_compute_capability)
+                  block_size(_block_size)
         {
         };
 
@@ -71,12 +69,9 @@ struct bond_args_t
     const unsigned int *d_gpu_n_bonds; //!< List of number of bonds stored on the GPU
     const unsigned int n_bond_types;   //!< Number of bond types in the simulation
     const unsigned int block_size;     //!< Block size to execute
-    const unsigned int compute_capability;  //!< Compute capability of the device
     };
 
 #ifdef NVCC
-//! Texture for reading particle positions
-scalar4_tex_t pdata_pos_tex;
 
 //! Kernel for calculating bond forces
 /*! This kernel is called to calculate the bond forces on all N particles. Actual evaluation of the potentials and
@@ -144,7 +139,7 @@ __global__ void gpu_compute_bond_forces_kernel(Scalar4 *d_force,
     int n_bonds =n_bonds_list[idx];
 
     // read in the position of our particle. (MEM TRANSFER: 16 bytes)
-    Scalar4 postype = texFetchScalar4(d_pos, pdata_pos_tex, idx);
+    Scalar4 postype = texFetchScalar4(d_pos, idx);
     Scalar3 pos = make_scalar3(postype.x, postype.y, postype.z);
 
     // read in the diameter of our particle if needed
@@ -180,7 +175,7 @@ __global__ void gpu_compute_bond_forces_kernel(Scalar4 *d_force,
         int cur_bond_type = cur_bond.idx[1];
 
         // get the bonded particle's position (MEM_TRANSFER: 16 bytes)
-        Scalar4 neigh_postypej = texFetchScalar4(d_pos, pdata_pos_tex, cur_bond_idx);
+        Scalar4 neigh_postypej = texFetchScalar4(d_pos, cur_bond_idx);
         Scalar3 neigh_pos= make_scalar3(neigh_postypej.x, neigh_postypej.y, neigh_postypej.z);
 
         // calculate dr (FLOPS: 3)
@@ -279,16 +274,6 @@ cudaError_t gpu_compute_bond_forces(const bond_args_t& bond_args,
     // setup the grid to run the kernel
     dim3 grid( bond_args.N / run_block_size + 1, 1, 1);
     dim3 threads(run_block_size, 1, 1);
-
-    // bind the position texture on pre sm35 devices
-    if (bond_args.compute_capability < 350)
-        {
-        pdata_pos_tex.normalized = false;
-        pdata_pos_tex.filterMode = cudaFilterModePoint;
-        cudaError_t error = cudaBindTexture(0, pdata_pos_tex, bond_args.d_pos, sizeof(Scalar4)*(bond_args.n_max));
-        if (error != cudaSuccess)
-            return error;
-        }
 
     unsigned int shared_bytes = sizeof(typename evaluator::param_type) *
                                 bond_args.n_bond_types;

--- a/hoomd/md/PotentialBondGPU.h
+++ b/hoomd/md/PotentialBondGPU.h
@@ -139,8 +139,7 @@ void PotentialBondGPU< evaluator, gpu_cgbf >::computeForces(unsigned int timeste
                              gpu_table_indexer,
                              d_gpu_n_bonds.data,
                              this->m_bond_data->getNTypes(),
-                             this->m_tuner->getParam(),
-                             this->m_exec_conf->getComputeCapability()),
+                             this->m_tuner->getParam()),
                  d_params.data,
                  d_flags.data);
         }

--- a/hoomd/md/PotentialPairDPDThermoGPU.cuh
+++ b/hoomd/md/PotentialPairDPDThermoGPU.cuh
@@ -49,9 +49,7 @@ struct dpd_pair_args_t
                     const Scalar _T,
                     const unsigned int _shift_mode,
                     const unsigned int _compute_virial,
-                    const unsigned int _threads_per_particle,
-                    const unsigned int _compute_capability,
-                    const unsigned int _max_tex1d_width)
+                    const unsigned int _threads_per_particle)
                         : d_force(_d_force),
                         d_virial(_d_virial),
                         virial_pitch(_virial_pitch),
@@ -74,9 +72,7 @@ struct dpd_pair_args_t
                         T(_T),
                         shift_mode(_shift_mode),
                         compute_virial(_compute_virial),
-                        threads_per_particle(_threads_per_particle),
-                        compute_capability(_compute_capability),
-                        max_tex1d_width(_max_tex1d_width)
+                        threads_per_particle(_threads_per_particle)
         {
         };
 
@@ -103,17 +99,9 @@ struct dpd_pair_args_t
     const unsigned int shift_mode;  //!< The potential energy shift mode
     const unsigned int compute_virial;  //!< Flag to indicate if virials should be computed
     const unsigned int threads_per_particle; //!< Number of threads per particle (maximum: 32==1 warp)
-    const unsigned int compute_capability;  //!< Compute capability of the device (20, 30, 35, ...)
-    const unsigned int max_tex1d_width;     //!< Maximum width of a 1d linear texture
     };
 
 #ifdef NVCC
-
-//! Texture for reading particle tags
-texture<unsigned int, 1, cudaReadModeElementType> pdata_dpd_tag_tex;
-
-//! Texture for reading neighbor list
-texture<unsigned int, 1, cudaReadModeElementType> nlist_tex;
 
 //! Kernel for calculating pair forces
 /*! This kernel is called to calculate the pair forces on all N particles. Actual evaluation of the potentials and
@@ -148,8 +136,6 @@ texture<unsigned int, 1, cudaReadModeElementType> nlist_tex;
     \tparam evaluator EvaluatorPair class to evaluate V(r) and -delta V(r)/r
     \tparam shift_mode 0: No energy shifting is done. 1: V(r) is shifted to be 0 at rcut.
     \tparam compute_virial When non-zero, the virial tensor is computed. When zero, the virial tensor is not computed.
-    \tparam use_gmem_nlist When non-zero, the neighbor list is read out of global memory. When zero, textures or __ldg
-                           is used depending on architecture.
 
     <b>Implementation details</b>
     Each block will calculate the forces on a block of particles.
@@ -217,26 +203,19 @@ __global__ void gpu_compute_dpd_forces_kernel(Scalar4 *d_force,
 
         // read in the position of our particle.
         // (MEM TRANSFER: 16 bytes)
-        Scalar4 postypei = texFetchScalar4(d_pos, idx);
+        Scalar4 postypei = __ldg(d_pos + idx);
         Scalar3 posi = make_scalar3(postypei.x, postypei.y, postypei.z);
 
         // read in the velocity of our particle.
         // (MEM TRANSFER: 16 bytes)
-        Scalar4 velmassi = texFetchScalar4(d_vel, idx);
+        Scalar4 velmassi = __ldg(d_vel + idx);
         Scalar3 veli = make_scalar3(velmassi.x, velmassi.y, velmassi.z);
 
         // prefetch neighbor index
         const unsigned int head_idx = d_head_list[idx];
         unsigned int cur_j = 0;
         unsigned int next_j(0);
-        if (use_gmem_nlist)
-            {
-            next_j = (threadIdx.x%tpp < n_neigh) ? d_nlist[head_idx + threadIdx.x%tpp] : 0;
-            }
-        else
-            {
-            next_j = (threadIdx.x%tpp < n_neigh) ? texFetchUint(d_nlist, nlist_tex, head_idx + threadIdx.x%tpp) : 0;
-            }
+        next_j = (threadIdx.x%tpp < n_neigh) ? __ldg(d_nlist + head_idx + threadIdx.x%tpp) : 0;
 
         // this particle's tag
         unsigned int tagi = d_tag[idx];
@@ -250,22 +229,15 @@ __global__ void gpu_compute_dpd_forces_kernel(Scalar4 *d_force,
                 cur_j = next_j;
                 if (neigh_idx+tpp < n_neigh)
                     {
-                    if (use_gmem_nlist)
-                        {
-                        next_j = d_nlist[head_idx + neigh_idx + tpp];
-                        }
-                    else
-                        {
-                        next_j = texFetchUint(d_nlist, nlist_tex, head_idx + neigh_idx + tpp);
-                        }
+                    next_j = __ldg(d_nlist + head_idx + neigh_idx + tpp);
                     }
 
                 // get the neighbor's position (MEM TRANSFER: 16 bytes)
-                Scalar4 postypej = texFetchScalar4(d_pos, cur_j);
+                Scalar4 postypej = __ldg(d_pos + cur_j);
                 Scalar3 posj = make_scalar3(postypej.x, postypej.y, postypej.z);
 
                 // get the neighbor's position (MEM TRANSFER: 16 bytes)
-                Scalar4 velmassj = texFetchScalar4(d_vel, cur_j);
+                Scalar4 velmassj = __ldg(d_vel + cur_j);
                 Scalar3 velj = make_scalar3(velmassj.x, velmassj.y, velmassj.z);
 
                 // calculate dr (with periodic boundary conditions) (FLOPS: 3)
@@ -303,7 +275,7 @@ __global__ void gpu_compute_dpd_forces_kernel(Scalar4 *d_force,
 
                 // Special Potential Pair DPD Requirements
                 // use particle i's and j's tags
-                unsigned int tagj = texFetchUint(d_tag, pdata_dpd_tag_tex, cur_j);
+                unsigned int tagj = __ldg(d_tag + cur_j);
                 eval.set_seed_ij_timestep(d_seed,tagi,tagj,d_timestep);
                 eval.setDeltaT(d_deltaT);
                 eval.setRDotV(rdotv);
@@ -369,20 +341,6 @@ int dpd_get_max_block_size(T func)
     return max_threads;
     }
 
-inline void gpu_dpd_pair_force_bind_textures(const dpd_pair_args_t pair_args)
-    {
-    pdata_dpd_tag_tex.normalized = false;
-    pdata_dpd_tag_tex.filterMode = cudaFilterModePoint;
-    cudaBindTexture(0, pdata_dpd_tag_tex, pair_args.d_tag, sizeof(unsigned int) * pair_args.n_max);
-
-    if (pair_args.size_nlist <= pair_args.max_tex1d_width)
-        {
-        nlist_tex.normalized = false;
-        nlist_tex.filterMode = cudaFilterModePoint;
-        cudaBindTexture(0, nlist_tex, pair_args.d_nlist, sizeof(unsigned int) * pair_args.size_nlist);
-        }
-    }
-
 //! DPD force compute kernel launcher
 /*!
  * \tparam evaluator EvaluatorPair class to evualuate V(r) and -delta V(r)/r
@@ -418,8 +376,6 @@ struct DPDForceComputeKernel
             static unsigned int max_block_size = UINT_MAX;
             if (max_block_size == UINT_MAX)
                 max_block_size = dpd_get_max_block_size(gpu_compute_dpd_forces_kernel<evaluator, shift_mode, compute_virial, use_gmem_nlist, tpp>);
-
-            if (args.compute_capability < 35) gpu_dpd_pair_force_bind_textures(args);
 
             block_size = block_size < max_block_size ? block_size : max_block_size;
             dim3 grid(args.N / (block_size/tpp) + 1, 1, 1);
@@ -477,82 +433,40 @@ cudaError_t gpu_compute_dpd_forces(const dpd_pair_args_t& args,
     assert(args.ntypes > 0);
 
     // run the kernel
-    if (args.compute_capability < 35 && args.size_nlist > args.max_tex1d_width)
+    if (args.compute_virial)
         {
-        if (args.compute_virial)
+        switch (args.shift_mode)
             {
-            switch (args.shift_mode)
+            case 0:
                 {
-                case 0:
-                    {
-                    DPDForceComputeKernel<evaluator, 0, 1, 1, gpu_dpd_pair_force_max_tpp>::launch(args, d_params);
-                    break;
-                    }
-                case 1:
-                    {
-                    DPDForceComputeKernel<evaluator, 1, 1, 1, gpu_dpd_pair_force_max_tpp>::launch(args, d_params);
-                    break;
-                    }
-                default:
-                    return cudaErrorUnknown;
+                DPDForceComputeKernel<evaluator, 0, 1, 0, gpu_dpd_pair_force_max_tpp>::launch(args, d_params);
+                break;
                 }
-            }
-        else
-            {
-            switch (args.shift_mode)
+            case 1:
                 {
-                case 0:
-                    {
-                    DPDForceComputeKernel<evaluator, 0, 0, 1, gpu_dpd_pair_force_max_tpp>::launch(args, d_params);
-                    break;
-                    }
-                case 1:
-                    {
-                    DPDForceComputeKernel<evaluator, 1, 0, 1, gpu_dpd_pair_force_max_tpp>::launch(args, d_params);
-                    break;
-                    }
-                default:
-                    return cudaErrorUnknown;
+                DPDForceComputeKernel<evaluator, 1, 1, 0, gpu_dpd_pair_force_max_tpp>::launch(args, d_params);
+                break;
                 }
+            default:
+                return cudaErrorUnknown;
             }
         }
     else
         {
-        if (args.compute_virial)
+        switch (args.shift_mode)
             {
-            switch (args.shift_mode)
+            case 0:
                 {
-                case 0:
-                    {
-                    DPDForceComputeKernel<evaluator, 0, 1, 0, gpu_dpd_pair_force_max_tpp>::launch(args, d_params);
-                    break;
-                    }
-                case 1:
-                    {
-                    DPDForceComputeKernel<evaluator, 1, 1, 0, gpu_dpd_pair_force_max_tpp>::launch(args, d_params);
-                    break;
-                    }
-                default:
-                    return cudaErrorUnknown;
+                DPDForceComputeKernel<evaluator, 0, 0, 0, gpu_dpd_pair_force_max_tpp>::launch(args, d_params);
+                break;
                 }
-            }
-        else
-            {
-            switch (args.shift_mode)
+            case 1:
                 {
-                case 0:
-                    {
-                    DPDForceComputeKernel<evaluator, 0, 0, 0, gpu_dpd_pair_force_max_tpp>::launch(args, d_params);
-                    break;
-                    }
-                case 1:
-                    {
-                    DPDForceComputeKernel<evaluator, 1, 0, 0, gpu_dpd_pair_force_max_tpp>::launch(args, d_params);
-                    break;
-                    }
-                default:
-                    return cudaErrorUnknown;
+                DPDForceComputeKernel<evaluator, 1, 0, 0, gpu_dpd_pair_force_max_tpp>::launch(args, d_params);
+                break;
                 }
+            default:
+                return cudaErrorUnknown;
             }
         }
 

--- a/hoomd/md/PotentialPairDPDThermoGPU.h
+++ b/hoomd/md/PotentialPairDPDThermoGPU.h
@@ -179,9 +179,7 @@ void PotentialPairDPDThermoGPU< evaluator, gpu_cpdf >::computeForces(unsigned in
                              this->m_T->getValue(timestep),
                              this->m_shift_mode,
                              flags[pdata_flag::pressure_tensor] || flags[pdata_flag::isotropic_virial],
-                             threads_per_particle,
-                             this->m_exec_conf->getComputeCapability()/10,
-                             this->m_exec_conf->dev_prop.maxTexture1DLinear),
+                             threads_per_particle),
              d_params.data);
 
     if (this->m_exec_conf->isCUDAErrorCheckingEnabled())

--- a/hoomd/md/PotentialPairGPU.cuh
+++ b/hoomd/md/PotentialPairGPU.cuh
@@ -53,8 +53,6 @@ struct pair_args_t
               const unsigned int _shift_mode,
               const unsigned int _compute_virial,
               const unsigned int _threads_per_particle,
-              const unsigned int _compute_capability,
-              const unsigned int _max_tex1d_width,
               const GPUPartition& _gpu_partition)
                 : d_force(_d_force),
                   d_virial(_d_virial),
@@ -76,8 +74,6 @@ struct pair_args_t
                   shift_mode(_shift_mode),
                   compute_virial(_compute_virial),
                   threads_per_particle(_threads_per_particle),
-                  compute_capability(_compute_capability),
-                  max_tex1d_width(_max_tex1d_width),
                   gpu_partition(_gpu_partition)
         {
         };
@@ -102,17 +98,10 @@ struct pair_args_t
     const unsigned int shift_mode;  //!< The potential energy shift mode
     const unsigned int compute_virial;  //!< Flag to indicate if virials should be computed
     const unsigned int threads_per_particle; //!< Number of threads per particle (maximum: 1 warp)
-    const unsigned int compute_capability;  //!< Compute capability (20 30 35, ...)
-    const unsigned int max_tex1d_width;     //!< Maximum width of a linear 1D texture
     const GPUPartition& gpu_partition;      //!< The load balancing partition of particles between GPUs
     };
 
 #ifdef NVCC
-
-// there is some naming conflict between the DPD pair force and PotentialPair because
-// the DPD does not extend PotentialPair, and so we need to choose a different name for this texture
-//! Texture for reading neighbor list
-texture<unsigned int, 1, cudaReadModeElementType> pair_nlist_tex;
 
 //! Kernel for calculating pair forces
 /*! This kernel is called to calculate the pair forces on all N particles. Actual evaluation of the potentials and
@@ -145,8 +134,6 @@ texture<unsigned int, 1, cudaReadModeElementType> pair_nlist_tex;
     \tparam shift_mode 0: No energy shifting is done. 1: V(r) is shifted to be 0 at rcut. 2: XPLOR switching is enabled
                        (See PotentialPair for a discussion on what that entails)
     \tparam compute_virial When non-zero, the virial tensor is computed. When zero, the virial tensor is not computed.
-    \tparam use_gmem_nlist When non-zero, the neighbor list is read out of global memory. When zero, textures or __ldg
-                           is used depending on architecture.
     \tparam tpp Number of threads to use per particle, must be power of 2 and smaller than warp size
 
     <b>Implementation details</b>
@@ -154,7 +141,7 @@ texture<unsigned int, 1, cudaReadModeElementType> pair_nlist_tex;
     Each group of \a tpp threads will calculate the total force on one particle.
     The neighborlist is arranged in columns so that reads are fully coalesced when doing this.
 */
-template< class evaluator, unsigned int shift_mode, unsigned int compute_virial, unsigned int use_gmem_nlist, int tpp>
+template< class evaluator, unsigned int shift_mode, unsigned int compute_virial, int tpp>
 __global__ void gpu_compute_pair_forces_shared_kernel(Scalar4 *d_force,
                                                Scalar *d_virial,
                                                const unsigned int virial_pitch,
@@ -223,7 +210,7 @@ __global__ void gpu_compute_pair_forces_shared_kernel(Scalar4 *d_force,
 
         // read in the position of our particle.
         // (MEM TRANSFER: 16 bytes)
-        Scalar4 postypei = texFetchScalar4(d_pos, idx);
+        Scalar4 postypei = __ldg(d_pos + idx);
         Scalar3 posi = make_scalar3(postypei.x, postypei.y, postypei.z);
 
         Scalar di;
@@ -241,14 +228,7 @@ __global__ void gpu_compute_pair_forces_shared_kernel(Scalar4 *d_force,
         unsigned int cur_j = 0;
 
         unsigned int next_j(0);
-        if (use_gmem_nlist)
-            {
-            next_j = (threadIdx.x%tpp < n_neigh) ? d_nlist[my_head + threadIdx.x%tpp] : 0;
-            }
-        else
-            {
-            next_j = threadIdx.x%tpp < n_neigh ? texFetchUint(d_nlist, pair_nlist_tex, my_head + threadIdx.x%tpp) : 0;
-            }
+        next_j = threadIdx.x%tpp < n_neigh ? __ldg(d_nlist + my_head + threadIdx.x%tpp) : 0;
 
         // loop over neighbors
         for (int neigh_idx = threadIdx.x%tpp; neigh_idx < n_neigh; neigh_idx+=tpp)
@@ -258,17 +238,10 @@ __global__ void gpu_compute_pair_forces_shared_kernel(Scalar4 *d_force,
                 cur_j = next_j;
                 if (neigh_idx+tpp < n_neigh)
                     {
-                    if (use_gmem_nlist)
-                        {
-                        next_j = d_nlist[my_head + neigh_idx + tpp];
-                        }
-                    else
-                        {
-                        next_j = texFetchUint(d_nlist, pair_nlist_tex, my_head + neigh_idx+tpp);
-                        }
+                    next_j = __ldg(d_nlist + my_head + neigh_idx+tpp);
                     }
                 // get the neighbor's position (MEM TRANSFER: 16 bytes)
-                Scalar4 postypej = texFetchScalar4(d_pos, cur_j);
+                Scalar4 postypej = __ldg(d_pos + cur_j);
                 Scalar3 posj = make_scalar3(postypej.x, postypej.y, postypej.z);
 
                 Scalar dj = Scalar(0.0);
@@ -415,39 +388,18 @@ int get_max_block_size(T func)
     return max_threads;
     }
 
-inline void gpu_pair_force_bind_textures(const pair_args_t pair_args)
-    {
-    // bind the neighborlist texture if it will fit
-    if (pair_args.size_neigh_list <= pair_args.max_tex1d_width)
-        {
-        pair_nlist_tex.normalized = false;
-        pair_nlist_tex.filterMode = cudaFilterModePoint;
-        cudaBindTexture(0, pair_nlist_tex, pair_args.d_nlist, sizeof(unsigned int) * pair_args.size_neigh_list);
-        }
-    }
-
-inline void gpu_pair_force_unbind_textures(const pair_args_t pair_args)
-    {
-    if (pair_args.size_neigh_list <= pair_args.max_tex1d_width)
-        {
-        cudaUnbindTexture(pair_nlist_tex);
-        }
-    }
-
 //! Pair force compute kernel launcher
 /*!
  * \tparam evaluator EvaluatorPair class to evaluate V(r) and -delta V(r)/r
  * \tparam shift_mode 0: No energy shifting is done. 1: V(r) is shifted to be 0 at rcut. 2: XPLOR switching is enabled
  *                       (See PotentialPair for a discussion on what that entails)
  * \tparam compute_virial When non-zero, the virial tensor is computed. When zero, the virial tensor is not computed.
- * \tparam use_gmem_nlist When non-zero, the neighbor list is read out of global memory. When zero, textures or __ldg
- *                        is used depending on architecture.
  * \tparam tpp Number of threads to use per particle, must be power of 2 and smaller than warp size
  *
  * Partial function template specialization is not allowed in C++, so instead we have to wrap this with a struct that
  * we are allowed to partially specialize.
  */
-template<class evaluator, unsigned int shift_mode, unsigned int compute_virial, unsigned int use_gmem_nlist, int tpp>
+template<class evaluator, unsigned int shift_mode, unsigned int compute_virial, int tpp>
 struct PairForceComputeKernel
     {
     //! Launcher for the pair force kernel
@@ -475,31 +427,27 @@ struct PairForceComputeKernel
 
             static unsigned int max_block_size = UINT_MAX;
             if (max_block_size == UINT_MAX)
-                max_block_size = get_max_block_size(gpu_compute_pair_forces_shared_kernel<evaluator, shift_mode, compute_virial, use_gmem_nlist, tpp>);
-
-            if (pair_args.compute_capability < 35) gpu_pair_force_bind_textures(pair_args);
+                max_block_size = get_max_block_size(gpu_compute_pair_forces_shared_kernel<evaluator, shift_mode, compute_virial, tpp>);
 
             block_size = block_size < max_block_size ? block_size : max_block_size;
             dim3 grid(N / (block_size/tpp) + 1, 1, 1);
 
-            gpu_compute_pair_forces_shared_kernel<evaluator, shift_mode, compute_virial, use_gmem_nlist, tpp>
+            gpu_compute_pair_forces_shared_kernel<evaluator, shift_mode, compute_virial, tpp>
               <<<grid, block_size, shared_bytes>>>(pair_args.d_force, pair_args.d_virial,
               pair_args.virial_pitch, N, pair_args.d_pos, pair_args.d_diameter,
               pair_args.d_charge, pair_args.box, pair_args.d_n_neigh, pair_args.d_nlist,
               pair_args.d_head_list, d_params, pair_args.d_rcutsq, pair_args.d_ronsq, pair_args.ntypes, offset);
-
-            if (pair_args.compute_capability < 35) gpu_pair_force_unbind_textures(pair_args);
             }
         else
             {
-            PairForceComputeKernel<evaluator, shift_mode, compute_virial, use_gmem_nlist, tpp/2>::launch(pair_args, range, d_params);
+            PairForceComputeKernel<evaluator, shift_mode, compute_virial, tpp/2>::launch(pair_args, range, d_params);
             }
         }
     };
 
 //! Template specialization to do nothing for the tpp = 0 case
-template<class evaluator, unsigned int shift_mode, unsigned int compute_virial, unsigned int use_gmem_nlist>
-struct PairForceComputeKernel<evaluator, shift_mode, compute_virial, use_gmem_nlist, 0>
+template<class evaluator, unsigned int shift_mode, unsigned int compute_virial>
+struct PairForceComputeKernel<evaluator, shift_mode, compute_virial, 0>
     {
     static void launch(const pair_args_t& pair_args, std::pair<unsigned int, unsigned int> range, const typename evaluator::param_type *d_params)
         {
@@ -528,102 +476,50 @@ cudaError_t gpu_compute_pair_forces(const pair_args_t& pair_args,
         auto range = pair_args.gpu_partition.getRangeAndSetGPU(idev);
 
         // Launch kernel
-        if (pair_args.compute_capability < 35 && pair_args.size_neigh_list > pair_args.max_tex1d_width)
-            { // fall back to slow global loads when the neighbor list is too big for texture memory
-            if (pair_args.compute_virial)
+        if (pair_args.compute_virial)
+            {
+            switch (pair_args.shift_mode)
                 {
-                switch (pair_args.shift_mode)
+                case 0:
                     {
-                    case 0:
-                        {
-                        PairForceComputeKernel<evaluator, 0, 1, 1, gpu_pair_force_max_tpp>::launch(pair_args, range, d_params);
-                        break;
-                        }
-                    case 1:
-                        {
-                        PairForceComputeKernel<evaluator, 1, 1, 1, gpu_pair_force_max_tpp>::launch(pair_args, range, d_params);
-                        break;
-                        }
-                    case 2:
-                        {
-                        PairForceComputeKernel<evaluator, 2, 1, 1, gpu_pair_force_max_tpp>::launch(pair_args, range, d_params);
-                        break;
-                        }
-                    default:
-                        break;
+                    PairForceComputeKernel<evaluator, 0, 1, gpu_pair_force_max_tpp>::launch(pair_args, range, d_params);
+                    break;
                     }
-                }
-            else
-                {
-                switch (pair_args.shift_mode)
+                case 1:
                     {
-                    case 0:
-                        {
-                        PairForceComputeKernel<evaluator, 0, 0, 1, gpu_pair_force_max_tpp>::launch(pair_args, range, d_params);
-                        break;
-                        }
-                    case 1:
-                        {
-                        PairForceComputeKernel<evaluator, 1, 0, 1, gpu_pair_force_max_tpp>::launch(pair_args, range, d_params);
-                        break;
-                        }
-                    case 2:
-                        {
-                        PairForceComputeKernel<evaluator, 2, 0, 1, gpu_pair_force_max_tpp>::launch(pair_args, range, d_params);
-                        break;
-                        }
-                    default:
-                        break;
+                    PairForceComputeKernel<evaluator, 1, 1, gpu_pair_force_max_tpp>::launch(pair_args, range, d_params);
+                    break;
                     }
+                case 2:
+                    {
+                    PairForceComputeKernel<evaluator, 2, 1, gpu_pair_force_max_tpp>::launch(pair_args, range, d_params);
+                    break;
+                    }
+                default:
+                    break;
                 }
             }
         else
             {
-            if (pair_args.compute_virial)
+            switch (pair_args.shift_mode)
                 {
-                switch (pair_args.shift_mode)
+                case 0:
                     {
-                    case 0:
-                        {
-                        PairForceComputeKernel<evaluator, 0, 1, 0, gpu_pair_force_max_tpp>::launch(pair_args, range, d_params);
-                        break;
-                        }
-                    case 1:
-                        {
-                        PairForceComputeKernel<evaluator, 1, 1, 0, gpu_pair_force_max_tpp>::launch(pair_args, range, d_params);
-                        break;
-                        }
-                    case 2:
-                        {
-                        PairForceComputeKernel<evaluator, 2, 1, 0, gpu_pair_force_max_tpp>::launch(pair_args, range, d_params);
-                        break;
-                        }
-                    default:
-                        break;
+                    PairForceComputeKernel<evaluator, 0, 0, gpu_pair_force_max_tpp>::launch(pair_args, range, d_params);
+                    break;
                     }
-                }
-            else
-                {
-                switch (pair_args.shift_mode)
+                case 1:
                     {
-                    case 0:
-                        {
-                        PairForceComputeKernel<evaluator, 0, 0, 0, gpu_pair_force_max_tpp>::launch(pair_args, range, d_params);
-                        break;
-                        }
-                    case 1:
-                        {
-                        PairForceComputeKernel<evaluator, 1, 0, 0, gpu_pair_force_max_tpp>::launch(pair_args, range, d_params);
-                        break;
-                        }
-                    case 2:
-                        {
-                        PairForceComputeKernel<evaluator, 2, 0, 0, gpu_pair_force_max_tpp>::launch(pair_args, range, d_params);
-                        break;
-                        }
-                    default:
-                        break;
+                    PairForceComputeKernel<evaluator, 1, 0, gpu_pair_force_max_tpp>::launch(pair_args, range, d_params);
+                    break;
                     }
+                case 2:
+                    {
+                    PairForceComputeKernel<evaluator, 2, 0, gpu_pair_force_max_tpp>::launch(pair_args, range, d_params);
+                    break;
+                    }
+                default:
+                    break;
                 }
             }
         }

--- a/hoomd/md/PotentialPairGPU.h
+++ b/hoomd/md/PotentialPairGPU.h
@@ -188,8 +188,6 @@ void PotentialPairGPU< evaluator, gpu_cgpf >::computeForces(unsigned int timeste
                          this->m_shift_mode,
                          flags[pdata_flag::pressure_tensor] || flags[pdata_flag::isotropic_virial],
                          threads_per_particle,
-                         this->m_exec_conf->getComputeCapability()/10,
-                         this->m_exec_conf->dev_prop.maxTexture1DLinear,
                          this->m_pdata->getGPUPartition()),
              d_params.data);
 

--- a/hoomd/md/PotentialSpecialPairGPU.h
+++ b/hoomd/md/PotentialSpecialPairGPU.h
@@ -140,8 +140,7 @@ void PotentialSpecialPairGPU< evaluator, gpu_cgbf >::computeForces(unsigned int 
                              gpu_table_indexer,
                              d_gpu_n_bonds.data,
                              this->m_pair_data->getNTypes(),
-                             this->m_tuner->getParam(),
-                             this->m_exec_conf->getComputeCapability()),
+                             this->m_tuner->getParam()),
                  d_params.data,
                  d_flags.data);
         }

--- a/hoomd/md/PotentialTersoffGPU.cuh
+++ b/hoomd/md/PotentialTersoffGPU.cuh
@@ -295,13 +295,11 @@ __global__ void gpu_compute_triplet_forces_kernel(Scalar4 *d_force,
             {
             Scalar phi = s_phi_ab[threadIdx.x*ntypes+typ_b];
 
-            #if (__CUDA_ARCH__ >= 300)
             // reduce in warp
             phi = hoomd::detail::WarpReduce<Scalar, tpp>().Sum(phi);
 
             // broadcast into shared mem
             s_phi_ab[threadIdx.x*ntypes+typ_b] = hoomd::detail::WarpScan<Scalar, tpp>().Broadcast(phi, 0);
-            #endif
 
             if (threadIdx.x % tpp == 0)
                 {

--- a/hoomd/md/PotentialTersoffGPU.cuh
+++ b/hoomd/md/PotentialTersoffGPU.cuh
@@ -89,9 +89,6 @@ struct tersoff_args_t
 
 
 #ifdef NVCC
-//! Texture for reading particle positions
-scalar4_tex_t pdata_pos_tex;
-
 //! Texture for reading neighbor list
 texture<unsigned int, 1, cudaReadModeElementType> nlist_tex;
 
@@ -216,7 +213,7 @@ __global__ void gpu_compute_triplet_forces_kernel(Scalar4 *d_force,
     unsigned int n_neigh = d_n_neigh[idx];
 
     // read in the position of the particle
-    Scalar4 postypei = texFetchScalar4(d_pos, pdata_pos_tex, idx);
+    Scalar4 postypei = texFetchScalar4(d_pos, idx);
     Scalar3 posi = make_scalar3(postypei.x, postypei.y, postypei.z);
 
     // initialize the force to 0
@@ -266,7 +263,7 @@ __global__ void gpu_compute_triplet_forces_kernel(Scalar4 *d_force,
                 }
 
             // read the position of j (MEM TRANSFER: 16 bytes)
-            Scalar4 postypej = texFetchScalar4(d_pos, pdata_pos_tex, cur_j);
+            Scalar4 postypej = texFetchScalar4(d_pos, cur_j);
             Scalar3 posj = make_scalar3(postypej.x, postypej.y, postypej.z);
 
             // initialize the force on j
@@ -350,7 +347,7 @@ __global__ void gpu_compute_triplet_forces_kernel(Scalar4 *d_force,
             }
 
         // read the position of j (MEM TRANSFER: 16 bytes)
-        Scalar4 postypej = texFetchScalar4(d_pos, pdata_pos_tex, cur_j);
+        Scalar4 postypej = texFetchScalar4(d_pos, cur_j);
         Scalar3 posj = make_scalar3(postypej.x, postypej.y, postypej.z);
 
         // initialize the force on j
@@ -416,7 +413,7 @@ __global__ void gpu_compute_triplet_forces_kernel(Scalar4 *d_force,
                         }
 
                     // get the position of neighbor k
-                    Scalar4 postypek = texFetchScalar4(d_pos, pdata_pos_tex, cur_k);
+                    Scalar4 postypek = texFetchScalar4(d_pos, cur_k);
                     Scalar3 posk = make_scalar3(postypek.x, postypek.y, postypek.z);
 
                     // get the type pair parameters for i and k
@@ -528,7 +525,7 @@ __global__ void gpu_compute_triplet_forces_kernel(Scalar4 *d_force,
                         }
 
                     // get the position of neighbor k
-                    Scalar4 postypek = texFetchScalar4(d_pos, pdata_pos_tex, cur_k);
+                    Scalar4 postypek = texFetchScalar4(d_pos, cur_k);
                     Scalar3 posk = make_scalar3(postypek.x, postypek.y, postypek.z);
 
                     // get the type pair parameters for i and k
@@ -735,10 +732,6 @@ struct TersoffComputeKernel
             // bind to texture
             if (pair_args.compute_capability < 35)
                 {
-                pdata_pos_tex.normalized = false;
-                pdata_pos_tex.filterMode = cudaFilterModePoint;
-                cudaBindTexture(0, pdata_pos_tex, pair_args.d_pos, sizeof(Scalar4) * (pair_args.N+pair_args.Nghosts));
-
                 if (pair_args.size_nlist <= (unsigned int) pair_args.devprop.maxTexture1DLinear)
                     {
                     nlist_tex.normalized = false;

--- a/hoomd/md/PotentialTersoffGPU.h
+++ b/hoomd/md/PotentialTersoffGPU.h
@@ -169,7 +169,6 @@ void PotentialTersoffGPU< evaluator, gpu_cgpf >::computeForces(unsigned int time
                             this->m_pdata->getNTypes(),
                             block_size,
                             threads_per_particle,
-                            this->m_exec_conf->getComputeCapability()/10,
                             this->m_exec_conf->dev_prop),
                             d_params.data);
 

--- a/hoomd/md/TableAngleForceComputeGPU.cc
+++ b/hoomd/md/TableAngleForceComputeGPU.cc
@@ -82,8 +82,7 @@ void TableAngleForceComputeGPU::computeForces(unsigned int timestep)
                              d_tables.data,
                              m_table_width,
                              m_table_value,
-                             m_tuner->getParam(),
-                             m_exec_conf->getComputeCapability());
+                             m_tuner->getParam());
         }
 
 

--- a/hoomd/md/TableAngleForceGPU.cuh
+++ b/hoomd/md/TableAngleForceGPU.cuh
@@ -30,7 +30,6 @@ cudaError_t gpu_compute_table_angle_forces(Scalar4* d_force,
                                      const Scalar2 *d_tables,
                                      const unsigned int table_width,
                                      const Index2D &table_value,
-                                     const unsigned int block_size,
-                                     const unsigned int compute_capability);
+                                     const unsigned int block_size);
 
 #endif

--- a/hoomd/md/TableDihedralForceComputeGPU.cc
+++ b/hoomd/md/TableDihedralForceComputeGPU.cc
@@ -83,8 +83,7 @@ void TableDihedralForceComputeGPU::computeForces(unsigned int timestep)
                              d_tables.data,
                              m_table_width,
                              m_table_value,
-                             m_tuner->getParam(),
-                             m_exec_conf->getComputeCapability());
+                             m_tuner->getParam());
         }
 
 

--- a/hoomd/md/TableDihedralForceGPU.cu
+++ b/hoomd/md/TableDihedralForceGPU.cu
@@ -18,10 +18,6 @@
     \brief Defines GPU kernel code for calculating the table dihedral forces. Used by TableDihedralForceComputeGPU.
 */
 
-
-//! Texture for reading table values
-scalar2_tex_t tables_tex;
-
 /*!  This kernel is called to calculate the table dihedral forces on all triples this is defined or
 
     \param d_force Device memory to write computed forces
@@ -39,10 +35,6 @@ scalar2_tex_t tables_tex;
     \param delta_phi dihedral delta of the table
 
     See TableDihedralForceCompute for information on the memory layout.
-
-    \b Details:
-    * Table entries are read from tables_tex. Note that currently this is bound to a 1D memory region. Performance tests
-      at a later date may result in this changing.
 */
 __global__ void gpu_compute_table_dihedral_forces_kernel(Scalar4* d_force,
                                      Scalar* d_virial,
@@ -206,8 +198,8 @@ __global__ void gpu_compute_table_dihedral_forces_kernel(Scalar4* d_force,
 
         // compute index into the table and read in values
         unsigned int value_i = value_f;
-        Scalar2 VT0 = texFetchScalar2(d_tables, tables_tex, table_value(value_i, cur_dihedral_type));
-        Scalar2 VT1 = texFetchScalar2(d_tables, tables_tex, table_value(value_i+1, cur_dihedral_type));
+        Scalar2 VT0 = __ldg(d_tables + table_value(value_i, cur_dihedral_type));
+        Scalar2 VT1 = __ldg(d_tables + table_value(value_i+1, cur_dihedral_type));
         // unpack the data
         Scalar V0 = VT0.x;
         Scalar V1 = VT1.x;
@@ -318,8 +310,7 @@ cudaError_t gpu_compute_table_dihedral_forces(Scalar4* d_force,
                                      const Scalar2 *d_tables,
                                      const unsigned int table_width,
                                      const Index2D &table_value,
-                                     const unsigned int block_size,
-                                     const unsigned int compute_capability)
+                                     const unsigned int block_size)
     {
     assert(d_tables);
     assert(table_width > 1);
@@ -340,16 +331,6 @@ cudaError_t gpu_compute_table_dihedral_forces(Scalar4* d_force,
     // setup the grid to run the kernel
     dim3 grid( N / run_block_size + 1, 1, 1);
     dim3 threads(run_block_size, 1, 1);
-
-    // bind the tables texture on pre sm35 devices
-    if (compute_capability < 350)
-        {
-        tables_tex.normalized = false;
-        tables_tex.filterMode = cudaFilterModePoint;
-        cudaError_t error = cudaBindTexture(0, tables_tex, d_tables, sizeof(Scalar2) * table_value.getNumElements());
-        if (error != cudaSuccess)
-            return error;
-        }
 
     Scalar delta_phi = Scalar(2.0*M_PI)/(Scalar)(table_width - 1);
 

--- a/hoomd/md/TableDihedralForceGPU.cuh
+++ b/hoomd/md/TableDihedralForceGPU.cuh
@@ -30,7 +30,6 @@ cudaError_t gpu_compute_table_dihedral_forces(Scalar4* d_force,
                                      const Scalar2 *d_tables,
                                      const unsigned int table_width,
                                      const Index2D &table_value,
-                                     const unsigned int block_size,
-                                     const unsigned int compute_capability);
+                                     const unsigned int block_size);
 
 #endif

--- a/hoomd/md/TablePotentialGPU.cc
+++ b/hoomd/md/TablePotentialGPU.cc
@@ -96,8 +96,6 @@ void TablePotentialGPU::computeForces(unsigned int timestep)
                              m_ntypes,
                              m_table_width,
                              m_tuner->getParam(),
-                             m_exec_conf->getComputeCapability(),
-                             m_exec_conf->dev_prop.maxTexture1DLinear,
                              m_pdata->getGPUPartition());
 
     if(m_exec_conf->isCUDAErrorCheckingEnabled())

--- a/hoomd/md/TablePotentialGPU.cuh
+++ b/hoomd/md/TablePotentialGPU.cuh
@@ -33,8 +33,6 @@ cudaError_t gpu_compute_table_forces(Scalar4* d_force,
                                      const unsigned int ntypes,
                                      const unsigned int table_width,
                                      const unsigned int block_size,
-                                     const unsigned int compute_capability,
-                                     const unsigned int max_tex1d_width,
                                      const GPUPartition& gpu_partition);
 
 #endif

--- a/hoomd/metal/EAMForceComputeGPU.cc
+++ b/hoomd/metal/EAMForceComputeGPU.cc
@@ -102,8 +102,7 @@ void EAMForceComputeGPU::computeForces(unsigned int timestep)
     eam_data.block_size = m_tuner->getParam();
     gpu_compute_eam_tex_inter_forces(d_force.data, d_virial.data, m_virial.getPitch(), m_pdata->getN(), d_pos.data, box,
             d_n_neigh.data, d_nlist.data, d_head_list.data, this->m_nlist->getNListArray().getPitch(), eam_data,
-            d_dFdP.data, d_F.data, d_rho.data, d_rphi.data, d_dF.data, d_drho.data, d_drphi.data,
-            m_exec_conf->getComputeCapability() / 10, m_exec_conf->dev_prop.maxTexture1DLinear);
+            d_dFdP.data, d_F.data, d_rho.data, d_rphi.data, d_dF.data, d_drho.data, d_drphi.data);
 
     if (m_exec_conf->isCUDAErrorCheckingEnabled())
         CHECK_CUDA_ERROR();

--- a/hoomd/metal/EAMForceGPU.cu
+++ b/hoomd/metal/EAMForceGPU.cu
@@ -13,14 +13,10 @@
  \brief Defines GPU kernel code for calculating the EAM forces. Used by EAMForceComputeGPU.
  */
 
-//! Texture for reading the neighbor list
-texture<unsigned int, 1, cudaReadModeElementType> nlist_tex;
-
 //! Storage space for EAM parameters on the GPU
 __constant__ EAMTexInterData eam_data_ti;
 
 //! Kernel for computing EAM forces on the GPU
-template<unsigned char use_gmem_nlist>
 __global__ void gpu_kernel_1(Scalar4 *d_force, Scalar *d_virial, const unsigned int virial_pitch, const unsigned int N,
         const Scalar4 *d_pos, BoxDim box, const unsigned int *d_n_neigh, const unsigned int *d_nlist,
         const unsigned int *d_head_list, const Scalar4 *d_F, const Scalar4 *d_rho, const Scalar4 *d_rphi,
@@ -38,7 +34,7 @@ __global__ void gpu_kernel_1(Scalar4 *d_force, Scalar *d_virial, const unsigned 
     const unsigned int head_idx = d_head_list[idx];
 
     // read in the position of our particle.
-    Scalar4 postype = texFetchScalar4(d_pos, idx);
+    Scalar4 postype = __ldg(d_pos + idx);
     Scalar3 pos = make_scalar3(postype.x, postype.y, postype.z);
 
     // index and remainder
@@ -54,14 +50,8 @@ __global__ void gpu_kernel_1(Scalar4 *d_force, Scalar *d_virial, const unsigned 
     // prefetch neighbor index
     int cur_neigh = 0;
     int next_neigh(0);
-    if (use_gmem_nlist)
-        {
-        next_neigh = d_nlist[head_idx];
-        }
-    else
-        {
-        next_neigh = texFetchUint(d_nlist, nlist_tex, head_idx);
-        }
+    next_neigh = __ldg(d_nlist + head_idx);
+
     int typei = __scalar_as_int(postype.w);
 
     // loop over neighbors
@@ -78,17 +68,10 @@ __global__ void gpu_kernel_1(Scalar4 *d_force, Scalar *d_virial, const unsigned 
         // read the current neighbor index
         // prefetch the next value and set the current one
         cur_neigh = next_neigh;
-        if (use_gmem_nlist)
-            {
-            next_neigh = d_nlist[head_idx + neigh_idx + 1];
-            }
-        else
-            {
-            next_neigh = texFetchUint(d_nlist, nlist_tex, head_idx + neigh_idx + 1);
-            }
+        next_neigh = __ldg(d_nlist + head_idx + neigh_idx + 1);
 
         // get the neighbor's position
-        Scalar4 neigh_postype = texFetchScalar4(d_pos, cur_neigh);
+        Scalar4 neigh_postype = __ldg(d_pos + cur_neigh);
         Scalar3 neigh_pos = make_scalar3(neigh_postype.x, neigh_postype.y, neigh_postype.z);
 
         // calculate dr (with periodic boundary conditions)
@@ -109,7 +92,7 @@ __global__ void gpu_kernel_1(Scalar4 *d_force, Scalar *d_virial, const unsigned 
             remainder = position - int_position;
             // calculate P = sum{rho}
             idxs = int_position + nr * (typej * ntypes + typei);
-            v = texFetchScalar4(d_rho, idxs);
+            v = __ldg(d_rho + idxs);
             atomElectronDensity += v.w + v.z * remainder + v.y * remainder * remainder
             + v.x * remainder * remainder * remainder;
             }
@@ -122,8 +105,8 @@ __global__ void gpu_kernel_1(Scalar4 *d_force, Scalar *d_virial, const unsigned 
     remainder = position - int_position;
 
     idxs = int_position + typei * nrho;
-    dv = texFetchScalar4(d_dF, idxs);
-    v = texFetchScalar4(d_F, idxs);
+    dv = __ldg(d_dF + idxs);
+    v = __ldg(d_F + idxs);
     // compute dF / dP
     d_dFdP[idx] = dv.z + dv.y * remainder + dv.x * remainder * remainder;
     // compute embedded energy F(P), sum up each particle
@@ -134,7 +117,6 @@ __global__ void gpu_kernel_1(Scalar4 *d_force, Scalar *d_virial, const unsigned 
     }
 
 //! Second stage kernel for computing EAM forces on the GPU
-template<unsigned char use_gmem_nlist>
 __global__ void gpu_kernel_2(Scalar4 *d_force, Scalar *d_virial, const unsigned int virial_pitch, const unsigned int N,
         const Scalar4 *d_pos, BoxDim box, const unsigned int *d_n_neigh, const unsigned int *d_nlist,
         const unsigned int *d_head_list, const Scalar4 *d_F, const Scalar4 *d_rho, const Scalar4 *d_rphi,
@@ -152,7 +134,7 @@ __global__ void gpu_kernel_2(Scalar4 *d_force, Scalar *d_virial, const unsigned 
     const unsigned int head_idx = d_head_list[idx];
 
     // read in the position of our particle. Texture reads of Scalar4's are faster than global reads
-    Scalar4 postype = texFetchScalar4(d_pos, idx);
+    Scalar4 postype = __ldg(d_pos + idx);
     Scalar3 pos = make_scalar3(postype.x, postype.y, postype.z);
     int typei = __scalar_as_int(postype.w);
 
@@ -166,14 +148,8 @@ __global__ void gpu_kernel_2(Scalar4 *d_force, Scalar *d_virial, const unsigned 
     // prefetch neighbor index
     int cur_neigh = 0;
     int next_neigh(0);
-    if (use_gmem_nlist)
-        {
-        next_neigh = d_nlist[head_idx];
-        }
-    else
-        {
-        next_neigh = texFetchUint(d_nlist, nlist_tex, head_idx);
-        }
+    next_neigh = __ldg(d_nlist + head_idx);
+
     //Scalar4 force = force_data.force[idx];
     Scalar4 force = make_scalar4(Scalar(0.0), Scalar(0.0), Scalar(0.0), Scalar(0.0));
     //force.w = force_data.force[idx].w;
@@ -195,17 +171,10 @@ __global__ void gpu_kernel_2(Scalar4 *d_force, Scalar *d_virial, const unsigned 
     for (int neigh_idx = 0; neigh_idx < n_neigh; neigh_idx++)
         {
         cur_neigh = next_neigh;
-        if (use_gmem_nlist)
-            {
-            next_neigh = d_nlist[head_idx + neigh_idx + 1];
-            }
-        else
-            {
-            next_neigh = texFetchUint(d_nlist, nlist_tex, head_idx + neigh_idx + 1);
-            }
+        next_neigh = __ldg(d_nlist + head_idx + neigh_idx + 1);
 
         // get the neighbor's position
-        Scalar4 neigh_postype = texFetchScalar4(d_pos, cur_neigh);
+        Scalar4 neigh_postype = __ldg(d_pos + cur_neigh);
         Scalar3 neigh_pos = make_scalar3(neigh_postype.x, neigh_postype.y, neigh_postype.z);
 
         // calculate dr (with periodic boundary conditions)
@@ -234,8 +203,8 @@ __global__ void gpu_kernel_2(Scalar4 *d_force, Scalar *d_virial, const unsigned 
         (int) (0.5 * (2 * ntypes - typei - 1) * typei + typej) * nr;
 
         idxs = int_position + shift;
-        v = texFetchScalar4(d_rphi, idxs);
-        dv = texFetchScalar4(d_drphi, idxs);
+        v = __ldg(d_rphi + idxs);
+        dv = __ldg(d_drphi + idxs);
         // aspair_potential = r * phi
         Scalar aspair_potential = v.w + v.z * remainder + v.y * remainder * remainder
         + v.x * remainder * remainder * remainder;
@@ -247,11 +216,11 @@ __global__ void gpu_kernel_2(Scalar4 *d_force, Scalar *d_virial, const unsigned 
         Scalar derivativePhi = (derivative_pair_potential - pair_eng) * inverseR;
         // derivativeRhoI = drho / dr of i
         idxs = int_position + typei * ntypes * nr + typej * nr;
-        dv = texFetchScalar4(d_drho, idxs);
+        dv = __ldg(d_drho + idxs);
         Scalar derivativeRhoI = dv.z + dv.y * remainder + dv.x * remainder * remainder;
         // derivativeRhoJ = drho / dr of j
         idxs = int_position + typej * ntypes * nr + typei * nr;
-        dv = texFetchScalar4(d_drho, idxs);
+        dv = __ldg(d_drho + idxs);
         Scalar derivativeRhoJ = dv.z + dv.y * remainder + dv.x * remainder * remainder;
         // fullDerivativePhi = dF/dP * drho / dr for j + dF/dP * drho / dr for j + phi
         Scalar d_dFdPcur = __ldg(d_dFdP + cur_neigh);
@@ -290,87 +259,39 @@ cudaError_t gpu_compute_eam_tex_inter_forces(Scalar4 *d_force, Scalar *d_virial,
         const unsigned int N, const Scalar4 *d_pos, const BoxDim &box, const unsigned int *d_n_neigh,
         const unsigned int *d_nlist, const unsigned int *d_head_list, const unsigned int size_nlist,
         const EAMTexInterData &eam_data, Scalar *d_dFdP, const Scalar4 *d_F, const Scalar4 *d_rho,
-        const Scalar4 *d_rphi, const Scalar4 *d_dF, const Scalar4 *d_drho, const Scalar4 *d_drphi,
-        const unsigned int compute_capability, const unsigned int max_tex1d_width)
+        const Scalar4 *d_rphi, const Scalar4 *d_dF, const Scalar4 *d_drho, const Scalar4 *d_drphi)
     {
-
-    cudaError_t error;
-
-    // bind the texture
-    if (compute_capability < 350 && size_nlist <= max_tex1d_width)
-        {
-        nlist_tex.normalized = false;
-        nlist_tex.filterMode = cudaFilterModePoint;
-        error = cudaBindTexture(0, nlist_tex, d_nlist, sizeof(unsigned int) * size_nlist);
-        if (error != cudaSuccess)
-            return error;
-        }
 
     // run the kernel
     cudaMemcpyToSymbol(eam_data_ti, &eam_data, sizeof(EAMTexInterData));
 
-    if (compute_capability < 350 && size_nlist > max_tex1d_width)
-        {
+    static unsigned int max_block_size_1 = UINT_MAX;
+    static unsigned int max_block_size_2 = UINT_MAX;
 
-        static unsigned int max_block_size_1 = UINT_MAX;
-        static unsigned int max_block_size_2 = UINT_MAX;
+    cudaFuncAttributes attr1;
+    cudaFuncGetAttributes(&attr1, gpu_kernel_1);
 
-        cudaFuncAttributes attr1;
-        cudaFuncGetAttributes(&attr1, gpu_kernel_1<1>);
+    cudaFuncAttributes attr2;
+    cudaFuncGetAttributes(&attr2, gpu_kernel_2);
 
-        cudaFuncAttributes attr2;
-        cudaFuncGetAttributes(&attr2, gpu_kernel_2<1>);
+    max_block_size_1 = attr1.maxThreadsPerBlock;
+    max_block_size_2 = attr2.maxThreadsPerBlock;
 
-        max_block_size_1 = attr1.maxThreadsPerBlock;
-        max_block_size_2 = attr2.maxThreadsPerBlock;
+    unsigned int run_block_size_1 = min(eam_data.block_size, max_block_size_1);
+    unsigned int run_block_size_2 = min(eam_data.block_size, max_block_size_2);
 
-        unsigned int run_block_size_1 = min(eam_data.block_size, max_block_size_1);
-        unsigned int run_block_size_2 = min(eam_data.block_size, max_block_size_2);
+    // setup the grid to run the kernel
 
-        // setup the grid to run the kernel
+    dim3 grid_1((int) ceil((double) N / (double) run_block_size_1), 1, 1);
+    dim3 threads_1(run_block_size_1, 1, 1);
 
-        dim3 grid_1((int) ceil((double) N / (double) run_block_size_1), 1, 1);
-        dim3 threads_1(run_block_size_1, 1, 1);
+    dim3 grid_2((int) ceil((double) N / (double) run_block_size_2), 1, 1);
+    dim3 threads_2(run_block_size_2, 1, 1);
 
-        dim3 grid_2((int) ceil((double) N / (double) run_block_size_2), 1, 1);
-        dim3 threads_2(run_block_size_2, 1, 1);
-
-        gpu_kernel_1<1> <<<grid_1, threads_1>>>(d_force, d_virial, virial_pitch, N, d_pos, box, d_n_neigh, d_nlist,
-                d_head_list, d_F, d_rho, d_rphi, d_dF, d_drho, d_drphi, d_dFdP);
-        gpu_kernel_2<1> <<<grid_2, threads_2>>>(d_force, d_virial, virial_pitch, N, d_pos, box, d_n_neigh, d_nlist,
-                d_head_list, d_F, d_rho, d_rphi, d_dF, d_drho, d_drphi, d_dFdP);
-        }
-    else
-        {
-
-        static unsigned int max_block_size_1 = UINT_MAX;
-        static unsigned int max_block_size_2 = UINT_MAX;
-
-        cudaFuncAttributes attr1;
-        cudaFuncGetAttributes(&attr1, gpu_kernel_1<0>);
-
-        cudaFuncAttributes attr2;
-        cudaFuncGetAttributes(&attr2, gpu_kernel_2<0>);
-
-        max_block_size_1 = attr1.maxThreadsPerBlock;
-        max_block_size_2 = attr2.maxThreadsPerBlock;
-
-        unsigned int run_block_size_1 = min(eam_data.block_size, max_block_size_1);
-        unsigned int run_block_size_2 = min(eam_data.block_size, max_block_size_2);
-
-        // setup the grid to run the kernel
-
-        dim3 grid_1((int) ceil((double) N / (double) run_block_size_1), 1, 1);
-        dim3 threads_1(run_block_size_1, 1, 1);
-
-        dim3 grid_2((int) ceil((double) N / (double) run_block_size_2), 1, 1);
-        dim3 threads_2(run_block_size_2, 1, 1);
-
-        gpu_kernel_1<0> <<<grid_1, threads_1>>>(d_force, d_virial, virial_pitch, N, d_pos, box, d_n_neigh, d_nlist,
-                d_head_list, d_F, d_rho, d_rphi, d_dF, d_drho, d_drphi, d_dFdP);
-        gpu_kernel_2<0> <<<grid_2, threads_2>>>(d_force, d_virial, virial_pitch, N, d_pos, box, d_n_neigh, d_nlist,
-                d_head_list, d_F, d_rho, d_rphi, d_dF, d_drho, d_drphi, d_dFdP);
-        }
+    gpu_kernel_1<<<grid_1, threads_1>>>(d_force, d_virial, virial_pitch, N, d_pos, box, d_n_neigh, d_nlist,
+            d_head_list, d_F, d_rho, d_rphi, d_dF, d_drho, d_drphi, d_dFdP);
+    gpu_kernel_2<<<grid_2, threads_2>>>(d_force, d_virial, virial_pitch, N, d_pos, box, d_n_neigh, d_nlist,
+            d_head_list, d_F, d_rho, d_rphi, d_dF, d_drho, d_drphi, d_dFdP);
 
     return cudaSuccess;
     }

--- a/hoomd/metal/EAMForceGPU.cuh
+++ b/hoomd/metal/EAMForceGPU.cuh
@@ -35,7 +35,6 @@ cudaError_t gpu_compute_eam_tex_inter_forces(Scalar4* d_force, Scalar* d_virial,
         const unsigned int N, const Scalar4 *d_pos, const BoxDim& box, const unsigned int *d_n_neigh,
         const unsigned int *d_nlist, const unsigned int *d_head_list, const unsigned int size_nlist,
         const EAMTexInterData& eam_data, Scalar *d_dFdP, const Scalar4 *d_F, const Scalar4 *d_rho,
-        const Scalar4 *d_rphi, const Scalar4 *d_dF, const Scalar4 *d_drho, const Scalar4 *d_drphi,
-        const unsigned int compute_capability, const unsigned int max_tex1d_width);
+        const Scalar4 *d_rphi, const Scalar4 *d_dF, const Scalar4 *d_drho, const Scalar4 *d_drphi);
 
 #endif


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should based on *maint*. -->
<!-- New features should based on *master*. -->

## Description

Remove support for compute 3.0 devices.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Compute 3.0 is seven years old at this point, so there is no reason to further support these devices. By removing support for compute 3.0, we can rely on `__ldg` in place of texture fetches everywhere. This simplifies the GPU kernels, especially the driver functions that call them.

<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves: #330 

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
CI testing.

## Change log

<!-- Propose a change log entry. -->
```
- Remove support for compute 3.0 GPUs.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/hoomd-blue/blob/master/sphinx-doc/credits.rst).
