### PR TITLE
Clarify mpcd force docs

### DIFF
--- a/hoomd/mpcd/force.py
+++ b/hoomd/mpcd/force.py
@@ -14,6 +14,12 @@ the force field does not cause the system to net accelerate (i.e., it must maint
 required to maintain temperature control in the driven system (see
 :py:mod:`.mpcd.collide`).
 
+.. note::
+
+    The external force **must** be attached to a streaming method
+    (see :py:mod:`.mpcd.stream`) using `set_force` to take effect.
+    On its own, the force object will not affect the system.
+
 """
 
 import hoomd
@@ -86,6 +92,12 @@ class block(_force):
         # default blocks to full box
         force.block(F=0.5)
 
+    .. note::
+
+        The external force **must** be attached to a streaming method
+        (see :py:mod:`.mpcd.stream`) using `set_force` to take effect.
+        On its own, the force object will not affect the system.
+
     .. versionadded:: 2.6
 
     """
@@ -156,6 +168,12 @@ class constant(_force):
         g = np.array([0.,0.,-1.])
         force.constant(g)
 
+    .. note::
+
+        The external force **must** be attached to a streaming method
+        (see :py:mod:`.mpcd.stream`) using `set_force` to take effect.
+        On its own, the force object will not affect the system.
+
     .. versionadded:: 2.6
 
     """
@@ -211,6 +229,12 @@ class sine(_force):
     The user will need to determine what value of *k* makes sense for their
     problem, as it is too difficult to validate all values of *k* for all
     streaming geometries.
+
+    .. note::
+
+        The external force **must** be attached to a streaming method
+        (see :py:mod:`.mpcd.stream`) using `set_force` to take effect.
+        On its own, the force object will not affect the system.
 
     .. versionadded:: 2.6
 


### PR DESCRIPTION
## Description

Make clear that the MPCD force needs to be attached to the streaming method to take effect. This was documented in the streaming methods, but not in the force objects.

## How Has This Been Tested?

Docs only.

## Checklist:

- [X] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [X] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [X] My name is on the [list of contributors](https://github.com/glotzerlab/hoomd-blue/blob/master/sphinx-doc/credits.rst).
