### PR TITLE
Fix deadlocks in Messenger

### DIFF
--- a/.azp/templates/build_test.yml
+++ b/.azp/templates/build_test.yml
@@ -21,6 +21,8 @@ steps:
     OMPI_MCA_btl: "vader,self"
     # prevent deadlocked MPI tests from causing the job to cancel
     MPIEXEC_TIMEOUT: $(mpiexec_timeout)
+    # workaround issues on Mac
+    TMPDIR: /tmp
 
 - script: cp $(Build.BinariesDirectory)/Testing/**/Test.xml $(Common.TestResultsDirectory)
   displayName: Copy test results

--- a/.azp/templates/build_test.yml
+++ b/.azp/templates/build_test.yml
@@ -18,7 +18,7 @@ steps:
     # allow openmpi to oversubscribe cores
     OMPI_MCA_rmaps_base_oversubscribe: 1
     # prevent errors from mis-configured openib systems
-    OMPI_MCA_btl: "tcp,self"
+    OMPI_MCA_btl: "vader,self"
     # prevent deadlocked MPI tests from causing the job to cancel
     MPIEXEC_TIMEOUT: $(mpiexec_timeout)
 

--- a/hoomd/CellList.cc
+++ b/hoomd/CellList.cc
@@ -617,7 +617,8 @@ bool CellList::checkConditions()
         {
         unsigned int n = conditions.y - 1;
         ArrayHandle<unsigned int> h_tag(m_pdata->getTags(), access_location::host, access_mode::read);
-        m_exec_conf->msg->error() << "Particle with unique tag " << h_tag.data[n] << " has NaN for its position." << endl;
+        m_exec_conf->msg->errorAllRanks() << "Particle with unique tag " << h_tag.data[n]
+                                          << " has NaN for its position." << endl;
         throw runtime_error("Error computing cell list");
         }
 
@@ -628,18 +629,19 @@ bool CellList::checkConditions()
         ArrayHandle<Scalar4> h_pos(m_pdata->getPositions(), access_location::host, access_mode::read);
         ArrayHandle<unsigned int> h_tag(m_pdata->getTags(), access_location::host, access_mode::read);
 
-        m_exec_conf->msg->error() <<"Particle with unique tag " << h_tag.data[n] << " is no longer in the simulation box."
-                                  << endl << endl;
-
-        m_exec_conf->msg->error() << "Cartesian coordinates: " << std::endl;
-        m_exec_conf->msg->error() << "x: " << h_pos.data[n].x << " y: " << h_pos.data[n].y << " z: " << h_pos.data[n].z << std::endl;
-        m_exec_conf->msg->error() << "Fractional coordinates: " << std::endl;
         Scalar3 f = m_pdata->getBox().makeFraction(make_scalar3(h_pos.data[n].x, h_pos.data[n].y, h_pos.data[n].z));
-        m_exec_conf->msg->error() << "f.x: " << f.x << " f.y: " << f.y << " f.z: " << f.z << std::endl;
         Scalar3 lo = m_pdata->getBox().getLo();
         Scalar3 hi = m_pdata->getBox().getHi();
-        m_exec_conf->msg->error() << "Local box lo: (" << lo.x << ", " << lo.y << ", " << lo.z << ")" << std::endl;
-        m_exec_conf->msg->error() << "          hi: (" << hi.x << ", " << hi.y << ", " << hi.z << ")" << std::endl;
+
+        m_exec_conf->msg->errorAllRanks()
+           << "Particle with unique tag " << h_tag.data[n]
+           << " is no longer in the simulation box." << std::endl << std::endl
+           << "Cartesian coordinates: " << std::endl
+           << "x: " << h_pos.data[n].x << " y: " << h_pos.data[n].y << " z: " << h_pos.data[n].z << std::endl
+           << "Fractional coordinates: " << std::endl
+           << "f.x: " << f.x << " f.y: " << f.y << " f.z: " << f.z << std::endl
+           << "Local box lo: (" << lo.x << ", " << lo.y << ", " << lo.z << ")" << std::endl
+           << "          hi: (" << hi.x << ", " << hi.y << ", " << hi.z << ")" << std::endl;
         throw runtime_error("Error computing cell list");
         }
 

--- a/hoomd/ExecutionConfiguration.cc
+++ b/hoomd/ExecutionConfiguration.cc
@@ -134,7 +134,7 @@ ExecutionConfiguration::ExecutionConfiguration(executionMode mode,
         {
         if (! m_concurrent && gpu_id.size() > 1)
             {
-            msg->error() << "Multi-GPU execution requested, but not all GPUs support concurrent managed access" << endl;
+            msg->errorAllRanks() << "Multi-GPU execution requested, but not all GPUs support concurrent managed access" << endl;
             throw runtime_error("Error initializing execution configuration");
             }
 
@@ -317,8 +317,8 @@ void ExecutionConfiguration::handleCUDAError(cudaError_t err, const char *file, 
             file += strlen(HOOMD_SOURCE_DIR);
 
         // print an error message
-        msg->error() << string(cudaGetErrorString(err)) << " before "
-                     << file << ":" << line << endl;
+        msg->errorAllRanks() << string(cudaGetErrorString(err)) << " before "
+                             << file << ":" << line << endl;
 
         // throw an error exception
         throw(runtime_error("CUDA Error"));
@@ -339,7 +339,7 @@ void ExecutionConfiguration::initializeGPU(int gpu_id, bool min_cpu)
     int capable_count = getNumCapableGPUs();
     if (capable_count == 0)
         {
-        msg->error() << "No capable GPUs were found!" << endl;
+        msg->errorAllRanks() << "No capable GPUs were found!" << endl;
         throw runtime_error("Error initializing execution configuration");
         }
 
@@ -356,20 +356,20 @@ void ExecutionConfiguration::initializeGPU(int gpu_id, bool min_cpu)
 
     if (gpu_id < -1)
         {
-        msg->error() << "The specified GPU id (" << gpu_id << ") is invalid." << endl;
+        msg->errorAllRanks() << "The specified GPU id (" << gpu_id << ") is invalid." << endl;
         throw runtime_error("Error initializing execution configuration");
         }
 
     if (gpu_id >= (int)getNumTotalGPUs())
         {
-        msg->error() << "The specified GPU id (" << gpu_id << ") is not present in the system." << endl;
-        msg->error() << "CUDA reports only " << getNumTotalGPUs() << endl;
+        msg->errorAllRanks() << "The specified GPU id (" << gpu_id << ") is not present in the system." << endl;
+        msg->errorAllRanks() << "CUDA reports only " << getNumTotalGPUs() << endl;
         throw runtime_error("Error initializing execution configuration");
         }
 
     if (!isGPUAvailable(gpu_id))
         {
-        msg->error() << "The specified GPU id (" << gpu_id << ") is not available for executing HOOMD." << endl;
+        msg->errorAllRanks() << "The specified GPU id (" << gpu_id << ") is not available for executing HOOMD." << endl;
         throw runtime_error("Error initializing execution configuration");
         }
 
@@ -505,7 +505,7 @@ void ExecutionConfiguration::scanGPUs(bool ignore_display)
         cudaError_t error = cudaGetDeviceProperties(&prop, dev);
         if (error != cudaSuccess)
             {
-            msg->error() << "Error calling cudaGetDeviceProperties()" << endl;
+            msg->errorAllRanks() << "Error calling cudaGetDeviceProperties()" << endl;
             throw runtime_error("Error initializing execution configuration");
             }
 
@@ -566,7 +566,7 @@ void ExecutionConfiguration::scanGPUs(bool ignore_display)
             cudaError_t error = cudaGetDeviceProperties(&prop, dev);
             if (error != cudaSuccess)
                 {
-                msg->error() << "Error calling cudaGetDeviceProperties()" << endl;
+                msg->errorAllRanks() << "Error calling cudaGetDeviceProperties()" << endl;
                 throw runtime_error("Error initializing execution configuration");
                 }
 

--- a/hoomd/GPUArray.h
+++ b/hoomd/GPUArray.h
@@ -911,7 +911,7 @@ template<class T> void GPUArray<T>::allocate()
     if (retval != 0)
         {
         if (m_exec_conf)
-            m_exec_conf->msg->error() << "Error allocating aligned memory" << std::endl;
+            m_exec_conf->msg->errorAllRanks() << "Error allocating aligned memory" << std::endl;
         throw std::runtime_error("Error allocating GPUArray.");
         }
 
@@ -1231,7 +1231,7 @@ template<class T> T* GPUArray<T>::resizeHostArray(unsigned int num_elements)
     if (retval != 0)
         {
         if (m_exec_conf)
-            m_exec_conf->msg->error() << "Error allocating aligned memory" << std::endl;
+            m_exec_conf->msg->errorAllRanks() << "Error allocating aligned memory" << std::endl;
         throw std::runtime_error("Error allocating GPUArray.");
         }
 
@@ -1286,7 +1286,7 @@ template<class T> T* GPUArray<T>::resize2DHostArray(unsigned int pitch, unsigned
     if (retval != 0)
         {
         if (m_exec_conf)
-            m_exec_conf->msg->error() << "Error allocating aligned memory" << std::endl;
+            m_exec_conf->msg->errorAllRanks() << "Error allocating aligned memory" << std::endl;
         throw std::runtime_error("Error allocating GPUArray.");
         }
 

--- a/hoomd/GPUFlags.h
+++ b/hoomd/GPUFlags.h
@@ -219,7 +219,7 @@ template<class T> void GPUFlags<T>::allocate()
             int retval = posix_memalign(&ptr, getpagesize(), sizeof(T));
             if (retval != 0)
                 {
-                m_exec_conf->msg->error() << "Error allocating aligned memory" << std::endl;
+                m_exec_conf->msg->errorAllRanks() << "Error allocating aligned memory" << std::endl;
                 throw std::runtime_error("Error allocating GPUArray.");
                 }
             h_data = (T *) ptr;
@@ -238,7 +238,7 @@ template<class T> void GPUFlags<T>::allocate()
             int retval = posix_memalign(&ptr, getpagesize(), sizeof(T));
             if (retval != 0)
                 {
-                m_exec_conf->msg->error() << "Error allocating aligned memory" << std::endl;
+                m_exec_conf->msg->errorAllRanks() << "Error allocating aligned memory" << std::endl;
                 throw std::runtime_error("Error allocating GPUArray.");
                 }
             h_data = (T *) ptr;

--- a/hoomd/Messenger.cc
+++ b/hoomd/Messenger.cc
@@ -10,6 +10,7 @@
 
 #include "ExecutionConfiguration.h"
 #include "Messenger.h"
+#include "ClockSource.h"
 
 #ifdef ENABLE_MPI
 #include "HOOMDMPI.h"
@@ -180,6 +181,9 @@ std::ostream& Messenger::errorAllRanks()
     assert(m_err_stream);
 
     reopenPythonIfNeeded();
+
+    // Delay so that multiple ranks calling this have a good chance of writing non-overlapping messages
+    Sleep(m_mpi_config->getRank()*10);
 
     if (m_err_prefix != string(""))
         *m_err_stream << m_err_prefix << ": ";

--- a/hoomd/Messenger.h
+++ b/hoomd/Messenger.h
@@ -117,6 +117,9 @@ class PYBIND11_EXPORT Messenger
         //! Get the error stream
         std::ostream& error();
 
+        //! Get the error stream on all ranks
+        std::ostream& errorAllRanks();
+
         //! Alternate method to print error strings
         void errorStr(const std::string& msg);
 
@@ -255,22 +258,6 @@ class PYBIND11_EXPORT Messenger
 
             openSharedFile();
             }
-
-        //! Returns true if this if this rank has exclusive stdout access for error messages
-        bool hasLock() const
-            {
-            return m_has_lock;
-            }
-
-        //! Returns true if any process has locked the output
-        bool isLocked() const
-            {
-            int flag;
-            MPI_Win_lock(MPI_LOCK_EXCLUSIVE, 0,0, m_mpi_win);
-            MPI_Get(&flag, 1, MPI_INT, 0, 0, 1, MPI_INT, m_mpi_win);
-            MPI_Win_unlock(0, m_mpi_win);
-            return flag;
-            }
 #endif
 
         //! Open stdout and stderr again, closing any open file
@@ -302,18 +289,9 @@ class PYBIND11_EXPORT Messenger
 
 #ifdef ENABLE_MPI
         std::string m_shared_filename;  //!< Filename of shared log file
-        MPI_Win m_mpi_win;              //!< MPI Window for atomic printing of error messages
-        int *m_error_flag;              //!< Flag on (on processor 0) to lock stdout
-        mutable bool m_has_lock;        //!< True if this rank has exclusive access to stdout
 
         //! Open a shared file for error, warning, and notice streams
         void openSharedFile();
-
-        //! Initialize RMA
-        void initializeSharedMem();
-
-        //! Free RMA
-        void releaseSharedMem();
 #endif
     };
 

--- a/hoomd/hpmc/IntegratorHPMCMono.h
+++ b/hoomd/hpmc/IntegratorHPMCMono.h
@@ -1480,7 +1480,7 @@ void IntegratorHPMCMono<Shape>::growAABBList(unsigned int N)
         int retval = posix_memalign((void**)&m_aabbs, 32, N*sizeof(detail::AABB));
         if (retval != 0)
             {
-            m_exec_conf->msg->error() << "Error allocating aligned memory" << std::endl;
+            m_exec_conf->msg->errorAllRanks() << "Error allocating aligned memory" << std::endl;
             throw std::runtime_error("Error allocating AABB memory");
             }
         }

--- a/hoomd/md/BondTablePotential.cc
+++ b/hoomd/md/BondTablePotential.cc
@@ -282,7 +282,7 @@ void BondTablePotential::computeForces(unsigned int timestep)
             }
         else
             {
-            m_exec_conf->msg->error() << "Table bond out of bounds" << endl;
+            m_exec_conf->msg->errorAllRanks() << "Table bond out of bounds" << endl;
             throw std::runtime_error("Error in bond calculation");
             }
 

--- a/hoomd/md/BondTablePotentialGPU.cc
+++ b/hoomd/md/BondTablePotentialGPU.cc
@@ -106,7 +106,7 @@ void BondTablePotentialGPU::computeForces(unsigned int timestep)
 
         if (h_flags.data[0])
             {
-            m_exec_conf->msg->error() << endl << "***Error! << Table bond out of bounds" << endl << endl;
+            m_exec_conf->msg->errorAllRanks() << endl << "Table bond out of bounds" << endl << endl;
             throw std::runtime_error("Error in bond calculation");
             }
         }

--- a/hoomd/md/ForceComposite.cc
+++ b/hoomd/md/ForceComposite.cc
@@ -854,8 +854,8 @@ void ForceComposite::computeForces(unsigned int timestep)
                 // if the central particle is local, the molecule should be complete
                 if (len != h_body_len.data[type] + 1)
                     {
-                    m_exec_conf->msg->error() << "constrain.rigid(): Composite particle with body tag " << central_tag << " incomplete"
-                        << std::endl << std::endl;
+                    m_exec_conf->msg->errorAllRanks() << "constrain.rigid(): Composite particle with body tag "
+                                                      << central_tag << " incomplete" << std::endl << std::endl;
                     throw std::runtime_error("Error computing composite particle forces.\n");
                     }
 
@@ -969,8 +969,8 @@ void ForceComposite::updateCompositeParticles(unsigned int timestep)
 
         if (central_idx == NOT_LOCAL)
             {
-            m_exec_conf->msg->error() << "constrain.rigid(): Missing central particle tag " << central_tag << "!"
-                << std::endl << std::endl;
+            m_exec_conf->msg->errorAllRanks() << "constrain.rigid(): Missing central particle tag " << central_tag
+                                              << "!" << std::endl << std::endl;
             throw std::runtime_error("Error updating composite particles.\n");
             }
 
@@ -994,8 +994,8 @@ void ForceComposite::updateCompositeParticles(unsigned int timestep)
             if (iptl < m_pdata->getN())
                 {
                 // if the molecule is incomplete and has local members, this is an error
-                m_exec_conf->msg->error() << "constrain.rigid(): Composite particle with body tag " << central_tag << " incomplete"
-                    << std::endl << std::endl;
+                m_exec_conf->msg->errorAllRanks() << "constrain.rigid(): Composite particle with body tag "
+                                                  << central_tag << " incomplete" << std::endl << std::endl;
                 throw std::runtime_error("Error while updating constituent particles.\n");
                 }
 

--- a/hoomd/md/ForceCompositeGPU.cc
+++ b/hoomd/md/ForceCompositeGPU.cc
@@ -181,8 +181,8 @@ void ForceCompositeGPU::computeForces(unsigned int timestep)
 
     if (flag.x)
         {
-        m_exec_conf->msg->error() << "constrain.rigid(): Composite particle with body tag " << flag.x-1 << " incomplete"
-            << std::endl << std::endl;
+        m_exec_conf->msg->errorAllRanks() << "constrain.rigid(): Composite particle with body tag " << flag.x-1
+                                          << " incomplete" << std::endl << std::endl;
         throw std::runtime_error("Error computing composite particle forces.\n");
         }
 
@@ -331,8 +331,8 @@ void ForceCompositeGPU::updateCompositeParticles(unsigned int timestep)
         unsigned int body_id = h_body.data[idx];
         unsigned int tag = h_tag.data[idx];
 
-        m_exec_conf->msg->error() << "constrain.rigid(): Particle " << tag << " part of composite body " << body_id << " is missing central particle"
-            << std::endl << std::endl;
+        m_exec_conf->msg->errorAllRanks() << "constrain.rigid(): Particle " << tag << " part of composite body "
+                                          << body_id << " is missing central particle" << std::endl << std::endl;
         throw std::runtime_error("Error while updating constituent particles");
         }
 
@@ -343,8 +343,8 @@ void ForceCompositeGPU::updateCompositeParticles(unsigned int timestep)
         unsigned int idx = flag.y - 1;
         unsigned int body_id = h_body.data[idx];
 
-        m_exec_conf->msg->error() << "constrain.rigid(): Composite particle with body id " << body_id << " incomplete"
-            << std::endl << std::endl;
+        m_exec_conf->msg->errorAllRanks() << "constrain.rigid(): Composite particle with body id " << body_id
+                                          << " incomplete" << std::endl << std::endl;
         throw std::runtime_error("Error while updating constituent particles");
         }
 

--- a/hoomd/md/NeighborListGPUTree.cc
+++ b/hoomd/md/NeighborListGPUTree.cc
@@ -440,9 +440,9 @@ void NeighborListGPUTree::calcMortonCodes()
         Scalar4 post_i = h_pos.data[morton_conditions-1];
         Scalar3 pos_i = make_scalar3(post_i.x, post_i.y, post_i.z);
         Scalar3 f = box.makeFraction(pos_i);
-        m_exec_conf->msg->error() << "nlist.tree(): Particle " << h_tag.data[morton_conditions-1] << " is out of bounds "
-                                  << "(x: " << post_i.x << ", y: " << post_i.y << ", z: " << post_i.z
-                                  << ", fx: "<< f.x <<", fy: "<<f.y<<", fz:"<<f.z<<")"<<endl;
+        m_exec_conf->msg->errorAllRanks() << "nlist.tree(): Particle " << h_tag.data[morton_conditions-1] << " is out of bounds "
+                                          << "(x: " << post_i.x << ", y: " << post_i.y << ", z: " << post_i.z
+                                          << ", fx: "<< f.x <<", fy: "<<f.y<<", fz:"<<f.z<<")"<<endl;
         throw runtime_error("Error updating neighborlist");
         }
 

--- a/hoomd/md/NeighborListTree.cc
+++ b/hoomd/md/NeighborListTree.cc
@@ -251,9 +251,9 @@ void NeighborListTree::buildTree()
             (f.z < Scalar(-0.00001) || f.z >= Scalar(1.00001))) && i < m_pdata->getN())
             {
             ArrayHandle<unsigned int> h_tag(m_pdata->getTags(), access_location::host, access_mode::read);
-            m_exec_conf->msg->error() << "nlist.tree(): Particle " << h_tag.data[i] << " is out of bounds "
-                                      << "(x: " << my_pos.x << ", y: " << my_pos.y << ", z: " << my_pos.z
-                                      << ", fx: "<< f.x <<", fy: "<<f.y<<", fz:"<<f.z<<")"<<endl;
+            m_exec_conf->msg->errorAllRanks() << "nlist.tree(): Particle " << h_tag.data[i] << " is out of bounds "
+                                              << "(x: " << my_pos.x << ", y: " << my_pos.y << ", z: " << my_pos.z
+                                              << ", fx: "<< f.x <<", fy: "<<f.y<<", fz:"<<f.z<<")"<<endl;
             throw runtime_error("Error updating neighborlist");
             return;
             }

--- a/hoomd/md/test/CMakeLists.txt
+++ b/hoomd/md/test/CMakeLists.txt
@@ -53,9 +53,8 @@ if(ENABLE_MPI)
 
     # define every test together with the number of processors
 
-    # test_communication tends to hang on CI platforms, I do not know why
-    # ADD_TO_MPI_TESTS(test_communication 8)
-    # ADD_TO_MPI_TESTS(test_communicator_grid 8)
+    ADD_TO_MPI_TESTS(test_communication 8)
+    ADD_TO_MPI_TESTS(test_communicator_grid 8)
 endif()
 
 foreach (CUR_TEST ${TEST_LIST} ${MPI_TEST_LIST})

--- a/hoomd/module.cc
+++ b/hoomd/module.cc
@@ -252,6 +252,8 @@ void abort_mpi(std::shared_ptr<ExecutionConfiguration> exec_conf)
     #ifdef ENABLE_MPI
     if(exec_conf->getMPIConfig()->getNRanksGlobal() > 1)
         {
+        // delay for a moment to give time for error messages to print
+        Sleep(1000);
         MPI_Abort(exec_conf->getMPICommunicator(), MPI_ERR_OTHER);
         }
     #endif

--- a/hoomd/mpcd/BounceBackNVE.h
+++ b/hoomd/mpcd/BounceBackNVE.h
@@ -248,7 +248,7 @@ bool BounceBackNVE<Geometry>::validateParticles()
         const Scalar3 pos = make_scalar3(postype.x, postype.y, postype.z);
         if (m_geom->isOutside(pos))
             {
-            m_exec_conf->msg->error() << "Particle with tag " << h_tag.data[pid] << " at (" << pos.x << "," << pos.y << "," << pos.z
+            m_exec_conf->msg->errorAllRanks() << "Particle with tag " << h_tag.data[pid] << " at (" << pos.x << "," << pos.y << "," << pos.z
                                       << ") lies outside the " << Geometry::getName() << " geometry. Fix configuration." << std::endl;
             return false;
             }

--- a/hoomd/mpcd/ConfinedStreamingMethod.h
+++ b/hoomd/mpcd/ConfinedStreamingMethod.h
@@ -192,7 +192,7 @@ bool ConfinedStreamingMethod<Geometry>::validateParticles()
         const Scalar3 pos = make_scalar3(postype.x, postype.y, postype.z);
         if (m_geom->isOutside(pos))
             {
-            m_exec_conf->msg->error() << "MPCD particle with tag " << h_tag.data[idx] << " at (" << pos.x << "," << pos.y << "," << pos.z
+            m_exec_conf->msg->errorAllRanks() << "MPCD particle with tag " << h_tag.data[idx] << " at (" << pos.x << "," << pos.y << "," << pos.z
                           << ") lies outside the " << Geometry::getName() << " geometry. Fix configuration." << std::endl;
             return false;
             }


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should based on *maint*. -->
<!-- New features should based on *master*. -->

## Description

<!-- Describe your changes in detail. -->
Remove the `MPI_Win_Lock` and related communication routines in Messenger. I replaced them with a separate `errorAllRanks()` method where the caller can opt in to sending error messages from all ranks that call it. `errorAllRanks()` uses a sleep call to disentagle output from multiple ranks. Sleep does not guarantee that there will be no race conditions, but it should be good enough most of the time.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
`MPI_Win_Lock` was causing MPI errors and random deadlocks in some runtime configurations, specifically some configurations used by the CI testing platform.

<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves: #438 

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
I tested `errorAllRanks()` with this script:
```import hoomd, hoomd.md
hoomd.context.initialize()

unitcell=hoomd.lattice.sc(a=10.0, type_name='A')
system = hoomd.init.create_lattice(unitcell=unitcell, n=10)

def set_box(step):
    system.box = hoomd.data.boxdim(20,20,20)

nl = hoomd.md.nlist.cell()
lj = hoomd.md.pair.lj(r_cut=3.0, nlist=nl)

lj.pair_coeff.set('A', 'A', epsilon=1.0, sigma=1.0)

all = hoomd.group.all();

hoomd.md.integrate.mode_standard(dt=0.005)
hoomd.md.integrate.langevin(group=all, kT=1.2, seed=4)
hoomd.run(10e3, callback=set_box, callback_period=1)
```
It produced the following output:
```

Ranks 0-3: HOOMD-blue is running on the CPU
test-errors.py:004  |  unitcell=hoomd.lattice.sc(a=10.0, type_name='A')
test-errors.py:005  |  system = hoomd.init.create_lattice(unitcell=unitcell, n=10)
HOOMD-blue is using domain decomposition: n_x = 1 n_y = 2 n_z = 2.
1 x 2 x 2 local grid on 1 nodes
notice(2): Group "all" created containing 1000 particles
test-errors.py:010  |  nl = hoomd.md.nlist.cell()
test-errors.py:011  |  lj = hoomd.md.pair.lj(r_cut=3.0, nlist=nl)
test-errors.py:013  |  lj.pair_coeff.set('A', 'A', epsilon=1.0, sigma=1.0)
test-errors.py:015  |  all = hoomd.group.all();
test-errors.py:017  |  hoomd.md.integrate.mode_standard(dt=0.005)
test-errors.py:018  |  hoomd.md.integrate.langevin(group=all, kT=1.2, seed=4)
notice(2): integrate.langevin/bd is using specified gamma values
test-errors.py:019  |  hoomd.run(10e3, callback=set_box, callback_period=1)
notice(2): -- Neighborlist exclusion statistics -- :
notice(2): Particles with 0 exclusions             : 1000
notice(2): Neighbors included by diameter          : no
notice(2): Neighbors excluded when in the same body: no
** starting run **
**ERROR**:  (Rank 0): Particle with unique tag 948 is no longer in the simulation box.

Cartesian coordinates:
x: 25 y: -5 z: -5
Fractional coordinates:
f.x: 1.75 f.y: 0.5 f.z: 0.5
Local box lo: (-10, -10, -10)
          hi: (10, 0, 0)
Traceback (most recent call last):
  File "test-errors.py", line 19, in <module>
    hoomd.run(10e3, callback=set_box, callback_period=1)
  File "/scratch/joaander/build/hoomd/hoomd/__init__.py", line 201, in run
    context.current.system.run(int(tsteps), callback_period, callback, limit_hours, int(limit_multiple));
RuntimeError: Error computing cell list
**ERROR**:  (Rank 1): Particle with unique tag 958 is no longer in the simulation box.

Cartesian coordinates:
x: 25 y: 5 z: -5
Fractional coordinates:
f.x: 1.75 f.y: 0.5 f.z: 0.5
Local box lo: (-10, 0, -10)
          hi: (10, 10, 0)
Traceback (most recent call last):
  File "test-errors.py", line 19, in <module>
    hoomd.run(10e3, callback=set_box, callback_period=1)
  File "/scratch/joaander/build/hoomd/hoomd/__init__.py", line 201, in run
    context.current.system.run(int(tsteps), callback_period, callback, limit_hours, int(limit_multiple));
RuntimeError: Error computing cell list
**ERROR**:  (Rank 2): Particle with unique tag 941 is no longer in the simulation box.

Cartesian coordinates:
x: 25 y: -5 z: 5
Fractional coordinates:
f.x: 1.75 f.y: 0.5 f.z: 0.5
Local box lo: (-10, -10, 0)
          hi: (10, 0, 10)
Traceback (most recent call last):
  File "test-errors.py", line 19, in <module>
    hoomd.run(10e3, callback=set_box, callback_period=1)
  File "/scratch/joaander/build/hoomd/hoomd/__init__.py", line 201, in run
    context.current.system.run(int(tsteps), callback_period, callback, limit_hours, int(limit_multiple));
RuntimeError: Error computing cell list
**ERROR**:  (Rank 3): Particle with unique tag 951 is no longer in the simulation box.

Cartesian coordinates:
x: 25 y: 5 z: 5
Fractional coordinates:
f.x: 1.75 f.y: 0.5 f.z: 0.5
Local box lo: (-10, 0, 0)
          hi: (10, 10, 10)
Traceback (most recent call last):
  File "test-errors.py", line 19, in <module>
    hoomd.run(10e3, callback=set_box, callback_period=1)
  File "/scratch/joaander/build/hoomd/hoomd/__init__.py", line 201, in run
    context.current.system.run(int(tsteps), callback_period, callback, limit_hours, int(limit_multiple));
RuntimeError: Error computing cell list
--------------------------------------------------------------------------
MPI_ABORT was invoked on rank 0 in communicator MPI_COMM_WORLD
with errorcode 16.
```

I used a global search for `error()` and believe I converted most of the cases to `errorAllRanks()` where only a subset of ranks could potentially trigger an error. In any case, the exception thrown will still be printed and cause an `MPI_Abort` even if the more detailed message is not sent to `error()` on rank 0.

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
- Better error message handling from multiple MPI ranks
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/hoomd-blue/blob/master/sphinx-doc/credits.rst).
