### PR TITLE
work around missing cerealConfig.cmake on Summit

### DIFF
--- a/CMake/hoomd/HOOMDMPISetup.cmake
+++ b/CMake/hoomd/HOOMDMPISetup.cmake
@@ -9,8 +9,13 @@ if (ENABLE_MPI)
     if (cereal_FOUND)
         find_package_message(cereal "Found cereal: ${cereal_DIR}" "[${cereal_DIR}]")
     else()
+        # work around missing ceralConfig.cmake
+
+        find_path(cereal_INCLUDE_DIR NAMES cereal/cereal.hpp
+            PATHS ${CMAKE_INSTALL_PREFIX}/include)
         add_library(cereal INTERFACE IMPORTED)
-        find_package_message(cereal "Could not find cereal, assuming it is on a default path" "[${cereal_DIR}]")
+        target_include_directories(cereal INTERFACE ${cereal_INCLUDE_DIR})
+        find_package_message(cereal "Could not find cereal, assuming it is on a default path" "[${cereal_INCLUDE_DIR}]")
     endif()
 
     mark_as_advanced(MPI_EXTRA_LIBRARY)

--- a/CMake/hoomd/HOOMDMPISetup.cmake
+++ b/CMake/hoomd/HOOMDMPISetup.cmake
@@ -14,7 +14,7 @@ if (ENABLE_MPI)
         find_path(cereal_INCLUDE_DIR NAMES cereal/cereal.hpp
             PATHS ${CMAKE_INSTALL_PREFIX}/include)
         add_library(cereal INTERFACE IMPORTED)
-        target_include_directories(cereal INTERFACE ${cereal_INCLUDE_DIR})
+        set_target_properties(cereal PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${cereal_INCLUDE_DIR}")
         find_package_message(cereal "Could not find cereal, assuming it is on a default path" "[${cereal_INCLUDE_DIR}]")
     endif()
 


### PR DESCRIPTION
## Description

Automatically find cereal even though the package doesn't have a `cerealConfig.cmake` file installed.

## Motivation and Context

The script now explicitly searches in the system directories known to CMake (including $CMAKE_PREFIX_PATH), and not only those known to the compiler. Enables compilation on summit.

Resolves: N/A

## How Has This Been Tested?

by building

## Change log

N/A

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/hoomd-blue/blob/master/sphinx-doc/credits.rst).
