### PR TITLE
Access net virial

### DIFF
--- a/hoomd/ForceCompute.cc
+++ b/hoomd/ForceCompute.cc
@@ -238,6 +238,32 @@ vec3<double> ForceCompute::calcForceGroup(std::shared_ptr<ParticleGroup> group)
     return vec3<double>(f_total);
     }
 
+/*! Sums the virial contributions of a particle group calculated by the last call to compute() and returns it.
+*/
+std::vector<Scalar> ForceCompute::calcVirialGroup(std::shared_ptr<ParticleGroup> group)
+    {
+    const unsigned int group_size = group->getNumMembers();
+    const ArrayHandle<Scalar> h_virial(m_virial,access_location::host,access_mode::read);
+
+    std::vector<Scalar> total_virial(6,0.);
+
+    for (unsigned int group_idx = 0; group_idx < group_size; group_idx++)
+        {
+        const unsigned int j = group->getMemberIndex(group_idx);
+
+        for(int i=0; i < 6; i++)
+            total_virial[i] += h_virial.data[m_virial_pitch*i +  j];
+        }
+#ifdef ENABLE_MPI
+    if (m_comm)
+        {
+        // reduce potential energy on all processors
+        MPI_Allreduce(MPI_IN_PLACE, total_virial.data(), 6, MPI_HOOMD_SCALAR, MPI_SUM, m_exec_conf->getMPICommunicator());
+        }
+#endif
+    return total_virial;
+
+    }
 
 
 /*! Performs the force computation.
@@ -395,5 +421,6 @@ void export_ForceCompute(py::module& m)
     .def("getEnergy", &ForceCompute::getEnergy)
     .def("calcEnergyGroup", &ForceCompute::calcEnergyGroup)
     .def("calcForceGroup", &ForceCompute::calcForceGroup)
+    .def("calcVirialGroup", &ForceCompute::calcVirialGroup)
     ;
     }

--- a/hoomd/ForceCompute.h
+++ b/hoomd/ForceCompute.h
@@ -86,6 +86,9 @@ class PYBIND11_EXPORT ForceCompute : public Compute
         //! Sum the all forces for a group
         vec3<double> calcForceGroup(std::shared_ptr<ParticleGroup> group);
 
+        //! Sum all virial terms for a group
+        std::vector<Scalar> calcVirialGroup(std::shared_ptr<ParticleGroup> group);
+
         //! Easy access to the torque on a single particle
         Scalar4 getTorque(unsigned int tag);
 

--- a/hoomd/md/force.py
+++ b/hoomd/md/force.py
@@ -186,7 +186,7 @@ class _force(hoomd.meta._metadata):
             g = group.all()
             virial = force.get_net_virial(g)
         """
-        return self.cpp_force.calcVirialGroup(group.cpp_group)
+        return np.asarray(self.cpp_force.calcVirialGroup(group.cpp_group))
 
 
 

--- a/hoomd/md/force.py
+++ b/hoomd/md/force.py
@@ -172,6 +172,24 @@ class _force(hoomd.meta._metadata):
 
         return (self.cpp_force.calcForceGroup(group.cpp_group).x, self.cpp_force.calcForceGroup(group.cpp_group).y, self.cpp_force.calcForceGroup(group.cpp_group).z)
 
+    def get_net_virial(self,group):
+        R""" Get the virial of a particle group.
+
+        Args:
+            group (:py:mod:`hoomd.group`): The particle group to query the virial for.
+
+        Returns:
+            The last computed virial for the members in the group.
+
+        Examples:
+
+            g = group.all()
+            virial = force.get_net_virial(g)
+        """
+        return self.cpp_force.calcVirialGroup(group.cpp_group)
+
+
+
 
     ## \internal
     # \brief updates force coefficients

--- a/hoomd/md/test-py/test_net_virial.py
+++ b/hoomd/md/test-py/test_net_virial.py
@@ -1,0 +1,64 @@
+# -*- coding: iso-8859-1 -*-
+
+from __future__ import print_function
+from __future__ import division
+
+from hoomd import *
+from hoomd import md
+context.initialize()
+import unittest
+import os
+import numpy
+
+numpy.random.seed(1)
+
+# unit tests for analyze.msd
+class compute_net_virial_tests (unittest.TestCase):
+    def setUp(self):
+        self.L = 6.
+        self.N = 1000
+        self.snap = data.make_snapshot(N=self.N, particle_types=['A'], box=data.boxdim(L=self.L))
+
+        if comm.get_rank() == 0:
+            for i in range(self.N):
+                self.snap.particles.position[i] = numpy.random.random( 3)
+                #no kinetic contribution to the pressure wanted
+                self.snap.particles.velocity[i] = numpy.zeros(3)
+
+        init.read_snapshot(self.snap)
+        context.current.sorter.set_params(grid=8)
+        nl = md.nlist.cell()
+        self.dpd = md.pair.dpd_conservative(r_cut=1.0,nlist=nl)
+        self.dpd.pair_coeff.set('A','A',A=1)
+        #no kinetic contribution to pressure wanted. Thus freeze the configuration
+        md.integrate.mode_standard(dt=0.)
+        md.integrate.nve(group=group.all())
+
+    # API test: tests basic calling the function
+    def test_api(self):
+        run(1);
+        dpd_virial = self.dpd.get_net_virial(group.all())
+
+    # Unit test: Validate virial and pressure computation
+    def test_virial_pressure(self):
+        #log the pressure quantities
+        qr = ["pressure_xx","pressure_xy","pressure_xz","pressure_yy","pressure_yz","pressure_zz"]
+        log = analyze.log(None,qr,period=1)
+
+        run(1);
+
+        #access only the DPD virial
+        dpd_virial = self.dpd.get_net_virial(group.all())
+
+        volume = self.L**3
+        for i in range(6):
+            log_pressure = log.query(qr[i])
+            numpy.testing.assert_allclose(log_pressure, dpd_virial[i]/volume)
+
+
+    def tearDown(self):
+        context.initialize();
+
+
+if __name__ == '__main__':
+    unittest.main(argv = ['test.py', '-v'])


### PR DESCRIPTION
## Description

I added a function to the ForceCompute class that sums the virial of a particle group analog to calcForceGroup or calcEnergyGroup.

## Motivation and Context

I want to access the virial of certain forces separately. I got the idea of accessing the virials separately when working with external walls.

## How Has This Been Tested?

If there is only a single force acting in the system and the particles have zero velocity the virial components of this force should be equal to the "pressure_ij" component as logged via analyze.log(). A python test script has been added as well, which checks this condition.

## Change log

<!-- Propose a change log entry. -->
```
Enable access to net virial of particle groups for separate ForceComputes
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/hoomd-blue/blob/master/sphinx-doc/credits.rst).
- [ ] I am a member of the [hoomd-contributors team](https://github.com/orgs/glotzerlab/teams/hoomd-contributors/members).
