### PR TITLE
fix wrong initialization of thermo-/barostat velocities

### DIFF
--- a/hoomd/md/TwoStepNPTMTK.cc
+++ b/hoomd/md/TwoStepNPTMTK.cc
@@ -901,7 +901,7 @@ void TwoStepNPTMTK::randomizeVelocities(unsigned int timestep)
         Scalar& xi = v.variable[1];
 
         unsigned int g = m_thermo_group->getNDOF();
-        Scalar sigmasq_t = Scalar(1.0)/((Scalar) g*m_T_randomize*m_tau*m_tau);
+        Scalar sigmasq_t = Scalar(1.0)/((Scalar) g*m_tau*m_tau);
 
         if (master)
             {
@@ -913,7 +913,7 @@ void TwoStepNPTMTK::randomizeVelocities(unsigned int timestep)
             {
             // update thermostat for rotational DOF
             Scalar &xi_rot = v.variable[8];
-            Scalar sigmasq_r = Scalar(1.0)/((Scalar)m_thermo_group->getRotationalNDOF()*m_T_randomize*m_tau*m_tau);
+            Scalar sigmasq_r = Scalar(1.0)/((Scalar)m_thermo_group->getRotationalNDOF()*m_tau*m_tau);
 
             if (master)
                 {
@@ -931,7 +931,7 @@ void TwoStepNPTMTK::randomizeVelocities(unsigned int timestep)
     Scalar& nuzz = v.variable[7];  // Barostat tensor, zz component
 
     unsigned int d = m_sysdef->getNDimensions();
-    Scalar sigmasq_baro = Scalar(1.0)/((Scalar)(m_ndof+d)/(Scalar)d*m_T_randomize*m_tauP*m_tauP);
+    Scalar sigmasq_baro = Scalar(1.0)/((Scalar)(m_ndof+d)/(Scalar)d*m_tauP*m_tauP);
 
     if (master)
         {

--- a/hoomd/md/TwoStepNVTMTK.cc
+++ b/hoomd/md/TwoStepNVTMTK.cc
@@ -453,7 +453,7 @@ void TwoStepNVTMTK::randomizeVelocities(unsigned int timestep)
     Scalar& xi = v.variable[0];
 
     unsigned int g = m_thermo->getNDOF();
-    Scalar sigmasq_t = Scalar(1.0)/((Scalar) g*m_T_randomize*m_tau*m_tau);
+    Scalar sigmasq_t = Scalar(1.0)/((Scalar) g*m_tau*m_tau);
 
     bool master = m_exec_conf->getRank() == 0;
     hoomd::RandomGenerator rng(hoomd::RNGIdentifier::TwoStepNVTMTK, m_seed_randomize, timestep);
@@ -476,7 +476,7 @@ void TwoStepNVTMTK::randomizeVelocities(unsigned int timestep)
         {
         // update thermostat for rotational DOF
         Scalar &xi_rot = v.variable[2];
-        Scalar sigmasq_r = Scalar(1.0)/((Scalar)m_thermo->getRotationalNDOF()*m_T_randomize*m_tau*m_tau);
+        Scalar sigmasq_r = Scalar(1.0)/((Scalar)m_thermo->getRotationalNDOF()*m_tau*m_tau);
 
         if (master)
             {


### PR DESCRIPTION
## Description

The thermostat and barostat momenta were incorrectly initialized, causing a blow-up of one of @syjlee 's simulations. The variance of the normal distribution from which these momenta were drawn was wrong. This PR fixes that. Going forward, we could implement unit tests which ensure that the equilibrated values of those momenta are within a confidence interval of the initial random values. However, the current test only ensures that they are non-zero.

## Motivation and Context

@syjlee 's was not able to use `npt.randomize_velocities()` in her simulation of a lattice. Since the initial velocities were only correct for `T=1` but in her case `T` was `0.2`, the initial box momenta were too large and the system blew up.

## How Has This Been Tested?

Double check that the energy units (`thermostat_energy` and `barostat_energy` log quantities) are consistent with the formula for the variance. Simulation now appears to run correctly.

## Change log

```
- Fix randomization of barostat and thermostat velocities with `randomize_velocities()` for non-unit temperatures
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/hoomd-blue/blob/master/sphinx-doc/credits.rst).
