### PR TITLE
Fix/issue477

### DIFF
--- a/hoomd/context.py
+++ b/hoomd/context.py
@@ -162,6 +162,7 @@ class SimulationContext(object):
 
         self.prev = current;
         current = self;
+        return self
 
     def __exit__(self, exc_type, exc_value, traceback):
         global current

--- a/hoomd/context.py
+++ b/hoomd/context.py
@@ -169,7 +169,7 @@ class SimulationContext(object):
 
         current = self.prev;
 
-def initialize(device=None):
+def initialize(args=None, device=None):
     R""" Initialize the execution context
 
     Args:
@@ -201,10 +201,10 @@ def initialize(device=None):
     global options, current
 
     options = hoomd.option.options();
-    hoomd.option._parse_command_line();
+    hoomd.option._parse_command_line(args);
 
     current = SimulationContext(device)
-    
+
     # ensure creation of global bibliography to print HOOMD base citations
     cite._ensure_global_bib()
 


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should based on *maint*. -->
<!-- New features should based on *master*. -->

## Description

Makes it possible to do `with SimulationContext() as c` and reenables passing `context.initialize('')`.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves: #477 


## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/hoomd-blue/blob/master/sphinx-doc/credits.rst).
