### PR TITLE
Fix debug mode assertion

### DIFF
--- a/hoomd/GlobalArray.h
+++ b/hoomd/GlobalArray.h
@@ -801,13 +801,12 @@ inline ArrayHandleDispatch<T> GlobalArray<T>::acquire(const access_location::Enu
             );
     #endif
 
+    checkAcquired(*this);
     m_acquired = true;
 
     // make sure a null array can be acquired
     if (!this->m_exec_conf || isNull() )
         return GlobalArrayDispatch<T>(nullptr, *this);
-
-    checkAcquired(*this);
 
     if (this->m_exec_conf && this->m_exec_conf->inMultiGPUBlock())
         {

--- a/hoomd/GlobalArray.h
+++ b/hoomd/GlobalArray.h
@@ -801,6 +801,8 @@ inline ArrayHandleDispatch<T> GlobalArray<T>::acquire(const access_location::Enu
             );
     #endif
 
+    m_acquired = true;
+
     // make sure a null array can be acquired
     if (!this->m_exec_conf || isNull() )
         return GlobalArrayDispatch<T>(nullptr, *this);
@@ -824,8 +826,6 @@ inline ArrayHandleDispatch<T> GlobalArray<T>::acquire(const access_location::Enu
             CHECK_CUDA_ERROR();
         }
     #endif
-
-    m_acquired = true;
 
     return GlobalArrayDispatch<T>(m_data.get(), *this);
     }


### PR DESCRIPTION
## Description

A plugin (neighbor) compiled in `Debug` mode against an `ALWAYS_USE_MANAGED_MEMORY` version of HOOMD threw an assertion assuming that an acquire flag was expected to be set, which was not.

## Motivation and Context

mainly to resolve the unsatisfactory test output in this particular combination of builds

## How Has This Been Tested?

standard unit tests

## Change log

N/A

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/hoomd-blue/blob/master/sphinx-doc/credits.rst).
