### PR TITLE
fix cuFFT calls on multiple GPUs

### DIFF
--- a/hoomd/md/PPPMForceComputeGPU.h
+++ b/hoomd/md/PPPMForceComputeGPU.h
@@ -103,7 +103,7 @@ class PYBIND11_EXPORT PPPMForceComputeGPU : public PPPMForceCompute
         std::unique_ptr<Autotuner> m_tuner_force; //!< Autotuner for populating the force array
         std::unique_ptr<Autotuner> m_tuner_influence; //!< Autotuner for computing the influence function
 
-        cufftHandle m_cufft_plan;          //!< The FFT plan
+        std::vector<cufftHandle> m_cufft_plan;          //!< The FFT plans
         bool m_local_fft;                  //!< True if we are only doing local FFTs (not distributed)
 
         #ifdef ENABLE_MPI


### PR DESCRIPTION

## Description

cuFFT requires creating plans separately on every device, otherwise the kernels will hang. We should perhaps cherry-pick this against maint.

## Motivation and Context

Resolves: N/A

## How Has This Been Tested?

spce benchmark in https://github.com/glotzerlab/hoomd-benchmarks/tree/next

## Change log

```
- Fix charge.pppm() execution on multiple GPUs
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/hoomd-blue/blob/master/sphinx-doc/credits.rst).
