### PR TITLE
Fix cell widths in MPI

### DIFF
--- a/.azp/templates/build_test.yml
+++ b/.azp/templates/build_test.yml
@@ -24,13 +24,9 @@ steps:
     # workaround issues on Mac
     TMPDIR: /tmp
 
-- script: cp $(Build.BinariesDirectory)/Testing/**/Test.xml $(Common.TestResultsDirectory)
-  displayName: Copy test results
-  condition: always()
-
 - task: PublishTestResults@2
-  condition: always()
+  condition: or(succeeded(), failed())
   inputs:
     testResultsFormat: 'cTest'
-    testResultsFiles: '$(Common.TestResultsDirectory)/*.xml'
+    testResultsFiles: '$(Build.BinariesDirectory)/Testing/**/Test.xml'
     testRunTitle: $(suite_name)


### PR DESCRIPTION
## Description

We should always round the number of cells down.

## Motivation and Context

I came across this oversight while searching for a different bug. This may have caused invalid MPI simulations in some cases (though I could not find an example of a test that actually failed because of this).

## How Has This Been Tested?

Standard unit tests

## Change log

```
- Fix calculation of cell widths in HPMC (GPU) and `nlist.cell()` with MPI
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/hoomd-blue/blob/master/sphinx-doc/credits.rst).
