### PR TITLE
Change auto_ptr to shared_ptr and update libgetar submodule to v1.0.0.

### DIFF
--- a/hoomd/GetarInitializer.h
+++ b/hoomd/GetarInitializer.h
@@ -87,7 +87,7 @@ namespace getardump{
             /// Saved execution configuration
             std::shared_ptr<const ExecutionConfiguration> m_exec_conf;
             /// Saved trajectory archive object
-            std::auto_ptr<gtar::GTAR> m_traj;
+            std::shared_ptr<gtar::GTAR> m_traj;
             /// Set of known records we found in the current trajectory archive
             std::vector<gtar::Record> m_knownRecords;
             /// Cached timestep


### PR DESCRIPTION
## Description

All the `auto_ptr` issues are gone. However, I missed one of the deprecation warnings in the update to libgetar for a function called `readdir_r` used by the Directory backend of libgetar. I'm not sure how to proceed with fixing this one. @klarh might have some knowledge about how this works?

```c++
[44/310] Building CXX object hoomd/CMakeF....dir/extern/libgetar/src/DirArchive.cpp.o
../hoomd/extern/libgetar/src/DirArchive.cpp: In member function ‘void gtar::DirArchive::searchDirectory(const string&)’:
../hoomd/extern/libgetar/src/DirArchive.cpp:187:47: warning: ‘int readdir_r(DIR*, dirent*, dirent**)’ is deprecated [-Wdeprecated-declarations]
  187 |             readdir_r(curDir, curEnt, &nextEnt);
      |                                               ^
In file included from ../hoomd/extern/libgetar/src/DirArchive.cpp:17:
/usr/include/dirent.h:183:12: note: declared here
  183 | extern int readdir_r (DIR *__restrict __dirp,
      |            ^~~~~~~~~
../hoomd/extern/libgetar/src/DirArchive.cpp:187:47: warning: ‘int readdir_r(DIR*, dirent*, dirent**)’ is deprecated [-Wdeprecated-declarations]
  187 |             readdir_r(curDir, curEnt, &nextEnt);
      |                                               ^
In file included from ../hoomd/extern/libgetar/src/DirArchive.cpp:17:
/usr/include/dirent.h:183:12: note: declared here
  183 | extern int readdir_r (DIR *__restrict __dirp,
      |            ^~~~~~~~~
```
## Motivation and Context

Resolves: #430.

## How Has This Been Tested?

I built HOOMD on the vislab and it did not show any `auto_ptr` deprecation warnings.

## Change log

```
Updated libgetar submodule to remove deprecation warnings.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/hoomd-blue/blob/master/sphinx-doc/credits.rst).