### PR TITLE
Fix invalid read of particle mass in MPCD AT

### DIFF
--- a/hoomd/mpcd/ATCollisionMethodGPU.cc
+++ b/hoomd/mpcd/ATCollisionMethodGPU.cc
@@ -29,7 +29,7 @@ void mpcd::ATCollisionMethodGPU::drawVelocities(unsigned int timestep)
     {
     // mpcd particle data
     ArrayHandle<unsigned int> d_tag(m_mpcd_pdata->getTags(), access_location::device, access_mode::read);
-    ArrayHandle<Scalar4> d_vel(m_mpcd_pdata->getAltVelocities(), access_location::device, access_mode::overwrite);
+    ArrayHandle<Scalar4> d_alt_vel(m_mpcd_pdata->getAltVelocities(), access_location::device, access_mode::overwrite);
     const unsigned int N_mpcd = m_mpcd_pdata->getN() + m_mpcd_pdata->getNVirtual();
     unsigned int N_tot = N_mpcd;
 
@@ -39,16 +39,18 @@ void mpcd::ATCollisionMethodGPU::drawVelocities(unsigned int timestep)
     if (m_embed_group)
         {
         ArrayHandle<unsigned int> d_embed_idx(m_embed_group->getIndexArray(), access_location::device, access_mode::read);
-        ArrayHandle<Scalar4> d_vel_embed(m_pdata->getAltVelocities(), access_location::device, access_mode::overwrite);
+        ArrayHandle<Scalar4> d_vel_embed(m_pdata->getVelocities(), access_location::device, access_mode::read);
+        ArrayHandle<Scalar4> d_alt_vel_embed(m_pdata->getAltVelocities(), access_location::device, access_mode::overwrite);
         ArrayHandle<unsigned int> d_tag_embed(m_pdata->getTags(), access_location::device, access_mode::read);
         N_tot += m_embed_group->getNumMembers();
 
         m_tuner_draw->begin();
-        mpcd::gpu::at_draw_velocity(d_vel.data,
-                                    d_vel_embed.data,
+        mpcd::gpu::at_draw_velocity(d_alt_vel.data,
+                                    d_alt_vel_embed.data,
                                     d_tag.data,
                                     m_mpcd_pdata->getMass(),
                                     d_embed_idx.data,
+                                    d_vel_embed.data,
                                     d_tag_embed.data,
                                     timestep,
                                     m_seed,
@@ -62,10 +64,11 @@ void mpcd::ATCollisionMethodGPU::drawVelocities(unsigned int timestep)
     else
         {
         m_tuner_draw->begin();
-        mpcd::gpu::at_draw_velocity(d_vel.data,
+        mpcd::gpu::at_draw_velocity(d_alt_vel.data,
                                     NULL,
                                     d_tag.data,
                                     m_mpcd_pdata->getMass(),
+                                    NULL,
                                     NULL,
                                     NULL,
                                     timestep,

--- a/hoomd/mpcd/ATCollisionMethodGPU.cuh
+++ b/hoomd/mpcd/ATCollisionMethodGPU.cuh
@@ -22,11 +22,12 @@ namespace gpu
 {
 
 //! Draw particle velocities for the Andersen thermostat from Gaussian distribution
-cudaError_t at_draw_velocity(Scalar4 *d_vel,
-                             Scalar4 *d_vel_embed,
+cudaError_t at_draw_velocity(Scalar4 *d_alt_vel,
+                             Scalar4 *d_alt_vel_embed,
                              const unsigned int *d_tag,
                              const Scalar mpcd_mass,
                              const unsigned int *d_embed_idx,
+                             const Scalar4 *d_vel_embed,
                              const unsigned int *d_tag_embed,
                              const unsigned int timestep,
                              const unsigned int seed,

--- a/hoomd/mpcd/test/at_collision_method_test.cc
+++ b/hoomd/mpcd/test/at_collision_method_test.cc
@@ -103,15 +103,98 @@ void at_collision_method_basic_test(std::shared_ptr<ExecutionConfiguration> exec
     CHECK_CLOSE(Tavg, 1.5, 0.02);
     }
 
+//! Test that embedding a particle produces valid values (not a rigorous test of physics of embedding)
+template<class CM>
+void at_collision_method_embed_test(std::shared_ptr<ExecutionConfiguration> exec_conf)
+    {
+    std::shared_ptr< SnapshotSystemData<Scalar> > snap( new SnapshotSystemData<Scalar>() );
+    snap->global_box = BoxDim(2.0);
+    snap->particle_data.type_mapping.push_back("A");
+        {
+        SnapshotParticleData<Scalar>& pdata_snap = snap->particle_data;
+        pdata_snap.resize(1);
+        pdata_snap.pos[0] = vec3<Scalar>(-0.6, -0.6, -0.6);
+        pdata_snap.vel[0] = vec3<Scalar>(1.0, 2.0, 3.0);
+        pdata_snap.mass[0] = 2.0;
+        }
+    std::shared_ptr<SystemDefinition> sysdef(new SystemDefinition(snap, exec_conf));
+
+    // 4 particle system
+    auto mpcd_sys_snap = std::make_shared<mpcd::SystemDataSnapshot>(sysdef);
+        {
+        auto mpcd_snap = mpcd_sys_snap->particles;
+        mpcd_snap->resize(4);
+
+        mpcd_snap->position[0] = vec3<Scalar>(-0.6, -0.6, -0.6);
+        mpcd_snap->position[1] = vec3<Scalar>(-0.6, -0.6, -0.6);
+        mpcd_snap->position[2] = vec3<Scalar>(0.5, 0.5, 0.5);
+        mpcd_snap->position[3] = vec3<Scalar>(0.5, 0.5, 0.5);
+
+        mpcd_snap->velocity[0] = vec3<Scalar>(2.0, 0.0, 0.0);
+        mpcd_snap->velocity[1] = vec3<Scalar>(1.0, 0.0, 0.0);
+        mpcd_snap->velocity[2] = vec3<Scalar>(5.0, -2.0, 3.0);
+        mpcd_snap->velocity[3] = vec3<Scalar>(-1.0, 2.0, -5.0);
+        }
+
+    // initialize system and collision method
+    auto mpcd_sys = std::make_shared<mpcd::SystemData>(mpcd_sys_snap);
+    std::shared_ptr<mpcd::ParticleData> pdata_4 = mpcd_sys->getParticleData();
+
+    // thermos and temperature variant
+    auto thermo = std::make_shared<mpcd::CellThermoCompute>(mpcd_sys);
+    AllThermoRequest thermo_req(thermo);
+
+    auto rand_thermo = std::make_shared<mpcd::CellThermoCompute>(mpcd_sys);
+    std::shared_ptr<::Variant> T = std::make_shared<::VariantConst>(1.5);
+
+    std::shared_ptr<mpcd::ATCollisionMethod> collide = std::make_shared<CM>(mpcd_sys, 0, 1, -1, 42, thermo, rand_thermo, T);
+    collide->enableGridShifting(false);
+
+    // embed the particle group into the mpcd system
+    std::shared_ptr<ParticleSelector> selector_one(new ParticleSelectorAll(sysdef));
+    std::shared_ptr<ParticleGroup> group_all(new ParticleGroup(sysdef, selector_one));
+    collide->setEmbeddedGroup(group_all);
+
+    // Save original momentum for comparison as well
+    thermo->compute(0);
+    const Scalar3 orig_mom = thermo->getNetMomentum();
+    collide->collide(0);
+        {
+        // velocity should be different now, but the mass should stay the same
+        ArrayHandle<Scalar4> h_vel(sysdef->getParticleData()->getVelocities(), access_location::host, access_mode::read);
+        UP_ASSERT(h_vel.data[0].x != 1.0);
+        UP_ASSERT(h_vel.data[0].y != 2.0);
+        UP_ASSERT(h_vel.data[0].z != 3.0);
+        CHECK_CLOSE(h_vel.data[0].w, 2.0, tol_small);
+        }
+
+    // compute properties after collision
+    thermo->compute(1);
+    Scalar3 mom = thermo->getNetMomentum();
+    CHECK_CLOSE(orig_mom.x, mom.x, tol_small);
+    CHECK_CLOSE(orig_mom.y, mom.y, tol_small);
+    CHECK_CLOSE(orig_mom.z, mom.z, tol_small);
+    }
+
 //! basic test case for MPCD ATCollisionMethod class
 UP_TEST( at_collision_method_basic )
     {
     at_collision_method_basic_test<mpcd::ATCollisionMethod>(std::make_shared<ExecutionConfiguration>(ExecutionConfiguration::CPU));
+    }
+//! test embedding of particles into the MPCD ATCollisionMethod class
+UP_TEST( at_collision_method_embed )
+    {
+    at_collision_method_embed_test<mpcd::ATCollisionMethod>(std::make_shared<ExecutionConfiguration>(ExecutionConfiguration::CPU));
     }
 #ifdef ENABLE_CUDA
 //! basic test case for MPCD ATCollisionMethodGPU class
 UP_TEST( at_collision_method_basic_gpu )
     {
     at_collision_method_basic_test<mpcd::ATCollisionMethodGPU>(std::make_shared<ExecutionConfiguration>(ExecutionConfiguration::GPU));
+    }
+//! test embedding of particles into the MPCD ATCollisionMethodGPU class
+UP_TEST( at_collision_method_embed_gpu )
+    {
+    at_collision_method_embed_test<mpcd::ATCollisionMethodGPU>(std::make_shared<ExecutionConfiguration>(ExecutionConfiguration::GPU));
     }
 #endif // ENABLE_CUDA


### PR DESCRIPTION
## Description

Fixes a bug in the MPCD AT collision rule when using embedded particles (#494). The mass of the embedded particle was incorrectly read out of the the alt. velocity array, where its value is undefined. (It could be zero initially, but it might also end up with junk values if uninitialized *or* it could have values leftover by the sorter, which would then only be correct if all the embedded particles in the system had the same mass and the sorter was called already.) This resulted in inf / NaN values on the CPU, as the mass read was zero and then used in a denominator. It's unclear exactly what happened on the GPU, as this did not crash probably by luck of the systems tested. The mass is now read correctly from the current velocity array.

## Motivation and Context

Resolves: #494

## How Has This Been Tested?

A basic unit test was missing for AT + embedded particles (only SRD was covered before), so I added one. This should also be covered by adding a validation test in future (#373).

## Change log

```
* Fix a bug for ``mpcd.collide.at`` with embedded particles, which may have given incorrect results or simulation crashes.
```

## Checklist:

- [X] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [X] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [X] My name is on the [list of contributors](https://github.com/glotzerlab/hoomd-blue/blob/master/sphinx-doc/credits.rst).
