### PR TITLE
Communicate particle positions after they are updated to remove drift

### DIFF
--- a/hoomd/hpmc/UpdaterRemoveDrift.h
+++ b/hoomd/hpmc/UpdaterRemoveDrift.h
@@ -66,8 +66,10 @@ class RemoveDriftUpdater : public Updater
                 {
                 unsigned int tag_i = h_tag.data[i];
                 // read in the current position and orientation
-                Scalar4 postype_i = h_postype.data[i];
-                vec3<Scalar> dr = vec3<Scalar>(postype_i) - vec3<Scalar>(h_r0.data[tag_i]) - origin;
+                vec3<Scalar> postype_i = vec3<Scalar>(h_postype.data[i]) - origin;
+		int3 tmp_image = make_int3(0, 0, 0);
+		box.wrap(postype_i, tmp_image);
+                vec3<Scalar> dr = postype_i - vec3<Scalar>(h_r0.data[tag_i]);
                 rshift += vec3<Scalar>(box.minImage(vec_to_scalar3(dr)));
                 }
 
@@ -94,6 +96,10 @@ class RemoveDriftUpdater : public Updater
                 }
 
             m_mc->invalidateAABBTree();
+
+	    // migrate and exchange particles
+	    m_mc->communicate(true);
+
             }
     protected:
                 std::shared_ptr<ExternalFieldLattice<Shape> > m_externalLattice;

--- a/hoomd/hpmc/UpdaterRemoveDrift.h
+++ b/hoomd/hpmc/UpdaterRemoveDrift.h
@@ -67,7 +67,7 @@ class RemoveDriftUpdater : public Updater
                 unsigned int tag_i = h_tag.data[i];
                 // read in the current position and orientation
                 vec3<Scalar> postype_i = vec3<Scalar>(h_postype.data[i]) - origin;
-		int3 tmp_image = make_int3(0, 0, 0);
+                int3 tmp_image = make_int3(0, 0, 0);
 		box.wrap(postype_i, tmp_image);
                 vec3<Scalar> dr = postype_i - vec3<Scalar>(h_r0.data[tag_i]);
                 rshift += vec3<Scalar>(box.minImage(vec_to_scalar3(dr)));
@@ -96,7 +96,6 @@ class RemoveDriftUpdater : public Updater
                 }
 
             m_mc->invalidateAABBTree();
-
 	    // migrate and exchange particles
 	    m_mc->communicate(true);
 

--- a/hoomd/hpmc/UpdaterRemoveDrift.h
+++ b/hoomd/hpmc/UpdaterRemoveDrift.h
@@ -68,7 +68,7 @@ class RemoveDriftUpdater : public Updater
                 // read in the current position and orientation
                 vec3<Scalar> postype_i = vec3<Scalar>(h_postype.data[i]) - origin;
                 int3 tmp_image = make_int3(0, 0, 0);
-		box.wrap(postype_i, tmp_image);
+                box.wrap(postype_i, tmp_image);
                 vec3<Scalar> dr = postype_i - vec3<Scalar>(h_r0.data[tag_i]);
                 rshift += vec3<Scalar>(box.minImage(vec_to_scalar3(dr)));
                 }
@@ -96,8 +96,8 @@ class RemoveDriftUpdater : public Updater
                 }
 
             m_mc->invalidateAABBTree();
-	    // migrate and exchange particles
-	    m_mc->communicate(true);
+            // migrate and exchange particles
+            m_mc->communicate(true);
 
             }
     protected:


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should based on *maint*. -->
<!-- New features should based on *master*. -->

## Description

The drift updater was not communicating particle positions after they were shifted to remove system drift.

## Motivation and Context

Since particle moves were not communicated, overlap checks failed to detect overlaps for particles that crossed periodic boundaries.

## How Has This Been Tested?

We can add a test for this if desired.

## Change log

<!-- Propose a change log entry. -->
```
UpdateRemoveDrift now communicates particle positions after updating them.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/hoomd-blue/blob/master/sphinx-doc/credits.rst).
