### PR TITLE
Fix potential issues with custom MPI types in MPCD

### DIFF
--- a/hoomd/Communicator.cc
+++ b/hoomd/Communicator.cc
@@ -1211,8 +1211,13 @@ Communicator::Communicator(std::shared_ptr<SystemDefinition> sysdef,
     offsets[12] = offsetof(pdata_element, net_torque);
     offsets[13] = offsetof(pdata_element, net_virial);
 
-    MPI_Type_create_struct(nitems, blocklengths, offsets, types, &m_mpi_pdata_element);
+    MPI_Datatype tmp;
+    MPI_Type_create_struct(nitems, blocklengths, offsets, types, &tmp);
+    MPI_Type_commit(&tmp);
+
+    MPI_Type_create_resized(tmp, 0, sizeof(pdata_element), &m_mpi_pdata_element);
     MPI_Type_commit(&m_mpi_pdata_element);
+    MPI_Type_free(&tmp);
     }
 
 //! Destructor

--- a/hoomd/mpcd/CellThermoTypes.h
+++ b/hoomd/mpcd/CellThermoTypes.h
@@ -72,25 +72,21 @@ struct CellVelocityPackOp
 
 struct CellEnergyPackOp
     {
-    typedef struct
-        {
-        double energy;
-        unsigned int np;
-        } element;
+    typedef double2 element;
 
     DEVICE element pack(const double3& val) const
         {
         element e;
-        e.energy = val.x;
-        e.np = __double_as_int(val.z);
+        e.x = val.x;
+        e.y = val.z;
         return e;
         }
 
     DEVICE double3 unpack(const element& e, const double3& val) const
         {
-        return make_double3(e.energy + val.x,
+        return make_double3(e.x + val.x,
                             val.y,
-                            __int_as_double(__double_as_int(val.z) + e.np));
+                            __int_as_double(__double_as_int(e.y) + __double_as_int(val.z)));
         }
     };
 

--- a/hoomd/mpcd/Communicator.cc
+++ b/hoomd/mpcd/Communicator.cc
@@ -62,6 +62,18 @@ mpcd::Communicator::Communicator(std::shared_ptr<mpcd::SystemData> system_data)
     // attach decomposition check to the box change signal
     m_mpcd_sys->getCellList()->getSizeChangeSignal().connect<mpcd::Communicator, &mpcd::Communicator::slotBoxChanged>(this);
 
+    // create new data type for the pdata_element
+    const int nitems = 4;
+    int blocklengths[nitems] = {4,4,1,1};
+    MPI_Datatype types[nitems] = {MPI_HOOMD_SCALAR, MPI_HOOMD_SCALAR, MPI_UNSIGNED, MPI_UNSIGNED};
+    MPI_Aint offsets[nitems];
+    offsets[0] = offsetof(mpcd::detail::pdata_element, pos);
+    offsets[1] = offsetof(mpcd::detail::pdata_element, vel);
+    offsets[2] = offsetof(mpcd::detail::pdata_element, tag);
+    offsets[3] = offsetof(mpcd::detail::pdata_element, comm_flag);
+    MPI_Type_create_struct(nitems, blocklengths, offsets, types, &m_pdata_element);
+    MPI_Type_commit(&m_pdata_element);
+
     initializeNeighborArrays();
     }
 
@@ -69,6 +81,7 @@ mpcd::Communicator::~Communicator()
     {
     m_exec_conf->msg->notice(5) << "Destroying MPCD Communicator" << std::endl;
     m_mpcd_sys->getCellList()->getSizeChangeSignal().disconnect<mpcd::Communicator, &mpcd::Communicator::slotBoxChanged>(this);
+    MPI_Type_free(&m_pdata_element);
     }
 
 void mpcd::Communicator::initializeNeighborArrays()
@@ -328,19 +341,19 @@ void mpcd::Communicator::migrateParticles(unsigned int timestep)
             int nreq = 0;
             if (n_send_right != 0)
                 {
-                MPI_Isend(h_sendbuf.data + n_keep, n_send_right*sizeof(mpcd::detail::pdata_element), MPI_BYTE, right_neigh, 1, m_mpi_comm, &m_reqs[nreq++]);
+                MPI_Isend(h_sendbuf.data + n_keep, n_send_right, m_pdata_element, right_neigh, 1, m_mpi_comm, &m_reqs[nreq++]);
                 }
             if (n_send_left != 0)
                 {
-                MPI_Isend(h_sendbuf.data + n_keep + n_send_right, n_send_left*sizeof(mpcd::detail::pdata_element), MPI_BYTE, left_neigh, 1, m_mpi_comm, &m_reqs[nreq++]);
+                MPI_Isend(h_sendbuf.data + n_keep + n_send_right, n_send_left, m_pdata_element, left_neigh, 1, m_mpi_comm, &m_reqs[nreq++]);
                 }
             if (n_recv_right != 0)
                 {
-                MPI_Irecv(h_recvbuf.data + n_recv, n_recv_right*sizeof(mpcd::detail::pdata_element), MPI_BYTE, right_neigh, 1, m_mpi_comm, &m_reqs[nreq++]);
+                MPI_Irecv(h_recvbuf.data + n_recv, n_recv_right, m_pdata_element, right_neigh, 1, m_mpi_comm, &m_reqs[nreq++]);
                 }
             if (n_recv_left != 0)
                 {
-                MPI_Irecv(h_recvbuf.data + n_recv + n_recv_right, n_recv_left*sizeof(mpcd::detail::pdata_element), MPI_BYTE, left_neigh, 1, m_mpi_comm, &m_reqs[nreq++]);
+                MPI_Irecv(h_recvbuf.data + n_recv + n_recv_right, n_recv_left, m_pdata_element, left_neigh, 1, m_mpi_comm, &m_reqs[nreq++]);
                 }
             MPI_Waitall(nreq, m_reqs.data(), MPI_STATUSES_IGNORE);
             if (m_prof) m_prof->pop(0, (n_send_left+n_send_right+n_recv_left+n_recv_right)*sizeof(mpcd::detail::pdata_element));

--- a/hoomd/mpcd/Communicator.cc
+++ b/hoomd/mpcd/Communicator.cc
@@ -63,15 +63,16 @@ mpcd::Communicator::Communicator(std::shared_ptr<mpcd::SystemData> system_data)
     m_mpcd_sys->getCellList()->getSizeChangeSignal().connect<mpcd::Communicator, &mpcd::Communicator::slotBoxChanged>(this);
 
     // create new data type for the pdata_element
-    const int nitems = 4;
-    int blocklengths[nitems] = {4,4,1,1};
-    MPI_Datatype types[nitems] = {MPI_HOOMD_SCALAR, MPI_HOOMD_SCALAR, MPI_UNSIGNED, MPI_UNSIGNED};
+    const int nitems = 5;
+    int blocklengths[nitems] = {4,4,1,1,1};
+    MPI_Datatype types[nitems] = {MPI_HOOMD_SCALAR, MPI_HOOMD_SCALAR, MPI_UNSIGNED, MPI_UNSIGNED, MPI_UB};
     MPI_Aint offsets[nitems];
     offsets[0] = offsetof(mpcd::detail::pdata_element, pos);
     offsets[1] = offsetof(mpcd::detail::pdata_element, vel);
     offsets[2] = offsetof(mpcd::detail::pdata_element, tag);
     offsets[3] = offsetof(mpcd::detail::pdata_element, comm_flag);
-    MPI_Type_create_struct(nitems, blocklengths, offsets, types, &m_pdata_element);
+    offsets[4] = sizeof(mpcd::detail::pdata_element);
+    MPI_Type_struct(nitems, blocklengths, offsets, types, &m_pdata_element);
     MPI_Type_commit(&m_pdata_element);
 
     initializeNeighborArrays();

--- a/hoomd/mpcd/Communicator.h
+++ b/hoomd/mpcd/Communicator.h
@@ -193,6 +193,7 @@ class PYBIND11_EXPORT Communicator
         //! Helper function to initialize adjacency arrays
         void initializeNeighborArrays();
 
+        MPI_Datatype m_pdata_element;                       //!< MPI struct for pdata_element
         GPUVector<mpcd::detail::pdata_element> m_sendbuf;   //!< Buffer for particles that are sent
         GPUVector<mpcd::detail::pdata_element> m_recvbuf;   //!< Buffer for particles that are received
         std::vector<MPI_Request> m_reqs;    //!< MPI requests

--- a/hoomd/mpcd/CommunicatorGPU.cc
+++ b/hoomd/mpcd/CommunicatorGPU.cc
@@ -278,8 +278,8 @@ void mpcd::CommunicatorGPU::migrateParticles(unsigned int timestep)
                 if (m_n_send_ptls[ineigh])
                     {
                     MPI_Isend(h_sendbuf.data+sendidx,
-                        m_n_send_ptls[ineigh]*sizeof(mpcd::detail::pdata_element),
-                        MPI_BYTE,
+                        m_n_send_ptls[ineigh],
+                        m_pdata_element,
                         neighbor,
                         1,
                         m_mpi_comm,
@@ -292,8 +292,8 @@ void mpcd::CommunicatorGPU::migrateParticles(unsigned int timestep)
                 if (m_n_recv_ptls[ineigh])
                     {
                     MPI_Irecv(h_recvbuf.data+m_offsets[ineigh],
-                        m_n_recv_ptls[ineigh]*sizeof(mpcd::detail::pdata_element),
-                        MPI_BYTE,
+                        m_n_recv_ptls[ineigh],
+                        m_pdata_element,
                         neighbor,
                         1,
                         m_mpi_comm,


### PR DESCRIPTION
## Description

Use custom MPI type for communication of MPCD particles, as proposed by Jens in PR #553.

The CellCommunicator also uses a custom struct for one MPI op. This was not easy to fix given the current template design, so I changed that struct to a contiguous type, which should still be OK. It adds 4B of message per cell, but if I remember right, latency is more of an issue than bandwidth anyway.

## Motivation and Context

No errors have been reported, so this is preventative maintenance.

## How Has This Been Tested?

Existing unit tests still pass, not sure of a case where it will fail. (Maybe running through valgrind?)

## Change log

```
* Fix potential memory-management issue in MPI for migrating MPCD particles and cell energy.
```

## Checklist:

- [X] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [X] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [X] My name is on the [list of contributors](https://github.com/glotzerlab/hoomd-blue/blob/master/sphinx-doc/credits.rst).
