### PR TITLE
Feature/new object api

### DIFF
--- a/hoomd/hpmc/ShapeEllipsoid.h
+++ b/hoomd/hpmc/ShapeEllipsoid.h
@@ -49,7 +49,7 @@ namespace hpmc
     \ingroup shape
 */
 
-// Original
+
 struct ell_params : param_base
     {
     OverlapReal x;                      //!< x semiaxis of the ellipsoid

--- a/hoomd/hpmc/ShapeEllipsoid.h
+++ b/hoomd/hpmc/ShapeEllipsoid.h
@@ -48,6 +48,8 @@ namespace hpmc
 
     \ingroup shape
 */
+
+// Original
 struct ell_params : param_base
     {
     OverlapReal x;                      //!< x semiaxis of the ellipsoid
@@ -61,6 +63,28 @@ struct ell_params : param_base
     void set_memory_hint() const
         {
         // default implementation does nothing
+        }
+    #endif
+
+    #ifndef NVCC
+    ell_params() { }
+
+    ell_params(pybind11::dict v)
+        {
+        ignore = v["ignore_statistics"].cast<unsigned int>();
+        x = v["a"].cast<OverlapReal>();
+        y = v["b"].cast<OverlapReal>();
+        z = v["c"].cast<OverlapReal>();
+        }
+
+    pybind11::dict asDict()
+        {
+        pybind11::dict v;
+        v["ignore_statistics"] = ignore;
+        v["a"] = x;
+        v["b"] = y;
+        v["c"] = z;
+        return v;
         }
     #endif
     } __attribute__((aligned(32)));

--- a/hoomd/hpmc/module.cc
+++ b/hoomd/hpmc/module.cc
@@ -82,7 +82,10 @@ PYBIND11_MODULE(_hpmc, m)
         .def(pybind11::init< pybind11::dict >())
         .def("asDict", &sph_params::asDict)
         ;
-    py::class_<ell_params, std::shared_ptr<ell_params> >(m, "ell_params");
+    py::class_<ell_params, std::shared_ptr<ell_params> >(m, "ell_params")
+        .def(pybind11::init< pybind11::dict >())
+        .def("asDict", &ell_params::asDict)
+        ;
     py::class_<poly2d_verts, std::shared_ptr<poly2d_verts> >(m, "poly2d_verts");
     py::class_<poly3d_data, std::shared_ptr<poly3d_data> >(m, "poly3d_data");
     py::class_< poly3d_verts, std::shared_ptr< poly3d_verts > >(m, "poly3d_verts");


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should based on *maint*. -->
<!-- New features should based on *master*. -->

## Description
I edited the ShapeEllipsoid.h and module.cc files to take in ellipsoid parameters as a dictionary, and to allow users to get these parameters back out in a dictionary by calling a method 'asDict()'.


## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
This is one step towards allowing a general type parameter class.
<!-- Replace ??? with the issue number that this pull request resolves. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
I created an object 'a = _hmpc.ell_params({parameters}'
I then made sure the dictionary outputted by 'a.asDict()' is {parameters}, the same that was inputted.
<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
31 October 2019: ellipsoid parameters can now be passed in and retrieved as a dictionary
```

## Checklist:

- [X] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [X] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [ ] My name is on the [list of contributors](https://github.com/glotzerlab/hoomd-blue/blob/master/sphinx-doc/credits.rst).
