### PR TITLE
Make Logger visible

### DIFF
--- a/hoomd/Logger.cc
+++ b/hoomd/Logger.cc
@@ -32,6 +32,12 @@ Logger::Logger(std::shared_ptr<SystemDefinition> sysdef)
 Logger::~Logger()
     {
     m_exec_conf->msg->notice(5) << "Destroying Logger" << endl;
+
+    // decrease the reference count on all held callbacks
+    for(auto i : m_callback_quantities)
+        {
+        pybind11::handle(i.second).dec_ref();
+        }
     }
 
 /*! \param compute The Compute to register
@@ -88,7 +94,7 @@ void Logger::registerUpdater(std::shared_ptr<Updater> updater)
     After the callback is registered \a name is available as a logger quantity. The callback must return a scalar
     value and accept the time step as an argument.
 */
-void Logger::registerCallback(std::string name, py::object callback)
+void Logger::registerCallback(std::string name, pybind11::handle callback)
     {
     // first check if this quantity is already set, printing a warning if so
     if (   m_compute_quantities.count(name)
@@ -97,7 +103,9 @@ void Logger::registerCallback(std::string name, py::object callback)
         )
     m_exec_conf->msg->warning() << "analyze.log: The log quantity " << name <<
                          " has been registered more than once. Only the most recent registration takes effect" << endl;
-    m_callback_quantities[name] = callback;
+
+    pybind11::handle(callback).inc_ref(); // increase the reference count on this handle while we hold it
+    m_callback_quantities[name] = callback.ptr();
     }
 
 /*! After calling removeAll(), no quantities are registered for logging
@@ -199,7 +207,7 @@ Scalar Logger::getValue(const std::string &quantity, int timestep)
         // get a quantity from a callback
         try
             {
-            py::object rv = m_callback_quantities[quantity](timestep);
+            py::object rv = pybind11::reinterpret_borrow<py::object>(m_callback_quantities[quantity])(timestep);
             Scalar extracted_rv = rv.cast<Scalar>();
             return extracted_rv;
             }

--- a/hoomd/Logger.h
+++ b/hoomd/Logger.h
@@ -45,7 +45,7 @@
 
     \ingroup analyzers
 */
-class __attribute__ ((visibility ("hidden"))) Logger : public Analyzer
+class Logger : public Analyzer
     {
     public:
         //! Constructs a logger
@@ -61,7 +61,7 @@ class __attribute__ ((visibility ("hidden"))) Logger : public Analyzer
         virtual void registerUpdater(std::shared_ptr<Updater> updater);
 
         //! Register a callback
-        virtual void registerCallback(std::string name, pybind11::object callback);
+        virtual void registerCallback(std::string name, pybind11::handle callback);
 
         //! Clears all registered computes and updaters
         virtual void removeAll();
@@ -97,7 +97,7 @@ class __attribute__ ((visibility ("hidden"))) Logger : public Analyzer
         //! A map of updaters indexed by logged quantity that they provide
         std::map< std::string, std::shared_ptr<Updater> > m_updater_quantities;
         //! List of callbacks
-        std::map< std::string, pybind11::object > m_callback_quantities;
+        std::map< std::string, PyObject * > m_callback_quantities;
         //! List of quantities to log
         std::vector< std::string > m_logged_quantities;
         //! Clock for the time log quantity

--- a/hoomd/Logger.h
+++ b/hoomd/Logger.h
@@ -45,7 +45,7 @@
 
     \ingroup analyzers
 */
-class Logger : public Analyzer
+class __attribute__((visibility("default"))) Logger : public Analyzer
     {
     public:
         //! Constructs a logger

--- a/hoomd/md/test-py/test_analyze_log.py
+++ b/hoomd/md/test-py/test_analyze_log.py
@@ -13,7 +13,7 @@ import numpy
 # unit tests for analyze.log
 class analyze_log_tests (unittest.TestCase):
     def setUp(self):
-        init.create_lattice(lattice.sc(a=2.1878096788957757),n=[5,5,4]);
+        self.system = init.create_lattice(lattice.sc(a=2.1878096788957757),n=[5,5,4]);
 
         hoomd.context.current.sorter.set_params(grid=8)
 
@@ -57,6 +57,10 @@ class analyze_log_tests (unittest.TestCase):
 
         self.assertRaises(RuntimeError, ana.enable);
         self.assertRaises(RuntimeError, ana.disable);
+
+    def test_callback(self):
+        ana = hoomd.analyze.log(quantities = ['test1', 'test2', 'test3'], period = 10, filename=self.tmp_file);
+        ana.register_callback('phi_p', lambda timestep: len(self.system.particles)/self.system.box.get_volume() * math.pi / 4.0)
 
     def tearDown(self):
         hoomd.context.initialize();


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should based on *maint*. -->
<!-- New features should based on *master*. -->

## Description

<!-- Describe your changes in detail. -->
Use `PyObject*`'s directly in Logger so that ``pybind::object`` class members do not force the class to be hidden.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Components other than `_hoomd` can now use Logger at the C++ level.

<!-- Replace ??? with the issue number that this pull request resolves. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
Tested externally with an external component that derives from `Logger` : @atravitz 

## Change log

<!-- Propose a change log entry. -->
```
* Allow components to use ``Logger`` at the C++ level
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/hoomd-blue/blob/master/sphinx-doc/credits.rst).
