### PR TITLE
Only sync GSD files when writing out properties rather than per property

### DIFF
--- a/hoomd/extern/gsd.c
+++ b/hoomd/extern/gsd.c
@@ -279,7 +279,7 @@ uint16_t __gsd_get_id(struct gsd_handle *handle, const char *name, uint8_t appen
 
         handle->namelist_num_entries++;
 
-        // sync the expanded namelist
+        // mark that synchronization is needed
         handle->needs_sync = true;
 
         return handle->namelist_num_entries-1;
@@ -918,6 +918,7 @@ int gsd_end_frame(struct gsd_handle* handle)
         handle->index_written_entries += entries_to_write;
         }
 
+    // this sync is triggered by the namelist update
     if (handle->needs_sync)
         {
         int retval = fsync(handle->fd);

--- a/hoomd/extern/gsd.c
+++ b/hoomd/extern/gsd.c
@@ -628,7 +628,7 @@ uint32_t gsd_make_version(unsigned int major, unsigned int minor)
 int gsd_create(const char *fname, const char *application, const char *schema, uint32_t schema_version)
     {
     int extra_flags = 0;
-    #ifdef WIN32
+    #ifdef _WIN32
     extra_flags = _O_BINARY;
     #endif
 
@@ -670,7 +670,7 @@ int gsd_create_and_open(struct gsd_handle* handle,
                         int exclusive_create)
     {
     int extra_flags = 0;
-    #ifdef WIN32
+    #ifdef _WIN32
     extra_flags = _O_BINARY;
     #endif
 
@@ -735,7 +735,7 @@ int gsd_open(struct gsd_handle* handle, const char *fname, const enum gsd_open_f
     handle->cur_frame = 0;
 
     int extra_flags = 0;
-    #ifdef WIN32
+    #ifdef _WIN32
     extra_flags = _O_BINARY;
     #endif
 

--- a/hoomd/extern/gsd.c
+++ b/hoomd/extern/gsd.c
@@ -280,9 +280,7 @@ uint16_t __gsd_get_id(struct gsd_handle *handle, const char *name, uint8_t appen
         handle->namelist_num_entries++;
 
         // sync the expanded namelist
-        int retval = fsync(handle->fd);
-        if (retval != 0)
-            return UINT16_MAX;
+        handle->needs_sync = true;
 
         return handle->namelist_num_entries-1;
         }
@@ -918,6 +916,14 @@ int gsd_end_frame(struct gsd_handle* handle)
             return -1;
 
         handle->index_written_entries += entries_to_write;
+        }
+
+    if (handle->needs_sync)
+        {
+        int retval = fsync(handle->fd);
+        if (retval != 0)
+            return -1;
+        handle->needs_sync = false;
         }
 
     return 0;

--- a/hoomd/extern/gsd.h
+++ b/hoomd/extern/gsd.h
@@ -6,6 +6,7 @@
 
 #include <stdint.h>
 #include <string.h>
+#include <stdbool.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -104,6 +105,7 @@ struct gsd_handle
     uint64_t cur_frame;
     int64_t file_size;                  //!< File size (in bytes)
     enum gsd_open_flag open_flags;      //!< Flags passed to gsd_open()
+    bool needs_sync; //!< Whether the handle requires an fsync call (new data was written)
     };
 
 //! Specify a version


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should based on *maint*. -->
<!-- New features should based on *master*. -->

## Description

Instead of syncing the namelist each time a particular property's id is added, only sync at the end.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

<!-- Replace ??? with the issue number that this pull request resolves. -->
On slow filesystems the fsync calls are extremely expensive and significantly degrade performance (by factors of >2).

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

Existing tests pass, ad hoc tests show substantial speed improvements.

## Change log

<!-- Propose a change log entry. -->
```
Update fsync calls for namelist to only call after all names are added to the list.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/hoomd-blue/blob/master/sphinx-doc/credits.rst).
