### PR TITLE
Fix failing unit tests

### DIFF
--- a/.azp/templates/build_test.yml
+++ b/.azp/templates/build_test.yml
@@ -24,13 +24,9 @@ steps:
     # workaround issues on Mac
     TMPDIR: /tmp
 
-- script: cp $(Build.BinariesDirectory)/Testing/**/Test.xml $(Common.TestResultsDirectory)
-  displayName: Copy test results
-  condition: always()
-
 - task: PublishTestResults@2
-  condition: always()
+  condition: or(succeeded(), failed())
   inputs:
     testResultsFormat: 'cTest'
-    testResultsFiles: '$(Common.TestResultsDirectory)/*.xml'
+    testResultsFiles: '$(Build.BinariesDirectory)/Testing/**/Test.xml'
     testRunTitle: $(suite_name)

--- a/hoomd/hpmc/IntegratorHPMCMonoGPU.cuh
+++ b/hoomd/hpmc/IntegratorHPMCMonoGPU.cuh
@@ -624,8 +624,8 @@ __global__ void hpmc_narrow_phase(Scalar4 *d_postype,
 
                 // check particle circumspheres
 
-                // load particle j
-                const Scalar4 postype_j = old ? d_postype[j] : d_trial_postype[j];
+                // load particle j (always load ghosts from particle data)
+                const Scalar4 postype_j = (old || j >= N_new) ? d_postype[j] : d_trial_postype[j];
                 unsigned int type_j = __scalar_as_int(postype_j.w);
                 vec3<Scalar> pos_j(postype_j);
                 Shape shape_j(quat<Scalar>(), s_params[type_j]);
@@ -1081,7 +1081,8 @@ __global__ void hpmc_insert_depletants(const Scalar4 *d_trial_postype,
                         next_j = __ldg(&d_excell_idx[excli(k>>1, my_cell)]);
 
                     // read in position of neighboring particle, do not need it's orientation for circumsphere check
-                    postype_j = old ? d_postype[j] : d_trial_postype[j];
+                    // for ghosts always load particle data
+                    postype_j = (old || j >= N_new) ? d_postype[j] : d_trial_postype[j];
                     unsigned int type_j = __scalar_as_int(postype_j.w);
                     Shape shape_j(quat<Scalar>(orientation_j), s_params[type_j]);
 

--- a/hoomd/mpcd/validation/validate_at_test.py
+++ b/hoomd/mpcd/validation/validate_at_test.py
@@ -21,7 +21,7 @@ class mpcd_at_validation(unittest.TestCase):
         # solute initially on simple cubic lattice
         self.solute = hoomd.init.create_lattice(hoomd.lattice.sc(a=1.0), L)
         snap = self.solute.take_snapshot(all=True)
-        if hoomd.comm.get_rank() == 0:
+        if hoomd.context.current.device.comm.rank == 0:
             snap.particles.mass[:] = self.density
         self.solute.restore_snapshot(snap)
 
@@ -38,7 +38,7 @@ class mpcd_at_validation(unittest.TestCase):
         # initial momentum of both should be zero
         slv = self.solvent.take_snapshot()
         slt = self.solute.take_snapshot()
-        if hoomd.comm.get_rank() == 0:
+        if hoomd.context.current.device.comm.rank == 0:
             slv_p0 = np.sum(slv.particles.velocity, axis=0)
             slt_p0 = self.density*np.sum(slt.particles.velocity, axis=0)
             np.testing.assert_allclose(slv_p0, [0,0,0], atol=1.e-6)
@@ -49,7 +49,7 @@ class mpcd_at_validation(unittest.TestCase):
         # both groups should still have zero momentum, since the solute is not coupled to solvent
         slv = self.solvent.take_snapshot()
         slt = self.solute.take_snapshot()
-        if hoomd.comm.get_rank() == 0:
+        if hoomd.context.current.device.comm.rank == 0:
             slv_p1 = np.sum(slv.particles.velocity, axis=0)
             slt_p1 = self.density*np.sum(slt.particles.velocity, axis=0)
             np.testing.assert_allclose(slv_p1, [0,0,0], atol=1.e-6)
@@ -63,7 +63,7 @@ class mpcd_at_validation(unittest.TestCase):
         # initial momentum of both should be zero
         slv = self.solvent.take_snapshot()
         slt = self.solute.take_snapshot()
-        if hoomd.comm.get_rank() == 0:
+        if hoomd.context.current.device.comm.rank == 0:
             slv_p0 = np.sum(slv.particles.velocity, axis=0)
             slt_p0 = self.density*np.sum(slt.particles.velocity, axis=0)
             np.testing.assert_allclose(slv_p0, [0,0,0], atol=1.e-6)
@@ -74,7 +74,7 @@ class mpcd_at_validation(unittest.TestCase):
         # each group should not have zero momentum, but total momentum should be zero
         slv = self.solvent.take_snapshot()
         slt = self.solute.take_snapshot()
-        if hoomd.comm.get_rank() == 0:
+        if hoomd.context.current.device.comm.rank == 0:
             slv_p1 = np.sum(slv.particles.velocity, axis=0)
             slt_p1 = self.density*np.sum(slt.particles.velocity, axis=0)
             self.assertFalse(np.allclose(slv_p1, [0,0,0]))

--- a/hoomd/mpcd/validation/validate_srd_test.py
+++ b/hoomd/mpcd/validation/validate_srd_test.py
@@ -21,7 +21,7 @@ class mpcd_srd_validation(unittest.TestCase):
         # solute initially on simple cubic lattice
         self.solute = hoomd.init.create_lattice(hoomd.lattice.sc(a=1.0), L)
         snap = self.solute.take_snapshot(all=True)
-        if hoomd.comm.get_rank() == 0:
+        if hoomd.context.current.device.comm.rank == 0:
             snap.particles.mass[:] = self.density
         self.solute.restore_snapshot(snap)
 
@@ -38,7 +38,7 @@ class mpcd_srd_validation(unittest.TestCase):
         # initial momentum of both should be zero
         slv = self.solvent.take_snapshot()
         slt = self.solute.take_snapshot()
-        if hoomd.comm.get_rank() == 0:
+        if hoomd.context.current.device.comm.rank == 0:
             slv_p0 = np.sum(slv.particles.velocity, axis=0)
             slt_p0 = self.density*np.sum(slt.particles.velocity, axis=0)
             np.testing.assert_allclose(slv_p0, [0,0,0], atol=1.e-6)
@@ -49,7 +49,7 @@ class mpcd_srd_validation(unittest.TestCase):
         # both groups should still have zero momentum, since the solute is not coupled to solvent
         slv = self.solvent.take_snapshot()
         slt = self.solute.take_snapshot()
-        if hoomd.comm.get_rank() == 0:
+        if hoomd.context.current.device.comm.rank == 0:
             slv_p1 = np.sum(slv.particles.velocity, axis=0)
             slt_p1 = self.density*np.sum(slt.particles.velocity, axis=0)
             np.testing.assert_allclose(slv_p1, [0,0,0], atol=1.e-6)
@@ -63,7 +63,7 @@ class mpcd_srd_validation(unittest.TestCase):
         # initial momentum of both should be zero
         slv = self.solvent.take_snapshot()
         slt = self.solute.take_snapshot()
-        if hoomd.comm.get_rank() == 0:
+        if hoomd.context.current.device.comm.rank == 0:
             slv_p0 = np.sum(slv.particles.velocity, axis=0)
             slt_p0 = self.density*np.sum(slt.particles.velocity, axis=0)
             np.testing.assert_allclose(slv_p0, [0,0,0], atol=1.e-6)
@@ -74,7 +74,7 @@ class mpcd_srd_validation(unittest.TestCase):
         # each group should not have zero momentum, but total momentum should be zero
         slv = self.solvent.take_snapshot()
         slt = self.solute.take_snapshot()
-        if hoomd.comm.get_rank() == 0:
+        if hoomd.context.current.device.comm.rank == 0:
             slv_p1 = np.sum(slv.particles.velocity, axis=0)
             slt_p1 = self.density*np.sum(slt.particles.velocity, axis=0)
             self.assertFalse(np.allclose(slv_p1, [0,0,0]))


### PR DESCRIPTION
## Description

Recently, the `stats-check.py` and related HPMC unit tests have been failing on `next` in the `mng-mpi` configuration. This PR fixes the problem.

## Motivation and Context

The failure was an illegal shared memory access occurring in the HPMC integrator where it wrongly tried to load the particle position and type for a ghost particle from the `d_trial_postype` array (which only contains local particles). In the managed configuration (`GlobalArray`), that array is uninitialized for ghost particles and an invalid type is loaded, even though the neighbor is later ignored anyway. However, a shared mem load for parameters is still attempted for this type, failing.

Resolves: failing unit tests in `next` and related branches

## How Has This Been Tested?

Unit tests have been failing.

## Change log

N/A
## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/hoomd-blue/blob/master/sphinx-doc/credits.rst).
