### PR TITLE
Avoid divide-by-zero in SRD thermostat

### DIFF
--- a/hoomd/mpcd/SRDCollisionMethod.cc
+++ b/hoomd/mpcd/SRDCollisionMethod.cc
@@ -110,7 +110,7 @@ void mpcd::SRDCollisionMethod::drawRotationVectors(unsigned int timestep)
                         // (don't use the kinetic energy of this cell, since this
                         // is total not relative to COM)
                         const double cur_ke = alpha * cell_energy.y;
-                        factor = fast::sqrt(rand_ke/cur_ke);
+                        factor = (cur_ke > 0.) ? fast::sqrt(rand_ke/cur_ke) : 1.;
                         }
                     h_factors->data[idx] = factor;
                     }

--- a/hoomd/mpcd/SRDCollisionMethodGPU.cu
+++ b/hoomd/mpcd/SRDCollisionMethodGPU.cu
@@ -82,7 +82,7 @@ __global__ void srd_draw_vectors(double3 *d_rotvec,
             // (don't use the kinetic energy of this cell, since this
             // is total not relative to COM)
             const double cur_ke = alpha * cell_energy.y;
-            factor = fast::sqrt(rand_ke/cur_ke);
+            factor = (cur_ke > 0.) ? fast::sqrt(rand_ke/cur_ke) : 1.;
             }
         d_factors[idx] = factor;
         }


### PR DESCRIPTION
## Description

Avoids rare divide-by-zero in SRD thermostat. The thermostat rescale factor should be 1.0 in those cases (no change applied).

## Motivation and Context

This seems to fix the issue reported on the [user forum](https://groups.google.com/d/msg/hoomd-users/4h6xNyEVGOM/H7h-ENyWAgAJ).

Resolves: #503 

## How Has This Been Tested?

A minimum version of the user's script failed before, and it did not fail after making this change. I couldn't find any other instances of dividing by the kinetic energy.

## Change log

```
* Fix a rare divide-by-zero in the ``collide.srd`` thermostat.
```

## Checklist:

- [X] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [X] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [X] My name is on the [list of contributors](https://github.com/glotzerlab/hoomd-blue/blob/master/sphinx-doc/credits.rst).
