### PR TITLE
Fix pppm exclusions

### DIFF
--- a/hoomd/md/PPPMForceCompute.cc
+++ b/hoomd/md/PPPMForceCompute.cc
@@ -1594,7 +1594,17 @@ Scalar PPPMForceCompute::getLogValue(const std::string& quantity, unsigned int t
     {
     if (quantity == m_log_names[0])
         {
-        return computePE();
+        // make sure values are current
+        compute(timestep);
+
+        Scalar result = computePE();
+
+        if(m_nlist->getExclusionsSet())
+            {
+            result += calcEnergySum();
+            }
+
+        return result;
         }
 
     // nothing found? return base class value

--- a/hoomd/md/PPPMForceCompute.cc
+++ b/hoomd/md/PPPMForceCompute.cc
@@ -1232,12 +1232,6 @@ Scalar PPPMForceCompute::computePE()
 
 void PPPMForceCompute::computeForces(unsigned int timestep)
     {
-    if (m_particles_sorted)
-        {
-        // need to recompute forces
-        m_force_compute = true;
-        }
-
     if (m_prof) m_prof->push("PPPM");
 
     if (m_need_initialize || m_ptls_added_removed)

--- a/hoomd/md/PPPMForceCompute.cc
+++ b/hoomd/md/PPPMForceCompute.cc
@@ -1302,6 +1302,7 @@ void PPPMForceCompute::computeForces(unsigned int timestep)
     // If there are exclusions, correct for the long-range part of the potential
     if(m_nlist->getExclusionsSet())
         {
+        m_nlist->compute(timestep);
         fixExclusions();
         }
 

--- a/hoomd/md/PPPMForceComputeGPU.h
+++ b/hoomd/md/PPPMForceComputeGPU.h
@@ -105,6 +105,8 @@ class PYBIND11_EXPORT PPPMForceComputeGPU : public PPPMForceCompute
 
         std::vector<cufftHandle> m_cufft_plan;          //!< The FFT plans
         bool m_local_fft;                  //!< True if we are only doing local FFTs (not distributed)
+        bool m_cufft_initialized;          //!< True if CUFFT has been initialized
+        bool m_cuda_dfft_initialized;      //!< True if dfft has been initialized
 
         #ifdef ENABLE_MPI
         typedef CommunicatorGridGPU<cufftComplex> CommunicatorGridGPUComplex;

--- a/hoomd/md/test-py/test_charge_pppm.py
+++ b/hoomd/md/test-py/test_charge_pppm.py
@@ -55,6 +55,66 @@ class charge_pppm_tests (unittest.TestCase):
         context.initialize()
 
 # charge.pppm
+class charge_pppm_bond_exclusions_test(unittest.TestCase):
+    def test_exclusion_energy(self):
+        # initialize a two particle system in a large box, to minimize effect of PBC
+        snap = data.make_snapshot(N=2, particle_types=[u'A1'], bond_types=['bondA'], box = data.boxdim(L=50))
+
+        if comm.get_rank() == 0:
+            snap.particles.position[0] = (0,0,0)
+            snap.particles.position[1] = (1,1,1)
+            snap.particles.charge[0] = 1
+            snap.particles.charge[1] = -1
+
+        self.s = init.read_snapshot(snap);
+
+        # measure the Coulomb energy with sufficient number of grid cells so that the exclusions are accurate
+        nl = md.nlist.cell()
+        c = md.charge.pppm(group.all(), nlist = nl);
+
+        # rcut should be larger than distance of pair, so we have a split into short range and long range energy
+        c.set_params(Nx=128, Ny=128, Nz=128, order=7, rcut=3);
+        log = analyze.log(quantities = ['potential_energy','pair_ewald_energy','pppm_energy'], period = 1, filename=None);
+        md.integrate.mode_standard(dt=0.0);
+        md.integrate.nve(group.all());
+        # trick to allow larger decompositions
+        nl.set_params(r_buff=0.1)
+        context.current.sorter.disable()
+
+        run(1)
+        pppm_energy_nobond = log.query('pppm_energy')
+        ewald_energy_nobond = log.query('pair_ewald_energy')
+        potential_energy_nobond = log.query('potential_energy')
+
+        # check that it is **roughly** equal to the Coulomb energy (not accounting for PBC)
+        import numpy as np
+        self.assertAlmostEqual(potential_energy_nobond,
+            -1/np.linalg.norm(np.array(self.s.particles[1].position)-np.array(self.s.particles[0].position)),3)
+
+        # now introduce a bond
+        self.s.bonds.add('bondA', 0,1)
+
+        # we need to manually add it to the exclusions currently
+        nl.reset_exclusions(exclusions=['bond'])
+        run(1)
+        pppm_energy_bond = log.query('pppm_energy')
+        ewald_energy_bond = log.query('pair_ewald_energy')
+        potential_energy_bond = log.query('potential_energy')
+
+        # energy should be practically zero
+        # but not exactly -- exclusions are computed analytically, the long range part using fft
+        self.assertAlmostEqual(pppm_energy_bond, 0.0, 3)
+        self.assertAlmostEqual(potential_energy_bond, 0.0, 3)
+
+        # but strictly zero for the short range part
+        self.assertEqual(ewald_energy_bond, 0.0)
+
+    def tearDown(self):
+        del self.s
+        context.initialize();
+
+
+# charge.pppm
 class charge_pppm_twoparticle_tests (unittest.TestCase):
     def setUp(self):
         print


### PR DESCRIPTION
## Description

Exclusions are sometimes ignored with `charge.pppm()`. The energy reported by the `pppm_energy` log quantity computed never accounted for exclusions. This PR fixes that.

## Motivation and Context

The issue came up a while ago while trying to verify Umbrella sampling for an alkane, and comparing energies between LAMMPS and HOOMD, and was referenced on the mailing list @ahy3nz 

Resolves: #328

## How Has This Been Tested?

unit test has been added

## Change log

```
- Fix bug where exclusions were sometimes ignored when `charge.pppm()` is the only potential using the neighbor list
- Fix bug where exclusions were not accounted for properly in the `pppm_energy` log quantity
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/hoomd-blue/blob/master/sphinx-doc/credits.rst).
