### PR TITLE
NVE integrators for MPCD geometries

### DIFF
--- a/hoomd/mpcd/ATCollisionMethod.h
+++ b/hoomd/mpcd/ATCollisionMethod.h
@@ -67,6 +67,6 @@ namespace detail
 void export_ATCollisionMethod(pybind11::module& m);
 } // end namespace detail
 
-} // end namespace azplugins
+} // end namespace mpcd
 
 #endif // MPCD_AT_COLLISION_METHOD_H_

--- a/hoomd/mpcd/BounceBackNVE.h
+++ b/hoomd/mpcd/BounceBackNVE.h
@@ -88,7 +88,7 @@ BounceBackNVE<Geometry>::BounceBackNVE(std::shared_ptr<SystemDefinition> sysdef,
     {
     m_exec_conf->msg->notice(5) << "Constructing BounceBackNVE + " << Geometry::getName() << std::endl;
 
-    m_pdata->getBoxChangeSignal().connect<BounceBackNVE<Geometry>, &BounceBackNVE<Geometry>::requestValidate>(this);
+    m_pdata->getBoxChangeSignal().template connect<BounceBackNVE<Geometry>, &BounceBackNVE<Geometry>::requestValidate>(this);
     }
 
 template<class Geometry>
@@ -96,7 +96,7 @@ BounceBackNVE<Geometry>::~BounceBackNVE()
     {
     m_exec_conf->msg->notice(5) << "Destroying BounceBackNVE + " << Geometry::getName() << std::endl;
 
-    m_pdata->getBoxChangeSignal().disconnect<BounceBackNVE<Geometry>, &BounceBackNVE<Geometry>::requestValidate>(this);
+    m_pdata->getBoxChangeSignal().template disconnect<BounceBackNVE<Geometry>, &BounceBackNVE<Geometry>::requestValidate>(this);
     }
 
 template<class Geometry>

--- a/hoomd/mpcd/BounceBackNVE.h
+++ b/hoomd/mpcd/BounceBackNVE.h
@@ -1,0 +1,277 @@
+// Copyright (c) 2009-2019 The Regents of the University of Michigan
+// This file is part of the HOOMD-blue project, released under the BSD 3-Clause License.
+
+// Maintainer: mphoward
+
+/*!
+ * \file BounceBackNVE.h
+ * \brief Declares the BounceBackNVE class for doing NVE integration with bounce-back
+ *        boundary conditions imposed by a geometry.
+ */
+
+#ifndef MPCD_BOUNCE_BACK_NVE_H_
+#define MPCD_BOUNCE_BACK_NVE_H_
+
+#ifdef NVCC
+#error This header cannot be compiled by nvcc
+#endif
+
+#include "hoomd/md/IntegrationMethodTwoStep.h"
+#include "hoomd/extern/pybind/include/pybind11/pybind11.h"
+
+namespace mpcd
+{
+//! Integrator that applies bounce-back boundary conditions in NVE.
+/*!
+ * This integrator applies "bounce-back" boundary conditions according to a template \a Geometry class.
+ * Particles away from the boundary evolve according to the standard velocity Verlet equations. When
+ * a particle moves to cross a boundary during the first Verlet step, its position is restored to the boundary.
+ * The particle's tangential velocity is then reflected according to the slip or no-slip condition, while the normal
+ * velocity is always reflected to maintain the no-penetration condition. The particle velocity during this collision
+ * is the halfway point (after the current acceleration has been applied). The final velocity step proceeds as usual
+ * for the Verlet algorithm after the reflections are completed. This reflection procedure may induce a small amount of
+ * slip near the surface from the acceleration.
+ */
+template<class Geometry>
+class PYBIND11_EXPORT BounceBackNVE : public ::IntegrationMethodTwoStep
+    {
+    public:
+        //! Constructor
+        BounceBackNVE(std::shared_ptr<SystemDefinition> sysdef,
+                      std::shared_ptr<ParticleGroup> group,
+                      std::shared_ptr<const Geometry> geom);
+
+        //! Destructor
+        virtual ~BounceBackNVE();
+
+        //! Performs the first step of the integration
+        virtual void integrateStepOne(unsigned int timestep);
+
+        //! Performs the second step of the integration
+        virtual void integrateStepTwo(unsigned int timestep);
+
+        //! Get the streaming geometry
+        std::shared_ptr<const Geometry> getGeometry()
+            {
+            return m_geom;
+            }
+
+        //! Set the streaming geometry
+        void setGeometry(std::shared_ptr<const Geometry> geom)
+            {
+            requestValidate();
+            m_geom = geom;
+            }
+
+    protected:
+        std::shared_ptr<const Geometry> m_geom;  //!< Bounce-back geometry
+        bool m_validate_geom;   //!< If true, run a validation check on the geometry
+
+        //! Validate the system with the streaming geometry
+        void validate();
+
+    private:
+        void requestValidate()
+            {
+            m_validate_geom = true;
+            }
+
+        //! Check that particles lie inside the geometry
+        bool validateParticles();
+    };
+
+template<class Geometry>
+BounceBackNVE<Geometry>::BounceBackNVE(std::shared_ptr<SystemDefinition> sysdef,
+                                       std::shared_ptr<ParticleGroup> group,
+                                       std::shared_ptr<const Geometry> geom)
+    : IntegrationMethodTwoStep(sysdef, group), m_geom(geom), m_validate_geom(true)
+    {
+    m_exec_conf->msg->notice(5) << "Constructing BounceBackNVE + " << Geometry::getName() << std::endl;
+
+    m_pdata->getBoxChangeSignal().connect<BounceBackNVE<Geometry>, &BounceBackNVE<Geometry>::requestValidate>(this);
+    }
+
+template<class Geometry>
+BounceBackNVE<Geometry>::~BounceBackNVE()
+    {
+    m_exec_conf->msg->notice(5) << "Destroying BounceBackNVE + " << Geometry::getName() << std::endl;
+
+    m_pdata->getBoxChangeSignal().disconnect<BounceBackNVE<Geometry>, &BounceBackNVE<Geometry>::requestValidate>(this);
+    }
+
+template<class Geometry>
+void BounceBackNVE<Geometry>::integrateStepOne(unsigned int timestep)
+    {
+    if (m_aniso)
+        {
+        m_exec_conf->msg->error() << "mpcd.integrate: anisotropic particles are not supported with bounce-back integrators." << std::endl;
+        throw std::runtime_error("Anisotropic integration not supported with bounce-back");
+        }
+
+    if (m_prof) m_prof->push("Bounce NVE step 1");
+
+    if (m_validate_geom) validate();
+
+    // particle data
+    ArrayHandle<Scalar4> h_pos(m_pdata->getPositions(), access_location::host, access_mode::readwrite);
+    ArrayHandle<int3> h_image(m_pdata->getImages(), access_location::host, access_mode::readwrite);
+    ArrayHandle<Scalar4> h_vel(m_pdata->getVelocities(), access_location::host, access_mode::readwrite);
+    ArrayHandle<Scalar3> h_accel(m_pdata->getAccelerations(), access_location::host, access_mode::read);
+    const BoxDim& box = m_pdata->getBox();
+
+    // group members
+    const unsigned int group_size = m_group->getNumMembers();
+    ArrayHandle<unsigned int> h_group(m_group->getIndexArray(), access_location::host, access_mode::read);
+
+    for (unsigned int idx = 0; idx < group_size; ++idx)
+        {
+        const unsigned int pid = h_group.data[idx];
+
+        // load velocity + mass
+        const Scalar4 velmass = h_vel.data[pid];
+        Scalar3 vel = make_scalar3(velmass.x, velmass.y, velmass.z);
+        const Scalar mass = velmass.w;
+
+        // update velocity first according to verlet step
+        const Scalar3 accel = h_accel.data[pid];
+        vel += Scalar(0.5) * m_deltaT * accel;
+
+        // load poosition and type
+        const Scalar4 postype = h_pos.data[pid];
+        Scalar3 pos = make_scalar3(postype.x, postype.y, postype.z);
+        const Scalar type = postype.w;
+
+        // update position while bouncing-back velocity
+        Scalar dt_remain = m_deltaT;
+        bool collide = false;
+        do
+            {
+            pos += dt_remain * vel;
+            collide = m_geom->detectCollision(pos, vel, dt_remain);
+            }
+        while (dt_remain > 0 && collide);
+
+        // wrap final position
+        box.wrap(pos, h_image.data[pid]);
+
+        // write position and velocity back out
+        h_pos.data[pid] = make_scalar4(pos.x, pos.y, pos.z, type);
+        h_vel.data[pid] = make_scalar4(vel.x, vel.y, vel.z, mass);
+        }
+
+    if (m_prof) m_prof->pop();
+    }
+
+template<class Geometry>
+void BounceBackNVE<Geometry>::integrateStepTwo(unsigned int timestep)
+    {
+    if (m_aniso)
+        {
+        m_exec_conf->msg->error() << "mpcd.integrate: anisotropic particles are not supported with bounce-back integrators." << std::endl;
+        throw std::runtime_error("Anisotropic integration not supported with bounce-back");
+        }
+    if (m_prof) m_prof->push("Bounce NVE step 2");
+
+    ArrayHandle<Scalar4> h_vel(m_pdata->getVelocities(), access_location::host, access_mode::readwrite);
+    ArrayHandle<Scalar3> h_accel(m_pdata->getAccelerations(), access_location::host, access_mode::readwrite);
+    ArrayHandle<Scalar4> h_net_force(m_pdata->getNetForce(), access_location::host, access_mode::read);
+
+    const unsigned int group_size = m_group->getNumMembers();
+    ArrayHandle<unsigned int> h_group(m_group->getIndexArray(), access_location::host, access_mode::read);
+
+    for (unsigned int idx = 0; idx < group_size; ++idx)
+        {
+        const unsigned int pid = h_group.data[idx];
+
+        // load net force and velocity, compute a = F / m
+        const Scalar4 net_force = h_net_force.data[pid];
+        Scalar3 accel = make_scalar3(net_force.x, net_force.y, net_force.z);
+        Scalar4 vel = h_vel.data[pid];
+        accel.x /= vel.w;
+        accel.y /= vel.w;
+        accel.z /= vel.w;
+
+        // then, update the velocity
+        vel.x += Scalar(0.5) * accel.x * m_deltaT;
+        vel.y += Scalar(0.5) * accel.y * m_deltaT;
+        vel.z += Scalar(0.5) * accel.z * m_deltaT;
+
+        h_vel.data[pid] = vel;
+        h_accel.data[pid] = accel;
+        }
+
+    if (m_prof) m_prof->pop();
+    }
+
+template<class Geometry>
+void BounceBackNVE<Geometry>::validate()
+    {
+    // ensure that the global box is padded enough for periodic boundaries
+    const BoxDim& box = m_pdata->getGlobalBox();
+    if (!m_geom->validateBox(box, 0.))
+        {
+        m_exec_conf->msg->error() << "BounceBackNVE: box too small for " << Geometry::getName() << " geometry. Increase box size." << std::endl;
+        throw std::runtime_error("Simulation box too small for bounce back method");
+        }
+
+    // check that no particles are out of bounds
+    unsigned char error = !validateParticles();
+    #ifdef ENABLE_MPI
+    if (m_exec_conf->getNRanks() > 1)
+        MPI_Allreduce(MPI_IN_PLACE, &error, 1, MPI_UNSIGNED_CHAR, MPI_LOR, m_exec_conf->getMPICommunicator());
+    #endif // ENABLE_MPI
+    if (error)
+        throw std::runtime_error("Invalid particle configuration for bounce back geometry");
+
+    // validation completed, unset flag
+    m_validate_geom = false;
+    }
+
+/*!
+ * Checks each particle position to determine if it lies within the geometry. If any particle is
+ * out of bounds, an error is raised.
+ */
+template<class Geometry>
+bool BounceBackNVE<Geometry>::validateParticles()
+    {
+    ArrayHandle<Scalar4> h_pos(m_pdata->getPositions(), access_location::host, access_mode::read);
+    ArrayHandle<unsigned int> h_tag(m_pdata->getTags(), access_location::host, access_mode::read);
+
+    ArrayHandle<unsigned int> h_group(m_group->getIndexArray(), access_location::host, access_mode::read);
+    const unsigned int group_size = m_group->getNumMembers();
+
+    for (unsigned int idx = 0; idx < group_size; ++idx)
+        {
+        const unsigned int pid = h_group.data[idx];
+
+        const Scalar4 postype = h_pos.data[pid];
+        const Scalar3 pos = make_scalar3(postype.x, postype.y, postype.z);
+        if (m_geom->isOutside(pos))
+            {
+            m_exec_conf->msg->error() << "Particle with tag " << h_tag.data[pid] << " at (" << pos.x << "," << pos.y << "," << pos.z
+                                      << ") lies outside the " << Geometry::getName() << " geometry. Fix configuration." << std::endl;
+            return false;
+            }
+        }
+
+    return true;
+    }
+
+namespace detail
+{
+//! Exports the BounceBackNVE class to python
+template<class Geometry>
+void export_BounceBackNVE(pybind11::module& m)
+    {
+    namespace py = pybind11;
+    const std::string name = "BounceBackNVE" + Geometry::getName();
+
+    py::class_<BounceBackNVE<Geometry>, std::shared_ptr<BounceBackNVE<Geometry>>>
+        (m, name.c_str(), py::base<IntegrationMethodTwoStep>())
+        .def(py::init<std::shared_ptr<SystemDefinition>, std::shared_ptr<ParticleGroup>, std::shared_ptr<const Geometry>>())
+        .def_property("geometry", &BounceBackNVE<Geometry>::getGeometry, &BounceBackNVE<Geometry>::setGeometry)
+        ;
+    }
+} // end namespace detail
+} // end namespace mpcd
+#endif // #ifndef MPCD_BOUNCE_BACK_NVE_H_

--- a/hoomd/mpcd/BounceBackNVE.h
+++ b/hoomd/mpcd/BounceBackNVE.h
@@ -136,7 +136,7 @@ void BounceBackNVE<Geometry>::integrateStepOne(unsigned int timestep)
         const Scalar3 accel = h_accel.data[pid];
         vel += Scalar(0.5) * m_deltaT * accel;
 
-        // load poosition and type
+        // load position and type
         const Scalar4 postype = h_pos.data[pid];
         Scalar3 pos = make_scalar3(postype.x, postype.y, postype.z);
         const Scalar type = postype.w;

--- a/hoomd/mpcd/BounceBackNVEGPU.cu
+++ b/hoomd/mpcd/BounceBackNVEGPU.cu
@@ -21,11 +21,9 @@ namespace gpu
 template cudaError_t nve_bounce_step_one<mpcd::detail::SlitGeometry>
     (const bounce_args_t& args, const mpcd::detail::SlitGeometry& geom);
 
-#if AZPLUGINS_API_INTEGRATE_SLIT_PORE
 //! Template instantiation of slit pore geometry streaming
 template cudaError_t nve_bounce_step_one<mpcd::detail::SlitPoreGeometry>
     (const bounce_args_t& args, const mpcd::detail::SlitPoreGeometry& geom);
-#endif
 
 namespace kernel
 {

--- a/hoomd/mpcd/BounceBackNVEGPU.cu
+++ b/hoomd/mpcd/BounceBackNVEGPU.cu
@@ -10,7 +10,7 @@
  */
 
 #include "BounceBackNVEGPU.cuh"
-#include "BounceBackGeometry.h"
+#include "StreamingGeometry.h"
 
 namespace mpcd
 {

--- a/hoomd/mpcd/BounceBackNVEGPU.cu
+++ b/hoomd/mpcd/BounceBackNVEGPU.cu
@@ -1,0 +1,110 @@
+// Copyright (c) 2009-2019 The Regents of the University of Michigan
+// This file is part of the HOOMD-blue project, released under the BSD 3-Clause License.
+
+// Maintainer: mphoward
+
+/*!
+ * \file BounceBackNVEGPU.cu
+ * \brief Template specialization of CUDA kernels for BounceBackNVEGPU geometries. Each instance of the
+ *        nve_bounce_step_one must be templated explicitly for each geometry.
+ */
+
+#include "BounceBackNVEGPU.cuh"
+#include "BounceBackGeometry.h"
+
+namespace mpcd
+{
+namespace gpu
+{
+
+//! Template instantiation of slit geometry streaming
+template cudaError_t nve_bounce_step_one<mpcd::detail::SlitGeometry>
+    (const bounce_args_t& args, const mpcd::detail::SlitGeometry& geom);
+
+#if AZPLUGINS_API_INTEGRATE_SLIT_PORE
+//! Template instantiation of slit pore geometry streaming
+template cudaError_t nve_bounce_step_one<mpcd::detail::SlitPoreGeometry>
+    (const bounce_args_t& args, const mpcd::detail::SlitPoreGeometry& geom);
+#endif
+
+namespace kernel
+{
+//! Kernel for applying second step of velocity Verlet algorithm with bounce back
+/*!
+ * \param d_vel Particle velocities
+ * \param d_accel Particle accelerations
+ * \param d_net_force Net force on each particle
+ * \param d_group Indexes in particle group
+ * \param dt Timestep
+ * \param N Number of particles in group
+ *
+ * \b Implementation:
+ * Using one thread per particle, the particle velocities are updated according to the second step of the velocity Verlet
+ * algorithm. This is the standard update as in MD, and is only reimplemented here in case future modifications are necessary.
+ */
+__global__ void nve_bounce_step_two(Scalar4 *d_vel,
+                                    Scalar3 *d_accel,
+                                    const Scalar4 *d_net_force,
+                                    const unsigned int *d_group,
+                                    const Scalar dt,
+                                    const unsigned int N)
+    {
+    // one thread per particle
+    unsigned int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx >= N)
+        return;
+    const unsigned int pid = d_group[idx];
+
+    const Scalar4 net_force = d_net_force[pid];
+    Scalar3 accel = make_scalar3(net_force.x, net_force.y, net_force.z);
+    Scalar4 vel = d_vel[pid];
+    accel.x /= vel.w;
+    accel.y /= vel.w;
+    accel.z /= vel.w;
+
+    // then, update the velocity
+    vel.x += Scalar(0.5) * accel.x * dt;
+    vel.y += Scalar(0.5) * accel.y * dt;
+    vel.z += Scalar(0.5) * accel.z * dt;
+
+    d_vel[pid] = vel;
+    d_accel[pid] = accel;
+    }
+} // end namespace kernel
+
+/*!
+ * \param d_vel Particle velocities
+ * \param d_accel Particle accelerations
+ * \param d_net_force Net force on each particle
+ * \param d_group Indexes in particle group
+ * \param dt Timestep
+ * \param N Number of particles in group
+ * \param block_size Number of threads per block
+ *
+ * \sa kernel::nve_bounce_step_two
+ */
+cudaError_t nve_bounce_step_two(Scalar4 *d_vel,
+                                Scalar3 *d_accel,
+                                const Scalar4 *d_net_force,
+                                const unsigned int *d_group,
+                                const Scalar dt,
+                                const unsigned int N,
+                                const unsigned int block_size)
+    {
+    static unsigned int max_block_size = UINT_MAX;
+    if (max_block_size == UINT_MAX)
+        {
+        cudaFuncAttributes attr;
+        cudaFuncGetAttributes(&attr, (const void*)kernel::nve_bounce_step_two);
+        max_block_size = attr.maxThreadsPerBlock;
+        }
+
+    unsigned int run_block_size = min(block_size, max_block_size);
+    dim3 grid(N / run_block_size + 1);
+    kernel::nve_bounce_step_two<<<grid, run_block_size>>>(d_vel, d_accel, d_net_force, d_group, dt, N);
+
+    return cudaSuccess;
+    }
+
+} // end namespace gpu
+} // end namespace mpcd

--- a/hoomd/mpcd/BounceBackNVEGPU.cuh
+++ b/hoomd/mpcd/BounceBackNVEGPU.cuh
@@ -1,0 +1,179 @@
+// Copyright (c) 2009-2019 The Regents of the University of Michigan
+// This file is part of the HOOMD-blue project, released under the BSD 3-Clause License.
+
+// Maintainer: mphoward
+
+/*!
+ * \file BounceBackNVEGPU.cuh
+ * \brief Declaration of CUDA kernels for BounceBackNVEGPU
+ */
+
+#ifndef MPCD_BOUNCE_BACK_NVE_GPU_CUH_
+#define MPCD_BOUNCE_BACK_NVE_GPU_CUH_
+
+#include <cuda_runtime.h>
+
+#include "hoomd/HOOMDMath.h"
+#include "hoomd/BoxDim.h"
+
+namespace mpcd
+{
+namespace gpu
+{
+
+//! Common arguments for bounce-back integrator
+struct bounce_args_t
+    {
+    //! Constructor
+    bounce_args_t(Scalar4 *_d_pos,
+                  int3 *_d_image,
+                  Scalar4 *_d_vel,
+                  const Scalar3 *_d_accel,
+                  const unsigned int *_d_group,
+                  const Scalar _dt,
+                  const BoxDim& _box,
+                  const unsigned int _N,
+                  const unsigned int _block_size)
+        : d_pos(_d_pos), d_image(_d_image), d_vel(_d_vel), d_accel(_d_accel), d_group(_d_group),
+          dt(_dt), box(_box), N(_N), block_size(_block_size)
+        { }
+
+    Scalar4 *d_pos;                 //!< Particle positions
+    int3 *d_image;                  //!< Particle images
+    Scalar4 *d_vel;                 //!< Particle velocities
+    const Scalar3 *d_accel;         //!< Particle accelerations
+    const unsigned int *d_group;    //!< Indexes in particle group
+    const Scalar dt;                //!< Timestep
+    const BoxDim& box;              //!< Simulation box
+    const unsigned int N;           //!< Number of particles in group
+    const unsigned int block_size;  //!< Number of threads per block
+    };
+
+//! Kernel driver to apply step one of the velocity Verlet algorithm with bounce-back rules
+template<class Geometry>
+cudaError_t nve_bounce_step_one(const bounce_args_t& args, const Geometry& geom);
+
+//! Kernel driver to apply step two of the velocity Verlet algorithm with bounce-back rules
+cudaError_t nve_bounce_step_two(Scalar4 *d_vel,
+                                Scalar3 *d_accel,
+                                const Scalar4 *d_net_force,
+                                const unsigned int *d_group,
+                                const Scalar dt,
+                                const unsigned int N,
+                                const unsigned int block_size);
+
+#ifdef NVCC
+namespace kernel
+{
+//! Kernel for applying first step of velocity Verlet algorithm with bounce-back
+/*!
+ * \param d_pos Particle positions
+ * \param d_image Particle images
+ * \param d_vel Particle velocities
+ * \param d_accel Particle accelerations
+ * \param d_group Indexes in particle group
+ * \param dt Timestep
+ * \param box Simulation box
+ * \param N Number of particles in group
+ * \param geom Bounce-back geometry
+ *
+ * \tparam Geometry type of bounce-back geometry
+ *
+ * \b Implementation:
+ * Using one thread per particle, the bounce-back equations of motion are applied within the velocity Verlet algorithm.
+ * This amounts to first updating the particle velocities according to the current acceleration, then integration the
+ * position forward while respecting bounce-back conditions any time the particle crosses a boundary.
+ */
+template<class Geometry>
+__global__ void nve_bounce_step_one(Scalar4 *d_pos,
+                                    int3 *d_image,
+                                    Scalar4 *d_vel,
+                                    const Scalar3 *d_accel,
+                                    const unsigned int *d_group,
+                                    const Scalar dt,
+                                    const BoxDim box,
+                                    const unsigned int N,
+                                    const Geometry geom)
+    {
+    // one thread per particle
+    unsigned int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx >= N)
+        return;
+    const unsigned int pid = d_group[idx];
+
+    // load velocity + mass
+    const Scalar4 velmass = d_vel[pid];
+    Scalar3 vel = make_scalar3(velmass.x, velmass.y, velmass.z);
+    const Scalar mass = velmass.w;
+
+    // update velocity first according to verlet step
+    const Scalar3 accel = d_accel[pid];
+    vel += Scalar(0.5) * dt * accel;
+
+    // load poosition and type
+    const Scalar4 postype = d_pos[pid];
+    Scalar3 pos = make_scalar3(postype.x, postype.y, postype.z);
+    const Scalar type = postype.w;
+
+    // update position while bouncing-back velocity
+    Scalar dt_remain = dt;
+    bool collide = false;
+    do
+        {
+        pos += dt_remain * vel;
+        collide = geom.detectCollision(pos, vel, dt_remain);
+        }
+    while (dt_remain > 0 && collide);
+
+    // wrap final position
+    int3 img = d_image[pid];
+    box.wrap(pos, img);
+
+    // write position and velocity back out
+    d_pos[pid] = make_scalar4(pos.x, pos.y, pos.z, type);
+    d_vel[pid] = make_scalar4(vel.x, vel.y, vel.z, mass);
+    d_image[pid] = img;
+    }
+
+} // end namespace kernel
+
+/*!
+ * \param args Common bounce-back integration arguments
+ * \param geom Bounce-back geometry
+ *
+ * \tparam Geometry type of bounce-back geometry
+ *
+ * This function \b must be explicitly templated once for each streaming geometry.
+ *
+ * \sa kernel::nve_bounce_step_one
+ */
+template<class Geometry>
+cudaError_t nve_bounce_step_one(const bounce_args_t& args, const Geometry& geom)
+    {
+    static unsigned int max_block_size = UINT_MAX;
+    if (max_block_size == UINT_MAX)
+        {
+        cudaFuncAttributes attr;
+        cudaFuncGetAttributes(&attr, (const void*)kernel::nve_bounce_step_one<Geometry>);
+        max_block_size = attr.maxThreadsPerBlock;
+        }
+
+    unsigned int run_block_size = min(args.block_size, max_block_size);
+    dim3 grid(args.N / run_block_size + 1);
+    kernel::nve_bounce_step_one<Geometry><<<grid, run_block_size>>>(args.d_pos,
+                                                                    args.d_image,
+                                                                    args.d_vel,
+                                                                    args.d_accel,
+                                                                    args.d_group,
+                                                                    args.dt,
+                                                                    args.box,
+                                                                    args.N,
+                                                                    geom);
+
+    return cudaSuccess;
+    }
+#endif // NVCC
+
+} // end namespace gpu
+} // end namespace mpcd
+#endif // MPCD_BOUNCE_BACK_NVE_GPU_CUH_

--- a/hoomd/mpcd/BounceBackNVEGPU.h
+++ b/hoomd/mpcd/BounceBackNVEGPU.h
@@ -1,0 +1,155 @@
+// Copyright (c) 2009-2019 The Regents of the University of Michigan
+// This file is part of the HOOMD-blue project, released under the BSD 3-Clause License.
+
+// Maintainer: mphoward
+
+/*!
+ * \file BounceBackNVEGPU.h
+ * \brief Declares the BounceBackNVEGPU class for doing NVE integration with bounce-back
+ *        boundary conditions imposed by a geometry using the GPU.
+ */
+
+#ifndef MPCD_BOUNCE_BACK_NVE_GPU_H_
+#define MPCD_BOUNCE_BACK_NVE_GPU_H_
+
+#ifdef NVCC
+#error This header cannot be compiled by nvcc
+#endif
+
+#include "BounceBackNVE.h"
+#include "BounceBackNVEGPU.cuh"
+
+namespace mpcd
+{
+//! Integrator that applies bounce-back boundary conditions in NVE using the GPU.
+/*!
+ * See BounceBackNVE for more details.
+ */
+template<class Geometry>
+class PYBIND11_EXPORT BounceBackNVEGPU : public BounceBackNVE<Geometry>
+    {
+    public:
+        //! Constructor
+        BounceBackNVEGPU(std::shared_ptr<SystemDefinition> sysdef,
+                         std::shared_ptr<ParticleGroup> group,
+                         std::shared_ptr<const Geometry> geom)
+            : BounceBackNVE<Geometry>(sysdef, group, geom)
+            {
+            m_tuner_1.reset(new Autotuner(32, 1024, 32, 5, 100000, "nve_bounce_1", this->m_exec_conf));
+            m_tuner_2.reset(new Autotuner(32, 1024, 32, 5, 100000, "nve_bounce_2", this->m_exec_conf));
+            }
+
+        //! Performs the first step of the integration
+        virtual void integrateStepOne(unsigned int timestep);
+
+        //! Performs the second step of the integration
+        virtual void integrateStepTwo(unsigned int timestep);
+
+        //! Set autotuner parameters
+        /*!
+         * \param enable Enable/disable autotuning
+         * \param period period (approximate) in time steps when returning occurs
+         *
+         * Derived classes should override this to set the parameters of their autotuners.
+         */
+        virtual void setAutotunerParams(bool enable, unsigned int period)
+            {
+            BounceBackNVE<Geometry>::setAutotunerParams(enable, period);
+            m_tuner_1->setEnabled(enable); m_tuner_1->setPeriod(period);
+            m_tuner_2->setEnabled(enable); m_tuner_2->setPeriod(period);
+            }
+
+    private:
+        std::unique_ptr<Autotuner> m_tuner_1;
+        std::unique_ptr<Autotuner> m_tuner_2;
+    };
+
+template<class Geometry>
+void BounceBackNVEGPU<Geometry>::integrateStepOne(unsigned int timestep)
+    {
+    if (this->m_aniso)
+        {
+        this->m_exec_conf->msg->error() << "mpcd.integrate: anisotropic particles are not supported with bounce-back integrators." << std::endl;
+        throw std::runtime_error("Anisotropic integration not supported with bounce-back");
+        }
+    if (this->m_prof) this->m_prof->push("Bounce NVE step 1");
+
+    if (this->m_validate_geom) this->validate();
+
+    // particle data
+    ArrayHandle<Scalar4> d_pos(this->m_pdata->getPositions(), access_location::device, access_mode::readwrite);
+    ArrayHandle<int3> d_image(this->m_pdata->getImages(), access_location::device, access_mode::readwrite);
+    ArrayHandle<Scalar4> d_vel(this->m_pdata->getVelocities(), access_location::device, access_mode::readwrite);
+    ArrayHandle<Scalar3> d_accel(this->m_pdata->getAccelerations(), access_location::device, access_mode::read);
+    const BoxDim& box = this->m_pdata->getBox();
+
+    // group members
+    const unsigned int group_size = this->m_group->getNumMembers();
+    ArrayHandle<unsigned int> d_group(this->m_group->getIndexArray(), access_location::device, access_mode::read);
+
+    this->m_tuner_1->begin();
+    gpu::bounce_args_t args(d_pos.data,
+                            d_image.data,
+                            d_vel.data,
+                            d_accel.data,
+                            d_group.data,
+                            this->m_deltaT,
+                            box,
+                            group_size,
+                            this->m_tuner_1->getParam());
+
+    gpu::nve_bounce_step_one<Geometry>(args, *(this->m_geom));
+    if (this->m_exec_conf->isCUDAErrorCheckingEnabled()) CHECK_CUDA_ERROR();
+    this->m_tuner_1->end();
+
+    if (this->m_prof) this->m_prof->pop();
+    }
+
+template<class Geometry>
+void BounceBackNVEGPU<Geometry>::integrateStepTwo(unsigned int timestep)
+    {
+    if (this->m_aniso)
+        {
+        this->m_exec_conf->msg->error() << "mpcd.integrate: anisotropic particles are not supported with bounce-back integrators." << std::endl;
+        throw std::runtime_error("Anisotropic integration not supported with bounce-back");
+        }
+    if (this->m_prof) this->m_prof->push("Bounce NVE step 2");
+
+    ArrayHandle<Scalar4> d_vel(this->m_pdata->getVelocities(), access_location::device, access_mode::readwrite);
+    ArrayHandle<Scalar3> d_accel(this->m_pdata->getAccelerations(), access_location::device, access_mode::readwrite);
+    ArrayHandle<Scalar4> d_net_force(this->m_pdata->getNetForce(), access_location::device, access_mode::read);
+
+    const unsigned int group_size = this->m_group->getNumMembers();
+    ArrayHandle<unsigned int> d_group(this->m_group->getIndexArray(), access_location::device, access_mode::read);
+
+    this->m_tuner_2->begin();
+    gpu::nve_bounce_step_two(d_vel.data,
+                             d_accel.data,
+                             d_net_force.data,
+                             d_group.data,
+                             this->m_deltaT,
+                             group_size,
+                             this->m_tuner_2->getParam());
+    if (this->m_exec_conf->isCUDAErrorCheckingEnabled()) CHECK_CUDA_ERROR();
+    this->m_tuner_2->end();
+
+    if (this->m_prof) this->m_prof->pop();
+    }
+
+namespace detail
+{
+//! Exports the BounceBackNVEGPU class to python
+template<class Geometry>
+void export_BounceBackNVEGPU(pybind11::module& m)
+    {
+    namespace py = pybind11;
+    const std::string name = "BounceBackNVE" + Geometry::getName() + "GPU";
+
+    py::class_<BounceBackNVEGPU<Geometry>, std::shared_ptr<BounceBackNVEGPU<Geometry>>>
+        (m, name.c_str(), py::base<BounceBackNVE<Geometry>>())
+        .def(py::init<std::shared_ptr<SystemDefinition>, std::shared_ptr<ParticleGroup>, std::shared_ptr<const Geometry>>())
+        ;
+    }
+} // end namespace detail
+} // end namespace mpcd
+#endif // MPCD_BOUNCE_BACK_NVE_GPU_H_

--- a/hoomd/mpcd/CMakeLists.txt
+++ b/hoomd/mpcd/CMakeLists.txt
@@ -95,6 +95,7 @@ endif()
 
 set(_mpcd_cu_sources
     ATCollisionMethodGPU.cu
+    BounceBackNVEGPU.cu
     CellThermoComputeGPU.cu
     CellListGPU.cu
     ConfinedStreamingMethodGPU.cu

--- a/hoomd/mpcd/CMakeLists.txt
+++ b/hoomd/mpcd/CMakeLists.txt
@@ -28,6 +28,7 @@ set(_mpcd_sources
 
 set(_mpcd_headers
     ATCollisionMethod.h
+    BounceBackNVE.h
     BoundaryCondition.h
     BulkGeometry.h
     CellCommunicator.h
@@ -69,6 +70,8 @@ list(APPEND _mpcd_sources
 list(APPEND _mpcd_headers
     ATCollisionMethodGPU.cuh
     ATCollisionMethodGPU.h
+    BounceBackNVEGPU.cuh
+    BounceBackNVEGPU.h
     CellCommunicator.cuh
     CellThermoComputeGPU.cuh
     CellThermoComputeGPU.h
@@ -164,6 +167,7 @@ set(files
     data.py
     force.py
     init.py
+    integrate.py
     stream.py
     update.py
     )

--- a/hoomd/mpcd/SRDCollisionMethod.h
+++ b/hoomd/mpcd/SRDCollisionMethod.h
@@ -110,6 +110,6 @@ namespace detail
 void export_SRDCollisionMethod(pybind11::module& m);
 } // end namespace detail
 
-} // end namespace azplugins
+} // end namespace mpcd
 
 #endif // MPCD_SRD_COLLISION_METHOD_H_

--- a/hoomd/mpcd/__init__.py
+++ b/hoomd/mpcd/__init__.py
@@ -102,6 +102,7 @@ from hoomd.mpcd import collide
 from hoomd.mpcd import data
 from hoomd.mpcd import force
 from hoomd.mpcd import init
+from hoomd.mpcd import integrate
 from hoomd.mpcd import stream
 from hoomd.mpcd import update
 

--- a/hoomd/mpcd/integrate.py
+++ b/hoomd/mpcd/integrate.py
@@ -7,11 +7,11 @@ R""" MPCD integration methods
 
 Defines bounce-back methods for integrating solutes (MD particles) embedded in an MPCD
 solvent. The integration scheme is velocity Verlet (NVE) with bounce-back performed at
-the solid boundaries defined by a geometry, as in :py:mod:`mpcd.stream`. This gives a
+the solid boundaries defined by a geometry, as in :py:mod:`.mpcd.stream`. This gives a
 simple approximation of the interactions required to keep a solute bounded in a geometry,
 and more complex interactions can be specified, for example, by writing custom external fields.
 
-Similar caveats apply to these methods as for the :py:mod:`mpcd.stream` methods. In particular:
+Similar caveats apply to these methods as for the :py:mod:`.mpcd.stream` methods. In particular:
 
     1. The simulation box is periodic, but the geometry imposes inherently non-periodic boundary
        conditions. You must ensure that the box is sufficiently large to enclose the geometry
@@ -24,7 +24,7 @@ Similar caveats apply to these methods as for the :py:mod:`mpcd.stream` methods.
        to achieve the right boundary conditions and reduce density fluctuations.
 
 The integration methods defined here are not restricted to only MPCD simulations: they can be
-used with both :py:class:`hoomd.md.mode_standard` and :py:class:`hoomd.mpcd.integrator`. For
+used with both :py:class:`.md.integrate.mode_standard` and :py:class:`.mpcd.integrator`. For
 example, the same integration methods might be used to run DPD simulations with surfaces.
 
 These bounce-back methods do not support anisotropic integration because torques are currently
@@ -47,7 +47,7 @@ class _bounce_back(hoomd.integrate._integration_method):
         group (:py:mod:`hoomd.group`): Group of particles on which to apply this method.
 
     :py:class:`_bounce_back` is a base class integration method. It must be used with
-    :py:class:`hoomd.md.mode_standard` or :py:class:`hoomd.mpcd.integrator`.
+    :py:class:`.md.integrate.mode_standard` or :py:class:`.mpcd.integrator`.
     Deriving classes implement the specific geometry and valid parameters for those geometries.
     Currently, there is no mechanism to share geometries between multiple instances of the same
     integration method.
@@ -100,7 +100,7 @@ class slit(_bounce_back):
         boundary : 'slip' or 'no_slip' boundary condition at wall (default: 'no_slip')
 
     This integration method applies to particles in *group* in the parallel-plate channel geometry.
-    This method is the MD analog of :py:class:`mpcd.stream.slit`, which documents additional details
+    This method is the MD analog of :py:class:`.stream.slit`, which documents additional details
     about the geometry.
 
     A :py:class:`hoomd.compute.thermo` is automatically specified and associated with *group*.
@@ -177,7 +177,7 @@ class slit_pore(_bounce_back):
         boundary : 'slip' or 'no_slip' boundary condition at wall (default: 'no_slip')
 
     This integration method applies to particles in *group* in the parallel-plate (slit) pore geometry.
-    This method is the MD analog of :py:class:`mpcd.stream.slit_pore`, which documents additional details
+    This method is the MD analog of :py:class:`.stream.slit_pore`, which documents additional details
     about the geometry.
 
     A :py:class:`hoomd.compute.thermo` is automatically specified and associated with *group*.

--- a/hoomd/mpcd/integrate.py
+++ b/hoomd/mpcd/integrate.py
@@ -1,0 +1,244 @@
+# Copyright (c) 2009-2019 The Regents of the University of Michigan
+# This file is part of the HOOMD-blue project, released under the BSD 3-Clause License.
+
+# Maintainer: mphoward
+
+R""" MPCD integration methods
+
+Defines bounce-back methods for integrating solutes (MD particles) embedded in an MPCD
+solvent. The integration scheme is velocity Verlet (NVE) with bounce-back performed at
+the solid boundaries defined by a geometry, as in :py:mod:`mpcd.stream`. This gives a
+simple approximation of the interactions required to keep a solute bounded in a geometry,
+and more complex interactions can be specified, for example, by writing custom external fields.
+
+Similar caveats apply to these methods as for the :py:mod:`mpcd.stream` methods. In particular:
+
+    1. The simulation box is periodic, but the geometry imposes inherently non-periodic boundary
+       conditions. You must ensure that the box is sufficiently large to enclose the geometry
+       and that all particles lie inside it, or an error will be raised at runtime.
+    2. You must also ensure that particles do not self-interact through the periodic boundaries.
+       This is usually achieved for simple pair potentials by padding the box size by the largest
+       cutoff radius. Failure to do so may result in unphysical interactions.
+    3. Bounce-back rules do not always enforce no-slip conditions at surfaces properly. It
+       may still be necessary to add additional 'ghost' MD particles in the surface
+       to achieve the right boundary conditions and reduce density fluctuations.
+
+The integration methods defined here are not restricted to only MPCD simulations: they can be
+used with both :py:class:`hoomd.md.mode_standard` and :py:class:`hoomd.mpcd.integrator`. For
+example, the same integration methods might be used to run DPD simulations with surfaces.
+
+These bounce-back methods do not support anisotropic integration because torques are currently
+not computed for collisions with the boundary. Similarly, rigid bodies will also not be treated
+correctly because the integrators are not aware of the extent of the particles; the surface
+reflections are treated as point particles. An error will be raised if an anisotropic integration
+mode is specified.
+
+"""
+
+import hoomd
+from hoomd import _hoomd
+
+from . import _mpcd
+
+class _bounce_back(hoomd.integrate._integration_method):
+    """ NVE integration with bounce-back rules.
+
+    Args:
+        group (:py:mod:`hoomd.group`): Group of particles on which to apply this method.
+
+    :py:class:`_bounce_back` is a base class integration method. It must be used with
+    :py:class:`hoomd.md.mode_standard` or :py:class:`hoomd.mpcd.integrator`.
+    Deriving classes implement the specific geometry and valid parameters for those geometries.
+    Currently, there is no mechanism to share geometries between multiple instances of the same
+    integration method.
+
+    A :py:class:`hoomd.compute.thermo` is automatically specified and associated with *group*.
+
+    """
+    def __init__(self, group):
+        # initialize base class
+        hoomd.integrate._integration_method.__init__(self)
+
+        # create the compute thermo
+        hoomd.compute._get_unique_thermo(group=group)
+
+        # store metadata
+        self.group = group
+        self.boundary = None
+        self.metadata_fields = ['group','boundary']
+
+    def _process_boundary(self, bc):
+        """ Process boundary condition string into enum
+
+        Args:
+            bc (str): Boundary condition, either "no_slip" or "slip"
+
+        Returns:
+            A valid boundary condition enum.
+
+        The enum interface is still fairly clunky for the user since the boundary
+        condition is buried too deep in the package structure. This is a convenience
+        method for interpreting.
+
+        """
+        if bc == "no_slip":
+            return _mpcd.boundary.no_slip
+        elif bc == "slip":
+            return _mpcd.boundary.slip
+        else:
+            hoomd.context.msg.error("mpcd.integrate: boundary condition " + bc + " not recognized.\n")
+            raise ValueError("Unrecognized streaming boundary condition")
+            return None
+
+class slit(_bounce_back):
+    """ NVE integration with bounce-back rules in a slit channel.
+
+    Args:
+        group (:py:mod:`hoomd.group`): Group of particles on which to apply this method.
+        H (float): channel half-width
+        V (float): wall speed (default: 0)
+        boundary : 'slip' or 'no_slip' boundary condition at wall (default: 'no_slip')
+
+    This integration method applies to particles in *group* in the parallel-plate channel geometry.
+    This method is the MD analog of :py:class:`mpcd.stream.slit`, which documents additional details
+    about the geometry.
+
+    A :py:class:`hoomd.compute.thermo` is automatically specified and associated with *group*.
+
+    Examples::
+
+        all = group.all()
+        slit = mpcd.integrate.slit(group=all, H=5.0)
+        slit = mpcd.integrate.slit(group=all, H=10.0, V=1.0)
+
+    .. versionadded:: 2.7
+
+    """
+    def __init__(self, group, H, V=0.0, boundary="no_slip"):
+        hoomd.util.print_status_line()
+
+        # initialize base class
+        _bounce_back.__init__(self,group)
+        self.metadata_fields += ['H','V']
+
+        # initialize the c++ class
+        if not hoomd.context.exec_conf.isCUDAEnabled():
+            cpp_class = _mpcd.BounceBackNVESlit
+        else:
+            cpp_class = _mpcd.BounceBackNVESlitGPU
+
+        self.H = H
+        self.V = V
+        self.boundary = boundary
+
+        bc = self._process_boundary(boundary)
+        geom = _mpcd.SlitGeometry(H, V, bc)
+
+        self.cpp_method = cpp_class(hoomd.context.current.system_definition, group.cpp_group, geom)
+        self.cpp_method.validateGroup()
+
+    def set_params(self, H=None, V=None, boundary=None):
+        """ Set parameters for the slit geometry.
+
+        Args:
+            H (float): channel half-width
+            V (float): wall speed (default: 0)
+            boundary : 'slip' or 'no_slip' boundary condition at wall (default: 'no_slip')
+
+        Examples::
+
+            slit.set_params(H=8.)
+            slit.set_params(V=2.0)
+            slit.set_params(boundary='slip')
+            slit.set_params(H=5, V=0., boundary='no_slip')
+
+        """
+        hoomd.util.print_status_line()
+
+        if H is not None:
+            self.H = H
+
+        if V is not None:
+            self.V = V
+
+        if boundary is not None:
+            self.boundary = boundary
+
+        bc = self._process_boundary(self.boundary)
+        self.cpp_method.geometry = _mpcd.SlitGeometry(self.H,self.V,bc)
+
+class slit_pore(_bounce_back):
+    """ NVE integration with bounce-back rules in a slit pore channel.
+
+    Args:
+        group (:py:mod:`hoomd.group`): Group of particles on which to apply this method.
+        H (float): channel half-width.
+        L (float): pore half-length.
+        boundary : 'slip' or 'no_slip' boundary condition at wall (default: 'no_slip')
+
+    This integration method applies to particles in *group* in the parallel-plate (slit) pore geometry.
+    This method is the MD analog of :py:class:`mpcd.stream.slit_pore`, which documents additional details
+    about the geometry.
+
+    A :py:class:`hoomd.compute.thermo` is automatically specified and associated with *group*.
+
+    Examples::
+
+        all = group.all()
+        slit_pore = mpcd.integrate.slit_pore(group=all, H=10.0, L=10.)
+
+    .. versionadded:: 2.7
+
+    """
+    def __init__(self, group, H, L, boundary="no_slip"):
+        hoomd.util.print_status_line()
+
+        # initialize base class
+        _bounce_back.__init__(self,group)
+        self.metadata_fields += ['H','L']
+
+        # initialize the c++ class
+        if not hoomd.context.exec_conf.isCUDAEnabled():
+            cpp_class = _mpcd.BounceBackNVESlitPore
+        else:
+            cpp_class = _mpcd.BounceBackNVESlitPoreGPU
+
+        self.H = H
+        self.L = L
+        self.boundary = boundary
+
+        bc = self._process_boundary(boundary)
+        geom = _mpcd.SlitPoreGeometry(H, L, bc)
+
+        self.cpp_method = cpp_class(hoomd.context.current.system_definition, group.cpp_group, geom)
+        self.cpp_method.validateGroup()
+
+    def set_params(self, H=None, L=None, boundary=None):
+        """ Set parameters for the slit pore geometry.
+
+        Args:
+            H (float): channel half-width.
+            L (float): pore half-length.
+            boundary : 'slip' or 'no_slip' boundary condition at wall (default: 'no_slip')
+
+        Examples::
+
+            slit_pore.set_params(H=8.)
+            slit_pore.set_params(L=2.0)
+            slit_pore.set_params(boundary='slip')
+            slit_pore.set_params(H=5, L=4., boundary='no_slip')
+
+        """
+        hoomd.util.print_status_line()
+
+        if H is not None:
+            self.H = H
+
+        if L is not None:
+            self.L = L
+
+        if boundary is not None:
+            self.boundary = boundary
+
+        bc = self._process_boundary(self.boundary)
+        self.cpp_method.geometry = _mpcd.SlitPoreGeometry(self.H,self.L,bc)

--- a/hoomd/mpcd/module.cc
+++ b/hoomd/mpcd/module.cc
@@ -41,6 +41,12 @@
 #include "ConfinedStreamingMethodGPU.h"
 #endif // ENABLE_CUDA
 
+// integration methods
+#include "BounceBackNVE.h"
+#ifdef ENABLE_CUDA
+#include "BounceBackNVEGPU.h"
+#endif
+
 // virtual particle fillers
 #include "VirtualParticleFiller.h"
 #include "SlitGeometryFiller.h"
@@ -143,6 +149,13 @@ PYBIND11_MODULE(_mpcd, m)
     mpcd::detail::export_ConfinedStreamingMethodGPU<mpcd::detail::BulkGeometry>(m);
     mpcd::detail::export_ConfinedStreamingMethodGPU<mpcd::detail::SlitGeometry>(m);
     mpcd::detail::export_ConfinedStreamingMethodGPU<mpcd::detail::SlitPoreGeometry>(m);
+    #endif // ENABLE_CUDA
+
+    mpcd::detail::export_BounceBackNVE<mpcd::detail::SlitGeometry>(m);
+    mpcd::detail::export_BounceBackNVE<mpcd::detail::SlitPoreGeometry>(m);
+    #ifdef ENABLE_CUDA
+    mpcd::detail::export_BounceBackNVEGPU<mpcd::detail::SlitGeometry>(m);
+    mpcd::detail::export_BounceBackNVEGPU<mpcd::detail::SlitPoreGeometry>(m);
     #endif // ENABLE_CUDA
 
     mpcd::detail::export_VirtualParticleFiller(m);

--- a/hoomd/mpcd/stream.py
+++ b/hoomd/mpcd/stream.py
@@ -35,7 +35,8 @@ Although a streaming geometry is enforced on the MPCD solvent particles, there a
 a few important caveats:
 
     1. Embedded particles are not coupled to the boundary walls. They must be confined
-       by an appropriate method, e.g., an external potential or an explicit particle wall.
+       by an appropriate method, e.g., an external potential, an explicit particle wall,
+       or a bounce-back method (see :py:mod:`mpcd.integrate`).
     2. The confined geometry exists inside a fully periodic simulation box. Hence, the
        box must be padded large enough that the MPCD cells do not interact through the
        periodic boundary. Usually, this means adding at least one extra layer of cells

--- a/hoomd/mpcd/stream.py
+++ b/hoomd/mpcd/stream.py
@@ -36,7 +36,7 @@ a few important caveats:
 
     1. Embedded particles are not coupled to the boundary walls. They must be confined
        by an appropriate method, e.g., an external potential, an explicit particle wall,
-       or a bounce-back method (see :py:mod:`mpcd.integrate`).
+       or a bounce-back method (see :py:mod:`.mpcd.integrate`).
     2. The confined geometry exists inside a fully periodic simulation box. Hence, the
        box must be padded large enough that the MPCD cells do not interact through the
        periodic boundary. Usually, this means adding at least one extra layer of cells

--- a/hoomd/mpcd/test-py/CMakeLists.txt
+++ b/hoomd/mpcd/test-py/CMakeLists.txt
@@ -10,6 +10,8 @@ set(TEST_LIST
     force_sine
     init_make_random
     integrate_integrator
+    integrate_slit
+    integrate_slit_pore
     stream_bulk
     stream_slit
     stream_slit_pore

--- a/hoomd/mpcd/test-py/integrate_slit_pore_test.py
+++ b/hoomd/mpcd/test-py/integrate_slit_pore_test.py
@@ -1,0 +1,86 @@
+# Copyright (c) 2009-2019 The Regents of the University of Michigan
+# This file is part of the HOOMD-blue project, released under the BSD 3-Clause License.
+
+# Maintainer: mphoward
+
+import hoomd
+from hoomd import md
+from hoomd import mpcd
+hoomd.context.initialize()
+import unittest
+import numpy as np
+
+# unit tests for slit pore bounce back geometry
+class integrate_slit_pore_tests(unittest.TestCase):
+    """ Unit tests for slit pore integrator.
+
+    Most of the physics is already tested in hoomd.mpcd, so
+    these unit tests are focused on the python API.
+
+    """
+    def setUp(self):
+        # establish the simulation context
+        hoomd.context.initialize()
+
+        # set the decomposition in z for mpi builds
+        if hoomd.comm.get_num_ranks() > 1:
+            hoomd.comm.decomposition(nz=2)
+
+        # default testing configuration
+        snap = hoomd.data.make_snapshot(N=2, box=hoomd.data.boxdim(L=10.))
+        if hoomd.comm.get_rank() == 0:
+            snap.particles.position[:] = [[4.95,-4.95,3.85],[0.,0.,-3.8]]
+            snap.particles.velocity[:] = [[1.,-1.,1.],[-1.,-1.,-1.]]
+            snap.particles.mass[:] = [1.,2.]
+        self.s = hoomd.init.read_snapshot(snap)
+        self.group = hoomd.group.all()
+
+        md.integrate.mode_standard(dt=0.1)
+
+    # test creation can happen (with all parameters set)
+    def test_create(self):
+        mpcd.integrate.slit_pore(group=self.group, H=4., L=2., boundary="no_slip")
+
+    # test for setting parameters
+    def test_set_params(self):
+        slit_pore = mpcd.integrate.slit_pore(group=self.group, H=4., L=2.)
+        self.assertAlmostEqual(slit_pore.H, 4.)
+        self.assertAlmostEqual(slit_pore.L, 2.)
+        self.assertEqual(slit_pore.boundary, "no_slip")
+        self.assertAlmostEqual(slit_pore.cpp_method.geometry.getH(), 4.)
+        self.assertAlmostEqual(slit_pore.cpp_method.geometry.getL(), 2.)
+        self.assertEqual(slit_pore.cpp_method.geometry.getBoundaryCondition(), hoomd.mpcd._mpcd.boundary.no_slip)
+
+        # change H and also ensure other parameters stay the same
+        slit_pore.set_params(H=2.)
+        self.assertAlmostEqual(slit_pore.H, 2.)
+        self.assertAlmostEqual(slit_pore.L, 2.)
+        self.assertEqual(slit_pore.boundary, "no_slip")
+        self.assertAlmostEqual(slit_pore.cpp_method.geometry.getH(), 2.)
+        self.assertAlmostEqual(slit_pore.cpp_method.geometry.getL(), 2.)
+        self.assertEqual(slit_pore.cpp_method.geometry.getBoundaryCondition(), hoomd.mpcd._mpcd.boundary.no_slip)
+
+        # change L
+        slit_pore.set_params(L=3.)
+        self.assertAlmostEqual(slit_pore.L, 3.)
+        self.assertAlmostEqual(slit_pore.cpp_method.geometry.getL(), 3.)
+
+        # change BCs
+        slit_pore.set_params(boundary="slip")
+        self.assertEqual(slit_pore.boundary, "slip")
+        self.assertEqual(slit_pore.cpp_method.geometry.getBoundaryCondition(), hoomd.mpcd._mpcd.boundary.slip)
+
+    # test for invalid boundary conditions being set
+    def test_bad_boundary(self):
+        slit_pore = mpcd.integrate.slit_pore(group=self.group, H=4., L=2.)
+        slit_pore.set_params(boundary="no_slip")
+        slit_pore.set_params(boundary="slip")
+
+        with self.assertRaises(ValueError):
+            slit_pore.set_params(boundary="invalid")
+
+    def tearDown(self):
+        del self.s, self.group
+
+if __name__ == '__main__':
+    unittest.main(argv = ['test.py', '-v'])

--- a/hoomd/mpcd/test-py/integrate_slit_test.py
+++ b/hoomd/mpcd/test-py/integrate_slit_test.py
@@ -1,0 +1,216 @@
+# Copyright (c) 2009-2019 The Regents of the University of Michigan
+# This file is part of the HOOMD-blue project, released under the BSD 3-Clause License.
+
+# Maintainer: mphoward
+
+import hoomd
+from hoomd import md
+from hoomd import mpcd
+hoomd.context.initialize()
+import unittest
+import numpy as np
+
+# unit tests for slit bounce back geometry
+class integrate_slit_tests(unittest.TestCase):
+    def setUp(self):
+        # establish the simulation context
+        hoomd.context.initialize()
+
+        # set the decomposition in z for mpi builds
+        if hoomd.comm.get_num_ranks() > 1:
+            hoomd.comm.decomposition(nz=2)
+
+        # default testing configuration
+        snap = hoomd.data.make_snapshot(N=2, box=hoomd.data.boxdim(L=10.))
+        if hoomd.comm.get_rank() == 0:
+            snap.particles.position[:] = [[4.95,-4.95,3.85],[0.,0.,-3.8]]
+            snap.particles.velocity[:] = [[1.,-1.,1.],[-1.,-1.,-1.]]
+            snap.particles.mass[:] = [1.,2.]
+        self.s = hoomd.init.read_snapshot(snap)
+        self.group = hoomd.group.all()
+
+        md.integrate.mode_standard(dt=0.1)
+
+    # test creation can happen (with all parameters set)
+    def test_create(self):
+        mpcd.integrate.slit(group=self.group, H=4., V=0.1, boundary="no_slip")
+
+    # test for setting parameters
+    def test_set_params(self):
+        slit = mpcd.integrate.slit(group=self.group, H=4.)
+        self.assertAlmostEqual(slit.H, 4.)
+        self.assertAlmostEqual(slit.V, 0.)
+        self.assertEqual(slit.boundary, "no_slip")
+        self.assertAlmostEqual(slit.cpp_method.geometry.getH(), 4.)
+        self.assertAlmostEqual(slit.cpp_method.geometry.getVelocity(), 0.)
+        self.assertEqual(slit.cpp_method.geometry.getBoundaryCondition(), hoomd.mpcd._mpcd.boundary.no_slip)
+
+        # change H and also ensure other parameters stay the same
+        slit.set_params(H=2.)
+        self.assertAlmostEqual(slit.H, 2.)
+        self.assertAlmostEqual(slit.V, 0.)
+        self.assertEqual(slit.boundary, "no_slip")
+        self.assertAlmostEqual(slit.cpp_method.geometry.getH(), 2.)
+        self.assertAlmostEqual(slit.cpp_method.geometry.getVelocity(), 0.)
+        self.assertEqual(slit.cpp_method.geometry.getBoundaryCondition(), hoomd.mpcd._mpcd.boundary.no_slip)
+
+        # change V
+        slit.set_params(V=0.1)
+        self.assertAlmostEqual(slit.V, 0.1)
+        self.assertAlmostEqual(slit.cpp_method.geometry.getVelocity(), 0.1)
+
+        # change BCs
+        slit.set_params(boundary="slip")
+        self.assertEqual(slit.boundary, "slip")
+        self.assertEqual(slit.cpp_method.geometry.getBoundaryCondition(), hoomd.mpcd._mpcd.boundary.slip)
+
+    # test for invalid boundary conditions being set
+    def test_bad_boundary(self):
+        slit = mpcd.integrate.slit(group=self.group, H=4.)
+        slit.set_params(boundary="no_slip")
+        slit.set_params(boundary="slip")
+
+        with self.assertRaises(ValueError):
+            slit.set_params(boundary="invalid")
+
+    # test basic stepping behavior with no slip boundary conditions
+    def test_step_noslip(self):
+        mpcd.integrate.slit(group=self.group, H=4.)
+
+        # take one step
+        hoomd.run(1)
+        snap = self.s.take_snapshot()
+        if hoomd.comm.get_rank() == 0:
+            np.testing.assert_array_almost_equal(snap.particles.position[0], [-4.95,4.95,3.95])
+            np.testing.assert_array_almost_equal(snap.particles.velocity[0], [1.,-1.,1.])
+            np.testing.assert_array_almost_equal(snap.particles.position[1], [-0.1,-0.1,-3.9])
+            np.testing.assert_array_almost_equal(snap.particles.velocity[1], [-1.,-1.,-1.])
+
+        # take another step where one particle will now hit the wall
+        hoomd.run(1)
+        snap = self.s.take_snapshot()
+        if hoomd.comm.get_rank() == 0:
+            np.testing.assert_array_almost_equal(snap.particles.position[0], [-4.95,4.95,3.95])
+            np.testing.assert_array_almost_equal(snap.particles.velocity[0], [-1.,1.,-1.])
+            np.testing.assert_array_almost_equal(snap.particles.position[1], [-0.2,-0.2,-4.0])
+            np.testing.assert_array_almost_equal(snap.particles.velocity[1], [-1.,-1.,-1.])
+
+        # take another step, wrapping the second particle through the boundary
+        hoomd.run(1)
+        snap = self.s.take_snapshot()
+        if hoomd.comm.get_rank() == 0:
+            np.testing.assert_array_almost_equal(snap.particles.position[0], [4.95,-4.95,3.85])
+            np.testing.assert_array_almost_equal(snap.particles.velocity[0], [-1.,1.,-1.])
+            np.testing.assert_array_almost_equal(snap.particles.position[1], [-0.1,-0.1,-3.9])
+            np.testing.assert_array_almost_equal(snap.particles.velocity[1], [1.,1.,1.])
+
+    def test_step_moving_wall(self):
+        md.integrate.mode_standard(dt=0.3)
+        mpcd.integrate.slit(group=self.group, H=4., boundary="no_slip", V=1.0)
+
+        # change velocity of lower particle so it is translating relative to wall
+        snap = self.s.take_snapshot()
+        if hoomd.comm.get_rank() == 0:
+            snap.particles.velocity[1] = [-2.,-1.,-1.]
+        self.s.restore_snapshot(snap)
+
+        # run one step and check bounce back of particles
+        hoomd.run(1)
+        snap = self.s.take_snapshot()
+        if hoomd.comm.get_rank() == 0:
+            # the first particle is matched exactly to the wall speed, and so it will translate at
+            # same velocity along +x. It will bounce back in y and z to where it started.
+            # (vx stays the same, and vy and vz flip.)
+            np.testing.assert_array_almost_equal(snap.particles.position[0], [-4.75,-4.95,3.85])
+            np.testing.assert_array_almost_equal(snap.particles.velocity[0], [1.,1.,-1.])
+
+            # the second particle has y and z velocities flip again, and since it started closer,
+            # it moves relative to original position.
+            np.testing.assert_array_almost_equal(snap.particles.position[1], [-0.4,-0.1,-3.9])
+            np.testing.assert_array_almost_equal(snap.particles.velocity[1], [0.,1.,1.])
+
+    # test basic stepping behavior with slip boundary conditions
+    def test_step_slip(self):
+        mpcd.integrate.slit(group=self.group, H=4., boundary="slip")
+
+        # take one step
+        hoomd.run(1)
+        snap = self.s.take_snapshot()
+        if hoomd.comm.get_rank() == 0:
+            np.testing.assert_array_almost_equal(snap.particles.position[0], [-4.95,4.95,3.95])
+            np.testing.assert_array_almost_equal(snap.particles.velocity[0], [1.,-1.,1.])
+            np.testing.assert_array_almost_equal(snap.particles.position[1], [-0.1,-0.1,-3.9])
+            np.testing.assert_array_almost_equal(snap.particles.velocity[1], [-1.,-1.,-1.])
+
+        # take another step where one particle will now hit the wall
+        hoomd.run(1)
+        snap = self.s.take_snapshot()
+        if hoomd.comm.get_rank() == 0:
+            np.testing.assert_array_almost_equal(snap.particles.position[0], [-4.85,4.85,3.95])
+            np.testing.assert_array_almost_equal(snap.particles.velocity[0], [1.,-1.,-1.])
+            np.testing.assert_array_almost_equal(snap.particles.position[1], [-0.2,-0.2,-4.0])
+            np.testing.assert_array_almost_equal(snap.particles.velocity[1], [-1.,-1.,-1.])
+
+        # take another step, wrapping the second particle through the boundary
+        hoomd.run(1)
+        snap = self.s.take_snapshot()
+        if hoomd.comm.get_rank() == 0:
+            np.testing.assert_array_almost_equal(snap.particles.position[0], [-4.75,4.75,3.85])
+            np.testing.assert_array_almost_equal(snap.particles.velocity[0], [1.,-1.,-1.])
+            np.testing.assert_array_almost_equal(snap.particles.position[1], [-0.3,-0.3,-3.9])
+            np.testing.assert_array_almost_equal(snap.particles.velocity[1], [-1.,-1.,1.])
+
+    # test for correct application of both verlet steps to particles away from boundary
+    def test_accel(self):
+        mpcd.integrate.slit(group=self.group, H=4.)
+        md.force.constant(fx=2.,fy=-2.,fz=4.)
+
+        snap = self.s.take_snapshot()
+        if hoomd.comm.get_rank() == 0:
+            snap.particles.position[:] = [[0,0,0],[0,0,0]]
+        self.s.restore_snapshot(snap)
+
+        hoomd.run(1)
+        snap = self.s.take_snapshot()
+        if hoomd.comm.get_rank() == 0:
+            np.testing.assert_array_almost_equal(snap.particles.position[0], [0.11,-0.11,0.12])
+            np.testing.assert_array_almost_equal(snap.particles.velocity[0], [1.2,-1.2,1.4])
+            np.testing.assert_array_almost_equal(snap.particles.position[1], [-0.095,-0.105,-0.09])
+            np.testing.assert_array_almost_equal(snap.particles.velocity[1], [-0.9,-1.1,-0.8])
+
+    # test that setting the slit size too large raises an error
+    def test_validate_box(self):
+        # initial configuration is invalid
+        slit = mpcd.integrate.slit(group=self.group, H=10.)
+        with self.assertRaises(RuntimeError):
+            hoomd.run(1)
+
+        # now it should be valid
+        slit.set_params(H=4.)
+        hoomd.run(2)
+
+        # make sure we can invalidate it again
+        slit.set_params(H=10.)
+        with self.assertRaises(RuntimeError):
+            hoomd.run(1)
+
+    # test that particles out of bounds can be caught
+    def test_out_of_bounds(self):
+        slit = mpcd.integrate.slit(group=self.group, H=3.8)
+        with self.assertRaises(RuntimeError):
+            hoomd.run(1)
+
+        slit.set_params(H=3.85)
+        hoomd.run(1)
+
+    def test_aniso(self):
+        md.integrate.mode_standard(dt=0.1, aniso=True)
+        slit = mpcd.integrate.slit(group=self.group, H=4.)
+        with self.assertRaises(RuntimeError):
+            hoomd.run(1)
+
+    def tearDown(self):
+        del self.s, self.group
+
+if __name__ == '__main__':
+    unittest.main(argv = ['test.py', '-v'])

--- a/sphinx-doc/credits.rst
+++ b/sphinx-doc/credits.rst
@@ -342,6 +342,7 @@ Michael P. Howard, Princeton University & University of Texas at Austin - **Lead
  * SRD and AT collision rules
  * Virtual particle filling framework
  * External force framework and block, constant, and sine forces
+ * Bounce-back integrator framework
 
 Source code
 -----------

--- a/sphinx-doc/module-mpcd-integrate.rst
+++ b/sphinx-doc/module-mpcd-integrate.rst
@@ -1,0 +1,18 @@
+mpcd.integrate
+-----------
+
+.. rubric:: Overview
+
+.. py:currentmodule:: hoomd.mpcd.integrate
+
+.. autosummary::
+    :nosignatures:
+
+    slit
+    slit_pore
+
+.. rubric:: Details
+
+.. automodule:: hoomd.mpcd.integrate
+    :synopsis: Integration methods for MD particles in confined geometries
+    :members:

--- a/sphinx-doc/module-mpcd-integrate.rst
+++ b/sphinx-doc/module-mpcd-integrate.rst
@@ -1,5 +1,5 @@
 mpcd.integrate
------------
+--------------
 
 .. rubric:: Overview
 

--- a/sphinx-doc/package-mpcd.rst
+++ b/sphinx-doc/package-mpcd.rst
@@ -23,5 +23,6 @@ mpcd
     module-mpcd-data
     module-mpcd-force
     module-mpcd-init
+    module-mpcd-integrate
     module-mpcd-stream
     module-mpcd-update


### PR DESCRIPTION
## Description

Implements the bounce-back NVE integrator described in #455 by treating particles as points reflecting from surfaces. Anisotropic integration is not supported, but it also currently is not really supported by MPCD in general. Some of the fancier NVE options (e.g., limit) are also not supported because they might cause issues in MPCD by breaking momentum conservation.

## Motivation and Context

Enhances the usefulness of the MPCD streaming geometries by also allowing solute (MD) particles to couple to the boundaries. These methods are not actually specific to MPCD, so they can be used in other types of MD simulations (e.g., DPD). But, since the geometries are contained in the MPCD module, I thought it best to implement the integrator here as well. This point is noted in the documentation.

Resolves: #455

## How Has This Been Tested?

There are python unit tests in place for integrators in both geometries. I've also used the slit integrator in published work. I'm just starting to use the slit-pore, but I ran one simulation and confirmed that the solute stayed in the correct part of the geometry. The geometries are also additionally validated for the MPCD solute.

## Change log

```
* ``mpcd.integrate`` supports integration of MD (solute) particles with bounce-back rules in MPCD streaming geometries.
```

## Checklist:

- [X] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [X] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [X] My name is on the [list of contributors](https://github.com/glotzerlab/hoomd-blue/blob/master/sphinx-doc/credits.rst).
- [ ] I am a member of the [hoomd-contributors team](https://github.com/orgs/glotzerlab/teams/hoomd-contributors/members).
