### PR TITLE
add missing GSD spec writer header to CMake

### DIFF
--- a/hoomd/CMakeLists.txt
+++ b/hoomd/CMakeLists.txt
@@ -107,6 +107,7 @@ set(_hoomd_headers
     GPUVector.h
     GSDDumpWriter.h
     GSDReader.h
+    GSDShapeSpecWriter.h
     HalfStepHook.h
     HOOMDMath.h
     HOOMDMPI.h


### PR DESCRIPTION
## Description

Compilation of MD potentials from external plugins fail because the GSD Spec Writer header is missing in the CMakeList.txt
Fails with a missing file error.

This is based on master and intended for master, eventhough it's a bugfix. I think the GSD Spec Writer feature is not yet available on maint.
With release of the new version, you warn plugin users that the potentials need to implement the spec-writer function, won't you?

## Motivation and Context

The introduction of GSD Spec Writer was missing adding the header to the CMakeList.txt.

<!-- Replace ??? with the issue number that this pull request resolves. -->
No issue submited first

## How Has This Been Tested?

I tested with my own external plugins and they compile and run now.

## Change log

None, it's only a minor bugfix

## Checklist:

- [ ] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [ ] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [ ] My name is on the [list of contributors](https://github.com/glotzerlab/hoomd-blue/blob/master/sphinx-doc/credits.rst).
