### PR TITLE
update the hpmc wall updater to 3.0 api

### DIFF
--- a/hoomd/hpmc/UpdaterExternalFieldWall.h
+++ b/hoomd/hpmc/UpdaterExternalFieldWall.h
@@ -62,20 +62,46 @@ class __attribute__ ((visibility ("hidden"))) UpdaterExternalFieldWall : public 
         //! Destructor
         virtual ~UpdaterExternalFieldWall(){}
 
-        //! Sets parameters
-        /*! \param move_ratio Probability of attempting external field update move
-        */
+        //! Get the seed
+        unsigned int getSeed()
+            {
+            return m_seed;
+            }
+
+        //! Set the move ratio
         void setMoveRatio(Scalar move_ratio)
             {
             m_move_ratio = move_ratio;
-            };
+            }
 
-        //! Get move_ratio parameter
-        /*! \returns move_ratio parameter
-        */
+        //! Get the move ratio
         Scalar getMoveRatio()
             {
             return m_move_ratio;
+            }
+
+        //! Get the python call back for external field update
+        pybind11::object getPyUpdater()
+            {
+            return m_py_updater;
+            }
+
+        //! Set the python call back for external field update
+        void setPyUpdater(pybind11::object py_updater)
+            {
+            m_py_updater=py_updater;
+            }
+
+        //! Get the field wall object
+        std::shared_ptr< ExternalFieldWall<Shape> > getWalls()
+            {
+            return m_external;
+            }
+
+        //! Set the field wall object
+        void setWalls(std::shared_ptr< ExternalFieldWall<Shape> > external)
+            {
+            m_external=external;
             }
 
         //! Print statistics
@@ -177,7 +203,7 @@ class __attribute__ ((visibility ("hidden"))) UpdaterExternalFieldWall : public 
     private:
         std::shared_ptr< IntegratorHPMCMono<Shape> > m_mc;      //!< Integrator
         std::shared_ptr< ExternalFieldWall<Shape> > m_external; //!< External field wall object
-        pybind11::object m_py_updater;                       //!< Python call back for external field update
+        pybind11::object m_py_updater;                          //!< Python call back for external field update
         Scalar m_move_ratio;                                      //!< Ratio of lattice vector length versus shearing move
         unsigned int m_count_accepted_rel;                        //!< Accepted moves count, relative to start of run
         unsigned int m_count_total_rel;                           //!< Accept/reject total count, relative to start of run
@@ -197,6 +223,10 @@ void export_UpdaterExternalFieldWall(pybind11::module& m, std::string name)
     .def("getAcceptedCount", &UpdaterExternalFieldWall<Shape>::getAcceptedCount)
     .def("getTotalCount", &UpdaterExternalFieldWall<Shape>::getTotalCount)
     .def("resetStats", &UpdaterExternalFieldWall<Shape>::resetStats)
+    .def_property("walls", &UpdaterExternalFieldWall<Shape>::getWalls, &UpdaterExternalFieldWall<Shape>::setWalls)
+    .def_property("py_updater", &UpdaterExternalFieldWall<Shape>::getPyUpdater, &UpdaterExternalFieldWall<Shape>::setPyUpdater)
+    .def_property("move_ratio", &UpdaterExternalFieldWall<Shape>::getMoveRatio, &UpdaterExternalFieldWall<Shape>::setMoveRatio)
+    .def_property_readonly("seed", &UpdaterExternalFieldWall<Shape>::getSeed)
     ;
     }
 } // namespace

--- a/hoomd/hpmc/update.py
+++ b/hoomd/hpmc/update.py
@@ -400,6 +400,7 @@ class boxmc(_updater):
 
 # TODO: consider updating the naming of move_ratio to move_probabilty
 # TODO: find out if logging documentation is still valid
+# TODO replace (periodic)trigger with :py:class:`hoomd.Triggers` once doc'ed
 class Wall(_updater):
     R""" Apply wall updates with a user-provided python callback.
 
@@ -409,16 +410,19 @@ class Wall(_updater):
         py_updater (`callable`): the python callback that performs the update
                                  moves. This must be a python method that is a
                                  function of the timestep of the simulation.
-               It must actually update the :py:class:`hoomd.hpmc.field.wall`)
-               managed object.
+                                 It must actually update the 
+                                 :py:class:`hoomd.hpmc.field.wall`) managed 
+                                 object.
         move_ratio (float): the probability with which an update move is
                             attempted.
         seed (int): the seed of the pseudo-random number generator that
                     determines whether or not an update move is attempted
-        trigger (int): the number of timesteps between update move attempt
-                       attempts.
+        trigger (int or `Trigger`): the trigger object which causes
+            the updater to be called. If an interger is given, default is 1, a
+            PeriodicTrigger with phase of 0 will be used.
+                    
 
-    Every *trigger* steps, a walls update move is tried with probability
+    Every *trigger* step, a walls update move is tried with probability
     *move_ratio*. This update move is provided by the *py_updater* callback.
     Then, update.wall only accepts an update move provided by the python
     callback if it maintains confinement conditions associated with all walls.
@@ -427,13 +431,13 @@ class Wall(_updater):
     Once initialized, the update provides the following log quantities that can
     be logged via :py:class:`hoomd.analyze.log`:
 
-    * **hpmc_wall_acceptance_ratio** - the acceptance ratio for wall update
+    **hpmc_wall_acceptance_ratio** - the acceptance ratio for wall update
     moves
 
     Examples::
 
         TODO: link to example notebook, move examples here to notebook
-
+        
     Example::
 
         mc = hpmc.integrate.sphere(seed = 415236);
@@ -444,7 +448,7 @@ class Wall(_updater):
           r = np.sqrt(ext_wall.get_sphere_wall_param(index = 0, param = "rsq"));
           ext_wall.set_sphere_wall(index = 0, radius = 1.5*r,
                                    origin = [0, 0, 0], inside = True);
-        wall_updater = hpmc.update.wall(mc, ext_wall, perturb,
+        wall_updater = hpmc.update.Wall(mc, ext_wall, perturb,
                                         move_ratio = 0.5, seed = 27,
                                         trigger = 50);
         log = analyze.log(quantities=['hpmc_wall_acceptance_ratio'],

--- a/sphinx-doc/module-hpmc-update.rst
+++ b/sphinx-doc/module-hpmc-update.rst
@@ -12,7 +12,7 @@ hpmc.update
     hpmc.update.Clusters
     hpmc.update.muvt
     hpmc.update.remove_drift
-    hpmc.update.wall
+    hpmc.update.Wall
 
 .. rubric:: Details
 


### PR DESCRIPTION
This is ready to go aside from the following todo's:
1. A parameter name issue. The variable "move_ratio" is actually a probability. Other updater use "move_probability" which seems much more clear but could be considered a breaking change. 
2. Verify that 3.0 won't invalidate the logged quantity in the documentation.
3. I think the examples might need a slight tune up but I'm not familiar with the rest of the API changes. These updated examples could then be moved to the notebook and linked.

fixes #513 