### PR TITLE
Fix startup of MPI simulations

### DIFF
--- a/hoomd/md/NeighborList.h
+++ b/hoomd/md/NeighborList.h
@@ -385,8 +385,13 @@ class PYBIND11_EXPORT NeighborList : public Compute
             }
 
         //! Return the requested ghost layer width
-        virtual Scalar getGhostLayerWidth(unsigned int type) const
+        virtual Scalar getGhostLayerWidth(unsigned int type)
             {
+            if (m_rcut_changed)
+                {
+                updateRList();
+                }
+
             ArrayHandle<Scalar> h_rcut_max(m_rcut_max, access_location::host, access_mode::read);
             const Scalar rcut_max_i = h_rcut_max.data[type];
 


### PR DESCRIPTION
## Description

MD simulations using MPI start off with a zero ghost layer, because `rmax` is not initialized. This may lead to dangerous builds or particle out of the box errors.

## Motivation and Context

Fixes a long-standing bug.

Resolves: #563 

## How Has This Been Tested?

Unfortunately this has not been caught by unit or validation tests. Long term, we could think about promoting warnings (like dangerous builds) to python `RuntimeWarning`s, and intercept those at the unit test level.

## Change log

```
- Fix a bug where MD simulations with MPI start off without a ghost layer, leading to crashes or dangerous builds shortly after `run()`
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/hoomd-blue/blob/master/sphinx-doc/credits.rst).
