### PR TITLE
fix Pak's author name

### DIFF
--- a/hoomd/cite.py
+++ b/hoomd/cite.py
@@ -416,7 +416,7 @@ def _ensure_global_bib():
                         author = ['J Glaser',
                                   'T D Nguyen',
                                   'J A Anderson',
-                                  'P Liu',
+                                  'P Lui',
                                   'F Spiga',
                                   'J A Millan',
                                   'D C Morse',


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should based on *maint*. -->
<!-- New features should based on *master*. -->

## Description

This corrects Pak Lui's author name in the base citation message.
see
https://www.sciencedirect.com/science/article/pii/S0010465515000867

## Motivation and Context

His last name was misspelled.

## How Has This Been Tested?

N/A

## Change log

N/A

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/hoomd-blue/blob/master/sphinx-doc/credits.rst).
