### PR TITLE
Feature/per type shape

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -30,6 +30,7 @@ Paul Dodd <pdodd@umich.edu> Paul M Dodd <Paul@host-112.subnet-108.med.umich.edu>
 Paul Dodd <pdodd@umich.edu> Paul M Dodd <Paul@host-226.subnet-108.med.umich.edu>
 Vyas Ramasubramani <vramasub@umich.edu> Vyas <vramasub@umich.edu>
 Vyas Ramasubramani <vramasub@umich.edu> vramasub <vramasub@umich.edu>
+Vyas Ramasubramani <vramasub@umich.edu> Vyas Ramasubramani <vyas.ramasubramani@gmail.com>
 Alex Travesset <trvsst@ameslab.gov>
 Benjamin Schultz <baschult@umich.edu> Benjamin Schultz <benjamin.a.schultz@gmail.com>
 Bradley Dice <bdice@bradleydice.com>

--- a/hoomd/md/AllDriverAnisoPotentialPairGPU.cu
+++ b/hoomd/md/AllDriverAnisoPotentialPairGPU.cu
@@ -11,13 +11,15 @@
 */
 
 cudaError_t gpu_compute_pair_aniso_forces_gb(const a_pair_args_t& pair_args,
-            const EvaluatorPairGB::param_type* d_param)
+            const EvaluatorPairGB::param_type* d_param,
+            const EvaluatorPairGB::shape_param_type* d_shape_param)
     {
-    return gpu_compute_pair_aniso_forces<EvaluatorPairGB>(pair_args, d_param);
+    return gpu_compute_pair_aniso_forces<EvaluatorPairGB>(pair_args, d_param, d_shape_param);
     }
 
 cudaError_t gpu_compute_pair_aniso_forces_dipole(const a_pair_args_t& pair_args,
-            const EvaluatorPairDipole::param_type* d_param)
+            const EvaluatorPairDipole::param_type* d_param,
+            const EvaluatorPairDipole::shape_param_type* d_shape_param)
     {
-    return gpu_compute_pair_aniso_forces<EvaluatorPairDipole>(pair_args, d_param);
+    return gpu_compute_pair_aniso_forces<EvaluatorPairDipole>(pair_args, d_param, d_shape_param);
     }

--- a/hoomd/md/AllDriverAnisoPotentialPairGPU.cuh
+++ b/hoomd/md/AllDriverAnisoPotentialPairGPU.cuh
@@ -18,9 +18,11 @@
 //! Compute dipole forces and torques on the GPU with EvaluatorPairDipole
 
 cudaError_t gpu_compute_pair_aniso_forces_gb(const a_pair_args_t&,
-            const EvaluatorPairGB::param_type*);
+            const EvaluatorPairGB::param_type*,
+            const EvaluatorPairGB::shape_param_type*);
 
 cudaError_t gpu_compute_pair_aniso_forces_dipole(const a_pair_args_t&,
-            const EvaluatorPairDipole::param_type*);
+            const EvaluatorPairDipole::param_type*,
+            const EvaluatorPairDipole::shape_param_type*);
 
 #endif

--- a/hoomd/md/AnisoPotentialPair.h
+++ b/hoomd/md/AnisoPotentialPair.h
@@ -445,16 +445,10 @@ void AnisoPotentialPair< aniso_evaluator >::computeForces(unsigned int timestep)
         // access diameter and charge (if needed)
         Scalar di = Scalar(0.0);
         Scalar qi = Scalar(0.0);
-        const shape_param_type *shape_i;
-        unsigned int tag_i = 0;
         if (aniso_evaluator::needsDiameter())
             di = h_diameter.data[i];
         if (aniso_evaluator::needsCharge())
             qi = h_charge.data[i];
-        if (aniso_evaluator::needsShape())
-            shape_i = &h_shape_params.data[typei];
-        if (aniso_evaluator::needsTags())
-            tag_i = h_tag.data[i];
 
         // initialize current particle force, torque, potential energy, and virial to 0
         Scalar fxi = Scalar(0.0);
@@ -492,16 +486,10 @@ void AnisoPotentialPair< aniso_evaluator >::computeForces(unsigned int timestep)
             // access diameter and charge (if needed)
             Scalar dj = Scalar(0.0);
             Scalar qj = Scalar(0.0);
-            const shape_param_type *shape_j;
-            unsigned int tag_j = 0;
             if (aniso_evaluator::needsDiameter())
                 dj = h_diameter.data[j];
             if (aniso_evaluator::needsCharge())
                 qj = h_charge.data[j];
-            if (aniso_evaluator::needsShape())
-                shape_j = &h_shape_params.data[typej];
-            if (aniso_evaluator::needsTags())
-                tag_j = h_tag.data[j];
 
             // apply periodic boundary conditions
             dx = box.minImage(dx);
@@ -531,9 +519,9 @@ void AnisoPotentialPair< aniso_evaluator >::computeForces(unsigned int timestep)
             if (aniso_evaluator::needsCharge())
                 eval.setCharge(qi, qj);
             if (aniso_evaluator::needsShape())
-                eval.setShape(shape_i, shape_j);
+                eval.setShape(&h_shape_params.data[typei], &h_shape_params.data[typej]);
             if (aniso_evaluator::needsTags())
-                eval.setTags(tag_i, tag_j);
+                eval.setTags(h_tag.data[i], h_tag.data[j]);
 
             bool evaluated = eval.evaluate(force, pair_eng, energy_shift,torque_i,torque_j);
 

--- a/hoomd/md/AnisoPotentialPair.h
+++ b/hoomd/md/AnisoPotentialPair.h
@@ -116,9 +116,9 @@ class AnisoPotentialPair : public ForceCompute
                 {
                 aniso_evaluator evaluator(dr,q,q,rcut,h_params.data[m_typpair_idx(i,i)]);
                 if (aniso_evaluator::needsShape())
-                {
+                    {
                     evaluator.setShape(&h_shape_params.data[i], &h_shape_params.data[i]);
-                }
+                    }
                 type_shape_mapping[i] = evaluator.getShapeSpec();
                 }
             return type_shape_mapping;

--- a/hoomd/md/AnisoPotentialPair.h
+++ b/hoomd/md/AnisoPotentialPair.h
@@ -183,12 +183,15 @@ class AnisoPotentialPair : public ForceCompute
             m_rcutsq.swap(rcutsq);
             GlobalArray<param_type> params(m_typpair_idx.getNumElements(), m_exec_conf, "my_params", true);
             m_params.swap(params);
+            GlobalArray<shape_param_type> shape_params(m_pdata->getNTypes(), m_exec_conf, "shape_params", true);
+            m_shape_params.swap(shape_params);
 
             #ifdef ENABLE_CUDA
             if (m_pdata->getExecConf()->isCUDAEnabled() && m_exec_conf->allConcurrentManagedAccess())
                 {
                 cudaMemAdvise(m_rcutsq.get(), m_rcutsq.getNumElements()*sizeof(Scalar), cudaMemAdviseSetReadMostly, 0);
                 cudaMemAdvise(m_params.get(), m_params.getNumElements()*sizeof(param_type), cudaMemAdviseSetReadMostly, 0);
+                cudaMemAdvise(m_shape_params.get(), m_shape_params.getNumElements()*sizeof(param_type), cudaMemAdviseSetReadMostly, 0);
 
                 // prefetch
                 auto& gpu_map = m_exec_conf->getGPUIds();
@@ -198,6 +201,7 @@ class AnisoPotentialPair : public ForceCompute
                     // prefetch data on all GPUs
                     cudaMemPrefetchAsync(m_rcutsq.get(), sizeof(Scalar)*m_rcutsq.getNumElements(), gpu_map[idev]);
                     cudaMemPrefetchAsync(m_params.get(), sizeof(param_type)*m_params.getNumElements(), gpu_map[idev]);
+                    cudaMemPrefetchAsync(m_shape_params.get(), sizeof(param_type)*m_shape_params.getNumElements(), gpu_map[idev]);
                     }
                 CHECK_CUDA_ERROR();
                 }

--- a/hoomd/md/AnisoPotentialPair.h
+++ b/hoomd/md/AnisoPotentialPair.h
@@ -405,6 +405,7 @@ void AnisoPotentialPair< aniso_evaluator >::computeForces(unsigned int timestep)
     ArrayHandle<Scalar> h_diameter(m_pdata->getDiameters(), access_location::host, access_mode::read);
     ArrayHandle<Scalar> h_charge(m_pdata->getCharges(), access_location::host, access_mode::read);
     ArrayHandle<Scalar4> h_orientation(m_pdata->getOrientationArray(), access_location::host,access_mode::read);
+    ArrayHandle<unsigned int> h_tag(m_pdata->getTags(), access_location::host, access_mode::read);
 
     //force arrays
     ArrayHandle<Scalar4> h_force(m_force,access_location::host, access_mode::overwrite);
@@ -440,12 +441,15 @@ void AnisoPotentialPair< aniso_evaluator >::computeForces(unsigned int timestep)
         Scalar di = Scalar(0.0);
         Scalar qi = Scalar(0.0);
         const shape_param_type *shape_i;
+        unsigned int tag_i = 0;
         if (aniso_evaluator::needsDiameter())
             di = h_diameter.data[i];
         if (aniso_evaluator::needsCharge())
             qi = h_charge.data[i];
         if (aniso_evaluator::needsShape())
             shape_i = &h_shape_params.data[typei];
+        if (aniso_evaluator::needsTags())
+            tag_i = h_tag.data[i];
 
         // initialize current particle force, torque, potential energy, and virial to 0
         Scalar fxi = Scalar(0.0);
@@ -484,12 +488,15 @@ void AnisoPotentialPair< aniso_evaluator >::computeForces(unsigned int timestep)
             Scalar dj = Scalar(0.0);
             Scalar qj = Scalar(0.0);
             const shape_param_type *shape_j;
+            unsigned int tag_j = 0;
             if (aniso_evaluator::needsDiameter())
                 dj = h_diameter.data[j];
             if (aniso_evaluator::needsCharge())
                 qj = h_charge.data[j];
             if (aniso_evaluator::needsShape())
                 shape_j = &h_shape_params.data[typej];
+            if (aniso_evaluator::needsTags())
+                tag_j = h_tag.data[j];
 
             // apply periodic boundary conditions
             dx = box.minImage(dx);
@@ -520,6 +527,8 @@ void AnisoPotentialPair< aniso_evaluator >::computeForces(unsigned int timestep)
                 eval.setCharge(qi, qj);
             if (aniso_evaluator::needsShape())
                 eval.setShape(shape_i, shape_j);
+            if (aniso_evaluator::needsTags())
+                eval.setTags(tag_i, tag_j);
 
             bool evaluated = eval.evaluate(force, pair_eng, energy_shift,torque_i,torque_j);
 

--- a/hoomd/md/AnisoPotentialPair.h
+++ b/hoomd/md/AnisoPotentialPair.h
@@ -20,6 +20,9 @@
 #include "hoomd/ForceCompute.h"
 #include "hoomd/GSDShapeSpecWriter.h"
 
+#include "hoomd/ManagedArray.h"
+#include "hoomd/VectorMath.h"
+
 /*! \file AnisoPotentialPair.h
     \brief Defines the template class for anisotropic pair potentials
     \details The heart of the code that computes anisotropic pair potentials is in this file.
@@ -72,6 +75,9 @@ class AnisoPotentialPair : public ForceCompute
         //! Param type from aniso_evaluator
         typedef typename aniso_evaluator::param_type param_type;
 
+        //! Shape param type from aniso_evaluator
+        typedef typename aniso_evaluator::shape_param_type shape_param_type;
+
         //! Construct the pair potential
         AnisoPotentialPair(std::shared_ptr<SystemDefinition> sysdef,
                       std::shared_ptr<NeighborList> nlist,
@@ -89,6 +95,9 @@ class AnisoPotentialPair : public ForceCompute
 
         //! Method that is called to connect to the gsd write state signal
         void connectGSDShapeSpec(std::shared_ptr<GSDDumpWriter> writer);
+
+        //! Set the shape parameters for a single type
+        virtual void setShape(unsigned int typ, const shape_param_type& shape_param);
 
         //! Returns a list of log quantities this compute calculates
         virtual std::vector< std::string > getProvidedLogQuantities();
@@ -150,6 +159,7 @@ class AnisoPotentialPair : public ForceCompute
         Index2D m_typpair_idx;                      //!< Helper class for indexing per type pair arrays
         GlobalArray<Scalar> m_rcutsq;                  //!< Cutoff radius squared per type pair
         GlobalArray<param_type> m_params;   //!< Pair parameters per type pair
+        GlobalArray<shape_param_type> m_shape_params;   //!< Pair parameters per type pair
         std::string m_prof_name;                    //!< Cached profiler name
         std::string m_log_name;                     //!< Cached log name
 
@@ -232,12 +242,15 @@ AnisoPotentialPair< aniso_evaluator >::AnisoPotentialPair(std::shared_ptr<System
     m_rcutsq.swap(rcutsq);
     GlobalArray<param_type> params(m_typpair_idx.getNumElements(), m_exec_conf, "my_params", true);
     m_params.swap(params);
+    GlobalArray<shape_param_type> shape_params(m_pdata->getNTypes(), m_exec_conf, "shape_params", true);
+    m_shape_params.swap(shape_params);
 
     #ifdef ENABLE_CUDA
     if (m_exec_conf->isCUDAEnabled() && m_exec_conf->allConcurrentManagedAccess())
         {
         cudaMemAdvise(m_rcutsq.get(), m_rcutsq.getNumElements()*sizeof(Scalar), cudaMemAdviseSetReadMostly, 0);
         cudaMemAdvise(m_params.get(), m_params.getNumElements()*sizeof(param_type), cudaMemAdviseSetReadMostly, 0);
+        cudaMemAdvise(m_shape_params.get(), m_shape_params.getNumElements()*sizeof(shape_param_type), cudaMemAdviseSetReadMostly, 0);
 
         // prefetch
         auto& gpu_map = m_exec_conf->getGPUIds();
@@ -247,6 +260,7 @@ AnisoPotentialPair< aniso_evaluator >::AnisoPotentialPair(std::shared_ptr<System
             // prefetch data on all GPUs
             cudaMemPrefetchAsync(m_rcutsq.get(), sizeof(Scalar)*m_rcutsq.getNumElements(), gpu_map[idev]);
             cudaMemPrefetchAsync(m_params.get(), sizeof(param_type)*m_params.getNumElements(), gpu_map[idev]);
+            cudaMemPrefetchAsync(m_shape_params.get(), sizeof(shape_param_type)*m_shape_params.getNumElements(), gpu_map[idev]);
             }
         }
     #endif
@@ -289,6 +303,24 @@ void AnisoPotentialPair< aniso_evaluator >::setParams(unsigned int typ1, unsigne
     ArrayHandle<param_type> h_params(m_params, access_location::host, access_mode::readwrite);
     h_params.data[m_typpair_idx(typ1, typ2)] = param;
     h_params.data[m_typpair_idx(typ2, typ1)] = param;
+    }
+
+/*! \param typ The type index.
+    \param param Shape parameter to set
+          set.
+*/
+template< class aniso_evaluator >
+void AnisoPotentialPair< aniso_evaluator >::setShape(unsigned int typ, const shape_param_type& shape_param)
+    {
+    if (typ >= m_pdata->getNTypes())
+        {
+        m_exec_conf->msg->error() << "pair." << aniso_evaluator::getName() << ": Trying to set shape params for a non existent type! "
+                  << typ << std::endl;
+        throw std::runtime_error("Error setting shape parameters in AnisoPotentialPair");
+        }
+
+    ArrayHandle<shape_param_type> h_shape_params(m_shape_params, access_location::host, access_mode::readwrite);
+    h_shape_params.data[typ] = shape_param;
     }
 
 /*! \param typ1 First type index in the pair
@@ -378,6 +410,7 @@ void AnisoPotentialPair< aniso_evaluator >::computeForces(unsigned int timestep)
     const BoxDim& box = m_pdata->getBox();
     ArrayHandle<Scalar> h_rcutsq(m_rcutsq, access_location::host, access_mode::read);
     ArrayHandle<param_type> h_params(m_params, access_location::host, access_mode::read);
+    ArrayHandle<shape_param_type> h_shape_params(m_shape_params, access_location::host, access_mode::read);
 
     {
     // need to start from a zero force, energy and virial
@@ -402,10 +435,13 @@ void AnisoPotentialPair< aniso_evaluator >::computeForces(unsigned int timestep)
         // access diameter and charge (if needed)
         Scalar di = Scalar(0.0);
         Scalar qi = Scalar(0.0);
+        const shape_param_type *shape_i;
         if (aniso_evaluator::needsDiameter())
             di = h_diameter.data[i];
         if (aniso_evaluator::needsCharge())
             qi = h_charge.data[i];
+        if (aniso_evaluator::needsShape())
+            shape_i = &h_shape_params.data[typei];
 
         // initialize current particle force, torque, potential energy, and virial to 0
         Scalar fxi = Scalar(0.0);
@@ -443,10 +479,13 @@ void AnisoPotentialPair< aniso_evaluator >::computeForces(unsigned int timestep)
             // access diameter and charge (if needed)
             Scalar dj = Scalar(0.0);
             Scalar qj = Scalar(0.0);
+            const shape_param_type *shape_j;
             if (aniso_evaluator::needsDiameter())
                 dj = h_diameter.data[j];
             if (aniso_evaluator::needsCharge())
                 qj = h_charge.data[j];
+            if (aniso_evaluator::needsShape())
+                shape_j = &h_shape_params.data[typej];
 
             // apply periodic boundary conditions
             dx = box.minImage(dx);
@@ -475,6 +514,8 @@ void AnisoPotentialPair< aniso_evaluator >::computeForces(unsigned int timestep)
                 eval.setDiameter(di, dj);
             if (aniso_evaluator::needsCharge())
                 eval.setCharge(qi, qj);
+            if (aniso_evaluator::needsShape())
+                eval.setShape(shape_i, shape_j);
 
             bool evaluated = eval.evaluate(force, pair_eng, energy_shift,torque_i,torque_j);
 
@@ -584,6 +625,7 @@ template < class T > void export_AnisoPotentialPair(pybind11::module& m, const s
     anisopotentialpair.def(pybind11::init< std::shared_ptr<SystemDefinition>, std::shared_ptr<NeighborList>, const std::string& >())
         .def("setParams", &T::setParams)
         .def("setRcut", &T::setRcut)
+        .def("setShape", &T::setShape)
         .def("setShiftMode", &T::setShiftMode)
         .def("slotWriteGSDShapeSpec", &T::slotWriteGSDShapeSpec)
         .def("connectGSDShapeSpec", &T::connectGSDShapeSpec)

--- a/hoomd/md/AnisoPotentialPairGPU.h
+++ b/hoomd/md/AnisoPotentialPairGPU.h
@@ -36,7 +36,8 @@
     \sa export_AnisoPotentialPairGPU()
 */
 template< class evaluator, cudaError_t gpu_cgpf(const a_pair_args_t& pair_args,
-                                                const typename evaluator::param_type *d_params) >
+                                                const typename evaluator::param_type *d_params,
+                                                const typename evaluator::shape_param_type *d_shape_params) >
 class AnisoPotentialPairGPU : public AnisoPotentialPair<evaluator>
     {
     public:
@@ -77,7 +78,8 @@ class AnisoPotentialPairGPU : public AnisoPotentialPair<evaluator>
     };
 
 template< class evaluator, cudaError_t gpu_cgpf(const a_pair_args_t& pair_args,
-                                                const typename evaluator::param_type *d_params) >
+                                                const typename evaluator::param_type *d_params,
+                                                const typename evaluator::shape_param_type *d_shape_params) >
 AnisoPotentialPairGPU< evaluator, gpu_cgpf >::AnisoPotentialPairGPU(std::shared_ptr<SystemDefinition> sysdef,
                                                           std::shared_ptr<NeighborList> nlist, const std::string& log_suffix)
     : AnisoPotentialPair<evaluator>(sysdef, nlist, log_suffix), m_param(0)
@@ -111,7 +113,8 @@ AnisoPotentialPairGPU< evaluator, gpu_cgpf >::AnisoPotentialPairGPU(std::shared_
     }
 
 template< class evaluator, cudaError_t gpu_cgpf(const a_pair_args_t& pair_args,
-                                                const typename evaluator::param_type *d_params) >
+                                                const typename evaluator::param_type *d_params,
+                                                const typename evaluator::shape_param_type *d_shape_params) >
 void AnisoPotentialPairGPU< evaluator, gpu_cgpf >::computeForces(unsigned int timestep)
     {
     this->m_nlist->compute(timestep);
@@ -145,6 +148,7 @@ void AnisoPotentialPairGPU< evaluator, gpu_cgpf >::computeForces(unsigned int ti
     // access parameters
     ArrayHandle<Scalar> d_rcutsq(this->m_rcutsq, access_location::device, access_mode::read);
     ArrayHandle<typename evaluator::param_type> d_params(this->m_params, access_location::device, access_mode::read);
+    ArrayHandle<typename evaluator::shape_param_type> d_shape_params(this->m_shape_params, access_location::device, access_mode::read);
 
     ArrayHandle<Scalar4> d_force(this->m_force, access_location::device, access_mode::overwrite);
     ArrayHandle<Scalar4> d_torque(this->m_torque, access_location::device, access_mode::overwrite);
@@ -188,7 +192,8 @@ void AnisoPotentialPairGPU< evaluator, gpu_cgpf >::computeForces(unsigned int ti
                            this->m_exec_conf->dev_prop,
                            first
                            ),
-             d_params.data);
+             d_params.data,
+             d_shape_params.data);
     if (!m_param) this->m_tuner->end();
 
     if (this->m_exec_conf->isCUDAErrorCheckingEnabled())

--- a/hoomd/md/AnisoPotentialPairGPU.h
+++ b/hoomd/md/AnisoPotentialPairGPU.h
@@ -142,6 +142,7 @@ void AnisoPotentialPairGPU< evaluator, gpu_cgpf >::computeForces(unsigned int ti
     ArrayHandle<Scalar> d_diameter(this->m_pdata->getDiameters(), access_location::device, access_mode::read);
     ArrayHandle<Scalar> d_charge(this->m_pdata->getCharges(), access_location::device, access_mode::read);
     ArrayHandle<Scalar4> d_orientation(this->m_pdata->getOrientationArray(),access_location::device,access_mode::read);
+    ArrayHandle<unsigned int> d_tag(this->m_pdata->getTags(), access_location::host, access_mode::read);
 
     BoxDim box = this->m_pdata->getBox();
 
@@ -178,6 +179,7 @@ void AnisoPotentialPairGPU< evaluator, gpu_cgpf >::computeForces(unsigned int ti
                            d_diameter.data,
                            d_charge.data,
                            d_orientation.data,
+                           d_tag.data,
                            box,
                            d_n_neigh.data,
                            d_nlist.data,

--- a/hoomd/md/AnisoPotentialPairGPU.h
+++ b/hoomd/md/AnisoPotentialPairGPU.h
@@ -142,7 +142,7 @@ void AnisoPotentialPairGPU< evaluator, gpu_cgpf >::computeForces(unsigned int ti
     ArrayHandle<Scalar> d_diameter(this->m_pdata->getDiameters(), access_location::device, access_mode::read);
     ArrayHandle<Scalar> d_charge(this->m_pdata->getCharges(), access_location::device, access_mode::read);
     ArrayHandle<Scalar4> d_orientation(this->m_pdata->getOrientationArray(),access_location::device,access_mode::read);
-    ArrayHandle<unsigned int> d_tag(this->m_pdata->getTags(), access_location::host, access_mode::read);
+    ArrayHandle<unsigned int> d_tag(this->m_pdata->getTags(), access_location::device, access_mode::read);
 
     BoxDim box = this->m_pdata->getBox();
 

--- a/hoomd/md/EvaluatorPairDipole.h
+++ b/hoomd/md/EvaluatorPairDipole.h
@@ -120,11 +120,11 @@ class EvaluatorPairDipole
             return false;
             }
 
-        //! Accept the optional diameter values
-        /*! \param di Diameter of particle i
-            \param dj Diameter of particle j
-        */
-        HOSTDEVICE void setDiameter(Scalar di, Scalar dj){}
+        //! Whether the pair potential needs particle tags.
+        HOSTDEVICE static bool needsTags()
+            {
+            return false;
+            }
 
         //! whether pair potential requires charges
         HOSTDEVICE static bool needsCharge()
@@ -133,6 +133,24 @@ class EvaluatorPairDipole
             }
 
         //! Accept the optional diameter values
+        /*! \param di Diameter of particle i
+            \param dj Diameter of particle j
+        */
+        HOSTDEVICE void setDiameter(Scalar di, Scalar dj){}
+
+        //! Accept the optional shape values
+        /*! \param shape_i Shape of particle i
+            \param shape_j Shape of particle j
+        */
+        HOSTDEVICE void setShape(const shape_param_type *shapei, const shape_param_type *shapej) {}
+
+        //! Accept the optional tags
+        /*! \param tag_i Tag of particle i
+            \param tag_j Tag of particle j
+        */
+        HOSTDEVICE void setTags(unsigned int tagi, unsigned int tagj) {}
+
+        //! Accept the optional charge values
         /*! \param qi Charge of particle i
             \param qj Charge of particle j
         */
@@ -141,12 +159,6 @@ class EvaluatorPairDipole
             q_i = qi;
             q_j = qj;
             }
-
-        //! Accept the optional shape values
-        /*! \param shape_i Shape of particle i
-            \param shape_j Shape of particle j
-        */
-        HOSTDEVICE void setShape(const shape_param_type *shapei, const shape_param_type *shapej) {}
 
         //! Evaluate the force and energy
         /*! \param force Output parameter to write the computed force.

--- a/hoomd/md/EvaluatorPairDipole.h
+++ b/hoomd/md/EvaluatorPairDipole.h
@@ -72,7 +72,7 @@ struct pair_dipole_params
 
 // Nullary structure required by AnisoPotentialPair.
 struct dipole_shape_params
-{
+    {
     HOSTDEVICE dipole_shape_params() {}
 
     //! Load dynamic data members into shared memory and increase pointer
@@ -85,7 +85,7 @@ struct dipole_shape_params
     //! Attach managed memory to CUDA stream
     void attach_to_stream(cudaStream_t stream) const {}
     #endif
-};
+    };
 
 class EvaluatorPairDipole
     {

--- a/hoomd/md/EvaluatorPairDipole.h
+++ b/hoomd/md/EvaluatorPairDipole.h
@@ -70,10 +70,15 @@ struct pair_dipole_params
         }
     };
 
+// Nullary structure required by AnisoPotentialPair.
+struct dipole_shape_params {};
+
 class EvaluatorPairDipole
     {
     public:
         typedef pair_dipole_params param_type;
+        typedef dipole_shape_params shape_param_type;
+
         //! Constructs the pair potential evaluator
         /*! \param _dr Displacement vector between particle centers of mass
             \param _rcutsq Squared distance at which the potential goes to 0
@@ -114,7 +119,6 @@ class EvaluatorPairDipole
             }
 
         //! Accept the optional diameter values
-        //! This function is pure virtual
         /*! \param qi Charge of particle i
             \param qj Charge of particle j
         */
@@ -123,6 +127,12 @@ class EvaluatorPairDipole
             q_i = qi;
             q_j = qj;
             }
+
+        //! Accept the optional shape values
+        /*! \param shape_i Shape of particle i
+            \param shape_j Shape of particle j
+        */
+        HOSTDEVICE void setShape(const shape_param_type *shapei, const shape_param_type *shapej) {}
 
         //! Evaluate the force and energy
         /*! \param force Output parameter to write the computed force.

--- a/hoomd/md/EvaluatorPairDipole.h
+++ b/hoomd/md/EvaluatorPairDipole.h
@@ -71,7 +71,21 @@ struct pair_dipole_params
     };
 
 // Nullary structure required by AnisoPotentialPair.
-struct dipole_shape_params {};
+struct dipole_shape_params
+{
+    HOSTDEVICE dipole_shape_params() {}
+
+    //! Load dynamic data members into shared memory and increase pointer
+    /*! \param ptr Pointer to load data to (will be incremented)
+        \param available_bytes Size of remaining shared memory allocation
+     */
+    HOSTDEVICE void load_shared(char *& ptr, unsigned int &available_bytes) const {}
+
+    #ifdef ENABLE_CUDA
+    //! Attach managed memory to CUDA stream
+    void attach_to_stream(cudaStream_t stream) const {}
+    #endif
+};
 
 class EvaluatorPairDipole
     {

--- a/hoomd/md/EvaluatorPairDipole.h
+++ b/hoomd/md/EvaluatorPairDipole.h
@@ -95,6 +95,12 @@ class EvaluatorPairDipole
             return false;
             }
 
+        //! Whether the pair potential uses shape.
+        HOSTDEVICE static bool needsShape()
+            {
+            return false;
+            }
+
         //! Accept the optional diameter values
         /*! \param di Diameter of particle i
             \param dj Diameter of particle j

--- a/hoomd/md/EvaluatorPairGB.h
+++ b/hoomd/md/EvaluatorPairGB.h
@@ -47,7 +47,7 @@ struct pair_gb_params
 
 // Nullary structure required by AnisoPotentialPair.
 struct gb_shape_params
-{
+    {
     HOSTDEVICE gb_shape_params() {}
 
     //! Load dynamic data members into shared memory and increase pointer
@@ -60,7 +60,7 @@ struct gb_shape_params
     //! Attach managed memory to CUDA stream
     void attach_to_stream(cudaStream_t stream) const {}
     #endif
-};
+    };
 
 /*!
  * Gay-Berne potential as formulated by Allen and Germano,

--- a/hoomd/md/EvaluatorPairGB.h
+++ b/hoomd/md/EvaluatorPairGB.h
@@ -102,11 +102,11 @@ class EvaluatorPairGB
             return false;
             }
 
-        //! Accept the optional diameter values
-        /*! \param di Diameter of particle i
-            \param dj Diameter of particle j
-        */
-        HOSTDEVICE void setDiameter(Scalar di, Scalar dj){}
+        //! Whether the pair potential needs particle tags.
+        HOSTDEVICE static bool needsTags()
+            {
+            return false;
+            }
 
         //! whether pair potential requires charges
         HOSTDEVICE static bool needsCharge( )
@@ -115,16 +115,28 @@ class EvaluatorPairGB
             }
 
         //! Accept the optional diameter values
-        /*! \param qi Charge of particle i
-            \param qj Charge of particle j
+        /*! \param di Diameter of particle i
+            \param dj Diameter of particle j
         */
-        HOSTDEVICE void setCharge(Scalar qi, Scalar qj){}
+        HOSTDEVICE void setDiameter(Scalar di, Scalar dj){}
 
         //! Accept the optional shape values
         /*! \param shape_i Shape of particle i
             \param shape_j Shape of particle j
         */
         HOSTDEVICE void setShape(const shape_param_type *shapei, const shape_param_type *shapej) {}
+
+        //! Accept the optional tags
+        /*! \param tag_i Tag of particle i
+            \param tag_j Tag of particle j
+        */
+        HOSTDEVICE void setTags(unsigned int tagi, unsigned int tagj) {}
+
+        //! Accept the optional charge values
+        /*! \param qi Charge of particle i
+            \param qj Charge of particle j
+        */
+        HOSTDEVICE void setCharge(Scalar qi, Scalar qj){}
 
         //! Evaluate the force and energy
         /*! \param force Output parameter to write the computed force.

--- a/hoomd/md/EvaluatorPairGB.h
+++ b/hoomd/md/EvaluatorPairGB.h
@@ -78,6 +78,12 @@ class EvaluatorPairGB
             return false;
             }
 
+        //! Whether the pair potential uses shape.
+        HOSTDEVICE static bool needsShape()
+            {
+            return false;
+            }
+
         //! Accept the optional diameter values
         /*! \param di Diameter of particle i
             \param dj Diameter of particle j

--- a/hoomd/md/EvaluatorPairGB.h
+++ b/hoomd/md/EvaluatorPairGB.h
@@ -45,6 +45,9 @@ struct pair_gb_params
     };
 
 
+// Nullary structure required by AnisoPotentialPair.
+struct gb_shape_params {};
+
 /*!
  * Gay-Berne potential as formulated by Allen and Germano,
  * with shape-independent energy parameter, for identical uniaxial particles.
@@ -54,6 +57,7 @@ class EvaluatorPairGB
     {
     public:
         typedef pair_gb_params param_type;
+        typedef gb_shape_params shape_param_type;
 
         //! Constructs the pair potential evaluator
         /*! \param _dr Displacement vector between particle centers of mass
@@ -97,11 +101,16 @@ class EvaluatorPairGB
             }
 
         //! Accept the optional diameter values
-        //! This function is pure virtual
         /*! \param qi Charge of particle i
             \param qj Charge of particle j
         */
         HOSTDEVICE void setCharge(Scalar qi, Scalar qj){}
+
+        //! Accept the optional shape values
+        /*! \param shape_i Shape of particle i
+            \param shape_j Shape of particle j
+        */
+        HOSTDEVICE void setShape(const shape_param_type *shapei, const shape_param_type *shapej) {}
 
         //! Evaluate the force and energy
         /*! \param force Output parameter to write the computed force.

--- a/hoomd/md/EvaluatorPairGB.h
+++ b/hoomd/md/EvaluatorPairGB.h
@@ -46,7 +46,21 @@ struct pair_gb_params
 
 
 // Nullary structure required by AnisoPotentialPair.
-struct gb_shape_params {};
+struct gb_shape_params
+{
+    HOSTDEVICE gb_shape_params() {}
+
+    //! Load dynamic data members into shared memory and increase pointer
+    /*! \param ptr Pointer to load data to (will be incremented)
+        \param available_bytes Size of remaining shared memory allocation
+     */
+    HOSTDEVICE void load_shared(char *& ptr, unsigned int &available_bytes) const {}
+
+    #ifdef ENABLE_CUDA
+    //! Attach managed memory to CUDA stream
+    void attach_to_stream(cudaStream_t stream) const {}
+    #endif
+};
 
 /*!
  * Gay-Berne potential as formulated by Allen and Germano,

--- a/hoomd/md/pair.py
+++ b/hoomd/md/pair.py
@@ -2118,7 +2118,7 @@ class mie(pair):
         return _hoomd.make_scalar4(mie1, mie2, mie3, mie4);
 
 class ai_pair(pair):
-    R""" Generic anisotropic pair potential.
+    R"""Generic anisotropic pair potential.
 
     Users should not instantiate :py:class:`ai_pair` directly. It is a base class that
     provides common features to all anisotropic pair forces. Rather than repeating all of that documentation in a
@@ -2153,8 +2153,10 @@ class ai_pair(pair):
         self.nlist.subscribe(lambda:self.get_rcut())
         self.nlist.update_rcut()
 
+        self._shape = {}
+
     def set_params(self, mode=None):
-        R""" Set parameters controlling the way forces are computed.
+        R"""Set parameters controlling the way forces are computed.
 
         Args:
             mode (str): (if set) Set the mode with which potentials are handled at the cutoff
@@ -2181,6 +2183,18 @@ class ai_pair(pair):
                 hoomd.context.msg.error("Invalid mode\n");
                 raise RuntimeError("Error changing parameters in pair force");
 
+    @property
+    def shape(self):
+        R"""Get or set shape parameters per type.
+
+        In addition to any pair-specific parameters required to characterize a
+        pair potential, individual particles that have anisotropic interactions
+        may also have their own shapes that affect the potentials. General
+        anisotropic pair potentials may set per-particle shapes using this
+        method.
+        """
+        return self._shape
+
     def update_coeffs(self):
         coeff_list = self.required_coeffs + ["r_cut"];
         # check that the pair coefficients are valid
@@ -2195,9 +2209,21 @@ class ai_pair(pair):
             type_list.append(hoomd.context.current.system_definition.getParticleData().getNameByType(i));
 
         for i in range(0,ntypes):
+            # Shape doesn't have to be set, depends on the potential.
+            try:
+                # Ensure that shape parameters are always 3D lists, even in 2D.
+                shape = self.shape[type_list[i]]
+                if hoomd.context.current.system_definition.getNDimensions() == 2:
+                    shape = [[v[0], v[1], 0] for v in shape]
+
+                param = _md.make_single_shape_table(shape, hoomd.context.exec_conf)
+                self.cpp_force.setShape(i, param)
+            except KeyError:
+                pass
+
             for j in range(i,ntypes):
                 # build a dict of the coeffs to pass to process_coeff
-                coeff_dict = {};
+                coeff_dict = {}
                 for name in coeff_list:
                     coeff_dict[name] = self.pair_coeff.get(type_list[i], type_list[j], name);
 

--- a/hoomd/md/pair.py
+++ b/hoomd/md/pair.py
@@ -2117,6 +2117,17 @@ class mie(pair):
         mie4 = m
         return _hoomd.make_scalar4(mie1, mie2, mie3, mie4);
 
+
+class _shape_dict(dict):
+    """Simple dictionary subclass to improve handling of anisotropic potential
+    shape information."""
+    def __getitem__(self, key):
+        try:
+            return super(_shape_dict, self).__getitem__(key)
+        except KeyError as e:
+            raise KeyError("No shape parameters specified for particle type {}!".format(key)) from e
+
+
 class ai_pair(pair):
     R"""Generic anisotropic pair potential.
 
@@ -2153,7 +2164,7 @@ class ai_pair(pair):
         self.nlist.subscribe(lambda:self.get_rcut())
         self.nlist.update_rcut()
 
-        self._shape = {}
+        self._shape = _shape_dict()
 
     def set_params(self, mode=None):
         R"""Set parameters controlling the way forces are computed.
@@ -2209,17 +2220,7 @@ class ai_pair(pair):
             type_list.append(hoomd.context.current.system_definition.getParticleData().getNameByType(i));
 
         for i in range(0,ntypes):
-            # Shape doesn't have to be set, depends on the potential.
-            try:
-                # Ensure that shape parameters are always 3D lists, even in 2D.
-                shape = self.shape[type_list[i]]
-                if hoomd.context.current.system_definition.getNDimensions() == 2:
-                    shape = [[v[0], v[1], 0] for v in shape]
-
-                param = _md.make_single_shape_table(shape, hoomd.context.exec_conf)
-                self.cpp_force.setShape(i, param)
-            except KeyError:
-                pass
+            self._set_cpp_shape(i, type_list[i])
 
             for j in range(i,ntypes):
                 # build a dict of the coeffs to pass to process_coeff
@@ -2230,6 +2231,13 @@ class ai_pair(pair):
                 param = self.process_coeff(coeff_dict);
                 self.cpp_force.setParams(i, j, param);
                 self.cpp_force.setRcut(i, j, coeff_dict['r_cut']);
+
+    def _set_cpp_shape(self, type_id, type_name):
+        """Update shape information in C++.
+
+        This method must be implemented by subclasses to generate the
+        appropriate shape structure. The default behavior is to do nothing."""
+        pass
 
 class gb(ai_pair):
     R""" Gay-Berne anisotropic pair potential.

--- a/hoomd/md/validation/CMakeLists.txt
+++ b/hoomd/md/validation/CMakeLists.txt
@@ -53,7 +53,6 @@ minimize_fire_rigid.py 0 0
 bd_angular.py 0 0
 compare_npt_nvt_rigid.py 0 2
 npt_dimer_eos.py 0 2
-alj_conservation.py 0 0
 )
 
 set(TEST_LIST_GPU
@@ -61,7 +60,6 @@ minimize_fire_rigid.py 0 0
 bd_angular.py 0 0
 compare_npt_nvt_rigid.py 0 2
 npt_dimer_eos.py 0 2
-alj_conservation.py 0 0
 )
 
 set(EXCLUDE_FROM_GPU_MPI

--- a/hoomd/md/validation/CMakeLists.txt
+++ b/hoomd/md/validation/CMakeLists.txt
@@ -53,6 +53,7 @@ minimize_fire_rigid.py 0 0
 bd_angular.py 0 0
 compare_npt_nvt_rigid.py 0 2
 npt_dimer_eos.py 0 2
+alj_conservation.py 0 0
 )
 
 set(TEST_LIST_GPU
@@ -60,6 +61,7 @@ minimize_fire_rigid.py 0 0
 bd_angular.py 0 0
 compare_npt_nvt_rigid.py 0 2
 npt_dimer_eos.py 0 2
+alj_conservation.py 0 0
 )
 
 set(EXCLUDE_FROM_GPU_MPI

--- a/sphinx-doc/credits.rst
+++ b/sphinx-doc/credits.rst
@@ -211,6 +211,7 @@ Vyas Ramasubramani, University of Michigan
  * Reverse communication for MPI
  * Enable simulation of floppy bodies that can be integrated separately but are ignored by the NeighborList
  * Enabled use of shared memory for Evaluator structs
+ * Added per-type shape information to anisotropic pair potentials
 
 Nathan Horst
 


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should based on *maint*. -->
<!-- New features should based on *master*. -->

## Description

This pull request enables generic per-type shape specification for arbitrary anisotropic potentials.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

In general, components of the anisotropy in anisotropic pair potentials can be represented as features that belong to a given particle type, rather than a specific pair. Currently, all such information must be provided for every pair in the interaction matrix. This PR separates per-type quantities into a `shape` field that captures the per-type anisotropy.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

Tests are on a private branch to be merged at a later date.

## Change log

<!-- Propose a change log entry. -->
```
Enable per-type shape information for anisotropic pair potentials that complements the existing pair parameters struct.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [ ] My name is on the [list of contributors](https://github.com/glotzerlab/hoomd-blue/blob/master/sphinx-doc/credits.rst).
