### PR TITLE
Support python 3.8

### DIFF
--- a/.azp/test.yml
+++ b/.azp/test.yml
@@ -184,7 +184,7 @@ stages:
       vmImage: 'ubuntu-16.04'
 
     container:
-      image: $(image_root)-ubuntu18.04
+      image: $(image_root)-gcc7_py37
       options: -u 0
 
     workspace:

--- a/.azp/test.yml
+++ b/.azp/test.yml
@@ -1,11 +1,5 @@
-trigger:
-  batch: true
-  branches:
-    include:
-    - '*'
-
 variables:
-  image_root: glotzerlab/ci:2019.08
+  image_root: glotzerlab/ci:2019.11
 
   # default build parameters, will override as needed with job matrix values
   enable_cuda: off
@@ -34,91 +28,68 @@ stages:
 
     strategy:
       matrix:
-        clang8_py37_mpi_tbb_llvm8:
-          container_image: ubuntu19.04
-          cc: clang-8
-          cxx: clang++-8
+        gcc9_py38_mpi_tbb:
+          container_image: gcc9_py38
+          enable_mpi: on
+          enable_tbb: on
+
+        clang9_py38_mpi_tbb:
+          container_image: clang9_py38
+          enable_mpi: on
+          enable_tbb: on
+          build_jit: on
+          llvm_version: '9'
+
+        clang8_py38_mpi_tbb:
+          container_image: clang8_py38
           enable_mpi: on
           enable_tbb: on
           build_jit: on
           llvm_version: '8'
 
-        clang7_py37_mpi_tbb_llvm7:
-          container_image: ubuntu19.04
-          cc: clang-7
-          cxx: clang++-7
+        clang7_py38_mpi_tbb:
+          container_image: clang7_py38
           enable_mpi: on
           enable_tbb: on
           build_jit: on
           llvm_version: '7'
 
-        gcc9_py37_mpi_tbb_llvm8:
-          container_image: ubuntu19.04
-          cc: gcc-9
-          cxx: g++-9
+        gcc8_py37_mpi_tbb:
+          container_image: gcc8_py37
           enable_mpi: on
           enable_tbb: on
-          build_jit: on
-          llvm_version: '8'
 
-        gcc9_py37_mpi_tbb_llvm7:
-          container_image: ubuntu19.04
-          cc: gcc-9
-          cxx: g++-9
-          enable_mpi: on
-          enable_tbb: on
-          build_jit: on
-          llvm_version: '7'
-
-        gcc8_py36_mpi_tbb_llvm6:
-          container_image: ubuntu18.04
-          cc: gcc-8
-          cxx: g++-8
-          enable_mpi: on
-          enable_tbb: on
-          build_jit: on
-          llvm_version: '6.0'
-
-        gcc7_py36_tbb:
-          container_image: ubuntu18.04
-          cc: gcc-7
-          cxx: g++-7
+        gcc7_py37_tbb:
+          container_image: gcc7_py37
           enable_tbb: on
 
-        gcc6_py36_mpi:
-          container_image: ubuntu18.04
-          cc: gcc-6
-          cxx: g++-6
+        gcc6_py37_mpi:
+          container_image: gcc6_py37
           enable_mpi: on
 
-        clang6_py36_mpi_tbb_llvm6:
-          container_image: ubuntu18.04
-          cc: clang-6.0
-          cxx: clang++-6.0
+        gcc5_py37:
+          container_image: gcc5_py37
+
+        gcc48_py37_mpi_tbb:
+          container_image: gcc48_py37
+          enable_mpi: on
+          enable_tbb: on
+
+        clang6_py37_mpi_tbb:
+          container_image: clang6_py37
           enable_mpi: on
           enable_tbb: on
           build_jit: on
           llvm_version: '6.0'
 
-        clang5_py36_tbb_llvm5:
-          container_image: ubuntu18.04
-          cc: clang-5.0
-          cxx: clang++-5.0
+        clang5_py37_tbb_llvm5:
+          container_image: clang5_py37
           enable_tbb: on
           build_jit: on
           llvm_version: '5.0'
 
-        gcc5_py36:
-          container_image: ubuntu18.04
-          cc: gcc-5
-          cxx: g++-5
-
-        gcc48_py36_mpi_tbb:
-          container_image: ubuntu18.04
-          cc: gcc-4.8
-          cxx: g++-4.8
-          enable_mpi: on
-          enable_tbb: on
+        gcc7_py36:
+          container_image: gcc7_py36
 
     pool:
       vmImage: 'ubuntu-16.04'
@@ -147,17 +118,8 @@ stages:
       vmImage: '$(mac_image)'
 
     steps:
-    - script: brew install cereal cmake eigen ninja open-mpi python numpy
+    - script: brew install cereal cmake eigen ninja open-mpi python numpy pybind11
       displayName: Brew install prereqs
-    # work around broken homebrew pybind11 package
-    - script: |
-        curl -sSL https://github.com/pybind/pybind11/archive/v2.4.2.tar.gz | tar -xzC ./ \
-        && cd pybind11-2.4.2 \
-        && mkdir build && cd build \
-        && cmake ../ -DCMAKE_INSTALL_PREFIX=/usr/local -DPYBIND11_TEST=off -DPYTHON_EXECUTABLE=/usr/local/bin/python3 \
-        && make install
-      displayName: Manually install pybind11
-      workingDirectory: $(Pipeline.Workspace)
     # Install Intel's provided TBB builds, homebrew's tbb does not support exception translation
     - script: |
         curl -sLO https://github.com/intel/tbb/releases/download/2019_U8/tbb2019_20190605oss_mac.tgz &&
@@ -185,23 +147,17 @@ stages:
 
     strategy:
       matrix:
-        gcc7_py36_cuda10_mng_mpi:
-          cc: gcc
-          cxx: g++
-          container_image: cuda10
+        cuda10_py37_mng_mpi:
+          container_image: cuda10_py37
           always_use_managed_memory: on
           enable_mpi: on
 
-        gcc7_py36_cuda9_mpi:
-          cc: gcc
-          cxx: g++
-          container_image: cuda9
+        cuda9_py37_mpi:
+          container_image: cuda9_py37
           enable_mpi: on
 
-        gcc7_py36_cuda9:
-          cc: gcc
-          cxx: g++
-          container_image: cuda9
+        cuda9_py37:
+          container_image: cuda9_py37
 
     pool:
       name: 'GPU'

--- a/.azp/validate.yml
+++ b/.azp/validate.yml
@@ -5,7 +5,7 @@
 trigger: none
 
 variables:
-  image_root: glotzerlab/ci:2019.08
+  image_root: glotzerlab/ci:2019.11
 
   # default build parameters, will override as needed with job matrix values
   enable_cuda: off
@@ -33,126 +33,102 @@ stages:
 
     strategy:
       matrix:
-        gcc8_py36_mpi_tbb2_llvm6_1:
-          container_image: ubuntu18.04
-          cc: gcc-8
-          cxx: g++-8
+        clang9_py38_mpi_tbb2_llvm6_1:
+          container_image: clang9_py38
           enable_mpi: on
           enable_tbb: on
           build_jit: on
-          llvm_version: '6.0'
+          llvm_version: '9.0'
           ctest_start: 1
           suite_name: CPU tbb2
-        gcc8_py36_mpi_tbb2_llvm6_2:
-          container_image: ubuntu18.04
-          cc: gcc-8
-          cxx: g++-8
+        clang9_py38_mpi_tbb2_llvm6_2:
+          container_image: clang9_py38
           enable_mpi: on
           enable_tbb: on
           build_jit: on
-          llvm_version: '6.0'
+          llvm_version: '9.0'
           ctest_start: 2
           suite_name: CPU tbb2
-        gcc8_py36_mpi_tbb2_llvm6_3:
-          container_image: ubuntu18.04
-          cc: gcc-8
-          cxx: g++-8
+        clang9_py38_mpi_tbb2_llvm6_3:
+          container_image: clang9_py38
           enable_mpi: on
           enable_tbb: on
           build_jit: on
-          llvm_version: '6.0'
+          llvm_version: '9.0'
           ctest_start: 3
           suite_name: CPU tbb2
-        gcc8_py36_mpi_tbb2_llvm6_4:
-          container_image: ubuntu18.04
-          cc: gcc-8
-          cxx: g++-8
+        clang9_py38_mpi_tbb2_llvm6_4:
+          container_image: clang9_py38
           enable_mpi: on
           enable_tbb: on
           build_jit: on
-          llvm_version: '6.0'
+          llvm_version: '9.0'
           ctest_start: 4
           suite_name: CPU tbb2
 
-        gcc8_py36_mpi_tbb1_llvm6_1:
-          container_image: ubuntu18.04
-          cc: gcc-8
-          cxx: g++-8
+        clang9_py38_mpi_tbb1_llvm6_1:
+          container_image: clang9_py38
           enable_mpi: on
           enable_tbb: on
           build_jit: on
-          llvm_version: '6.0'
+          llvm_version: '9.0'
           omp_num_threads: '1'
           ctest_start: 1
           suite_name: CPU tbb1
-        gcc8_py36_mpi_tbb1_llvm6_2:
-          container_image: ubuntu18.04
-          cc: gcc-8
-          cxx: g++-8
+        clang9_py38_mpi_tbb1_llvm6_2:
+          container_image: clang9_py38
           enable_mpi: on
           enable_tbb: on
           build_jit: on
-          llvm_version: '6.0'
+          llvm_version: '9.0'
           omp_num_threads: '1'
           ctest_start: 2
           suite_name: CPU tbb1
-        gcc8_py36_mpi_tbb1_llvm6_3:
-          container_image: ubuntu18.04
-          cc: gcc-8
-          cxx: g++-8
+        clang9_py38_mpi_tbb1_llvm6_3:
+          container_image: clang9_py38
           enable_mpi: on
           enable_tbb: on
           build_jit: on
-          llvm_version: '6.0'
+          llvm_version: '9.0'
           omp_num_threads: '1'
           ctest_start: 3
           suite_name: CPU tbb1
-        gcc8_py36_mpi_tbb1_llvm6_4:
-          container_image: ubuntu18.04
-          cc: gcc-8
-          cxx: g++-8
+        clang9_py38_mpi_tbb1_llvm6_4:
+          container_image: clang9_py38
           enable_mpi: on
           enable_tbb: on
           build_jit: on
-          llvm_version: '6.0'
+          llvm_version: '9.0'
           omp_num_threads: '1'
           ctest_start: 4
           suite_name: CPU tbb1
 
-        gcc8_py36_mpi_llvm6_1:
-          container_image: ubuntu18.04
-          cc: gcc-8
-          cxx: g++-8
+        clang9_py38_mpi_llvm6_1:
+          container_image: clang9_py38
           enable_mpi: on
           build_jit: on
-          llvm_version: '6.0'
+          llvm_version: '9.0'
           ctest_start: 1
           suite_name: CPU no-tbb
-        gcc8_py36_mpi_llvm6_2:
-          container_image: ubuntu18.04
-          cc: gcc-8
-          cxx: g++-8
+        clang9_py38_mpi_llvm6_2:
+          container_image: clang9_py38
           enable_mpi: on
           build_jit: on
-          llvm_version: '6.0'
+          llvm_version: '9.0'
           ctest_start: 2
           suite_name: CPU no-tbb
-        gcc8_py36_mpi_llvm6_3:
-          container_image: ubuntu18.04
-          cc: gcc-8
-          cxx: g++-8
+        clang9_py38_mpi_llvm6_3:
+          container_image: clang9_py38
           enable_mpi: on
           build_jit: on
-          llvm_version: '6.0'
+          llvm_version: '9.0'
           ctest_start: 3
           suite_name: CPU no-tbb
-        gcc8_py36_mpi_llvm6_4:
-          container_image: ubuntu18.04
-          cc: gcc-8
-          cxx: g++-8
+        clang9_py38_mpi_llvm6_4:
+          container_image: clang9_py38
           enable_mpi: on
           build_jit: on
-          llvm_version: '6.0'
+          llvm_version: '9.0'
           ctest_start: 4
           suite_name: CPU no-tbb
 
@@ -179,31 +155,26 @@ stages:
 
     strategy:
       matrix:
-        gcc7_py36_cuda10_mpi_1:
-          cc: gcc
-          cxx: g++
-          container_image: cuda10
+        cuda10_py37_cuda10_mpi_1:
+          container_image: cuda10_py37
           enable_mpi: on
           ctest_start: 1
           suite_name: GPU cuda10
-        gcc7_py36_cuda10_mpi_2:
-          cc: gcc
-          cxx: g++
-          container_image: cuda10
+
+        cuda10_py37_cuda10_mpi_2:
+          container_image: cuda10_py37
           enable_mpi: on
           ctest_start: 2
           suite_name: GPU cuda10
-        gcc7_py36_cuda10_mpi_3:
-          cc: gcc
-          cxx: g++
-          container_image: cuda10
+
+        cuda10_py37_cuda10_mpi_3:
+          container_image: cuda10_py37
           enable_mpi: on
           ctest_start: 3
           suite_name: GPU cuda10
-        gcc7_py36_cuda10_mpi_4:
-          cc: gcc
-          cxx: g++
-          container_image: cuda10
+
+        cuda10_py37_cuda10_mpi_4:
+          container_image: cuda10_py37
           enable_mpi: on
           ctest_start: 4
           suite_name: GPU cuda10

--- a/hoomd/context.py
+++ b/hoomd/context.py
@@ -20,7 +20,7 @@ import platform
 # The following global variables keep track of the walltime and processing time since the import of hoomd
 import time
 TIME_START = time.time()
-CLOCK_START = time.clock()
+CLOCK_START = time.perf_counter()
 
 ## Global Messenger
 msg = None;
@@ -456,7 +456,7 @@ class ExecutionContext(hoomd.meta._metadata):
     # \brief Return the CPU clock time since the import of hoomd
     @property
     def cputime(self):
-        return time.clock() - CLOCK_START
+        return time.perf_counter() - CLOCK_START
 
     # \brief Return the job id
     @property


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should based on *maint*. -->
<!-- New features should based on *master*. -->

## Description

<!-- Describe your changes in detail. -->
Use `time.perf_counter` instead of `time.clock`
Test and validate on python 3.8.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Python 3.8 removed the deprecated method `time.clock`.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
CI test.

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
* Support python 3.8
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/hoomd-blue/blob/master/sphinx-doc/credits.rst).
