### PR TITLE
Doc fixes

### DIFF
--- a/hoomd/dump.py
+++ b/hoomd/dump.py
@@ -675,14 +675,12 @@ class gsd(hoomd.analyze._analyzer):
             hoomd.context.msg.warning("GSD is not currently support for {name}".format(obj.__class__.__name__));
 
     def dump_shape(self, obj):
-        """This method writes particle shape information stored by a hoomd
-           object into a GSD file, in the chunk :code:`particle/type_shapes`.
-           This information can be used by other libraries for visualization.
+        """Writes particle shape information stored by a hoomd object.
 
-
-        Call :py:meth:`dump_shape` if you want to write the shape of a hoomd object
-        to the gsd file. The following classes support writing shape information to
-        GSD files:
+        This method writes particle shape information into a GSD file, in the
+        chunk :code:`particle/type_shapes`. This information can be used by
+        other libraries for visualization. The following classes support
+        writing shape information to GSD files:
 
         * :py:class:`hoomd.hpmc.integrate.sphere`
         * :py:class:`hoomd.hpmc.integrate.convex_polyhedron`

--- a/hoomd/hpmc/integrate.py
+++ b/hoomd/hpmc/integrate.py
@@ -1195,6 +1195,9 @@ class polyhedron(mode_hpmc):
           don't translate the shape such that (0,0,0) right next to a face).
 
     * *faces* (**required**) - a list of vertex indices for every face
+
+        * For visualization purposes, the faces **MUST** be defined with a counterclockwise winding order to produce an outward normal.
+
     * *sweep_radius* (**default: 0.0**) - rounding radius applied to polyhedron
     * *ignore_statistics* (**default: False**) - set to True to disable ignore for statistics tracking
     * *ignore_overlaps* (**default: False**) - set to True to disable overlap checks between this and other types with *ignore_overlaps=True*


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should based on *maint*. -->
<!-- New features should based on *master*. -->

## Description
This PR adds a note  to the `hpmc.integrate.polyhedron` documentation to clarify the ordering convention of the faces and fixes a small rendering problem with the `dump_shape` doc string.

<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves: No corresponding issue.

## How Has This Been Tested?
Doc fixes only, no additional tests required

## Change log

<!-- Propose a change log entry. -->
```
Misc doc fixes
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/hoomd-blue/blob/master/sphinx-doc/credits.rst).
