### PR TITLE
fix diameter shifting across pbc

### DIFF
--- a/hoomd/md/NeighborListGPUTree.cc
+++ b/hoomd/md/NeighborListGPUTree.cc
@@ -381,6 +381,8 @@ void NeighborListGPUTree::traverseTree()
     // clear the neighbor counts
     cudaMemset(d_n_neigh.data, 0, sizeof(unsigned int)*m_pdata->getN());
 
+    const BoxDim& box = m_pdata->getBox();
+
     // traverse all pairs in (now-transposed) streams
     cudaDeviceSynchronize();
     for (unsigned int i=0; i < m_pdata->getNTypes(); ++i)
@@ -430,7 +432,8 @@ void NeighborListGPUTree::traverseTree()
                                                       Ni,
                                                       m_pdata->getN(),
                                                       rcut,
-                                                      rlist);
+                                                      rlist,
+                                                      box);
                 m_traversers[j]->traverse(nlist_op, query_op, map, *m_lbvhs[j], m_image_list, m_streams[i]);
                 }
             else if (m_filter_body && !m_diameter_shift)
@@ -442,7 +445,8 @@ void NeighborListGPUTree::traverseTree()
                                                      Ni,
                                                      m_pdata->getN(),
                                                      rcut,
-                                                     rlist);
+                                                     rlist,
+                                                     box);
                 m_traversers[j]->traverse(nlist_op, query_op, map, *m_lbvhs[j], m_image_list, m_streams[i]);
                 }
             else if (!m_filter_body && m_diameter_shift)
@@ -454,7 +458,8 @@ void NeighborListGPUTree::traverseTree()
                                                      Ni,
                                                      m_pdata->getN(),
                                                      rcut,
-                                                     rlist);
+                                                     rlist,
+                                                     box);
                 m_traversers[j]->traverse(nlist_op, query_op, map, *m_lbvhs[j], m_image_list, m_streams[i]);
                 }
             else
@@ -466,7 +471,8 @@ void NeighborListGPUTree::traverseTree()
                                                     Ni,
                                                     m_pdata->getN(),
                                                     rcut,
-                                                    rlist);
+                                                    rlist,
+                                                    box);
                 m_traversers[j]->traverse(nlist_op, query_op, map, *m_lbvhs[j], m_image_list, m_streams[i]);
                 }
             }

--- a/hoomd/md/NeighborListGPUTree.cuh
+++ b/hoomd/md/NeighborListGPUTree.cuh
@@ -245,6 +245,7 @@ struct ParticleQueryOp
     /*!
      * \param q The current thread data.
      * \param primitive Index of the intersected primitive.
+     * \param image the current image
      * \returns True If the volumes still overlap after refinement.
      *
      * HOOMD's neighbor lists require additional filtering. This first ensures
@@ -253,7 +254,7 @@ struct ParticleQueryOp
      * enabled, the cutoff radius is adjusted based on the diameters of the
      * particles.
      */
-    DEVICE bool refine(const ThreadData& q, const int primitive) const
+    DEVICE bool refine(const ThreadData& q, const int primitive, const Scalar3& image) const
         {
         bool exclude = (q.idx == primitive);
 
@@ -277,7 +278,7 @@ struct ParticleQueryOp
             rc2 *= rc2;
 
             // compute distance and wrap back into box
-            const Scalar3 dr = r - q.position;
+            const Scalar3 dr = r - q.position - image;
             const Scalar drsq = dot(dr,dr);
 
             // exclude if outside the sphere

--- a/hoomd/md/NeighborListGPUTree.cuh
+++ b/hoomd/md/NeighborListGPUTree.cuh
@@ -154,9 +154,10 @@ struct ParticleQueryOp
                     unsigned int N_,
                     unsigned int Nown_,
                     const Scalar rcut_,
-                    const Scalar rlist_)
+                    const Scalar rlist_,
+                    const BoxDim& box_)
         : positions(positions_), bodies(bodies_), diams(diams_), map(map_),
-          N(N_), Nown(Nown_), rcut(rcut_), rlist(rlist_)
+          N(N_), Nown(Nown_), rcut(rcut_), rlist(rlist_), box(box_)
           {}
 
     #ifdef NVCC
@@ -245,7 +246,6 @@ struct ParticleQueryOp
     /*!
      * \param q The current thread data.
      * \param primitive Index of the intersected primitive.
-     * \param image the current image
      * \returns True If the volumes still overlap after refinement.
      *
      * HOOMD's neighbor lists require additional filtering. This first ensures
@@ -254,7 +254,7 @@ struct ParticleQueryOp
      * enabled, the cutoff radius is adjusted based on the diameters of the
      * particles.
      */
-    DEVICE bool refine(const ThreadData& q, const int primitive, const Scalar3& image) const
+    DEVICE bool refine(const ThreadData& q, const int primitive) const
         {
         bool exclude = (q.idx == primitive);
 
@@ -278,7 +278,7 @@ struct ParticleQueryOp
             rc2 *= rc2;
 
             // compute distance and wrap back into box
-            const Scalar3 dr = r - q.position - image;
+            const Scalar3 dr = box.minImage(r - q.position);
             const Scalar drsq = dot(dr,dr);
 
             // exclude if outside the sphere
@@ -303,6 +303,7 @@ struct ParticleQueryOp
     unsigned int Nown;          //!< Number of particles owned by the local rank
     Scalar rcut;                //!< True cutoff radius + buffer
     Scalar rlist;               //!< Maximum cutoff (may include shifting)
+    const BoxDim box;           //!< Box dimensions
     };
 
 //! Operation to write the neighbor list

--- a/hoomd/md/test/test_neighborlist.cc
+++ b/hoomd/md/test/test_neighborlist.cc
@@ -851,6 +851,74 @@ void neighborlist_diameter_shift_tests(std::shared_ptr<ExecutionConfiguration> e
         }
     }
 
+//! Tests the ability of the neighbor list to filter by diameter, wrapping across periodic boundary conditions
+template <class NL>
+void neighborlist_diameter_shift_periodic_tests(std::shared_ptr<ExecutionConfiguration> exec_conf)
+    {
+    /////////////////////////////////////////////////////////
+    // 3 particles in a huge box, close to boundaries
+    std::shared_ptr<SystemDefinition> sysdef_3(new SystemDefinition(4, BoxDim(25.0), 1, 0, 0, 0, 0, exec_conf));
+    std::shared_ptr<ParticleData> pdata_3 = sysdef_3->getParticleData();
+
+    {
+    ArrayHandle<Scalar4> h_pos(pdata_3->getPositions(), access_location::host, access_mode::readwrite);
+    ArrayHandle<Scalar> h_diameter(pdata_3->getDiameters(), access_location::host, access_mode::readwrite);
+
+    h_pos.data[0].x = 0; h_pos.data[0].y = 12; h_pos.data[0].z = -10.5; h_pos.data[0].w = 0.0; h_diameter.data[0] = 3.0;
+    h_pos.data[2].x = 0; h_pos.data[2].y = 12; h_pos.data[2].z = -8; h_pos.data[2].w = 0.0; h_diameter.data[2] = 2.0;
+    h_pos.data[1].x = 0; h_pos.data[1].y = 12; h_pos.data[1].z = 11.5; h_pos.data[1].w = 0.0; h_diameter.data[1] = 1.0;
+    h_pos.data[3].x = 0; h_pos.data[3].y = -10.49; h_pos.data[3].z = -10.5; h_pos.data[3].w = 0.0; h_diameter.data[3] = 0;
+
+    pdata_3->notifyParticleSort();
+    }
+
+    // test construction of the neighborlist
+    std::shared_ptr<NeighborList> nlist_2(new NL(sysdef_3, 1.5, 0.5));
+    nlist_2->setRCutPair(0,0,1.5);
+    nlist_2->compute(1);
+    nlist_2->setStorageMode(NeighborList::full);
+
+    // with the given settings, there should be no neighbors: check that
+        {
+        ArrayHandle<unsigned int> h_n_neigh(nlist_2->getNNeighArray(), access_location::host, access_mode::read);
+
+        CHECK_EQUAL_UINT(h_n_neigh.data[0], 0);
+        CHECK_EQUAL_UINT(h_n_neigh.data[1], 0);
+        CHECK_EQUAL_UINT(h_n_neigh.data[2], 0);
+        }
+
+    // enable diameter shifting
+    nlist_2->setDiameterShift(true);
+    nlist_2->setMaximumDiameter(3.0);
+    nlist_2->compute(2);
+
+    // the particle 0 should now be neighbors with 1 and 2
+        {
+        ArrayHandle<unsigned int> h_n_neigh(nlist_2->getNNeighArray(), access_location::host, access_mode::read);
+        ArrayHandle<unsigned int> h_nlist(nlist_2->getNListArray(), access_location::host, access_mode::read);
+        ArrayHandle<unsigned int> h_head_list(nlist_2->getHeadList(), access_location::host, access_mode::read);
+
+        CHECK_EQUAL_UINT(h_n_neigh.data[0], 2);
+            {
+            vector<unsigned int> nbrs(2, 0);
+            nbrs[0] = h_nlist.data[h_head_list.data[0] + 0];
+            nbrs[1] = h_nlist.data[h_head_list.data[0] + 1];
+            sort(nbrs.begin(), nbrs.end());
+            unsigned int check_nbrs[] = {1,2};
+            for (unsigned int i=0; i < 2; ++i)
+                {
+                UP_ASSERT_EQUAL(nbrs[i],check_nbrs[i]);
+                }
+            }
+
+        CHECK_EQUAL_UINT(h_n_neigh.data[1], 1);
+        CHECK_EQUAL_UINT(h_nlist.data[h_head_list.data[1]], 0);
+
+        CHECK_EQUAL_UINT(h_n_neigh.data[2], 1);
+        CHECK_EQUAL_UINT(h_nlist.data[h_head_list.data[2]], 0);
+        }
+    }
+
 
 //! Test two implementations of NeighborList and verify that the output is identical
 template <class NLA, class NLB>
@@ -1210,6 +1278,11 @@ UP_TEST( NeighborListBinned_diameter_shift )
     {
     neighborlist_diameter_shift_tests<NeighborListBinned>(std::shared_ptr<ExecutionConfiguration>(new ExecutionConfiguration(ExecutionConfiguration::CPU)));
     }
+//! diameter filter test case for binned class with periodic boundary conditions
+UP_TEST( NeighborListBinned_diameter_shift_periodic )
+    {
+    neighborlist_diameter_shift_periodic_tests<NeighborListBinned>(std::shared_ptr<ExecutionConfiguration>(new ExecutionConfiguration(ExecutionConfiguration::CPU)));
+    }
 //! particle asymmetry test case for binned class
 UP_TEST( NeighborListBinned_particle_asymm )
     {
@@ -1259,6 +1332,11 @@ UP_TEST( NeighborListStencil_body_filter)
 UP_TEST( NeighborListStencil_diameter_shift )
     {
     neighborlist_diameter_shift_tests<NeighborListStencil>(std::shared_ptr<ExecutionConfiguration>(new ExecutionConfiguration(ExecutionConfiguration::CPU)));
+    }
+//! diameter filter test case for binned class with periodic boundary conditions
+UP_TEST( NeighborListStencil_diameter_shift_periodic )
+    {
+    neighborlist_diameter_shift_periodic_tests<NeighborListStencil>(std::shared_ptr<ExecutionConfiguration>(new ExecutionConfiguration(ExecutionConfiguration::CPU)));
     }
 //! particle asymmetry test case for stencil class
 UP_TEST( NeighborListStencil_particle_asymm )
@@ -1313,6 +1391,11 @@ UP_TEST( NeighborListTree_body_filter)
 UP_TEST( NeighborListTree_diameter_shift )
     {
     neighborlist_diameter_shift_tests<NeighborListTree>(std::shared_ptr<ExecutionConfiguration>(new ExecutionConfiguration(ExecutionConfiguration::CPU)));
+    }
+//! diameter filter test case for binned class with periodic boundary conditions
+UP_TEST( NeighborListTree_diameter_shift_periodic )
+    {
+    neighborlist_diameter_shift_periodic_tests<NeighborListTree>(std::shared_ptr<ExecutionConfiguration>(new ExecutionConfiguration(ExecutionConfiguration::CPU)));
     }
 //! particle asymmetry test case for tree class
 UP_TEST( NeighborListTree_particle_asymm )
@@ -1369,6 +1452,12 @@ UP_TEST( NeighborListGPUBinned_diameter_shift )
     {
     neighborlist_diameter_shift_tests<NeighborListGPUBinned>(std::shared_ptr<ExecutionConfiguration>(new ExecutionConfiguration(ExecutionConfiguration::GPU)));
     }
+//! diameter filter test case for GPUBinned class with periodic boundary conditions
+UP_TEST( NeighborListGPUBinned_diameter_shift_periodic )
+    {
+    std::shared_ptr<ExecutionConfiguration> exec_conf(new ExecutionConfiguration(ExecutionConfiguration::GPU));
+    neighborlist_diameter_shift_periodic_tests<NeighborListGPUBinned>(exec_conf);
+    }
 //! particle asymmetry test case for GPUBinned class
 UP_TEST( NeighborListGPUBinned_particle_asymm )
     {
@@ -1422,6 +1511,12 @@ UP_TEST( NeighborListGPUStencil_body_filter)
 UP_TEST( NeighborListGPUStencil_diameter_shift )
     {
     neighborlist_diameter_shift_tests<NeighborListGPUStencil>(std::shared_ptr<ExecutionConfiguration>(new ExecutionConfiguration(ExecutionConfiguration::GPU)));
+    }
+//! diameter filter test case for GPUStencil class with periodic boundary conditions
+UP_TEST( NeighborListGPUStencil_diameter_shift_periodic )
+    {
+    std::shared_ptr<ExecutionConfiguration> exec_conf(new ExecutionConfiguration(ExecutionConfiguration::GPU));
+    neighborlist_diameter_shift_periodic_tests<NeighborListGPUStencil>(exec_conf);
     }
 //! particle asymmetry test case for GPUStencil class
 UP_TEST( NeighborListGPUStencil_particle_asymm )
@@ -1486,6 +1581,12 @@ UP_TEST( NeighborListGPUTree_diameter_shift )
     {
     std::shared_ptr<ExecutionConfiguration> exec_conf(new ExecutionConfiguration(ExecutionConfiguration::GPU));
     neighborlist_diameter_shift_tests<NeighborListGPUTree>(exec_conf);
+    }
+//! diameter filter test case for GPUTree class with periodic boundary conditions
+UP_TEST( NeighborListGPUTree_diameter_shift_periodic )
+    {
+    std::shared_ptr<ExecutionConfiguration> exec_conf(new ExecutionConfiguration(ExecutionConfiguration::GPU));
+    neighborlist_diameter_shift_periodic_tests<NeighborListGPUTree>(exec_conf);
     }
 //! particle asymmetry test case for GPUTree class
 UP_TEST( NeighborListGPUTree_particle_asymm )


### PR DESCRIPTION
## Description

Fixes the application of particle diameter shifts in the tree neighbor lists across periodic boundary conditions. Requires an updated version of the neighbor plugin, see
https://github.com/mphoward/neighbor/pull/8

I'll update the `neighbor` submodule in this PR once that above PR for `neighbor` has been merged into master. This is required for the checks in this PR to pass.

## Motivation and Context

The `patchy_protein` benchmark in `hoomd-benchmarks` failed with a particle out of the box error when the neighbor list is changed to `nlist.tree()`
https://github.com/glotzerlab/hoomd-benchmarks/tree/next

## How Has This Been Tested?

Unfortunately, the `test_neighbor_list` benchmark doesn't test the combination of periodic boundary conditions and particle diameter shifting.

## Change log

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/hoomd-blue/blob/master/sphinx-doc/credits.rst).
