### PR TITLE
Skip shape spec unit tests if modules are not installed.

### DIFF
--- a/hoomd/test-py/test_gsd_shape_spec.py
+++ b/hoomd/test-py/test_gsd_shape_spec.py
@@ -4,8 +4,29 @@ import unittest
 import os
 import tempfile
 import numpy as np
-from hoomd import _hoomd, hpmc, dem, md
+from hoomd import _hoomd
 import json
+
+try:
+    from hoomd import hpmc
+except ImportError:
+    HPMC = False
+else:
+    HPMC = True
+
+try:
+    from hoomd import dem
+except ImportError:
+    DEM = False
+else:
+    DEM = True
+
+try:
+    from hoomd import md
+except ImportError:
+    MD = False
+else:
+    MD = True
 
 HPMC_CLASSES = ['sphere', 'ellipsoid', 'convex_polyhedron', \
                 'convex_spheropolyhedron','polyhedron', \
@@ -76,6 +97,7 @@ class gsd_shape_spec_base(unittest.TestCase):
             os.remove(self.tmp_file);
         comm.barrier_all();
 
+@unittest.skipIf(not HPMC, "hpmc_gsd_shape_spec requires the hpmc module.")
 class hpmc_gsd_shape_spec(gsd_shape_spec_base):
 
     def test_sphere(self):
@@ -167,6 +189,7 @@ class hpmc_gsd_shape_spec(gsd_shape_spec_base):
         self.setup_system(cls=hpmc.integrate.simple_polygon, shape_params=shape_params, \
                           expected_shapespec=expected_shapespec, filename=self.tmp_file, dim=2);
 
+@unittest.skipIf(not DEM, "dem_gsd_shape_spec requires the dem module.")
 class dem_gsd_shape_spec(gsd_shape_spec_base):
 
     def test_wca_2d(self):
@@ -271,6 +294,7 @@ class dem_gsd_shape_spec(gsd_shape_spec_base):
         self.setup_system(cls=dem.pair.SWCA, shape_params=shape_params, \
                           expected_shapespec=expected_shapespec, filename=self.tmp_file, dim=3);
 
+@unittest.skipIf(not MD, "md_gsd_shape_spec requires the md module.")
 class md_gsd_shape_spec(gsd_shape_spec_base):
 
     def test_gay_berne(self):


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should based on *maint*. -->
<!-- New features should based on *master*. -->

## Description
This PR adds logic to skip `gsd_shape_spec` unit tests if the required modules are not installed.

## Motivation and Context
Avoid unit tests failing when users compile with any of te flags `BUILD_MD`, `BUILD_DEM` or `BUILD_HPMC` turned off.

<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves: Issue was reported up by a user on the `hoomd` mailing list.

## How Has This Been Tested?
Compiled locally with the aforementioned flags off and checked that tests were actually skipped in each case.

## Change log

<!-- Propose a change log entry. -->
```
Skip gsd shape spec unit test when required modules are not installed.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/hoomd-blue/blob/master/sphinx-doc/credits.rst).
