### PR TITLE
fix `couple='none'` argument in conjunction with `npt.randomize_velocites()`

### DIFF
--- a/hoomd/md/TwoStepNPTMTK.cc
+++ b/hoomd/md/TwoStepNPTMTK.cc
@@ -984,7 +984,7 @@ void TwoStepNPTMTK::randomizeVelocities(unsigned int timestep)
             {
             nuxx = nuyy = nuzz;
             }
-        else
+        else if (couple != couple_none)
             {
             m_exec_conf->msg->error() << "integrate.npt: Invalid coupling mode." << std::endl << std::endl;
             throw std::runtime_error("Error in NPT integration");

--- a/hoomd/md/test-py/test_integrate_npt.py
+++ b/hoomd/md/test-py/test_integrate_npt.py
@@ -61,6 +61,15 @@ class integrate_npt_tests (unittest.TestCase):
         npt.set_params(rescale_all=True)
         run(1);
 
+    # tests randomize_velocities()
+    def test(self):
+        all = group.all();
+        md.integrate.mode_standard(dt=0.005);
+        npt = md.integrate.npt(all, kT=1.2, tau=0.5, P=1.0, tauP=0.5,couple='none');
+        npt.randomize_velocities(seed=42)
+        run(1);
+
+
     # test w/ empty group
     def test_empty(self):
         # currently cannot catch run-time errors in MPI simulations


### PR DESCRIPTION
## Description

Fixes an issue reported by @syjlee that the couple='none' argument to `md.integrate.npt()` cannot be used together with `randomize_velocities()`, or an error will be thrown.

## Motivation and Context

Resolves: #471 

## How Has This Been Tested?

added unit test

## Change log
```
- Fix bug where `couple='none'` option to `md.integrate.npt()` was not working when randomly initializing velocities
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/hoomd-blue/blob/master/sphinx-doc/credits.rst).
