### PR TITLE
Report detailed CUDA errors on initialization

### DIFF
--- a/hoomd/ExecutionConfiguration.cc
+++ b/hoomd/ExecutionConfiguration.cc
@@ -485,37 +485,20 @@ void ExecutionConfiguration::scanGPUs(bool ignore_display)
     {
     // check the CUDA driver version
     int driverVersion = 0;
-    cudaDriverGetVersion(&driverVersion);
+    cudaError_t error = cudaDriverGetVersion(&driverVersion);
 
-    // first handle the situation where no driver is installed (or it is a CUDA 2.1 or earlier driver)
-    if (driverVersion == 0)
+    if (error != cudaSuccess)
         {
-        msg->notice(2) << "NVIDIA driver not installed or is too old, ignoring any GPUs in the system." << endl;
-        return;
-        }
-
-    // next, check to see if the driver is capable of running the version of CUDART that HOOMD was compiled against
-    if (driverVersion < CUDART_VERSION)
-        {
-        int driver_major = driverVersion / 1000;
-        int driver_minor = (driverVersion - driver_major * 1000) / 10;
-        int cudart_major = CUDART_VERSION / 1000;
-        int cudart_minor = (CUDART_VERSION - cudart_major * 1000) / 10;
-
-        msg->notice(2) << "The NVIDIA driver only supports CUDA versions up to " << driver_major << "."
-             << driver_minor << ", but HOOMD was built against CUDA " << cudart_major << "." << cudart_minor << endl;
-        msg->notice(2) << "Ignoring any GPUs in the system." << endl;
+        msg->notice(1) << string(cudaGetErrorString(error)) << endl;
         return;
         }
 
     // determine the number of GPUs that CUDA thinks there is
     int dev_count;
-    cudaError_t error = cudaGetDeviceCount(&dev_count);
+    error = cudaGetDeviceCount(&dev_count);
     if (error != cudaSuccess)
         {
-        msg->notice(2) << "Error calling cudaGetDeviceCount(). No NVIDIA driver is present, or this user" << endl;
-        msg->notice(2) << "does not have readwrite permissions on /dev/nvidia*" << endl;
-        msg->notice(2) << "Ignoring any GPUs in the system." << endl;
+        msg->notice(1) << string(cudaGetErrorString(error)) << endl;
         return;
         }
 


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should based on *maint*. -->
<!-- New features should based on *master*. -->

## Description

Report detailed CUDA error strings reported by the runtime during CUDA initialization.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
CUDA was reporting out of memory errors during initialization on some mis-configured queuing systems. This change will make root cause of the failure apparent to users.

<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves: #356

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
I manually introduced error conditions and observed the expected output.

## Change log

<!-- Propose a change log entry. -->
```
- Report detailed CUDA errors on initialization
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/hoomd-blue/blob/master/sphinx-doc/credits.rst).
