### PR TITLE
Update ComputeFreeVolume for 2d systems

### DIFF
--- a/hoomd/hpmc/ComputeFreeVolume.h
+++ b/hoomd/hpmc/ComputeFreeVolume.h
@@ -175,7 +175,14 @@ void ComputeFreeVolume<Shape>::computeFreeVolume(unsigned int timestep)
 
             Scalar xrand = hoomd::detail::generate_canonical<Scalar>(rng_i);
             Scalar yrand = hoomd::detail::generate_canonical<Scalar>(rng_i);
-            Scalar zrand = hoomd::detail::generate_canonical<Scalar>(rng_i);
+            if (m_sysdef->getNDimensions() == 2)
+                {
+                Scalar zrand = 0.5;
+                }
+            else
+                {
+                Scalar zrand = hoomd::detail::generate_canonical<Scalar>(rng_i);
+                }
 
             Scalar3 f = make_scalar3(xrand, yrand, zrand);
             vec3<Scalar> pos_i = vec3<Scalar>(box.makeCoordinates(f));
@@ -183,7 +190,14 @@ void ComputeFreeVolume<Shape>::computeFreeVolume(unsigned int timestep)
             Shape shape_i(quat<Scalar>(), params[m_type]);
             if (shape_i.hasOrientation())
                 {
-                shape_i.orientation = generateRandomOrientation(rng_i);
+                if (m_sysdef->getNDimensions() == 2)
+                    {
+                    shape_i.orientation = generateRandomOrientation2D(rng_i);
+                    }
+                else
+                    {
+                    shape_i.orientation = generateRandomOrientation(rng_i);
+                    }
                 }
 
             // check for overlaps with neighboring particle's positions

--- a/hoomd/hpmc/ComputeFreeVolume.h
+++ b/hoomd/hpmc/ComputeFreeVolume.h
@@ -175,13 +175,10 @@ void ComputeFreeVolume<Shape>::computeFreeVolume(unsigned int timestep)
 
             Scalar xrand = hoomd::detail::generate_canonical<Scalar>(rng_i);
             Scalar yrand = hoomd::detail::generate_canonical<Scalar>(rng_i);
+            Scalar zrand = hoomd::detail::generate_canonical<Scalar>(rng_i);
             if (m_sysdef->getNDimensions() == 2)
                 {
-                Scalar zrand = 0.5;
-                }
-            else
-                {
-                Scalar zrand = hoomd::detail::generate_canonical<Scalar>(rng_i);
+                zrand = 0.5;
                 }
 
             Scalar3 f = make_scalar3(xrand, yrand, zrand);


### PR DESCRIPTION
## Description

This PR modifies the free volume compute in hpmc to properly handle 2d shapes.

## Motivation and Context

The current implementation of `ComputeFreeVolume` does not properly account for the position and orientation of the trial particles for 2d systems. This PR fixes that.

## How Has This Been Tested?

Testing is ongoing...

## Change log

<!-- Propose a change log entry. -->
```
- Fix ComputeFreeVolume for 2d systems
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/hoomd-blue/blob/master/sphinx-doc/credits.rst).
