### PR TITLE
Move HPMC ellipsoid integrator to v.3.0 API

### DIFF
--- a/hoomd/dump.py
+++ b/hoomd/dump.py
@@ -8,13 +8,14 @@ Commands in the dump package write the system state out to a file every
 each command writes.
 """
 
-from collections import namedtuple;
+from collections import namedtuple
+from hoomd.filters import All
 from hoomd import _hoomd
-import hoomd;
-import json;
-import os;
-import sys;
-import types;
+import hoomd
+import json
+import os
+import sys
+import types
 
 class dcd(hoomd.analyze._analyzer):
     R""" Writes simulation snapshots in the DCD format
@@ -612,10 +613,11 @@ class GSD(hoomd.meta._Analyzer):
     TODO: should ``filter_`` default to All?
 
     """
+
     def __init__(self,
                  filename,
                  trigger,
-                 filter_,
+                 filter=All(),
                  overwrite=False,
                  truncate=False,
                  dynamic=None):
@@ -623,7 +625,7 @@ class GSD(hoomd.meta._Analyzer):
         super().__init__(trigger)
 
         self._param_dict = dict(filename=filename,
-                                filter=filter_,
+                                filter=filter,
                                 overwrite=overwrite,
                                 truncate=truncate,
                                 dynamic=dynamic,

--- a/hoomd/hpmc/integrate.py
+++ b/hoomd/hpmc/integrate.py
@@ -1387,9 +1387,9 @@ class convex_spheropolyhedron(mode_hpmc):
         """
         return super(convex_spheropolyhedron, self)._return_type_shapes()
 
-class ellipsoid(mode_hpmc):
+class Ellipsoid(mode_hpmc):
     R""" HPMC integration for ellipsoids (2D/3D).
-
+​
     Args:
         seed (int): Random number seed.
         d (float): Maximum move displacement, Scalar to set for all types, or a dict containing {type:size} to set by type.
@@ -1398,66 +1398,73 @@ class ellipsoid(mode_hpmc):
         nselect (int): The number of trial moves to perform in each cell.
         restore_state(bool): Restore internal state from initialization file when True. See :py:class:`mode_hpmc`
                              for a description of what state data restored. (added in version 2.2)
-
+​
     Ellipsoid parameters:
-
+​
     * *a* (**required**) - principle axis a of the ellipsoid (radius in the x direction) (distance units)
     * *b* (**required**) - principle axis b of the ellipsoid (radius in the y direction) (distance units)
     * *c* (**required**) - principle axis c of the ellipsoid (radius in the z direction) (distance units)
     * *ignore_statistics* (**default: False**) - set to True to disable ignore for statistics tracking
-
+​
     Example::
-
+​
         mc = hpmc.integrate.ellipsoid(seed=415236, d=0.3, a=0.4)
         mc.shape_param.set('A', a=0.5, b=0.25, c=0.125);
         print('ellipsoids parameters (a,b,c) = ', mc.shape_param['A'].a, mc.shape_param['A'].b, mc.shape_param['A'].c)
-
+​
     Depletants Example::
-
+​
         mc = hpmc.integrate.ellipsoid(seed=415236, d=0.3, a=0.4)
         mc.set_param(nselect=1)
         mc.shape_param.set('A', a=0.5, b=0.25, c=0.125);
         mc.shape_param.set('B', a=0.05, b=0.05, c=0.05);
         mc.set_fugacity('B',fugacity=3.0)
     """
-    def __init__(self, seed, d=0.1, a=0.1, move_ratio=0.5, nselect=4, restore_state=False):
-
+    def __init__(self, seed, d=0.1, a=0.1, move_ratio=0.5, nselect=4):
         # initialize base class
-        mode_hpmc.__init__(self);
-
+        super().__init__()
+        self._param_dict = dict(seed=seed,
+                                move_ratio=move_ratio,
+                                nselect=nselect)
+        typeparam_d = TypeParameter('d', type_kind='particle_types',
+                                    param_dict=TypeParameterDict(d, len_keys=1)
+                                    )
+        typeparam_a = TypeParameter('a', type_kind='particle_types',
+                                    param_dict=TypeParameterDict(a, len_keys=1)
+                                    )
+        typeparam_shape = TypeParameter('shape', type_kind='particle_types',
+                                        param_dict=TypeParameterDict(
+                                            a=RequiredArg,
+                                            b=RequiredArg,
+                                            c=RequiredArg,
+                                            ignore_statistics=False,
+                                            len_keys=1)
+                                    )
+        self._extend_typeparam([typeparam_a, typeparam_d, typeparam_shape])
+    def attach(self, simulation):
         # initialize the reflected c++ class
-        if not hoomd.context.current.device.cpp_exec_conf.isCUDAEnabled():
-            self.cpp_integrator = _hpmc.IntegratorHPMCMonoEllipsoid(hoomd.context.current.system_definition, seed);
+        sys_def = simulation.state._cpp_sys_def
+        if not simulation.device.mode == 'GPU':
+            self._cpp_obj = _hpmc.IntegratorHPMCMonoEllipsoid(sys_def, self.seed)
+            cl_c = None
         else:
-            cl_c = _hoomd.CellListGPU(hoomd.context.current.system_definition);
-            hoomd.context.current.system.overwriteCompute(cl_c, "auto_cl2")
-            self.cpp_integrator = _hpmc.IntegratorHPMCMonoGPUEllipsoid(hoomd.context.current.system_definition, cl_c, seed);
-
-        # set default parameters
-        setD(self.cpp_integrator,d);
-        setA(self.cpp_integrator,a);
-        self.cpp_integrator.setMoveRatio(move_ratio)
-
-        self.cpp_integrator.setNSelect(nselect);
-
-        hoomd.context.current.system.setIntegrator(self.cpp_integrator);
-        self.initialize_shape_params();
-
-        if restore_state:
-            self.restore_state()
+            cl_c = hoomd.CellListGPU(sys_def)
+            self._cpp_obj = hpmc.IntegratorHPMCMonoGPUEllipsoid(sys_def, cl_c, self.seed)
+        # set the non type specfic parameters
+        self._apply_param_dict()
+        # Deal with type specific properties
+        self._apply_typeparam_dict(self._cpp_obj, simulation)
+        return [cl_c] if cl_c is not None else None
 
     def get_type_shapes(self):
         """Get all the types of shapes in the current simulation.
-
         Example:
-
             >>> mc.get_type_shapes()
             [{'type': 'Ellipsoid', 'a': 1.0, 'b': 1.5, 'c': 1}]
-
         Returns:
             A list of dictionaries, one for each particle type in the system.
         """
-        return super(ellipsoid, self)._return_type_shapes()
+        return super()._return_type_shapes()
 
 class sphere_union(mode_hpmc):
     R""" HPMC integration for unions of spheres (3D).

--- a/hoomd/simulation.py
+++ b/hoomd/simulation.py
@@ -1,5 +1,6 @@
 import hoomd._hoomd as _hoomd
 from hoomd.state import State
+from hoomd.snapshot import Snapshot
 from hoomd.operations import Operations
 
 
@@ -55,7 +56,8 @@ class Simulation:
         # Grab snapshot and timestep
         reader = _hoomd.GSDReader(self.device.cpp_exec_conf,
                                   filename, abs(frame), frame < 0)
-        snapshot = reader.getSnapshot()
+        snapshot = Snapshot._from_cpp_snapshot(reader.getSnapshot(),
+                                               self.device.comm)
 
         step = reader.getTimeStep() if self.timestep is None else self.timestep
         self._state = State(self, snapshot)

--- a/hoomd/snapshot.py
+++ b/hoomd/snapshot.py
@@ -93,6 +93,13 @@ class Snapshot:
         else:
             return None
 
+    @classmethod
+    def _from_cpp_snapshot(cls, snapshot, comm):
+        sp = cls()
+        sp._comm = comm
+        sp._cpp_obj = snapshot
+        return sp
+
     def replicate(self, nx, ny, nz):
         self._cpp_obj.replicate(nx, ny, nz)
 

--- a/hoomd/state.py
+++ b/hoomd/state.py
@@ -3,6 +3,7 @@ from hoomd.groups import Groups
 from .data import boxdim
 from hoomd.snapshot import Snapshot
 
+
 def _create_domain_decomposition(device, box):
     """ Create a default domain decomposition.
 
@@ -27,6 +28,7 @@ def _create_domain_decomposition(device, box):
                                         False)
 
     return result
+
 
 class State:
     R"""
@@ -55,9 +57,9 @@ class State:
 
     @property
     def snapshot(self):
-        result = Snapshot(self._simulation.device.comm)
-        result._cpp_obj = self._cpp_sys_def.takeSnapshot_double()
-        return result
+        cpp_snapshot = self._cpp_sys_def.takeSnapshot_double()
+        return Snapshot._from_cpp_snapshot(cpp_snapshot,
+                                           self._simulation.device.comm)
 
     @snapshot.setter
     def snapshot(self, snapshot):
@@ -66,12 +68,14 @@ class State:
         Args:
             snapshot:. The snapshot to initialize the system from.
 
-        Snapshots temporarily store system data. Snapshots contain the complete simulation state in a
-        single object. They can be used to restart a simulation.
+        Snapshots temporarily store system data. Snapshots contain the complete
+        simulation state in a single object. They can be used to restart a
+        simulation.
 
-        Example use cases in which a simulation may be restarted from a snapshot include python-script-level
-        Monte-Carlo schemes, where the system state is stored after a move has been accepted (according to
-        some criterion), and where the system is re-initialized from that same state in the case
+        Example use cases in which a simulation may be restarted from a snapshot
+        include python-script-level Monte-Carlo schemes, where the system state
+        is stored after a move has been accepted (according to some criterion),
+        and where the system is re-initialized from that same state in the case
         when a move is not accepted.
 
         Example::
@@ -85,10 +89,13 @@ class State:
             system.restore_snapshot(snapshot)
 
         Warning:
-                restore_snapshot() may invalidate force coefficients, neighborlist r_cut values, and other per type
-                quantities if called within a callback during a run(). You can restore a snapshot during a run only
-                if the snapshot is of a previous state of the currently running system. Otherwise, you need to use
-                restore_snapshot() between run() commands to ensure that all per type coefficients are updated properly.
+                restore_snapshot() may invalidate force coefficients,
+                neighborlist r_cut values, and other per type quantities if
+                called within a callback during a run(). You can restore a
+                snapshot during a run only if the snapshot is of a previous
+                state of the currently running system. Otherwise, you need to
+                use restore_snapshot() between run() commands to ensure that all
+                per type coefficients are updated properly.
 
         """
 


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should based on *maint*. -->
<!-- New features should based on *master*. -->

## Description

<!-- Describe your changes in detail. -->

## Motivation and Context

Move HPMC ellipsoid integrator to v.3.0 API

## How Has This Been Tested?

Test was not finished due to following error from `sim.operations.schedule()`
```TypeError: __init__(): incompatible constructor arguments. The following argument types are supported:
    1. hoomd._hoomd.ParticleGroup(arg0: hoomd._hoomd.SystemDefinition, arg1: ParticleFilter, arg2: bool)
    2. hoomd._hoomd.ParticleGroup(arg0: hoomd._hoomd.SystemDefinition, arg1: ParticleFilter)
    3. hoomd._hoomd.ParticleGroup(arg0: hoomd._hoomd.SystemDefinition, arg1: hoomd._hoomd.std_vector_uint)
    4. hoomd._hoomd.ParticleGroup()```


## Change log


## Checklist:

- [ ] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [ ] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [ ] My name is on the [list of contributors](https://github.com/glotzerlab/hoomd-blue/blob/master/sphinx-doc/credits.rst).
