### PR TITLE
Feature/update harmonic dihedral

### DIFF
--- a/hoomd/md/HarmonicDihedralForceCompute.cc
+++ b/hoomd/md/HarmonicDihedralForceCompute.cc
@@ -90,8 +90,8 @@ void HarmonicDihedralForceCompute::setParams(unsigned int type, Scalar K, int si
         m_exec_conf->msg->warning() << "dihedral.harmonic: specified K <= 0" << endl;
     if (sign != 1 && sign != -1)
         m_exec_conf->msg->warning() << "dihedral.harmonic: a non unitary sign was specified" << endl;
-    if (phi_0 <= 0)
-        m_exec_conf->msg->warning() << "dihedral.harmonic: specified phi_0 <= 0" << endl;
+    if (phi_0 < 0 || phi_0 >= 2*M_PI)
+        m_exec_conf->msg->warning() << "dihedral.harmonic: specified phi_0 outside [0, 2pi)" << endl;
     }
 
 /*! DihedralForceCompute provides
@@ -257,8 +257,9 @@ void HarmonicDihedralForceCompute::computeForces(unsigned int timestep)
 
         Scalar sign = m_sign[dihedral_type];
         Scalar phi_0 = m_phi_0[dihedral_type];
-        p = p*sign + dfab*sin(phi_0);
-        dfab = dfab*sign - ddfab*sin(phi_0);
+        Scalar sin_phi_0 = fast::sin(phi_0)
+        p = p*sign + dfab*sin_phi_0;
+        dfab = dfab*sign - ddfab*sin_phi_0;
         dfab *= (Scalar)-multi;
         p += Scalar(1.0);
 

--- a/hoomd/md/HarmonicDihedralForceCompute.cc
+++ b/hoomd/md/HarmonicDihedralForceCompute.cc
@@ -252,14 +252,18 @@ void HarmonicDihedralForceCompute::computeForces(unsigned int timestep)
 
 /////////////////////////
 // FROM LAMMPS: sin_shift is always 0... so dropping all sin_shift terms!!!!
-// Adding charmm dihedral functionality, sin_shift not always 0 
+// Adding charmm dihedral functionality, sin_shift not always 0,
+// cos_shift not always 1
 /////////////////////////
 
         Scalar sign = m_sign[dihedral_type];
         Scalar phi_0 = m_phi_0[dihedral_type];
-        Scalar sin_phi_0 = fast::sin(phi_0)
-        p = p*sign + dfab*sin_phi_0;
-        dfab = dfab*sign - ddfab*sin_phi_0;
+        Scalar sin_phi_0 = fast::sin(phi_0);
+        Scalar cos_phi_0 = fast::cos(phi_0);
+        p = p*cos_phi_0 + dfab*sin_phi_0;
+        p = p*sign;
+        dfab = dfab*cos_phi_0 - ddfab*sin_phi_0;
+        dfab = dfab*sign;
         dfab *= (Scalar)-multi;
         p += Scalar(1.0);
 

--- a/hoomd/md/HarmonicDihedralForceCompute.cc
+++ b/hoomd/md/HarmonicDihedralForceCompute.cc
@@ -28,7 +28,7 @@ using namespace std;
     \post Memory is allocated, and forces are zeroed.
 */
 HarmonicDihedralForceCompute::HarmonicDihedralForceCompute(std::shared_ptr<SystemDefinition> sysdef)
-    : ForceCompute(sysdef), m_K(NULL), m_sign(NULL), m_multi(NULL), m_p_0(NULL)
+    : ForceCompute(sysdef), m_K(NULL), m_sign(NULL), m_multi(NULL), m_phi_0(NULL)
     {
     m_exec_conf->msg->notice(5) << "Constructing HarmonicDihedralForceCompute" << endl;
 
@@ -46,7 +46,7 @@ HarmonicDihedralForceCompute::HarmonicDihedralForceCompute(std::shared_ptr<Syste
     m_K = new Scalar[m_dihedral_data->getNTypes()];
     m_sign = new Scalar[m_dihedral_data->getNTypes()];
     m_multi = new Scalar[m_dihedral_data->getNTypes()];
-    m_p_0 = new Scalar[m_dihedral_data->getNTypes()];
+    m_phi_0 = new Scalar[m_dihedral_data->getNTypes()];
 
     }
 
@@ -57,11 +57,11 @@ HarmonicDihedralForceCompute::~HarmonicDihedralForceCompute()
     delete[] m_K;
     delete[] m_sign;
     delete[] m_multi;
-    delete[] m_p_0;
+    delete[] m_phi_0;
     m_K = NULL;
     m_sign = NULL;
     m_multi = NULL;
-    m_p_0 = NULL;
+    m_phi_0 = NULL;
     }
 
 /*! \param type Type of the dihedral to set parameters for
@@ -71,7 +71,7 @@ HarmonicDihedralForceCompute::~HarmonicDihedralForceCompute()
 
     Sets parameters for the potential of a particular dihedral type
 */
-void HarmonicDihedralForceCompute::setParams(unsigned int type, Scalar K, int sign, unsigned int multiplicity, Scalar p_0)
+void HarmonicDihedralForceCompute::setParams(unsigned int type, Scalar K, int sign, unsigned int multiplicity, Scalar phi_0)
     {
     // make sure the type is valid
     if (type >= m_dihedral_data->getNTypes())
@@ -83,15 +83,15 @@ void HarmonicDihedralForceCompute::setParams(unsigned int type, Scalar K, int si
     m_K[type] = K;
     m_sign[type] = (Scalar)sign;
     m_multi[type] = (Scalar)multiplicity;
-    m_p_0[type] = p_0;
+    m_phi_0[type] = phi_0;
 
     // check for some silly errors a user could make
     if (K <= 0)
         m_exec_conf->msg->warning() << "dihedral.harmonic: specified K <= 0" << endl;
     if (sign != 1 && sign != -1)
         m_exec_conf->msg->warning() << "dihedral.harmonic: a non unitary sign was specified" << endl;
-    if (p_0 <= 0)
-        m_exec_conf->msg->warning() << "dihedral.harmonic: specified p_0 <= 0" << endl;
+    if (phi_0 <= 0)
+        m_exec_conf->msg->warning() << "dihedral.harmonic: specified phi_0 <= 0" << endl;
     }
 
 /*! DihedralForceCompute provides
@@ -256,9 +256,9 @@ void HarmonicDihedralForceCompute::computeForces(unsigned int timestep)
 /////////////////////////
 
         Scalar sign = m_sign[dihedral_type];
-        Scalar p_0 = m_p_0[dihedral_type];
-        p = p*sign + dfab*sin(p_0);
-        dfab = dfab*sign - ddfab*sin(p_0);
+        Scalar phi_0 = m_phi_0[dihedral_type];
+        p = p*sign + dfab*sin(phi_0);
+        dfab = dfab*sign - ddfab*sin(phi_0);
         dfab *= (Scalar)-multi;
         p += Scalar(1.0);
 

--- a/hoomd/md/HarmonicDihedralForceCompute.cc
+++ b/hoomd/md/HarmonicDihedralForceCompute.cc
@@ -28,7 +28,7 @@ using namespace std;
     \post Memory is allocated, and forces are zeroed.
 */
 HarmonicDihedralForceCompute::HarmonicDihedralForceCompute(std::shared_ptr<SystemDefinition> sysdef)
-    : ForceCompute(sysdef), m_K(NULL), m_sign(NULL), m_multi(NULL)
+    : ForceCompute(sysdef), m_K(NULL), m_sign(NULL), m_multi(NULL), m_p_0(NULL)
     {
     m_exec_conf->msg->notice(5) << "Constructing HarmonicDihedralForceCompute" << endl;
 
@@ -46,6 +46,7 @@ HarmonicDihedralForceCompute::HarmonicDihedralForceCompute(std::shared_ptr<Syste
     m_K = new Scalar[m_dihedral_data->getNTypes()];
     m_sign = new Scalar[m_dihedral_data->getNTypes()];
     m_multi = new Scalar[m_dihedral_data->getNTypes()];
+    m_p_0 = new Scalar[m_dihedral_data->getNTypes()];
 
     }
 
@@ -56,9 +57,11 @@ HarmonicDihedralForceCompute::~HarmonicDihedralForceCompute()
     delete[] m_K;
     delete[] m_sign;
     delete[] m_multi;
+    delete[] m_p_0;
     m_K = NULL;
     m_sign = NULL;
     m_multi = NULL;
+    m_p_0 = NULL;
     }
 
 /*! \param type Type of the dihedral to set parameters for
@@ -68,7 +71,7 @@ HarmonicDihedralForceCompute::~HarmonicDihedralForceCompute()
 
     Sets parameters for the potential of a particular dihedral type
 */
-void HarmonicDihedralForceCompute::setParams(unsigned int type, Scalar K, int sign, unsigned int multiplicity)
+void HarmonicDihedralForceCompute::setParams(unsigned int type, Scalar K, int sign, unsigned int multiplicity, Scalar p_0)
     {
     // make sure the type is valid
     if (type >= m_dihedral_data->getNTypes())
@@ -80,12 +83,15 @@ void HarmonicDihedralForceCompute::setParams(unsigned int type, Scalar K, int si
     m_K[type] = K;
     m_sign[type] = (Scalar)sign;
     m_multi[type] = (Scalar)multiplicity;
+    m_p_0[type] = p_0;
 
     // check for some silly errors a user could make
     if (K <= 0)
         m_exec_conf->msg->warning() << "dihedral.harmonic: specified K <= 0" << endl;
     if (sign != 1 && sign != -1)
         m_exec_conf->msg->warning() << "dihedral.harmonic: a non unitary sign was specified" << endl;
+    if (p_0 <= 0)
+        m_exec_conf->msg->warning() << "dihedral.harmonic: specified p_0 <= 0" << endl;
     }
 
 /*! DihedralForceCompute provides
@@ -246,11 +252,13 @@ void HarmonicDihedralForceCompute::computeForces(unsigned int timestep)
 
 /////////////////////////
 // FROM LAMMPS: sin_shift is always 0... so dropping all sin_shift terms!!!!
+// Adding charmm dihedral functionality, sin_shift not always 0 
 /////////////////////////
 
         Scalar sign = m_sign[dihedral_type];
-        p = p*sign;
-        dfab = dfab*sign;
+        Scalar p_0 = m_p_0[dihedral_type];
+        p = p*sign + dfab*sin(p_0);
+        dfab = dfab*sign - ddfab*sin(p_0);
         dfab *= (Scalar)-multi;
         p += Scalar(1.0);
 

--- a/hoomd/md/HarmonicDihedralForceCompute.h
+++ b/hoomd/md/HarmonicDihedralForceCompute.h
@@ -40,7 +40,7 @@ class PYBIND11_EXPORT HarmonicDihedralForceCompute : public ForceCompute
         virtual ~HarmonicDihedralForceCompute();
 
         //! Set the parameters
-        virtual void setParams(unsigned int type, Scalar K, int sign, unsigned int multiplicity);
+        virtual void setParams(unsigned int type, Scalar K, int sign, unsigned int multiplicity, Scalar p_0);
 
         //! Returns a list of log quantities this compute calculates
         virtual std::vector< std::string > getProvidedLogQuantities();
@@ -65,6 +65,7 @@ class PYBIND11_EXPORT HarmonicDihedralForceCompute : public ForceCompute
         Scalar *m_K;     //!< K parameter for multiple dihedral tyes
         Scalar *m_sign;  //!< sign parameter for multiple dihedral types
         Scalar *m_multi; //!< multiplicity parameter for multiple dihedral types
+        Scalar *m_p_0; //!< p_0 parameter for multiple dihedral types
 
         std::shared_ptr<DihedralData> m_dihedral_data;    //!< Dihedral data to use in computing dihedrals
 

--- a/hoomd/md/HarmonicDihedralForceCompute.h
+++ b/hoomd/md/HarmonicDihedralForceCompute.h
@@ -40,7 +40,7 @@ class PYBIND11_EXPORT HarmonicDihedralForceCompute : public ForceCompute
         virtual ~HarmonicDihedralForceCompute();
 
         //! Set the parameters
-        virtual void setParams(unsigned int type, Scalar K, int sign, unsigned int multiplicity, Scalar p_0);
+        virtual void setParams(unsigned int type, Scalar K, int sign, unsigned int multiplicity, Scalar phi_0);
 
         //! Returns a list of log quantities this compute calculates
         virtual std::vector< std::string > getProvidedLogQuantities();
@@ -65,7 +65,7 @@ class PYBIND11_EXPORT HarmonicDihedralForceCompute : public ForceCompute
         Scalar *m_K;     //!< K parameter for multiple dihedral tyes
         Scalar *m_sign;  //!< sign parameter for multiple dihedral types
         Scalar *m_multi; //!< multiplicity parameter for multiple dihedral types
-        Scalar *m_p_0; //!< p_0 parameter for multiple dihedral types
+        Scalar *m_phi_0; //!< phi_0 parameter for multiple dihedral types
 
         std::shared_ptr<DihedralData> m_dihedral_data;    //!< Dihedral data to use in computing dihedrals
 

--- a/hoomd/md/HarmonicDihedralForceComputeGPU.cc
+++ b/hoomd/md/HarmonicDihedralForceComputeGPU.cc
@@ -42,18 +42,18 @@ HarmonicDihedralForceComputeGPU::~HarmonicDihedralForceComputeGPU()
     \param K Stiffness parameter for the force computation
     \param sign the sign of the cosine term
         \param multiplicity the multiplicity of the cosine term
-    \param p_0 the phase offset
+    \param phi_0 the phase offset
 
     Sets parameters for the potential of a particular dihedral type and updates the
     parameters on the GPU.
 */
-void HarmonicDihedralForceComputeGPU::setParams(unsigned int type, Scalar K, int sign, unsigned int multiplicity, Scalar p_0)
+void HarmonicDihedralForceComputeGPU::setParams(unsigned int type, Scalar K, int sign, unsigned int multiplicity, Scalar phi_0)
     {
-    HarmonicDihedralForceCompute::setParams(type, K, sign, multiplicity, p_0);
+    HarmonicDihedralForceCompute::setParams(type, K, sign, multiplicity, phi_0);
 
     ArrayHandle<Scalar4> h_params(m_params, access_location::host, access_mode::readwrite);
     // update the local copy of the memory
-    h_params.data[type] = make_scalar4(Scalar(K), Scalar(sign), Scalar(multiplicity), Scalar(p_0));
+    h_params.data[type] = make_scalar4(Scalar(K), Scalar(sign), Scalar(multiplicity), Scalar(phi_0));
     }
 
 /*! Internal method for computing the forces on the GPU.

--- a/hoomd/md/HarmonicDihedralForceComputeGPU.cc
+++ b/hoomd/md/HarmonicDihedralForceComputeGPU.cc
@@ -42,13 +42,14 @@ HarmonicDihedralForceComputeGPU::~HarmonicDihedralForceComputeGPU()
     \param K Stiffness parameter for the force computation
     \param sign the sign of the cosine term
         \param multiplicity the multiplicity of the cosine term
+    \param p_0 the phase offset
 
     Sets parameters for the potential of a particular dihedral type and updates the
     parameters on the GPU.
 */
-void HarmonicDihedralForceComputeGPU::setParams(unsigned int type, Scalar K, int sign, unsigned int multiplicity)
+void HarmonicDihedralForceComputeGPU::setParams(unsigned int type, Scalar K, int sign, unsigned int multiplicity, Scalar p_0)
     {
-    HarmonicDihedralForceCompute::setParams(type, K, sign, multiplicity);
+    HarmonicDihedralForceCompute::setParams(type, K, sign, multiplicity, p_0);
 
     ArrayHandle<Scalar4> h_params(m_params, access_location::host, access_mode::readwrite);
     // update the local copy of the memory

--- a/hoomd/md/HarmonicDihedralForceComputeGPU.cc
+++ b/hoomd/md/HarmonicDihedralForceComputeGPU.cc
@@ -53,7 +53,7 @@ void HarmonicDihedralForceComputeGPU::setParams(unsigned int type, Scalar K, int
 
     ArrayHandle<Scalar4> h_params(m_params, access_location::host, access_mode::readwrite);
     // update the local copy of the memory
-    h_params.data[type] = make_scalar4(Scalar(K), Scalar(sign), Scalar(multiplicity), Scalar(0.0));
+    h_params.data[type] = make_scalar4(Scalar(K), Scalar(sign), Scalar(multiplicity), Scalar(p_0));
     }
 
 /*! Internal method for computing the forces on the GPU.

--- a/hoomd/md/HarmonicDihedralForceComputeGPU.h
+++ b/hoomd/md/HarmonicDihedralForceComputeGPU.h
@@ -49,7 +49,7 @@ class PYBIND11_EXPORT HarmonicDihedralForceComputeGPU : public HarmonicDihedralF
             }
 
         //! Set the parameters
-        virtual void setParams(unsigned int type, Scalar K, int sign, unsigned int multiplicity);
+        virtual void setParams(unsigned int type, Scalar K, int sign, unsigned int multiplicity, Scalar p_0);
 
     protected:
         std::unique_ptr<Autotuner> m_tuner; //!< Autotuner for block size

--- a/hoomd/md/HarmonicDihedralForceComputeGPU.h
+++ b/hoomd/md/HarmonicDihedralForceComputeGPU.h
@@ -49,7 +49,7 @@ class PYBIND11_EXPORT HarmonicDihedralForceComputeGPU : public HarmonicDihedralF
             }
 
         //! Set the parameters
-        virtual void setParams(unsigned int type, Scalar K, int sign, unsigned int multiplicity, Scalar p_0);
+        virtual void setParams(unsigned int type, Scalar K, int sign, unsigned int multiplicity, Scalar phi_0);
 
     protected:
         std::unique_ptr<Autotuner> m_tuner; //!< Autotuner for block size

--- a/hoomd/md/HarmonicDihedralForceGPU.cu
+++ b/hoomd/md/HarmonicDihedralForceGPU.cu
@@ -180,13 +180,15 @@ void gpu_compute_harmonic_dihedral_forces_kernel(Scalar4* d_force,
 
 /////////////////////////
 // FROM LAMMPS: sin_shift is always 0... so dropping all sin_shift terms!!!!
-// Adding charmm dihedral functionality, sin_shift not always 0
+// Adding charmm dihedral functionality, sin_shift not always 0,
+// cos_shift not always 1
 /////////////////////////
         Scalar sin_phi_0 = fast::sin(phi_0);
+        Scalar cos_phi_0 = fast::cos(phi_0);
+        p = p*cos_phi_0 + dfab*sin_phi_0
         p *= sign;
-        p += dfab * sin_phi_0;
+        dfab = dfab*cos_phi_0 - ddfab*sin_phi_0;
         dfab *= sign;
-        dfab -= ddfab * sin_phi_0;
         dfab *= -multi;
         p += Scalar(1.0);
 

--- a/hoomd/md/HarmonicDihedralForceGPU.cu
+++ b/hoomd/md/HarmonicDihedralForceGPU.cu
@@ -138,7 +138,7 @@ void gpu_compute_harmonic_dihedral_forces_kernel(Scalar4* d_force,
         Scalar K = params.x;
         Scalar sign = params.y;
         Scalar multi = params.z;
-        Scalar p_0 = params.w;
+        Scalar phi_0 = params.w;
 
         Scalar aax = dab.y*dcbm.z - dab.z*dcbm.y;
         Scalar aay = dab.z*dcbm.x - dab.x*dcbm.z;
@@ -183,9 +183,9 @@ void gpu_compute_harmonic_dihedral_forces_kernel(Scalar4* d_force,
 // Adding charmm dihedral functionality, sin_shift not always 0
 /////////////////////////
         p *= sign;
-        p += dfab * fast::sin(p_0);
+        p += dfab * fast::sin(phi_0);
         dfab *= sign;
-        dfab -= ddfab * fast::sin(p_0);
+        dfab -= ddfab * fast::sin(phi_0);
         dfab *= -multi;
         p += Scalar(1.0);
 

--- a/hoomd/md/HarmonicDihedralForceGPU.cu
+++ b/hoomd/md/HarmonicDihedralForceGPU.cu
@@ -185,7 +185,7 @@ void gpu_compute_harmonic_dihedral_forces_kernel(Scalar4* d_force,
 /////////////////////////
         Scalar sin_phi_0 = fast::sin(phi_0);
         Scalar cos_phi_0 = fast::cos(phi_0);
-        p = p*cos_phi_0 + dfab*sin_phi_0
+        p = p*cos_phi_0 + dfab*sin_phi_0;
         p *= sign;
         dfab = dfab*cos_phi_0 - ddfab*sin_phi_0;
         dfab *= sign;

--- a/hoomd/md/HarmonicDihedralForceGPU.cu
+++ b/hoomd/md/HarmonicDihedralForceGPU.cu
@@ -183,9 +183,9 @@ void gpu_compute_harmonic_dihedral_forces_kernel(Scalar4* d_force,
 // Adding charmm dihedral functionality, sin_shift not always 0
 /////////////////////////
         p *= sign;
-        p += dfab*sin(p_0);
+        p += dfab * fast::sin(p_0);
         dfab *= sign;
-        dfab -= ddfab*sin(p_0);
+        dfab -= ddfab * fast::sin(p_0);
         dfab *= -multi;
         p += Scalar(1.0);
 

--- a/hoomd/md/HarmonicDihedralForceGPU.cu
+++ b/hoomd/md/HarmonicDihedralForceGPU.cu
@@ -182,10 +182,11 @@ void gpu_compute_harmonic_dihedral_forces_kernel(Scalar4* d_force,
 // FROM LAMMPS: sin_shift is always 0... so dropping all sin_shift terms!!!!
 // Adding charmm dihedral functionality, sin_shift not always 0
 /////////////////////////
+        Scalar sin_phi_0 = fast::sin(phi_0);
         p *= sign;
-        p += dfab * fast::sin(phi_0);
+        p += dfab * sin_phi_0;
         dfab *= sign;
-        dfab -= ddfab * fast::sin(phi_0);
+        dfab -= ddfab * sin_phi_0;
         dfab *= -multi;
         p += Scalar(1.0);
 

--- a/hoomd/md/HarmonicDihedralForceGPU.cu
+++ b/hoomd/md/HarmonicDihedralForceGPU.cu
@@ -138,6 +138,7 @@ void gpu_compute_harmonic_dihedral_forces_kernel(Scalar4* d_force,
         Scalar K = params.x;
         Scalar sign = params.y;
         Scalar multi = params.z;
+        Scalar p_0 = params.w;
 
         Scalar aax = dab.y*dcbm.z - dab.z*dcbm.y;
         Scalar aay = dab.z*dcbm.x - dab.x*dcbm.z;
@@ -179,9 +180,12 @@ void gpu_compute_harmonic_dihedral_forces_kernel(Scalar4* d_force,
 
 /////////////////////////
 // FROM LAMMPS: sin_shift is always 0... so dropping all sin_shift terms!!!!
+// Adding charmm dihedral functionality, sin_shift not always 0
 /////////////////////////
         p *= sign;
+        p += dfab*sin(p_0);
         dfab *= sign;
+        dfab -= ddfab*sin(p_0);
         dfab *= -multi;
         p += Scalar(1.0);
 

--- a/hoomd/md/HarmonicDihedralForceGPU.cuh
+++ b/hoomd/md/HarmonicDihedralForceGPU.cuh
@@ -26,7 +26,7 @@ cudaError_t gpu_compute_harmonic_dihedral_forces(Scalar4* d_force,
                                                  const unsigned int *dihedral_ABCD,
                                                  const unsigned int pitch,
                                                  const unsigned int *n_dihedrals_list,
-                                                 Scalar4 *d_params,
+                                                 Scalar5 *d_params,
                                                  unsigned int n_dihedral_types,
                                                  int block_size);
 

--- a/hoomd/md/HarmonicDihedralForceGPU.cuh
+++ b/hoomd/md/HarmonicDihedralForceGPU.cuh
@@ -26,7 +26,7 @@ cudaError_t gpu_compute_harmonic_dihedral_forces(Scalar4* d_force,
                                                  const unsigned int *dihedral_ABCD,
                                                  const unsigned int pitch,
                                                  const unsigned int *n_dihedrals_list,
-                                                 Scalar5 *d_params,
+                                                 Scalar4 *d_params,
                                                  unsigned int n_dihedral_types,
                                                  int block_size);
 

--- a/hoomd/md/dihedral.py
+++ b/hoomd/md/dihedral.py
@@ -220,15 +220,15 @@ class harmonic(force._force):
     - :math:`k` - strength of force (in energy units)
     - :math:`d` - sign factor (unitless)
     - :math:`n` - angle scaling factor (unitless)
-    - :math:`\phi_0` - rest angle  ``phi_0`` (in radians)
+    - :math:`\phi_0` - phase shift  ``phi_0`` (in radians) - *optional*: defaults to 0.0
 
     Coefficients :math:`k`, :math:`d`, :math:`n` must be set for each type of dihedral in the simulation using
     :py:meth:`dihedral_coeff.set() <coeff.set()>`.
 
     Examples::
 
-        harmonic.dihedral_coeff.set('phi-ang', k=30.0, d=-1, n=3, phi_0=0)
-        harmonic.dihedral_coeff.set('psi-ang', k=100.0, d=1, n=4, phi_0=3.14)
+        harmonic.dihedral_coeff.set('phi-ang', k=30.0, d=-1, n=3)
+        harmonic.dihedral_coeff.set('psi-ang', k=100.0, d=1, n=4, phi_0=math.pi/2)
     """
     def __init__(self):
         hoomd.util.print_status_line();

--- a/hoomd/md/dihedral.py
+++ b/hoomd/md/dihedral.py
@@ -211,7 +211,7 @@ class harmonic(force._force):
 
     .. math::
 
-        V(r) = \frac{1}{2}k \left( 1 + d \cos\left(n * \phi(r) \right) \right)
+        V(r) = \frac{1}{2}k \left( 1 + d \cos\left(n * \phi(r) - \phi_0 \right) \right)
 
     where :math:`\phi` is angle between two sides of the dihedral.
 
@@ -220,14 +220,15 @@ class harmonic(force._force):
     - :math:`k` - strength of force (in energy units)
     - :math:`d` - sign factor (unitless)
     - :math:`n` - angle scaling factor (unitless)
+    - :math:`\phi_0` - rest angle  ``p0`` (in radians)
 
     Coefficients :math:`k`, :math:`d`, :math:`n` must be set for each type of dihedral in the simulation using
     :py:meth:`dihedral_coeff.set() <coeff.set()>`.
 
     Examples::
 
-        harmonic.dihedral_coeff.set('phi-ang', k=30.0, d=-1, n=3)
-        harmonic.dihedral_coeff.set('psi-ang', k=100.0, d=1, n=4)
+        harmonic.dihedral_coeff.set('phi-ang', k=30.0, d=-1, n=3, p0=0)
+        harmonic.dihedral_coeff.set('psi-ang', k=100.0, d=1, n=4, p0=3.14)
     """
     def __init__(self):
         hoomd.util.print_status_line();
@@ -249,7 +250,7 @@ class harmonic(force._force):
 
         hoomd.context.current.system.addCompute(self.cpp_force, self.force_name);
 
-        self.required_coeffs = ['k', 'd', 'n'];
+        self.required_coeffs = ['k', 'd', 'n', 'p0'];
 
     ## \internal
     # \brief Update coefficients in C++

--- a/hoomd/md/dihedral.py
+++ b/hoomd/md/dihedral.py
@@ -220,15 +220,15 @@ class harmonic(force._force):
     - :math:`k` - strength of force (in energy units)
     - :math:`d` - sign factor (unitless)
     - :math:`n` - angle scaling factor (unitless)
-    - :math:`\phi_0` - rest angle  ``p0`` (in radians)
+    - :math:`\phi_0` - rest angle  ``phi_0`` (in radians)
 
     Coefficients :math:`k`, :math:`d`, :math:`n` must be set for each type of dihedral in the simulation using
     :py:meth:`dihedral_coeff.set() <coeff.set()>`.
 
     Examples::
 
-        harmonic.dihedral_coeff.set('phi-ang', k=30.0, d=-1, n=3, p0=0)
-        harmonic.dihedral_coeff.set('psi-ang', k=100.0, d=1, n=4, p0=3.14)
+        harmonic.dihedral_coeff.set('phi-ang', k=30.0, d=-1, n=3, phi_0=0)
+        harmonic.dihedral_coeff.set('psi-ang', k=100.0, d=1, n=4, phi_0=3.14)
     """
     def __init__(self):
         hoomd.util.print_status_line();
@@ -250,7 +250,8 @@ class harmonic(force._force):
 
         hoomd.context.current.system.addCompute(self.cpp_force, self.force_name);
 
-        self.required_coeffs = ['k', 'd', 'n', 'p0'];
+        self.required_coeffs = ['k', 'd', 'n', 'phi_0'];
+        self.dihedral_coeff.set_default_coeff('phi_0', 0.0);
 
     ## \internal
     # \brief Update coefficients in C++
@@ -273,7 +274,7 @@ class harmonic(force._force):
             for name in coeff_list:
                 coeff_dict[name] = self.dihedral_coeff.get(type_list[i], name);
 
-            self.cpp_force.setParams(i, coeff_dict['k'], coeff_dict['d'], coeff_dict['n']);
+            self.cpp_force.setParams(i, coeff_dict['k'], coeff_dict['d'], coeff_dict['n'], coeff_dict['phi_0']);
 
     ## \internal
     # \brief Get metadata

--- a/hoomd/md/test-py/test_dihedral_harmonic.py
+++ b/hoomd/md/test-py/test_dihedral_harmonic.py
@@ -45,7 +45,16 @@ class dihedral_harmonic_tests (unittest.TestCase):
     # test setting coefficients
     def test_set_coeff(self):
         harmonic = md.dihedral.harmonic();
-        harmonic.dihedral_coeff.set('dihedralA', k=1.0, d=1, n=4, p0=0)
+        harmonic.dihedral_coeff.set('dihedralA', k=1.0, d=1, n=4, phi_0=0)
+        all = group.all();
+        md.integrate.mode_standard(dt=0.005);
+        md.integrate.nve(all);
+        run(100);
+        
+    # test setting coefficients with default phi_0
+    def test_set_coeff_default(self):
+        harmonic = md.dihedral.harmonic();
+        harmonic.dihedral_coeff.set('dihedralA', k=1.0, d=1, n=4)
         all = group.all();
         md.integrate.mode_standard(dt=0.005);
         md.integrate.nve(all);

--- a/hoomd/md/test-py/test_dihedral_harmonic.py
+++ b/hoomd/md/test-py/test_dihedral_harmonic.py
@@ -45,7 +45,7 @@ class dihedral_harmonic_tests (unittest.TestCase):
     # test setting coefficients
     def test_set_coeff(self):
         harmonic = md.dihedral.harmonic();
-        harmonic.dihedral_coeff.set('dihedralA', k=1.0, d=1, n=4)
+        harmonic.dihedral_coeff.set('dihedralA', k=1.0, d=1, n=4, p0=0)
         all = group.all();
         md.integrate.mode_standard(dt=0.005);
         md.integrate.nve(all);

--- a/hoomd/md/test/test_harmonic_dihedral_force.cc
+++ b/hoomd/md/test/test_harmonic_dihedral_force.cc
@@ -52,7 +52,7 @@ void dihedral_force_basic_tests(dihedralforce_creator tf_creator, std::shared_pt
 
     // create the dihedral force compute to check
     std::shared_ptr<HarmonicDihedralForceCompute> fc_4 = tf_creator(sysdef_4);
-    fc_4->setParams(0, Scalar(30.0), -1, 3); // type=0, K=30.0,sign=-1,multiplicity=3
+    fc_4->setParams(0, Scalar(30.0), -1, 3, Scalar(0)); // type=0, K=30.0,sign=-1,multiplicity=3, phaseoffset=0
 
     // compute the force and check the results
     fc_4->compute(0);
@@ -199,8 +199,8 @@ void dihedral_force_basic_tests(dihedralforce_creator tf_creator, std::shared_pt
     }
 
     std::shared_ptr<HarmonicDihedralForceCompute> fc_8 = tf_creator(sysdef_8);
-    fc_8->setParams(0, 50.0, -1, 3);
-    fc_8->setParams(1, 30.0,  1, 4);
+    fc_8->setParams(0, 50.0, -1, 3, 0.0);
+    fc_8->setParams(1, 30.0,  1, 4, 0.0);
 
     sysdef_8->getDihedralData()->addBondedGroup(Dihedral(0, 0,1,2,3));
     sysdef_8->getDihedralData()->addBondedGroup(Dihedral(1, 4,5,6,7));
@@ -309,7 +309,7 @@ void dihedral_force_basic_tests(dihedralforce_creator tf_creator, std::shared_pt
 
     // build the dihedral force compute and try it out
     std::shared_ptr<HarmonicDihedralForceCompute> fc_5 = tf_creator(sysdef_5);
-    fc_5->setParams(0, 15.0, -1, 4);
+    fc_5->setParams(0, 15.0, -1, 4, 0.0);
 
     sysdef_5->getDihedralData()->addBondedGroup(Dihedral(0, 0,1,2,3));
     sysdef_5->getDihedralData()->addBondedGroup(Dihedral(0, 1,2,3,4));
@@ -381,8 +381,8 @@ void dihedral_force_comparison_tests(dihedralforce_creator tf_creator1,
 
     std::shared_ptr<HarmonicDihedralForceCompute> fc1 = tf_creator1(sysdef);
     std::shared_ptr<HarmonicDihedralForceCompute> fc2 = tf_creator2(sysdef);
-    fc1->setParams(0, Scalar(3.0), -1, 3);
-    fc2->setParams(0, Scalar(3.0), -1, 3);
+    fc1->setParams(0, Scalar(3.0), -1, 3, Scalar(0.0));
+    fc2->setParams(0, Scalar(3.0), -1, 3, Scalar(0.0));
 
     // add dihedrals
     for (unsigned int i = 0; i < N-3; i++)

--- a/hoomd/md/test/test_harmonic_dihedral_force.cc
+++ b/hoomd/md/test/test_harmonic_dihedral_force.cc
@@ -365,6 +365,107 @@ void dihedral_force_basic_tests(dihedralforce_creator tf_creator, std::shared_pt
     }
     }
 
+//! Perform tests for harmonic dihedrals with phase shift
+void dihedral_force_phase_shift(dihedralforce_creator tf_creator, std::shared_ptr<ExecutionConfiguration> exec_conf)
+    {
+    /////////////////////////////////////////////////////////
+    // start with the simplest possible test: 4 particles in a huge box with only one dihedral type !!!! NO DIHEDRALS
+    std::shared_ptr<SystemDefinition> sysdef_4(new SystemDefinition(4, BoxDim(1000.0), 1, 0, 0, 1, 0, exec_conf));
+    std::shared_ptr<ParticleData> pdata_4 = sysdef_4->getParticleData();
+
+    pdata_4->setPosition(0,make_scalar3(0.0,1.0,0.0));
+    pdata_4->setPosition(1,make_scalar3(0.0,0.0,0.0));
+    pdata_4->setPosition(2,make_scalar3(1.0,0.0,0.0));
+    pdata_4->setPosition(3,make_scalar3(0.0,0.0,1.0));
+
+    // create the dihedral force compute to check
+    std::shared_ptr<HarmonicDihedralForceCompute> fc_4 = tf_creator(sysdef_4);
+    fc_4->setParams(0, Scalar(10.0), 1, 1, Scalar(0.5*M_PI)); // type=0, K=30.0,sign=-1,multiplicity=3, phaseoffset=0, i think the ref angle is 0.240454
+
+    // compute the force and check the results
+    fc_4->compute(0);
+
+    {
+    GlobalArray<Scalar4>& force_array_1 =  fc_4->getForceArray();
+    GlobalArray<Scalar>& virial_array_1 =  fc_4->getVirialArray();
+
+    ArrayHandle<Scalar4> h_force_1(force_array_1,access_location::host,access_mode::read);
+    ArrayHandle<Scalar> h_virial_1(virial_array_1,access_location::host,access_mode::read);
+
+    unsigned int pitch = 0;
+    // check that the force is correct, it should be 0 since we haven't created any dihedrals yet
+    MY_CHECK_SMALL(h_force_1.data[0].x, tol);
+    MY_CHECK_SMALL(h_force_1.data[0].y, tol);
+    MY_CHECK_SMALL(h_force_1.data[0].z, tol);
+    MY_CHECK_SMALL(h_force_1.data[0].w, tol);
+    MY_CHECK_SMALL(h_virial_1.data[0*pitch], tol);
+    MY_CHECK_SMALL(h_virial_1.data[1*pitch], tol);
+    MY_CHECK_SMALL(h_virial_1.data[2*pitch], tol);
+    MY_CHECK_SMALL(h_virial_1.data[3*pitch], tol);
+    MY_CHECK_SMALL(h_virial_1.data[4*pitch], tol);
+    MY_CHECK_SMALL(h_virial_1.data[5*pitch], tol);
+    }
+
+
+    // add dihedral 
+    sysdef_4->getDihedralData()->addBondedGroup(Dihedral(0,0,1,2,3)); // add type 0 dihedral between atoms 0-1-2-3
+    fc_4->compute(1);
+
+    {
+    // this time there should be a force (but they're 0 because eq)
+    GlobalArray<Scalar4>& force_array_2 =  fc_4->getForceArray();
+    GlobalArray<Scalar>& virial_array_2 =  fc_4->getVirialArray();
+    unsigned int pitch = virial_array_2.getPitch();
+    ArrayHandle<Scalar4> h_force_2(force_array_2,access_location::host,access_mode::read);
+    ArrayHandle<Scalar> h_virial_2(virial_array_2,access_location::host,access_mode::read);
+    /*
+    printf(" Particle 1: x = %f  y = %f  z = %f w = %f \n", h_force_2.data[0].x, h_force_2.data[0].y, h_force_2.data[0].z, h_force_2.data[0].w);
+    printf(" Particle 2: x = %f  y = %f  z = %f w = %f \n", h_force_2.data[1].x, h_force_2.data[1].y, h_force_2.data[1].z, h_force_2.data[1].w);
+    printf(" Particle 3: x = %f  y = %f  z = %f w = %f \n", h_force_2.data[2].x, h_force_2.data[2].y, h_force_2.data[2].z, h_force_2.data[2].w);
+    printf(" Particle 4: x = %f  y = %f  z = %f w = %f \n", h_force_2.data[3].x, h_force_2.data[3].y, h_force_2.data[3].z, h_force_2.data[3].w);
+    printf( "Virial: %f %f %f %f %f %f \n", h_virial_2.data[0*pitch], h_virial_2.data[1*pitch], h_virial_2.data[2*pitch], h_virial_2.data[3*pitch], h_virial_2.data[4*pitch], h_virial_2.data[5*pitch]);
+    printf("\n");
+    */
+
+
+    MY_CHECK_SMALL(h_force_2.data[0].x, tol);
+    MY_CHECK_SMALL(h_force_2.data[0].y, tol);
+    MY_CHECK_SMALL(h_force_2.data[0].z, tol);
+    MY_CHECK_CLOSE(h_force_2.data[0].w, 2.5, tol);
+    MY_CHECK_SMALL(h_virial_2.data[0*pitch+0]
+                        +h_virial_2.data[3*pitch+0]
+                        +h_virial_2.data[5*pitch+0], tol);
+
+    MY_CHECK_SMALL(h_force_2.data[1].x, tol);
+    MY_CHECK_SMALL(h_force_2.data[1].y, tol);
+    MY_CHECK_SMALL(h_force_2.data[1].z, tol);
+    MY_CHECK_CLOSE(h_force_2.data[1].w, 2.5, tol);
+    MY_CHECK_SMALL(h_virial_2.data[0*pitch+1]
+                        +h_virial_2.data[3*pitch+1]
+                        +h_virial_2.data[5*pitch+1], tol);
+
+    MY_CHECK_SMALL(h_force_2.data[2].x, tol);
+    MY_CHECK_SMALL(h_force_2.data[2].y, tol);
+    MY_CHECK_SMALL(h_force_2.data[2].z, tol);
+    MY_CHECK_CLOSE(h_force_2.data[2].w, 2.5, tol);
+    MY_CHECK_SMALL(h_virial_2.data[0*pitch+2]
+                        +h_virial_2.data[3*pitch+2]
+                        +h_virial_2.data[5*pitch+2], tol);
+
+    MY_CHECK_SMALL(h_force_2.data[3].x, tol);
+    MY_CHECK_SMALL(h_force_2.data[3].y, tol);
+    MY_CHECK_SMALL(h_force_2.data[3].z, tol);
+    MY_CHECK_CLOSE(h_force_2.data[3].w, 2.5, tol);
+    MY_CHECK_SMALL(h_virial_2.data[0*pitch+3]
+                        +h_virial_2.data[3*pitch+3]
+                        +h_virial_2.data[5*pitch+3], tol);
+    }
+
+    
+    }
+
+    
+
 //! Compares the output of two HarmonicDihedralForceComputes
 void dihedral_force_comparison_tests(dihedralforce_creator tf_creator1,
                                      dihedralforce_creator tf_creator2,
@@ -440,6 +541,7 @@ void dihedral_force_comparison_tests(dihedralforce_creator tf_creator1,
     }
     }
 
+
 //! HarmonicDihedralForceCompute creator for dihedral_force_basic_tests()
 std::shared_ptr<HarmonicDihedralForceCompute> base_class_tf_creator(std::shared_ptr<SystemDefinition> sysdef)
     {
@@ -460,6 +562,7 @@ UP_TEST( HarmonicDihedralForceCompute_basic )
     printf(" IN UP_TEST: CPU \n");
     dihedralforce_creator tf_creator = bind(base_class_tf_creator, _1);
     dihedral_force_basic_tests(tf_creator, std::shared_ptr<ExecutionConfiguration>(new ExecutionConfiguration(ExecutionConfiguration::CPU)));
+    dihedral_force_phase_shift(tf_creator, std::shared_ptr<ExecutionConfiguration>(new ExecutionConfiguration(ExecutionConfiguration::CPU)));
     }
 
 #ifdef ENABLE_CUDA
@@ -469,6 +572,7 @@ UP_TEST( HarmonicDihedralForceComputeGPU_basic )
     printf(" IN UP_TEST: GPU \n");
     dihedralforce_creator tf_creator = bind(gpu_tf_creator, _1);
     dihedral_force_basic_tests(tf_creator, std::shared_ptr<ExecutionConfiguration>(new ExecutionConfiguration(ExecutionConfiguration::GPU)));
+    dihedral_force_phase_shift(tf_creator, std::shared_ptr<ExecutionConfiguration>(new ExecutionConfiguration(ExecutionConfiguration::GPU)));
     }
 
 //! test case for comparing bond GPU and CPU BondForceComputes

--- a/sphinx-doc/credits.rst
+++ b/sphinx-doc/credits.rst
@@ -281,6 +281,11 @@ Luis Rivera-Rivera, University of Michigan
 
   * ``hoomd.dump.gsd.dump_shape`` implementation
 
+
+Alex Yang, Vanderbilt University
+
+  * ``hoomd.md.dihedral.harmonic`` update for phase shift
+
 HPMC developers
 ---------------
 


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should based on *maint*. -->
<!-- New features should based on *master*. -->

## Description

<!-- Describe your changes in detail. -->
Implementing [charmm (periodic) dihedrals](https://lammps.sandia.gov/doc/dihedral_charmm.html)
## Motivation and Context
For implementing some atomistic force fields, these types of dihedrals are needed
<!--- Why is this change required? What problem does it solve? -->

<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves: #491 

## How Has This Been Tested?
Updating some of the existing `hoomd.md.dihedral.harmonic` tests to account for the additional phase offset coefficient
<!--- Please describe in detail how you tested your changes. -->

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
* The `hoomd.md.dihedral.harmonic` now accepts phase offsets, p0, for CHARMM-style periodic dihedrals
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/hoomd-blue/blob/master/sphinx-doc/credits.rst).
