### PR TITLE
Set correct default values in addParticle()

### DIFF
--- a/hoomd/ParticleData.cc
+++ b/hoomd/ParticleData.cc
@@ -2268,6 +2268,8 @@ unsigned int ParticleData::addParticle(unsigned int type)
         ArrayHandle<Scalar> h_charge(getCharges(), access_location::host, access_mode::readwrite);
         ArrayHandle<Scalar> h_diameter(getDiameters(), access_location::host, access_mode::readwrite);
         ArrayHandle<int3> h_image(getImages(), access_location::host, access_mode::readwrite);
+        ArrayHandle<Scalar4> h_angmom(getAngularMomentumArray(), access_location::host, access_mode::readwrite);
+        ArrayHandle<Scalar3> h_inertia(getMomentsOfInertiaArray(), access_location::host, access_mode::readwrite);
         ArrayHandle<unsigned int> h_body(getBodies(), access_location::host, access_mode::readwrite);
         ArrayHandle<Scalar4> h_orientation(getOrientationArray(), access_location::host, access_mode::readwrite);
         ArrayHandle<unsigned int> h_tag(getTags(), access_location::host, access_mode::readwrite);
@@ -2280,8 +2282,10 @@ unsigned int ParticleData::addParticle(unsigned int type)
         h_vel.data[idx] = make_scalar4(0,0,0,1.0);
         h_accel.data[idx] = make_scalar3(0,0,0);
         h_charge.data[idx] = 0.0;
-        h_diameter.data[idx] = 0.0;
+        h_diameter.data[idx] = 1.0;
         h_image.data[idx] = make_int3(0,0,0);
+        h_angmom.data[idx] = make_scalar4(0,0,0,0);
+        h_inertia.data[idx] = make_scalar3(0,0,0);
         h_body.data[idx] = NO_BODY;
         h_orientation.data[idx] = make_scalar4(1.0,0.0,0.0,0.0);
         h_tag.data[idx] = tag;


### PR DESCRIPTION
Per issue #480, this commits fixes the default values added to new
particles that are added to the system with ParticleData::addParticle().


Resolves #480 

## How Has This Been Tested?

I tested this locally. The new particles added have the correct diameter in the gsd file (1.0), whereas they previously had diameter values of 0.0.

## Change log

```
- Fix default particle properties when new particles are added to the system (e.g., via the muVT updater)
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/hoomd-blue/blob/master/sphinx-doc/credits.rst).
