### PR TITLE
Removed DL_LIB and UTIL_LIB from CMake file.

### DIFF
--- a/CMake/hoomd/HOOMDCommonLibsSetup.cmake
+++ b/CMake/hoomd/HOOMDCommonLibsSetup.cmake
@@ -5,18 +5,6 @@ include_directories(${PYTHON_INCLUDE_DIR})
 ################################
 ## Define common libraries used by every target in HOOMD
 
-## An update to to CentOS5's python broke linking of the hoomd exe. According
-## to an ancient post online, adding -lutil fixed this in python 2.2
-set(ADDITIONAL_LIBS "")
-if (UNIX AND NOT APPLE)
-    find_library(UTIL_LIB util /usr/lib)
-    find_library(DL_LIB dl /usr/lib)
-    set(ADDITIONAL_LIBS ${UTIL_LIB} ${DL_LIB})
-    if (DL_LIB AND UTIL_LIB)
-    mark_as_advanced(UTIL_LIB DL_LIB)
-    endif (DL_LIB AND UTIL_LIB)
-endif (UNIX AND NOT APPLE)
-
 option(ENABLE_TBB "Enable support for Threading Building Blocks (TBB)" off)
 
 if(ENABLE_TBB)


### PR DESCRIPTION
## Description

CMake throws an error when building related to `DL_LIB` and `UTIL_LIB`. See #466.

## Motivation and Context

Resolves: #466.

This has already been removed on the `next` branch for HOOMD v3.0.

## How Has This Been Tested?

I can now build locally.

## Change log

<!-- Propose a change log entry. -->
```
Removed DL_LIB and UTIL_LIB from CMake configuration to resolve a build issue.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/hoomd-blue/blob/master/sphinx-doc/credits.rst).
