### PR TITLE
User provided log quantities in gsd 

### DIFF
--- a/hoomd/GSDDumpWriter.h
+++ b/hoomd/GSDDumpWriter.h
@@ -88,6 +88,7 @@ class PYBIND11_EXPORT GSDDumpWriter : public Analyzer
 
         std::shared_ptr<ParticleGroup> m_group;   //!< Group to write out to the file
         std::map<std::string, bool> m_nondefault; //!< Map of quantities (true when non-default in frame 0)
+        std::map<std::string, pybind11::function> m_user_log;   //!< Map of user-defined quantities to log
 
         hoomd::detail::SharedSignal<int (gsd_handle&)> m_write_signal;
 
@@ -117,11 +118,16 @@ class PYBIND11_EXPORT GSDDumpWriter : public Analyzer
                            ConstraintData::Snapshot& constraint,
                            PairData::Snapshot& pair);
 
+        //! Write user defined log data
+        void writeUser(unsigned int timestep, bool root);
+
         //! Check and raise an exception if an error occurs
         void checkError(int retval);
 
         //! Populate the non-default map
         void populateNonDefault();
+
+        friend void export_GSDDumpWriter(pybind11::module& m);
     };
 
 //! Exports the GSDDumpWriter class to python

--- a/hoomd/dump.py
+++ b/hoomd/dump.py
@@ -507,8 +507,8 @@ class gsd(hoomd.analyze._analyzer):
 
     Write a simulation snapshot to the specified GSD file at regular intervals. GSD is capable of storing all particle
     and bond data fields in hoomd, in every frame of the trajectory. This allows GSD to store simulations where the
-    number of particles, number of particle types, particle types, diameter, mass, charge, or anything is changing over
-    time. GSD can also store integrator state information necessary for restarting simulations and user-defined log
+    number of particles, number of particle types, particle types, diameter, mass, charge, and other quantities change
+    over time. GSD can also store integrator state information necessary for restarting simulations and user-defined log
     quantities.
 
     To save on space, GSD does not write values that are all set at defaults. So if all masses, orientations, angular

--- a/hoomd/dump.py
+++ b/hoomd/dump.py
@@ -511,15 +511,14 @@ class gsd(hoomd.analyze._analyzer):
     number of particles, number of particle types, particle types, diameter, mass,
     charge, or anything is changing over time.
 
-    To save on space, GSD does not write values that are all set at defaults. So if
-    all masses are left set at the default of 1.0, mass will not take up any space in
-    the file. Additionally, only **dynamic** quantities are written to all frames, non-dynamic
-    quantities are only written to frame 0. The GSD schema defines that data not present in frame *i* is to
-    be read from frame 0. This makes every single frame of a GSD file fully specified and simulations
-    initialized with :py:func:`hoomd.init.read_gsd()` can select any frame of the file.
+    To save on space, GSD does not write values that are all set at defaults. So if all masses, orientations, angular
+    momenta, etc... are left default, these fields  will not take up any space in the file. Additionally, only
+    **dynamic** quantities are written to all frames, non-dynamic quantities are only written to frame 0. The GSD schema
+    defines that data not present in frame *i* is to be read from frame 0. This makes every single frame of a GSD file
+    fully specified and simulations initialized with :py:func:`hoomd.init.read_gsd()` can select any frame of the file.
 
-    You can control what quantities are dynamic by category. ``property`` is always dynamic.
-    The categories listed in the **dynamic** will also be written out to every frame.
+    You can control what quantities are dynamic by category. ``property`` is always dynamic. The categories listed in
+    the **dynamic** will also be written out to every frame, but only if they have changed from the defaults.
 
     * ``attribute``
 
@@ -535,12 +534,12 @@ class gsd(hoomd.analyze._analyzer):
     * ``property``
 
         * particles/position
-        * particles/orientation
+        * particles/orientation (*only written when changed from default*)
 
     * ``momentum``
 
         * particles/velocity
-        * particles/angmom
+        * particles/angmom (*only written when changed from default*)
         * particles/image
 
     * ``topology``

--- a/hoomd/test-py/test_gsd.py
+++ b/hoomd/test-py/test_gsd.py
@@ -124,7 +124,7 @@ class gsd_write_tests (unittest.TestCase):
             self.assertRaises(RuntimeError, data.gsd_snapshot, self.tmp_file, frame=1);
 
     # tests write_restart
-    def write_restart(self):
+    def test_write_restart(self):
         g = dump.gsd(filename=self.tmp_file, group=group.all(), period=1000000, truncate=True, overwrite=True);
         run(5);
         g.write_restart();
@@ -187,6 +187,43 @@ class gsd_write_tests (unittest.TestCase):
         self.s.particles.remove(2)
         self.s.particles.remove(3)
         dump.gsd(filename=self.tmp_file, group=group.all(), period=1, overwrite=True);
+        run(1)
+
+    def test_log(self):
+        gsd = dump.gsd(filename=self.tmp_file, group=group.all(), period=1, overwrite=True);
+        gsd.log['uint8'] = lambda step: numpy.array([1, 2, 3, 4], dtype=numpy.uint8)
+        gsd.log['uint16'] = lambda step: numpy.array([1, 2, 3, 4], dtype=numpy.uint16)
+        gsd.log['uint32'] = lambda step: numpy.array([1, 2, 3, 4], dtype=numpy.uint32)
+        gsd.log['uint64'] = lambda step: numpy.array([1, 2, 3, 4], dtype=numpy.uint64)
+
+        gsd.log['int8'] = lambda step: numpy.array([1, 2, 3, 4, -10], dtype=numpy.int8)
+        gsd.log['int16'] = lambda step: numpy.array([1, 2, 3, 4, -10], dtype=numpy.int16)
+        gsd.log['int32'] = lambda step: numpy.array([1, 2, 3, 4, -10], dtype=numpy.int32)
+        gsd.log['int64'] = lambda step: numpy.array([1, 2, 3, 4, -10], dtype=numpy.int64)
+
+        gsd.log['float32'] = lambda step: numpy.array([1, 2, 3, 4], dtype=numpy.float32)
+        gsd.log['float64'] = lambda step: numpy.array([1, 2, 3, 4], dtype=numpy.float64)
+
+        gsd.log['2d'] = lambda step: numpy.array([[1, 2], [3, 4], [5, 6], [7, 8]], dtype=numpy.float64)
+        run(1)
+
+        # skip these tests in MPI, only the root rank raises the runtime error resulting in deadlock
+        if hoomd.comm.get_num_ranks() == 1:
+            gsd.log['complex64'] = lambda step: numpy.array([1, 2, 3, 4], dtype=numpy.complex64)
+            self.assertRaises(RuntimeError, run, 1);
+
+            del gsd.log['complex64'];
+            run(1)
+
+            gsd.log['3d'] = lambda step: numpy.array([[[1, 2], [3, 4]], [[5, 6], [7, 8]]], dtype=numpy.float64)
+            self.assertRaises(RuntimeError, run, 1);
+
+            del gsd.log['3d']
+            run(1)
+
+            gsd.log['scalar'] = lambda step: 5
+            self.assertRaises(RuntimeError, run, 1);
+
 
     def tearDown(self):
         if (hoomd.comm.get_rank()==0):


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should based on *maint*. -->
<!-- New features should based on *master*. -->

## Description

<!-- Describe your changes in detail. -->
Implement user-defined log quantities defined in glotzerlab/gsd#38. Users can now provide callbacks that provide custom log quantities in gsd frames. These quantities can be scalars, strings, per-particle, per-bond, etc... In a future release, OVITO will disover these data and make them available in the data pipeline.

Users provide data via callables that return numpy arrays:
```python
gsd = hoomd.dump.gsd(filename="trajectory.gsd", period=1000, group=hoomd.group.all(), overwrite=True)
gsd.log['particles/potential_energy'] = lambda step: numpy.array([p.net_energy for p in system.particles], dtype=numpy.float32)
gsd.log['particles/net_force'] = lambda step: numpy.array([p.net_force for p in system.particles], dtype=numpy.float32)
gsd.log['potential_energy'] = lambda step: numpy.array([log.query('potential_energy')], dtype=numpy.float64)
message = 'hello OVITO'
gsd.log['string'] = lambda step: numpy.array([message], dtype=numpy.dtype((bytes, len(message)+1))).view(dtype=numpy.int8)
gsd.log['bonds/tag'] = lambda step: numpy.array([b.tag for b in system.bonds], dtype=numpy.uint32)
hoomd.run(1)
```

`log` is a dictionary. You can remove some entries to prevent them from being written on later frames:
```
del gsd.log['bonds/tag']
del gsd.log['string']

hoomd.run(10e3)
```

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Users would like to store arbitrary information in gsd files and use that information in analysis and visualization pipelines.

<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves: #423 

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
Added unit tests.

## Change log

<!-- Propose a change log entry. -->
```
* User-defined log quantities in ``dump.gsd`` 
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/hoomd-blue/blob/master/sphinx-doc/credits.rst).
- [ ] (Glotzer group members): I am a member of the [hoomd-contributors team](https://github.com/orgs/glotzerlab/teams/hoomd-contributors/members).
