### PR TITLE
Fix hoomd.hdf5.log.query bug for matrix quantities

### DIFF
--- a/hoomd/hdf5.py
+++ b/hoomd/hdf5.py
@@ -166,7 +166,7 @@ class log(hoomd.analyze._analyzer):
         if not matrix:
             return self.cpp_analyzer.getQuantity(quantity, timestep, use_cache)
         else:
-            return self.cpp_analyzer.getMatrixQuantity(quantity, timestep, use_cache)
+            return self.cpp_analyzer.getMatrixQuantity(quantity, timestep)
 
     def register_callback(self, name, callback, matrix=False):
         R""" Register a callback to produce a logged quantity.


### PR DESCRIPTION
## Description

Fixes a bug which did not allow the query of matrix quantities from the hdf5 logger. See #436 

## Change log

<!-- Propose a change log entry. -->
```
Bugfix: hoomd.hdf5.log.query for matrix quantities
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/hoomd-blue/blob/master/sphinx-doc/credits.rst).
