### PR TITLE
added revcross potential 

### DIFF
--- a/hoomd/md/AllTripletPotentials.h
+++ b/hoomd/md/AllTripletPotentials.h
@@ -9,10 +9,14 @@
 #include "PotentialTersoff.h"
 #include "EvaluatorTersoff.h"
 #include "EvaluatorSquareDensity.h"
+#include "PotentialRevCross.h"
+#include "EvaluatorRevCross.h"
 
 #ifdef ENABLE_CUDA
 #include "PotentialTersoffGPU.h"
 #include "DriverTersoffGPU.cuh"
+#include "PotentialRevCrossGPU.h"
+#include "DriverRevCrossGPU.cuh"
 #endif
 
 /*! \file AllTripletPotentials.h
@@ -29,11 +33,16 @@ typedef PotentialTersoff< EvaluatorTersoff > PotentialTripletTersoff;
 //! Three-body potential force compute forces for soft vdW fluid
 typedef PotentialTersoff< EvaluatorSquareDensity > PotentialTripletSquareDensity;
 
+//! Three-body potential force compute for Reversible Crosslinker
+typedef PotentialRevCross< EvaluatorRevCross > PotentialTripletRevCross;
+
 #ifdef ENABLE_CUDA
 //! Three-body potential force compute for Tersoff forces on the GPU
 typedef PotentialTersoffGPU< EvaluatorTersoff, gpu_compute_tersoff_forces > PotentialTripletTersoffGPU;
 //! Three-body potential force compute for Tersoff forces on the GPU
 typedef PotentialTersoffGPU< EvaluatorSquareDensity, gpu_compute_sq_density_forces > PotentialTripletSquareDensityGPU;
+//! Three-body potential force compute for Reversible Crosslinker on the GPU
+typedef PotentialRevCrossGPU< EvaluatorRevCross, gpu_compute_revcross_forces > PotentialTripletRevCrossGPU;
 #endif // ENABLE_CUDA
 
 #endif // __TRIPLET_POTENTIALS_H__

--- a/hoomd/md/CMakeLists.txt
+++ b/hoomd/md/CMakeLists.txt
@@ -92,6 +92,7 @@ set(_md_headers ActiveForceComputeGPU.h
                 EvaluatorPairYukawa.h
                 EvaluatorPairZBL.h
                 EvaluatorTersoff.h
+                EvaluatorRevCross.h
                 EvaluatorWalls.h
                 FIREEnergyMinimizerGPU.h
                 FIREEnergyMinimizer.h
@@ -134,7 +135,9 @@ set(_md_headers ActiveForceComputeGPU.h
                 PotentialSpecialPairGPU.h
                 PotentialSpecialPair.h
                 PotentialTersoffGPU.h
+                PotentialRevCrossGPU.h
                 PotentialTersoff.h
+                PotentialRevCross.h
                 PPPMForceComputeGPU.h
                 PPPMForceCompute.h
                 QuaternionMath.h
@@ -224,6 +227,7 @@ set(_md_cu_sources ActiveForceComputeGPU.cu
                       ConstraintSphereGPU.cu
                       OneDConstraintGPU.cu
                       DriverTersoffGPU.cu
+                      DriverRevCrossGPU.cu
                       Enforce2DUpdaterGPU.cu
                       FIREEnergyMinimizerGPU.cu
                       ForceCompositeGPU.cu

--- a/hoomd/md/DriverRevCrossGPU.cu
+++ b/hoomd/md/DriverRevCrossGPU.cu
@@ -1,0 +1,18 @@
+// Copyright (c) 2009-2019 The Regents of the University of Michigan
+// This file is part of the HOOMD-blue project, released under the BSD 3-Clause License.
+//
+// Maintainer: SCiarella
+
+/*! \file DriverRevCrossGPU.cu
+    \brief Defines the driver functions for computing all types of three-body forces on the GPU
+*/
+
+#include "DriverRevCrossGPU.cuh"
+#include "EvaluatorRevCross.h"
+
+cudaError_t gpu_compute_revcross_forces(const revcross_args_t& pair_args,
+                                       const revcross_params *d_params)
+    {
+    return gpu_compute_tripletrevcross_forces<EvaluatorRevCross>(pair_args,
+                                                           d_params);
+    }

--- a/hoomd/md/DriverRevCrossGPU.cuh
+++ b/hoomd/md/DriverRevCrossGPU.cuh
@@ -1,0 +1,20 @@
+// Copyright (c) 2009-2019 The Regents of the University of Michigan
+// This file is part of the HOOMD-blue project, released under the BSD 3-Clause License.
+//
+// Maintainer: SCiarella
+
+/*! \file DriverRevCrossGPU.cuh
+    \brief Declares driver functions for computing all types of pair forces on the GPU
+*/
+
+#ifndef __DRIVER_REVCROSS_GPU_CUH__
+#define __DRIVER_REVCROSS_GPU_CUH__
+
+#include "PotentialRevCrossGPU.cuh"
+#include "EvaluatorRevCross.h"
+
+//! Compute RevCross forces on the GPU with EvaluatorRevCross
+cudaError_t gpu_compute_revcross_forces(const revcross_args_t& pair_args,
+                                       const revcross_params *d_params);
+
+#endif

--- a/hoomd/md/EvaluatorRevCross.h
+++ b/hoomd/md/EvaluatorRevCross.h
@@ -156,7 +156,7 @@ class EvaluatorRevCross
 		       				
 		}
 		       	
-		//~~~~~~~~~~~~~~~~then case (3), look at REF_Ciarella for details
+		//~~~~~~~~~~~~~~~~then case (3), look at S. Ciarella and W.G. Ellenbroek 2019 https://arxiv.org/abs/1912.08569 for details
 		else if ((rij > rm) && (rik > rm) ){
 		
 		       //starting with the contribute of the particle j in the 3B term	

--- a/hoomd/md/EvaluatorRevCross.h
+++ b/hoomd/md/EvaluatorRevCross.h
@@ -1,0 +1,196 @@
+// Copyright (c) 2009-2019 The Regents of the University of Michigan
+// This file is part of the HOOMD-blue project, released under the BSD 3-Clause License.
+//
+// Maintainer: SCiarella
+
+#ifndef __EVALUATOR_REVCROSS__
+#define __EVALUATOR_REVCROSS__
+
+#ifndef NVCC
+#include <string>
+#endif
+
+#include "hoomd/HOOMDMath.h"
+
+/*! \file EvaluatorRevCross.h
+    \brief Defines the evaluator class for the three-body RevCross potential
+*/
+
+#ifdef NVCC
+#define DEVICE __device__
+#define HOSTDEVICE __host__ __device__
+#else
+#define DEVICE
+#define HOSTDEVICE
+#endif
+
+//! Parameter type for this potential
+struct revcross_params
+    {
+    Scalar sigma; //!< hard body of the particle
+    Scalar n; //!< exponent
+    Scalar epsilon; //!< unit energy
+    Scalar lambda3; //!< three body parameter
+    
+};
+
+//! Function to make the parameter type
+HOSTDEVICE inline revcross_params make_revcross_params(Scalar sigma,
+                                                     Scalar n,
+                                                     Scalar epsilon,
+                                                     Scalar lambda3
+                                                     )
+    {
+    revcross_params retval;
+
+    retval.sigma = sigma;
+    retval.n = n;
+    retval.epsilon = epsilon;
+    retval.lambda3 = lambda3;
+    return retval;
+    }
+
+//! Class for evaluating the RevCross three-body potential
+class EvaluatorRevCross
+    {
+    public:
+        //! Define the parameter type used by this evaluator
+        typedef revcross_params param_type;
+
+        //! Constructs the evaluator
+        /*! \param _rij_sq Squared distance between particles i and j
+            \param _rcutsq Squared distance at which the potential goes to zero
+            \param _params Per type-pair parameters for this potential
+        */
+        DEVICE EvaluatorRevCross(Scalar _rij_sq, Scalar _rcutsq, const param_type& _params)          //here it receives also r cutoff
+            : rij_sq(_rij_sq), rcutsq(_rcutsq),
+              sigma_dev(_params.sigma), n_dev(_params.n),
+              epsilon_dev(_params.epsilon), lambda3_dev(_params.lambda3) 
+            {
+            }
+
+        //! Set the square distance between particles i and j
+        DEVICE void setRij(Scalar rsq)
+            {
+            rij_sq = rsq;
+            }
+
+        //! Set the square distance between particles i and k
+        DEVICE void setRik(Scalar rsq)
+            {
+            rik_sq = rsq;
+            }
+
+        //! Check whether a pair of particles is interactive
+        DEVICE bool areInteractive()
+            {
+            if ((rik_sq < rcutsq )&&(epsilon_dev!=Scalar(0.0)))                 
+            //if rik_sq < rcutsq                 
+                return true;
+            else return false;
+            }
+
+        //! Evaluate the repulsive and attractive terms of the force
+        DEVICE bool evalRepulsiveAndAttractive(Scalar& invratio, Scalar& invratio2)
+            {
+            if ((rij_sq < rcutsq )&&(epsilon_dev!=Scalar(0.0)))
+                {
+                // compute rij
+                Scalar rij = fast::sqrt(rij_sq);
+
+                // compute the power of the ratio
+                invratio = fast::pow( sigma_dev/rij,n_dev );
+                invratio2 = invratio*invratio;
+
+                return true;
+                }
+            else return false;
+            }
+
+        //! Evaluate the force and potential energy due to ij interactions
+        DEVICE void evalForceij(Scalar invratio,
+                                Scalar invratio2,
+                                Scalar& force_divr,
+                                Scalar& potential_eng)
+            {
+            // compute the ij force
+	    // the force term includes rij_sq^-1 from the derivative over the distance and a factor 0.5 to compensate for double countings
+            force_divr = Scalar(2.0) *epsilon_dev * n_dev * (Scalar(2.0)*invratio2-invratio) / rij_sq;    
+
+	    // compute the potential energy
+            potential_eng = epsilon_dev*( invratio2 - invratio);   
+            }                                                                     
+                                                                           
+        //! Evaluate the forces due to ijk interactions
+        DEVICE bool evalForceik(Scalar ijinvratio,
+                                Scalar ijinvratio2,
+                                Scalar& force_divr_ij,
+                                Scalar& force_divr_ik)
+            {
+            if (rik_sq < rcutsq)
+                {
+                // compute rij, rik, rcut
+                Scalar rij = fast::sqrt(rij_sq);
+                Scalar rik = fast::sqrt(rik_sq);
+                Scalar rm = sigma_dev * fast::pow(Scalar(2.0),Scalar(1.0)/n_dev);    
+                Scalar ikinvratio = fast::pow(sigma_dev/rik, n_dev);
+                Scalar ikinvratio2 = ikinvratio*ikinvratio;
+
+		//In this case the three particles interact and we have to find which one of the three scenarios is realized:
+		// (1) both k and j closer than rm ----> no forces from the three body term
+		// (2) only one closer than rm ----> two body interaction compensated by the three body for i and the closer 
+		// (3) both farther than rm ----> complete avaluation of the forces
+		
+		//case (1) is trivial. The following are the two realization of case (2) 
+		if ((rij > rm) && (rik <= rm) ){	
+		       	
+		       force_divr_ij = Scalar(-4.0) * epsilon_dev * n_dev * lambda3_dev * (Scalar(2.0)*ijinvratio2-ijinvratio) / rij_sq;		
+		       force_divr_ik = 0;		
+		       				
+		}
+		else if ((rij <= rm ) && (rik > rm) ){
+		
+		       force_divr_ij = 0;		
+		       //each triplets is evaluated only once
+		       force_divr_ik = Scalar(-4.0) * epsilon_dev * n_dev * lambda3_dev * (Scalar(2.0)*ikinvratio2-ikinvratio) / rik_sq;	
+		       				
+		}
+		       	
+		//~~~~~~~~~~~~~~~~then case (3), look at REF_Ciarella for details
+		else if ((rij > rm) && (rik > rm) ){
+		
+		       //starting with the contribute of the particle j in the 3B term	
+		       force_divr_ij = lambda3_dev * Scalar(16.0) * epsilon_dev * n_dev * ( Scalar(2.0)*ijinvratio2 - ijinvratio )*( ikinvratio2 - ikinvratio ) / rij_sq ;							
+		
+		       //then the contribute of the particle k in the 3B term	
+		       force_divr_ik = lambda3_dev * Scalar(16.0) * epsilon_dev * n_dev * ( Scalar(2.0)*ikinvratio2 - ikinvratio )*( ijinvratio2 - ijinvratio ) / rik_sq ;		
+		       	
+		}
+	
+                return true;
+                }
+            else return false;
+            }
+
+        #ifndef NVCC
+        //! Get the name of this potential
+        /*! \returns The potential name.  Must be short and all lowercase, as this is the name
+            energies will be logged as via analyze.log.
+        */
+        static std::string getName()
+            {
+            return std::string("revcross");
+            }
+        #endif
+
+    protected:
+        Scalar rij_sq; //!< Stored rij_sq from the constructor
+        Scalar rik_sq; //!< Stored rik_sq from the constructor
+        Scalar rcutsq; //!< Stored rcutsq from the constructor
+        Scalar sigma_dev;
+        Scalar n_dev;
+        Scalar epsilon_dev;
+        Scalar lambda3_dev;
+    };
+
+#endif

--- a/hoomd/md/PotentialRevCross.h
+++ b/hoomd/md/PotentialRevCross.h
@@ -1,0 +1,524 @@
+// Copyright (c) 2009-2019 The Regents of the University of Michigan
+// This file is part of the HOOMD-blue project, released under the BSD 3-Clause License.
+//
+// Maintainer: SCiarella
+
+#ifndef __POTENTIAL_REVCROSS_H__
+#define __POTENTIAL_REVCROSS_H__
+
+#include <iostream>
+#include <stdexcept>
+#include <memory>
+#include <fstream>
+
+#include "hoomd/HOOMDMath.h"
+#include "hoomd/Index1D.h"
+#include "hoomd/GPUArray.h"
+#include "hoomd/ForceCompute.h"
+#include "NeighborList.h"
+
+
+/*! \file PotentialRevCross.h
+    \brief Defines the template class for standard three-body potentials
+    \details The heart of the code that computes three-body potentials is in this file.
+    \note This header cannot be compiled by nvcc
+*/
+
+#ifdef NVCC
+#error This header cannot be compiled by nvcc
+#endif
+
+#include <hoomd/extern/pybind/include/pybind11/pybind11.h>
+
+//! Template class for computing three-body potentials
+/*! <b>Overview:</b>
+    PotentialRevCross computes standard three-body potentials and forces between all particles in the
+    simulation.  It employs the use of a neighbor list to limit the number of comutations done to
+    only those particles within the cutoff radius of each other.  the computation of the actual
+    potential is not performed directly by this class, but by an evaluator class (e.g.
+    EvaluatorRevCross) which is passed in as a template parameter so the computations are performed
+    as efficiently as possible.
+
+    PotentialRevCross handles most of the internal details common to all standard three-body potentials.
+     - A cutoff radius to be specified per particle type-pair
+     - Per type-pair parameters are stored and a set method is provided
+     - Logging methods are provided for the energy
+     - All the details about looping through the particles, computing dr, computing the virial, etc. are handled
+
+    <b>Implementation details</b>
+
+    Unlike the pair potentials, the three-body potentials offer two force directions: ij and ik.
+    In addition, some three-body potentials (such as the RevCross potential) compute unique forces on
+    each of the three particles involved.  Three-body evaluators must thus return six force magnitudes:
+    two for each particle.  These values are returned in the Scalar3 values \a force_divr_ij and
+    \a force_divr_ik.  The x components refer to particle i, y to particle j, and z to particle k.
+    If your particular three-body potential does not compute one of these forces, then the evaluator
+    can simply return 0 for that force.  In addition, the potential energy is stored in the w component
+    of force_divr_ij.
+
+    rcutsq, ronsq, and the params are stored per particle type-pair. It wastes a little bit of space, but benchmarks
+    show that storing the symmetric type pairs and indexing with Index2D is faster than not storing redudant pairs
+    and indexing with Index2DUpperTriangular. All of these values are stored in GPUArray
+    for easy access on the GPU by a derived class. The type of the parameters is defined by \a param_type in the
+    potential evaluator class passed in. See the appropriate documentation for the evaluator for the definition of each
+    element of the parameters.
+
+    For profiling and logging, PotentialRevCross needs to know the name of the potential. For now, that will be queried from
+    the evaluator. Perhaps in the future we could allow users to change that so multiple pair potentials could be logged
+    independently.
+
+    \sa export_PotentialRevCross()
+*/
+template < class evaluator >
+class PotentialRevCross : public ForceCompute
+    {
+    public:
+        //! Param type from evaluator
+        typedef typename evaluator::param_type param_type;
+
+        //! Construct the potential
+        PotentialRevCross(std::shared_ptr<SystemDefinition> sysdef,
+                         std::shared_ptr<NeighborList> nlist,
+                         const std::string& log_suffix="");
+        //! Destructor
+        virtual ~PotentialRevCross();
+
+        //! Set the pair parameters for a single type pair
+        virtual void setParams(unsigned int typ1, unsigned int typ2, const param_type& param);
+        //! Set the rcut for a single type pair
+        virtual void setRcut(unsigned int typ1, unsigned int typ2, Scalar rcut);
+        //! Set ron for a single type pair
+        virtual void setRon(unsigned int typ1, unsigned int typ2, Scalar ron);
+
+        //! Returns a list of log quantities this compute calculates
+        virtual std::vector< std::string > getProvidedLogQuantities();
+        //! Calculates the requested log value and returns it
+        virtual Scalar getLogValue(const std::string& quantity, unsigned int timestep);
+
+
+    protected:
+        std::shared_ptr<NeighborList> m_nlist;    //!< The neighborlist to use for the computation
+        Index2D m_typpair_idx;                      //!< Helper class for indexing per type pair arrays
+        GPUArray<Scalar> m_rcutsq;                  //!< Cuttoff radius squared per type pair
+        GPUArray<Scalar> m_ronsq;                   //!< ron squared per type pair
+        GPUArray<param_type> m_params;   //!< Pair parameters per type pair
+        std::string m_prof_name;                    //!< Cached profiler name
+        std::string m_log_name;                     //!< Cached log name
+
+        //! Actually compute the forces
+        virtual void computeForces(unsigned int timestep);
+
+        //! Method to be called when number of types changes
+        virtual void slotNumTypesChange()
+            {
+            // skip the reallocation if the number of types does not change
+            // this keeps old potential coefficients when restoring a snapshot
+            // it will result in invalid coeficients if the snapshot has a different type id -> name mapping
+            if (m_pdata->getNTypes() == m_typpair_idx.getW())
+                return;
+
+            m_typpair_idx = Index2D(m_pdata->getNTypes());
+
+            // reallocate parameter arrays
+            GPUArray<Scalar> rcutsq(m_typpair_idx.getNumElements(), m_exec_conf);
+            m_rcutsq.swap(rcutsq);
+            GPUArray<Scalar> ronsq(m_typpair_idx.getNumElements(), m_exec_conf);
+            m_ronsq.swap(ronsq);
+            GPUArray<param_type> params(m_typpair_idx.getNumElements(), m_exec_conf);
+            m_params.swap(params);
+            }
+    };
+
+/*! \param sysdef System to compute forces on
+    \param nlist Neighborlist to use for computing the forces
+    \param log_suffix Name given to this instance of the force
+*/
+template < class evaluator >
+PotentialRevCross< evaluator >::PotentialRevCross(std::shared_ptr<SystemDefinition> sysdef,
+                                                std::shared_ptr<NeighborList> nlist,
+                                                const std::string& log_suffix)
+    : ForceCompute(sysdef), m_nlist(nlist), m_typpair_idx(m_pdata->getNTypes())
+    {
+    this->m_exec_conf->msg->notice(5) << "Constructing PotentialRevCross" << std::endl;
+
+    assert(m_pdata);
+    assert(m_nlist);
+
+    GPUArray<Scalar> rcutsq(m_typpair_idx.getNumElements(), m_exec_conf);
+    m_rcutsq.swap(rcutsq);
+    GPUArray<Scalar> ronsq(m_typpair_idx.getNumElements(), m_exec_conf);
+    m_ronsq.swap(ronsq);
+    GPUArray<param_type> params(m_typpair_idx.getNumElements(), m_exec_conf);
+    m_params.swap(params);
+
+    // initialize name
+    m_prof_name = std::string("Triplet ") + evaluator::getName();
+    m_log_name = std::string("pair_") + evaluator::getName() + std::string("_energy") + log_suffix;
+
+    // connect to the ParticleData to receive notifications when the maximum number of particles changes
+    m_pdata->getNumTypesChangeSignal().template connect<PotentialRevCross<evaluator>, &PotentialRevCross<evaluator>::slotNumTypesChange>(this);
+    }
+
+template < class evaluator >
+PotentialRevCross< evaluator >::~PotentialRevCross()
+    {
+    this->m_exec_conf->msg->notice(5) << "Destroying PotentialRevCross" << std::endl;
+    m_pdata->getNumTypesChangeSignal().template disconnect<PotentialRevCross<evaluator>, &PotentialRevCross<evaluator>::slotNumTypesChange>(this);
+    }
+
+/*! \param typ1 First type index in the pair
+    \param typ2 Second type index in the pair
+    \param param Parameter to set
+    \note When setting the value for (\a typ1, \a typ2), the parameter for (\a typ2, \a typ1) is automatically
+          set.
+*/
+template< class evaluator >
+void PotentialRevCross< evaluator >::setParams(unsigned int typ1, unsigned int typ2, const param_type& param)
+    {
+    if (typ1 >= m_pdata->getNTypes() || typ2 >= m_pdata->getNTypes())
+        {
+        this->m_exec_conf->msg->error() << "pair." << evaluator::getName() << ": Trying to set pair params for a non existant type! "
+                  << typ1 << "," << typ2 << std::endl << std::endl;
+        throw std::runtime_error("Error setting parameters in PotentialRevCross");
+        }
+
+    ArrayHandle<param_type> h_params(m_params, access_location::host, access_mode::readwrite);
+    h_params.data[m_typpair_idx(typ1, typ2)] = param;
+    h_params.data[m_typpair_idx(typ2, typ1)] = param;
+    }
+
+/*! \param typ1 First type index in the pair
+    \param typ2 Second type index in the pair
+    \param rcut Cuttoff radius to set
+    \note When setting the value for (\a typ1, \a typ2), the parameter for (\a typ2, \a typ1) is automatically
+          set.
+*/
+template< class evaluator >
+void PotentialRevCross< evaluator >::setRcut(unsigned int typ1, unsigned int typ2, Scalar rcut)
+    {
+    if (typ1 >= m_pdata->getNTypes() || typ2 >= m_pdata->getNTypes())
+        {
+        m_exec_conf->msg->error() << std::endl << "Trying to set rcut for a non existant type! "
+                                  << typ1 << "," << typ2 << std::endl;
+        throw std::runtime_error("Error setting parameters in PotentialRevCross");
+        }
+
+    ArrayHandle<Scalar> h_rcutsq(m_rcutsq, access_location::host, access_mode::readwrite);
+    h_rcutsq.data[m_typpair_idx(typ1, typ2)] = rcut * rcut;
+    h_rcutsq.data[m_typpair_idx(typ2, typ1)] = rcut * rcut;
+    }
+
+/*! \param typ1 First type index in the pair
+    \param typ2 Second type index in the pair
+    \param ron XPLOR r_on radius to set
+    \note When setting the value for (\a typ1, \a typ2), the parameter for (\a typ2, \a typ1) is automatically
+          set.
+*/
+template< class evaluator >
+void PotentialRevCross< evaluator >::setRon(unsigned int typ1, unsigned int typ2, Scalar ron)
+    {
+    if (typ1 >= m_pdata->getNTypes() || typ2 >= m_pdata->getNTypes())
+        {
+        m_exec_conf->msg->error() << std::endl << "Trying to set ron for a non existant type! "
+                                  << typ1 << "," << typ2 << std::endl;
+        throw std::runtime_error("Error setting parameters in PotentialRevCross");
+        }
+
+    ArrayHandle<Scalar> h_ronsq(m_ronsq, access_location::host, access_mode::readwrite);
+    h_ronsq.data[m_typpair_idx(typ1, typ2)] = ron * ron;
+    h_ronsq.data[m_typpair_idx(typ2, typ1)] = ron * ron;
+    }
+
+/*! PotentialRevCross provides:
+     - \c pair_"name"_energy
+    where "name" is replaced with evaluator::getName()
+*/
+template< class evaluator >
+std::vector< std::string > PotentialRevCross< evaluator >::getProvidedLogQuantities()
+    {
+    std::vector<std::string> list;
+    list.push_back(m_log_name);
+    return list;
+    }
+
+/*! \param quantity Name of the log value to get
+    \param timestep Current timestep of the simulation
+*/
+template< class evaluator >
+Scalar PotentialRevCross< evaluator >::getLogValue(const std::string& quantity, unsigned int timestep)
+    {
+    if (quantity == m_log_name)
+        {
+        compute(timestep);
+        return calcEnergySum();
+        }
+    else
+        {
+        this->m_exec_conf->msg->error() << "pair." << evaluator::getName() << ": " << quantity << " is not a valid log quantity"
+                                        << std::endl;
+        throw std::runtime_error("Error getting log value");
+        }
+    }
+
+/*! \post The forces are computed for the given timestep. The neighborlist's compute method is called to ensure
+    that it is up to date before proceeding.
+
+    \param timestep specifies the current time step of the simulation
+*/
+template< class evaluator >
+void PotentialRevCross< evaluator >::computeForces(unsigned int timestep)
+    {
+    // start by updating the neighborlist
+    m_nlist->compute(timestep);
+
+    // start the profile for this compute
+    if (m_prof) m_prof->push(m_prof_name);
+
+    // The three-body potentials can't handle a half neighbor list, so check now.
+    bool third_law = m_nlist->getStorageMode() == NeighborList::half;
+    if (third_law)
+        {
+        m_exec_conf->msg->error() << std::endl << "PotentialRevCross cannot handle a half neighborlist"
+                                  << std::endl;
+        throw std::runtime_error("Error computing forces in PotentialRevCross");
+        }
+
+    // access the neighbor list, particle data, and system box
+    ArrayHandle<unsigned int> h_n_neigh(m_nlist->getNNeighArray(), access_location::host, access_mode::read);
+    ArrayHandle<unsigned int> h_nlist(m_nlist->getNListArray(), access_location::host, access_mode::read);
+    ArrayHandle<unsigned int> h_head_list(m_nlist->getHeadList(), access_location::host, access_mode::read);
+
+    ArrayHandle<Scalar4> h_pos(m_pdata->getPositions(), access_location::host, access_mode::read);
+
+
+    //force arrays
+    ArrayHandle<Scalar4> h_force(m_force,access_location::host, access_mode::overwrite);
+    //vir array
+    ArrayHandle<Scalar>  h_virial(m_virial,access_location::host, access_mode::overwrite);        
+
+
+    const BoxDim& box = m_pdata->getBox();
+    ArrayHandle<Scalar> h_ronsq(m_ronsq, access_location::host, access_mode::read);
+    ArrayHandle<Scalar> h_rcutsq(m_rcutsq, access_location::host, access_mode::read);
+    ArrayHandle<param_type> h_params(m_params, access_location::host, access_mode::read);
+
+    //from potentialpair.h
+    PDataFlags flags = this->m_pdata->getFlags();
+    bool compute_virial = flags[pdata_flag::pressure_tensor] || flags[pdata_flag::isotropic_virial];
+
+    // need to start from a zero force, energy
+    memset(h_force.data, 0, sizeof(Scalar4)*m_pdata->getN());
+    //vir
+    memset((void*)h_virial.data,0,sizeof(Scalar)*m_virial.getNumElements());
+
+    // for each particle
+    for (int i = 0; i < (int)m_pdata->getN(); i++)
+        {
+        // access the particle's position and type (MEM TRANSFER: 4 scalars)
+        Scalar3 posi = make_scalar3(h_pos.data[i].x, h_pos.data[i].y, h_pos.data[i].z);
+        unsigned int typei = __scalar_as_int(h_pos.data[i].w);
+        const unsigned int head_i = h_head_list.data[i];
+        // sanity check
+        assert(typei < m_pdata->getNTypes());
+
+        // initialize current force and potential energy of particle i to 0
+        Scalar3 fi = make_scalar3(0.0, 0.0, 0.0);
+        Scalar pei = 0.0;
+	
+	//and vir for i     (I need to declare them also if compute_virial is false)
+	Scalar ivirialxx = 0.0;
+        Scalar ivirialxy = 0.0;
+        Scalar ivirialxz = 0.0;
+        Scalar ivirialyy = 0.0;
+        Scalar ivirialyz = 0.0;
+        Scalar ivirialzz = 0.0;
+	       
+        // loop over all of the neighbors of this particle
+        const unsigned int size = (unsigned int)h_n_neigh.data[i];
+        for (unsigned int j = 0; j < size; j++)
+            {
+            // access the index of neighbor j (MEM TRANSFER: 1 scalar)
+            unsigned int jj = h_nlist.data[head_i + j];
+            assert(jj < m_pdata->getN());
+
+            // access the position and type of particle j
+            Scalar3 posj = make_scalar3(h_pos.data[jj].x, h_pos.data[jj].y, h_pos.data[jj].z);
+            unsigned int typej = __scalar_as_int(h_pos.data[jj].w);
+            assert(typej < m_pdata->getNTypes());
+
+            // initialize the current force and potential energy of particle j to 0
+            Scalar3 fj = make_scalar3(0.0, 0.0, 0.0);
+            Scalar pej = 0.0;
+            
+            // calculate dr_ij (MEM TRANSFER: 3 scalars / FLOPS: 3)
+            Scalar3 dxij = posi - posj;
+
+            // apply periodic boundary conditions
+            dxij = box.minImage(dxij);
+
+            // compute rij_sq (FLOPS: 5)
+            Scalar rij_sq = dot(dxij, dxij);
+	    
+            // get parameters for this type pair
+            unsigned int typpair_idx = m_typpair_idx(typei, typej);
+            param_type param = h_params.data[typpair_idx];
+            Scalar rcutsq = h_rcutsq.data[typpair_idx];
+
+            // evaluate the base repulsive and attractive terms
+            Scalar invratio = 0.0;
+            Scalar invratio2 = 0.0;
+            evaluator eval(rij_sq, rcutsq, param);
+            bool evaluated = eval.evalRepulsiveAndAttractive(invratio, invratio2);
+
+	    // Even though the i-j interaction is symmetric so in principle I could consider i>j only,
+	    // I have to loop over both i-j-k and j-i-k because I search only in neighbors of of the first element
+	    // (since nl are type-wise I can not even merge them because i, j and k could be different types)
+            if (evaluated)
+                {
+		//printf("\nEvaluating the pair (i,j)=(%d, %d)  from inside HOOMD CPU",i,jj);
+                // evaluate the force and energy from the ij interaction
+                Scalar force_divr = Scalar(0.0);
+                Scalar potential_eng = Scalar(0.0);
+                eval.evalForceij(invratio, invratio2, force_divr, potential_eng);
+
+                // add this force to particle i
+                fi += force_divr * dxij;
+                pei += potential_eng ;
+
+                // add this force to particle j
+                fj += Scalar(-1.0) * force_divr * dxij;
+                pej += potential_eng ;
+                
+                //vir contribute for i j direct interaction on particle i and j
+		if (compute_virial)
+		    {
+            	    ivirialxx += force_divr*dxij.x*dxij.x;
+            	    ivirialxy += force_divr*dxij.x*dxij.y;
+            	    ivirialxz += force_divr*dxij.x*dxij.z;
+            	    ivirialyy += force_divr*dxij.y*dxij.y;
+            	    ivirialyz += force_divr*dxij.y*dxij.z;
+		    ivirialzz += force_divr*dxij.z*dxij.z;
+		    }
+                
+                // evaluate the force from the ik interactions
+                for (unsigned int k = j+1; k < size; k++)                    //I want to account only a single time for each triplets 
+                    {
+                    // access the index of neighbor k
+                    unsigned int kk = h_nlist.data[head_i + k];
+                    assert(kk < m_pdata->getN());
+
+                    // access the position and type of neighbor k
+                    Scalar3 posk = make_scalar3(h_pos.data[kk].x, h_pos.data[kk].y, h_pos.data[kk].z);
+                    unsigned int typek = __scalar_as_int(h_pos.data[kk].w);
+                    assert(typek < m_pdata->getNTypes());
+
+                    // access the type pair parameters for i and k
+                    typpair_idx = m_typpair_idx(typei, typek);
+                    param_type temp_param = h_params.data[typpair_idx];             // use this to control the species wich have to interact
+					
+                    // compute dr_ik
+                    Scalar3 dxik = posi - posk;
+                    // apply periodic boundary conditions
+                    dxik = box.minImage(dxik);
+                    // compute rik_sq
+                    Scalar rik_sq = dot(dxik, dxik);
+                    
+                    // check if k interacts using a temporary evaluator to analyze i-k parameters                        
+                    evaluator temp_eval(rij_sq, rcutsq, temp_param);
+                    temp_eval.setRik(rik_sq);
+                    bool temp_evaluated = temp_eval.areInteractive();
+
+		    // 3 Body interaction ******
+                    if (temp_evaluated)
+                        {
+			eval.setRik(rik_sq);
+                        // compute the total force and energy
+                        Scalar3 fk = make_scalar3(0.0, 0.0, 0.0);
+                        Scalar force_divr_ij = 0.0;
+                        Scalar force_divr_ik = 0.0;
+                        bool evaluatedk = eval.evalForceik(invratio,invratio2, force_divr_ij, force_divr_ik);
+			// k interacts with the i-j as an additional third body
+			if(evaluatedk)
+				{
+				//printf("\nEvaluating the triplet (i,j,k)=(%d, %d, %d)  from inside HOOMD CPU",i,jj,kk);
+				// add the force to particle i
+				fi += force_divr_ij * dxij + force_divr_ik * dxik;
+
+				// add the force to particle j (FLOPS: 17)
+				fj += force_divr_ij * dxij * Scalar(-1.0);
+
+				// add the force to particle k
+				fk += force_divr_ik * dxik * Scalar(-1.0);
+				
+				if (compute_virial)
+			   	{
+					//***look at 3 body pressure notes
+					//i just need a single term to account for all of the 3 body virial that i decide to store in the i particle's data 
+					//and i just defined the diagonal component of pressure tensor, I don't know how the off diagonal terms can be included
+					ivirialxx += (force_divr_ij*dxij.x*dxij.x + force_divr_ik*dxik.x*dxik.x);	
+					ivirialyy += (force_divr_ij*dxij.y*dxij.y + force_divr_ik*dxik.y*dxik.y);	
+					ivirialzz += (force_divr_ij*dxij.z*dxij.z + force_divr_ik*dxik.z*dxik.z);	
+					ivirialxy += (force_divr_ij*dxij.x*dxij.y + force_divr_ik*dxik.x*dxik.y);
+                   			ivirialxz += (force_divr_ij*dxij.x*dxij.z + force_divr_ik*dxik.x*dxik.z);
+                 			ivirialyz += (force_divr_ij*dxij.y*dxij.z + force_divr_ik*dxik.y*dxik.z);
+	                	}
+
+                              
+				// increment the force for particle k
+				unsigned int mem_idx = kk;
+				h_force.data[mem_idx].x += fk.x;
+				h_force.data[mem_idx].y += fk.y;
+				h_force.data[mem_idx].z += fk.z;
+			    }
+                        }
+                    }
+                }
+                    
+            // increment the force and potential energy for particle j
+            unsigned int mem_idx = jj;
+            h_force.data[mem_idx].x += fj.x;
+            h_force.data[mem_idx].y += fj.y;
+            h_force.data[mem_idx].z += fj.z;
+            h_force.data[mem_idx].w += pej;
+
+	    }
+            
+        // finally, increment the force and potential energy for particle i
+        unsigned int mem_idx = i;
+        h_force.data[mem_idx].x += fi.x;
+        h_force.data[mem_idx].y += fi.y;
+        h_force.data[mem_idx].z += fi.z;
+        h_force.data[mem_idx].w += pei;
+        
+        //imcrement vir for i
+        if (compute_virial)
+            {
+            h_virial.data[0*m_virial_pitch+mem_idx] += ivirialxx;
+            h_virial.data[1*m_virial_pitch+mem_idx] += ivirialxy;
+            h_virial.data[2*m_virial_pitch+mem_idx] += ivirialxz;
+            h_virial.data[3*m_virial_pitch+mem_idx] += ivirialyy;
+	    h_virial.data[4*m_virial_pitch+mem_idx] += ivirialyz;
+            h_virial.data[5*m_virial_pitch+mem_idx] += ivirialzz;
+            }
+
+        }
+
+    if (m_prof) m_prof->pop();
+    }
+
+//! Export this triplet potential to python
+/*! \param name Name of the class in the exported python module
+    \tparam T Class type to export. \b Must be an instantiated PotentialRevCross class template.
+*/
+template < class T > void export_PotentialRevCross(pybind11::module& m, const std::string& name)
+    {
+        pybind11::class_<T, std::shared_ptr<T> >(m, name.c_str(), pybind11::base<ForceCompute>())
+            .def(pybind11::init< std::shared_ptr<SystemDefinition>, std::shared_ptr<NeighborList>, const std::string& >())
+            .def("setParams", &T::setParams)
+            .def("setRcut", &T::setRcut)
+            .def("setRon", &T::setRon)
+        ;
+    }
+
+
+#endif

--- a/hoomd/md/PotentialRevCrossGPU.cuh
+++ b/hoomd/md/PotentialRevCrossGPU.cuh
@@ -1,0 +1,571 @@
+// Copyright (c) 2009-2019 The Regents of the University of Michigan
+// This file is part of the HOOMD-blue project, released under the BSD 3-Clause License.
+//
+// Maintainer: SCiarella
+
+
+#include "hoomd/HOOMDMath.h"
+#include "hoomd/TextureTools.h"
+#include "hoomd/ParticleData.cuh"
+#include "hoomd/Index1D.h"
+#ifdef NVCC
+#include "hoomd/WarpTools.cuh"
+//#include "hoomd/md/PotentialTersoffGPU.cuh"
+#endif // NVCC
+#include <assert.h>
+
+/*! \file PotentialRevCrossGPU.cuh
+    \brief Defines templated GPU kernel code for calculating certain three-body forces
+*/
+
+#ifndef __POTENTIAL_REVCROSS_GPU_CUH__
+#define __POTENTIAL_REVCROSS_GPU_CUH__
+
+//! Maximum number of threads (width of a warp)
+const int gpu_revcross_max_tpp = 32;
+
+//! Wraps arguments to gpu_cgpf
+struct revcross_args_t
+    {
+    //! Construct a revcross_args_t
+    revcross_args_t(Scalar4 *_d_force,
+                   const unsigned int _N,
+                   const unsigned int _Nghosts,
+                   Scalar * _d_virial,
+                   unsigned int _virial_pitch,
+                   bool _compute_virial,
+                   const Scalar4 *_d_pos,
+                   const BoxDim& _box,
+                   const unsigned int *_d_n_neigh,
+                   const unsigned int *_d_nlist,
+                   const unsigned int *_d_head_list,
+                   const Scalar *_d_rcutsq,
+                   const Scalar *_d_ronsq,
+                   const unsigned int _size_nlist,
+                   const unsigned int _ntypes,
+                   const unsigned int _block_size,
+                   const unsigned int _tpp,
+                   const cudaDeviceProp& _devprop)
+                   : d_force(_d_force),
+                     N(_N),
+                     Nghosts(_Nghosts),
+                     d_virial(_d_virial),
+                     virial_pitch(_virial_pitch),
+                     compute_virial(_compute_virial),
+                     d_pos(_d_pos),
+                     box(_box),
+                     d_n_neigh(_d_n_neigh),
+                     d_nlist(_d_nlist),
+                     d_head_list(_d_head_list),
+                     d_rcutsq(_d_rcutsq),
+                     d_ronsq(_d_ronsq),
+                     size_nlist(_size_nlist),
+                     ntypes(_ntypes),
+                     block_size(_block_size),
+                     tpp(_tpp),
+                     devprop(_devprop)
+        {
+        };
+
+    Scalar4 *d_force;                //!< Force to write out
+    const unsigned int N;            //!< Number of particles
+    const unsigned int Nghosts;      //!< Number of ghost particles
+    Scalar *d_virial;                //!< Virial to write out
+    const unsigned int virial_pitch; //!< Pitch for N*6 virial array
+    bool compute_virial;             //!< True if we are supposed to compute the virial
+    const Scalar4 *d_pos;            //!< particle positions
+    const BoxDim& box;                //!< Simulation box in GPU format
+    const unsigned int *d_n_neigh;  //!< Device array listing the number of neighbors on each particle
+    const unsigned int *d_nlist;    //!< Device array listing the neighbors of each particle
+    const unsigned int *d_head_list;//!< Indexes for accessing d_nlist
+    const Scalar *d_rcutsq;          //!< Device array listing r_cut squared per particle type pair
+    const Scalar *d_ronsq;           //!< Device array listing r_on squared per particle type pair
+    const unsigned int size_nlist;  //!< Number of elements in the neighborlist
+    const unsigned int ntypes;      //!< Number of particle types in the simulation
+    const unsigned int block_size;  //!< Block size to execute
+    const unsigned int tpp;         //!< Threads per particle
+    const cudaDeviceProp& devprop;   //!< CUDA device properties
+    };
+
+#ifdef NVCC
+
+#if !defined(SINGLE_PRECISION)
+
+#if (__CUDA_ARCH__ < 600)
+//! atomicAdd function for double-precision floating point numbers
+/*! This function is only used when hoomd is compiled for double precision on the GPU.
+
+    \param address Address to write the double to
+    \param val Value to add to address
+*/
+__device__ double RevCrossAtomicAdd(double* address, double val)
+    {
+    unsigned long long int* address_as_ull = (unsigned long long int*)address;
+    unsigned long long int old = *address_as_ull, assumed;
+
+    do {
+        assumed = old;
+        old = atomicCAS(address_as_ull,
+                        assumed,
+                        __double_as_longlong(val + __longlong_as_double(assumed)));
+    } while (assumed != old);
+
+    return __longlong_as_double(old);
+    }
+#else // CUDA_ARCH > 600)
+__device__ double RevCrossAtomicAdd(double* address, double val)
+    {
+    return atomicAdd(address, val);
+    }
+#endif
+#endif
+
+__device__ float RevCrossAtomicAdd(float* address, float val)
+    {
+    return atomicAdd(address, val);
+    }
+
+//! Kernel for calculating the RevCross forces
+/*! This kernel is called to calculate the forces on all N particles. Actual evaluation of the potentials and
+    forces for each pair is handled via the template class \a evaluator.
+
+    \param d_force Device memory to write computed forces
+    \param N Number of particles in the system
+    \param d_pos Positions of all the particles
+    \param box Box dimensions used to implement periodic boundary conditions
+    \param d_n_neigh Device memory array listing the number of neighbors for each particle
+    \param d_nlist Device memory array containing the neighbor list contents
+    \param d_head_list Indexes for reading \a d_nlist
+    \param d_params Parameters for the potential, stored per type pair
+    \param d_rcutsq rcut squared, stored per type pair
+    \param d_ronsq ron squared, stored per type pair
+    \param ntypes Number of types in the simulation
+
+    \a d_params, \a d_rcutsq, and \a d_ronsq must be indexed with an Index2DUpperTriangular(typei, typej) to access the
+    unique value for that type pair. These values are all cached into shared memory for quick access, so a dynamic
+    amount of shared memory must be allocated for this kernel launch. The amount is
+    (2*sizeof(Scalar) + sizeof(typename evaluator::param_type)) * typpair_idx.getNumElements()
+
+    Certain options are controlled via template parameters to avoid the performance hit when they are not enabled.
+    \tparam evaluator EvaluatorPair class to evaluate V(r) and -delta V(r)/r
+
+    <b>Implementation details</b>
+    Each block will calculate the forces on a block of particles.
+    Each thread will calculate the total force on one particle.
+    The neighborlist is arranged in columns so that reads are fully coalesced when doing this.
+*/
+template< class evaluator, unsigned char compute_virial, int tpp>
+__global__ void gpu_compute_revcross_forces_kernel(Scalar4 *d_force,
+                                                  const unsigned int N,
+                                                  Scalar *d_virial,
+                                                  unsigned int virial_pitch,
+                                                  const Scalar4 *d_pos,
+                                                  const BoxDim box,
+                                                  const unsigned int *d_n_neigh,
+                                                  const unsigned int *d_nlist,
+                                                  const unsigned int *d_head_list,
+                                                  const typename evaluator::param_type *d_params,
+                                                  const Scalar *d_rcutsq,
+                                                  const Scalar *d_ronsq,
+                                                  const unsigned int ntypes)
+    {
+    Index2D typpair_idx(ntypes);
+    const unsigned int num_typ_parameters = typpair_idx.getNumElements();
+
+    // shared arrays for per type pair parameters
+    extern __shared__ char s_data[];
+    typename evaluator::param_type *s_params =
+        (typename evaluator::param_type *)(&s_data[0]);
+    Scalar *s_rcutsq = (Scalar *)(&s_data[num_typ_parameters*sizeof(evaluator::param_type)]);
+
+    Scalar *s_phi_ab = s_rcutsq + num_typ_parameters;
+
+    // load in the per type pair parameters
+    for (unsigned int cur_offset = 0; cur_offset < num_typ_parameters; cur_offset += blockDim.x)
+        {
+        if (cur_offset + threadIdx.x < num_typ_parameters)
+            {
+            s_rcutsq[cur_offset + threadIdx.x] = d_rcutsq[cur_offset + threadIdx.x];
+            s_params[cur_offset + threadIdx.x] = d_params[cur_offset + threadIdx.x];
+            }
+        }
+
+    __syncthreads();
+
+    for (unsigned int i = 0; i < ntypes; ++i)
+        {
+        // reset phi term
+        s_phi_ab[threadIdx.x*ntypes+i] = Scalar(0.0);
+        }
+
+    // start by identifying which particle we are to handle
+    unsigned int idx = blockIdx.x * (blockDim.x/tpp) + threadIdx.x/tpp;
+
+    if (idx >= N)
+        return;
+
+    // load in the length of the neighbor list (MEM_TRANSFER: 4 bytes)
+    unsigned int n_neigh = d_n_neigh[idx];
+
+    // read in the position of the particle
+    Scalar4 postypei = __ldg(d_pos + idx);
+    Scalar3 posi = make_scalar3(postypei.x, postypei.y, postypei.z);
+
+    // initialize the force to 0
+    Scalar4 forcei = make_scalar4(Scalar(0.0), Scalar(0.0), Scalar(0.0), Scalar(0.0));
+
+    Scalar virialxx(0.0);
+    Scalar virialxy(0.0);
+    Scalar virialxz(0.0);
+    Scalar virialyy(0.0);
+    Scalar virialyz(0.0);
+    Scalar virialzz(0.0);
+
+    // prefetch neighbor index
+    const unsigned int head_idx = d_head_list[idx];
+    unsigned int cur_j = 0;
+    unsigned int next_j(0);
+    unsigned int my_head = d_head_list[idx];
+
+    next_j = threadIdx.x%tpp < n_neigh ? __ldg(d_nlist + my_head + threadIdx.x%tpp) : 0;
+
+    // loop over neighbors in strided way
+    for (int neigh_idx = threadIdx.x%tpp; neigh_idx < n_neigh; neigh_idx+=tpp)
+        {
+        // read the current neighbor index (MEM TRANSFER: 4 bytes)
+        // prefetch the next value and set the current one
+        cur_j = next_j;
+        if (neigh_idx+tpp < n_neigh)
+            {
+            next_j = __ldg(d_nlist + head_idx + neigh_idx + tpp);
+            }
+
+	// Since the i-j interaction is symmetric in principle I could consider i>j only.
+	// However the third body k is searched only from the neighbour list of i, so I might miss it exploiting this symmetry,
+	// thus i need to directly do i-j-k and j-i-k, because I want to get each possible triplet.
+	// (*Consider that j is in the NL of i only if their types have a non zero interaction.)
+	// The second important point is that I have to consider each triplet only ONCE, so
+	// I am imposing k>j such that we only have a single evaluation of i-j-k or i-k-j (both j and k came from i's NL). 
+
+        // read the position of j (MEM TRANSFER: 16 bytes)
+        Scalar4 postypej = __ldg(d_pos + cur_j);
+        Scalar3 posj = make_scalar3(postypej.x, postypej.y, postypej.z);
+    
+        // initialize the force on j
+        Scalar4 forcej = make_scalar4(Scalar(0.0), Scalar(0.0), Scalar(0.0), Scalar(0.0));
+    
+        // compute r_ij (FLOPS: 3)
+        Scalar3 dxij = posi - posj;
+    
+        // apply periodic boundary conditions (FLOPS: 12)
+        dxij = box.minImage(dxij);
+    
+        // compute rij_sq (FLOPS: 5)
+        Scalar rij_sq = dot(dxij, dxij);
+    
+        // access the per type-pair parameters
+        unsigned int typpair = typpair_idx(__scalar_as_int(postypei.w), __scalar_as_int(postypej.w));
+        Scalar rcutsq = s_rcutsq[typpair];
+        typename evaluator::param_type param = s_params[typpair];
+    
+        // compute the base repulsive and attractive terms of the potential
+        Scalar invratio = 0.0;        
+        Scalar invratio2 = 0.0;
+        evaluator eval(rij_sq, rcutsq, param);
+        bool evaluatedij = eval.evalRepulsiveAndAttractive(invratio, invratio2);
+    
+        if (evaluatedij)
+            {
+            // evaluate the force and energy from the ij interaction
+            Scalar force_divr = Scalar(0.0);
+            Scalar potential_eng = Scalar(0.0);
+            eval.evalForceij(invratio, invratio2, force_divr, potential_eng);
+    
+            // add the forces and energies to their respective particles
+            forcei.x += dxij.x * force_divr;
+            forcei.y += dxij.y * force_divr;
+            forcei.z += dxij.z * force_divr;
+    
+            forcej.x -= dxij.x * force_divr;
+            forcej.y -= dxij.y * force_divr;
+            forcej.z -= dxij.z * force_divr;
+    
+            forcej.w += potential_eng;
+            forcei.w += potential_eng;
+            
+            // calculate the virial
+            if (compute_virial)
+               {
+               virialxx +=  dxij.x * dxij.x * force_divr;
+               virialxy +=  dxij.x * dxij.y * force_divr;
+               virialxz +=  dxij.x * dxij.z * force_divr;
+               virialyy +=  dxij.y * dxij.y * force_divr;
+               virialyz +=  dxij.y * dxij.z * force_divr;
+               virialzz +=  dxij.z * dxij.z * force_divr;
+               }
+    
+            // now evaluate the force from the ik interactions
+            unsigned int cur_k = 0;
+            unsigned int next_k(0);  
+    
+            // loop over k neighbors one by one
+            for (int neigh_idy = 0; neigh_idy < n_neigh; neigh_idy++)
+                {
+                // read the current neighbor index and prefetch the next one
+                cur_k = next_k;
+                next_k = __ldg(d_nlist + head_idx + neigh_idy+1);
+    
+    	        // I continue only if k is not the same as j
+    	        if((cur_k>cur_j)&&(cur_j>idx))
+    	            {
+                    // get the position of neighbor k
+                    Scalar4 postypek = __ldg(d_pos + cur_k);
+                    Scalar3 posk = make_scalar3(postypek.x, postypek.y, postypek.z);
+    
+                    // get the type pair parameters for i and k
+                    typpair = typpair_idx(__scalar_as_int(postypei.w), __scalar_as_int(postypek.w));
+                    Scalar temp_rcutsq = s_rcutsq[typpair];
+                    typename evaluator::param_type temp_param = s_params[typpair];
+                    
+                     // compute rik
+                    Scalar3 dxik = posi - posk;
+                    // apply the periodic boundary conditions
+                    dxik = box.minImage(dxik);
+                    // compute rik_sq
+                    Scalar rik_sq = dot(dxik, dxik);
+    
+                    evaluator temp_eval(rij_sq, temp_rcutsq, temp_param);
+                    temp_eval.setRik(rik_sq);
+                    bool temp_evaluated = temp_eval.areInteractive();
+    
+                    if (temp_evaluated)
+                        {
+                        Scalar4 forcek = make_scalar4(Scalar(0.0), Scalar(0.0), Scalar(0.0), Scalar(0.0));
+    
+                        // set up the evaluator
+                        eval.setRik(rik_sq);
+    
+                        // compute the force
+                        Scalar force_divr_ij = 0.0;
+                        Scalar force_divr_ik = 0.0;                    
+                        
+                        bool evaluatedjk = eval.evalForceik(invratio, invratio2, force_divr_ij, force_divr_ik);
+    
+                        if (evaluatedjk)
+                            {
+                            // add the forces to their respective particles
+                            forcei.x += force_divr_ij * dxij.x + force_divr_ik * dxik.x;
+                            forcei.y += force_divr_ij * dxij.y + force_divr_ik * dxik.y;
+                            forcei.z += force_divr_ij * dxij.z + force_divr_ik * dxik.z;
+    
+                            forcej.x -= force_divr_ij * dxij.x;
+                            forcej.y -= force_divr_ij * dxij.y;
+                            forcej.z -= force_divr_ij * dxij.z;
+    
+                            forcek.x -= force_divr_ik * dxik.x;
+                            forcek.y -= force_divr_ik * dxik.y;
+                            forcek.z -= force_divr_ik * dxik.z;
+    
+                            RevCrossAtomicAdd(&d_force[cur_k].x, forcek.x);
+                            RevCrossAtomicAdd(&d_force[cur_k].y, forcek.y);
+                            RevCrossAtomicAdd(&d_force[cur_k].z, forcek.z);
+                        
+    	        	       //evaluate the virial contribute of this 3 body interaction    
+    	        	       if (compute_virial)
+    	        	           {
+    	        	           //a single term is needed to account for all of the 3 body virial that is stored in the 'i' particle data
+    	        	           //look at REF_Ciarella for the definition of the virial tensor
+    	        	           virialxx += (force_divr_ij*dxij.x*dxij.x + force_divr_ik*dxik.x*dxik.x);	
+    	        	           virialyy += (force_divr_ij*dxij.y*dxij.y + force_divr_ik*dxik.y*dxik.y);	
+    	        	           virialzz += (force_divr_ij*dxij.z*dxij.z + force_divr_ik*dxik.z*dxik.z);	
+    	        	           virialxy += (force_divr_ij*dxij.x*dxij.y + force_divr_ik*dxik.x*dxik.y);
+    	        	           virialxz += (force_divr_ij*dxij.x*dxij.z + force_divr_ik*dxik.x*dxik.z);
+    	        	           virialyz += (force_divr_ij*dxij.y*dxij.z + force_divr_ik*dxik.y*dxik.z);
+    	        	           }
+                            }    
+                        }
+                    }
+	        }
+
+            // potential energy of j must be halved
+            // write out the result for particle j
+            RevCrossAtomicAdd(&d_force[cur_j].x, forcej.x);
+            RevCrossAtomicAdd(&d_force[cur_j].y, forcej.y);
+            RevCrossAtomicAdd(&d_force[cur_j].z, forcej.z);
+            RevCrossAtomicAdd(&d_force[cur_j].w, forcej.w);
+            }
+	}
+    // potential energy per particle must be halved
+    // now that the force calculation is complete, write out the result (MEM TRANSFER: 20 bytes)
+    RevCrossAtomicAdd(&d_force[idx].x, forcei.x);
+    RevCrossAtomicAdd(&d_force[idx].y, forcei.y);
+    RevCrossAtomicAdd(&d_force[idx].z, forcei.z);
+    RevCrossAtomicAdd(&d_force[idx].w, forcei.w);
+    
+    if (compute_virial)
+        {
+	RevCrossAtomicAdd(&d_virial[0*virial_pitch+idx], virialxx);
+	RevCrossAtomicAdd(&d_virial[1*virial_pitch+idx], virialxy);
+	RevCrossAtomicAdd(&d_virial[2*virial_pitch+idx], virialxz);
+	RevCrossAtomicAdd(&d_virial[3*virial_pitch+idx], virialyy);
+	RevCrossAtomicAdd(&d_virial[4*virial_pitch+idx], virialyz);
+	RevCrossAtomicAdd(&d_virial[5*virial_pitch+idx], virialzz);     
+	}        
+    
+    
+    }
+
+//! Kernel for zeroing forces and virial before computation with atomic additions.
+/*! \param d_force Device memory to write forces to
+    \param N Number of particles in the system
+
+*/
+__global__ void gpu_zero_forces_kernel_revcross(Scalar4 *d_force,
+                                       Scalar *d_virial,
+                                       unsigned int virial_pitch,
+                                       const unsigned int N)
+    {
+    // identify the particle we are supposed to handle
+    unsigned int idx = blockIdx.x * blockDim.x + threadIdx.x;
+
+    if (idx >= N)
+        return;
+
+    // zero the force
+    d_force[idx] = make_scalar4(Scalar(0.0), Scalar(0.0), Scalar(0.0), Scalar(0.0));
+
+    // zero the virial
+    d_virial[0*virial_pitch+idx] = Scalar(0.0);
+    d_virial[1*virial_pitch+idx] = Scalar(0.0);
+    d_virial[2*virial_pitch+idx] = Scalar(0.0);
+    d_virial[3*virial_pitch+idx] = Scalar(0.0);
+    d_virial[4*virial_pitch+idx] = Scalar(0.0);
+    d_virial[5*virial_pitch+idx] = Scalar(0.0);
+    }
+
+
+template<typename T>
+void get_max_block_size_revcross(T func, const revcross_args_t& pair_args, unsigned int& max_block_size, unsigned int& kernel_shared_bytes)
+    {
+    cudaFuncAttributes attr;
+    cudaFuncGetAttributes(&attr, (const void *)func);
+
+    max_block_size = attr.maxThreadsPerBlock;
+    max_block_size &= ~(pair_args.devprop.warpSize - 1);
+
+    kernel_shared_bytes = attr.sharedSizeBytes;
+    }
+
+//! RevCross compute kernel launcher
+/*!
+ * \tparam evaluator Evaluator class
+ * \tparam use_gmem_nlist When non-zero, the neighbor list is read out of global memory. When zero, textures or __ldg
+ *                        is used depending on architecture.
+ * \tparam compute_virial When non-zero, the virial tensor is computed. When zero, the virial tensor is not computed.
+ * \tparam tpp Number of threads to use per particle, must be power of 2 and smaller than warp size
+ *
+ * Partial function template specialization is not allowed in C++, so instead we have to wrap this with a struct that
+ * we are allowed to partially specialize.
+ */
+template<class evaluator, unsigned int compute_virial, int tpp>
+struct RevCrossComputeKernel
+    {
+    //! Launcher for the revcross triplet kernel
+    /*!
+     * \param pair_args Other arguments to pass onto the kernel
+     * \param d_params Parameters for the potential, stored per type pair
+     */
+    static void launch(const revcross_args_t& pair_args, const typename evaluator::param_type *d_params)
+        {
+        if (tpp == pair_args.tpp)
+            {
+            static unsigned int max_block_size = UINT_MAX;
+            static unsigned int kernel_shared_bytes = 0;
+            if (max_block_size == UINT_MAX)
+                get_max_block_size_revcross(gpu_compute_revcross_forces_kernel<evaluator, compute_virial, tpp>, pair_args, max_block_size, kernel_shared_bytes);
+            int run_block_size = min(pair_args.block_size, max_block_size);
+
+            // size shared bytes
+            Index2D typpair_idx(pair_args.ntypes);
+            unsigned int shared_bytes = (sizeof(Scalar) + sizeof(typename evaluator::param_type))
+                                        * typpair_idx.getNumElements() + pair_args.ntypes*run_block_size*sizeof(Scalar);
+
+            while (shared_bytes + kernel_shared_bytes >= pair_args.devprop.sharedMemPerBlock)
+                {
+                run_block_size -= pair_args.devprop.warpSize;
+
+                shared_bytes = (sizeof(Scalar) + sizeof(typename evaluator::param_type))
+                               * typpair_idx.getNumElements() + pair_args.ntypes*run_block_size*sizeof(Scalar);
+                }
+
+            // zero the forces
+            gpu_zero_forces_kernel_revcross<<<(pair_args.N + pair_args.Nghosts)/run_block_size + 1, run_block_size>>>(pair_args.d_force,
+                                                    pair_args.d_virial,
+                                                    pair_args.virial_pitch,
+                                                    pair_args.N + pair_args.Nghosts);
+
+            // setup the grid to run the kernel
+            dim3 grid( pair_args.N / (run_block_size/pair_args.tpp) + 1, 1, 1);
+            dim3 threads(run_block_size, 1, 1);
+
+            gpu_compute_revcross_forces_kernel<evaluator, compute_virial, tpp>
+              <<<grid, threads, shared_bytes>>>(pair_args.d_force,
+                                                pair_args.N,
+                                                pair_args.d_virial,
+                                                pair_args.virial_pitch,
+                                                pair_args.d_pos,
+                                                pair_args.box,
+                                                pair_args.d_n_neigh,
+                                                pair_args.d_nlist,
+                                                pair_args.d_head_list,
+                                                d_params,
+                                                pair_args.d_rcutsq,
+                                                pair_args.d_ronsq,
+                                                pair_args.ntypes);
+            }
+        else
+            {
+            RevCrossComputeKernel<evaluator, compute_virial, tpp/2>::launch(pair_args, d_params);
+            }
+        }
+    };
+
+//! Template specialization to do nothing for the tpp = 0 case
+template<class evaluator, unsigned int compute_virial>
+struct RevCrossComputeKernel<evaluator, compute_virial, 0>
+    {
+    static void launch(const revcross_args_t& pair_args, const typename evaluator::param_type *d_params)
+        {
+        // do nothing
+        }
+    };
+
+//! Kernel driver that computes the three-body forces
+/*! \param pair_args Other arguments to pass onto the kernel
+    \param d_params Parameters for the potential, stored per type pair
+
+    This is just a driver function for gpu_compute_revcross_forces_kernel(), see it for details.
+*/
+template< class evaluator >
+cudaError_t gpu_compute_tripletrevcross_forces(const revcross_args_t& pair_args,
+                                       const typename evaluator::param_type *d_params)
+    {
+    assert(d_params);
+    assert(pair_args.d_rcutsq);
+    assert(pair_args.d_ronsq);
+    assert(pair_args.ntypes > 0);
+
+    // compute the new forces
+    if (!pair_args.compute_virial)
+        {
+        RevCrossComputeKernel<evaluator, 0, gpu_revcross_max_tpp>::launch(pair_args, d_params);
+        }
+    else
+        {
+        RevCrossComputeKernel<evaluator, 1, gpu_revcross_max_tpp>::launch(pair_args, d_params);
+        }
+    return cudaSuccess;
+    }
+#endif
+
+#endif // __POTENTIAL_REVCROSS_GPU_CUH__

--- a/hoomd/md/PotentialRevCrossGPU.cuh
+++ b/hoomd/md/PotentialRevCrossGPU.cuh
@@ -374,7 +374,7 @@ __global__ void gpu_compute_revcross_forces_kernel(Scalar4 *d_force,
     	        	       if (compute_virial)
     	        	           {
     	        	           //a single term is needed to account for all of the 3 body virial that is stored in the 'i' particle data
-    	        	           //look at REF_Ciarella for the definition of the virial tensor
+    	        	           //look at S. Ciarella and W.G. Ellenbroek 2019 https://arxiv.org/abs/1912.08569 for the definition of the virial tensor
     	        	           virialxx += (force_divr_ij*dxij.x*dxij.x + force_divr_ik*dxik.x*dxik.x);	
     	        	           virialyy += (force_divr_ij*dxij.y*dxij.y + force_divr_ik*dxik.y*dxik.y);	
     	        	           virialzz += (force_divr_ij*dxij.z*dxij.z + force_divr_ik*dxik.z*dxik.z);	

--- a/hoomd/md/PotentialRevCrossGPU.h
+++ b/hoomd/md/PotentialRevCrossGPU.h
@@ -1,0 +1,198 @@
+// Copyright (c) 2009-2019 The Regents of the University of Michigan
+// This file is part of the HOOMD-blue project, released under the BSD 3-Clause License.
+//
+// Maintainer: SCiarella
+
+#ifndef __POTENTIAL_REVCROSS_GPU_H__
+#define __POTENTIAL_REVCROSS_GPU_H__
+
+#ifdef ENABLE_CUDA
+
+#include <memory>
+
+#include "PotentialRevCross.h"
+#include "PotentialRevCrossGPU.cuh"
+
+/*! \file PotentialRevCrossGPU.h
+    \brief Defines the template class computing certain three-body forces on the GPU
+    \note This header cannot be compiled by nvcc
+*/
+
+#ifdef NVCC
+#error This header cannot be compiled by nvcc
+#endif
+
+//! Template class for computing three-body potentials and forces on the GPU
+/*! Derived from PotentialRevCross, this class provides exactly the same interface for computing
+    the three-body potentials and forces.  In the same way as PotentialRevCross, this class serves
+    as a shell dealing with all the details of looping while the evaluator actually computes the
+    potential and forces.
+
+    \tparam evaluator Evaluator class used to evaluate V(r) and F(r)/r
+    \tparam gpu_cgpf Driver function that calls gpu_compute_revcross_forces<evaluator>()
+
+    \sa export_PotentialRevCrossGPU()
+*/
+template< class evaluator, cudaError_t gpu_cgpf(const revcross_args_t& pair_args,
+                                                const typename evaluator::param_type *d_params) >
+class PotentialRevCrossGPU : public PotentialRevCross<evaluator>
+    {
+    public:
+        //! Construct the potential
+        PotentialRevCrossGPU(std::shared_ptr<SystemDefinition> sysdef,
+                            std::shared_ptr<NeighborList> nlist,
+                            const std::string& log_suffix="");
+        //! Destructor
+        virtual ~PotentialRevCrossGPU();
+
+        //! Set autotuner parameters
+        /*! \param enable Enable/disable autotuning
+            \param period period (approximate) in time steps when returning occurs
+        */
+        virtual void setAutotunerParams(bool enable, unsigned int period)
+            {
+            PotentialRevCross<evaluator>::setAutotunerParams(enable, period);
+            this->m_tuner->setPeriod(period);
+            this->m_tuner->setEnabled(enable);
+            }
+
+    protected:
+        std::unique_ptr<Autotuner> m_tuner; //!< Autotuner for block size
+
+        //! Actually compute the forces
+        virtual void computeForces(unsigned int timestep);
+    };
+
+template< class evaluator, cudaError_t gpu_cgpf(const revcross_args_t& pair_args,
+                                                const typename evaluator::param_type *d_params) >
+PotentialRevCrossGPU< evaluator, gpu_cgpf >::PotentialRevCrossGPU(std::shared_ptr<SystemDefinition> sysdef,
+                                                                std::shared_ptr<NeighborList> nlist,
+                                                                const std::string& log_suffix)
+    : PotentialRevCross<evaluator>(sysdef, nlist, log_suffix)
+    {
+    this->m_exec_conf->msg->notice(5) << "Constructing PotentialRevCrossGPU" << std::endl;
+
+    // can't run on the GPU if there aren't any GPUs in the execution configuration
+    if (!this->m_exec_conf->isCUDAEnabled())
+        {
+        this->m_exec_conf->msg->error() << "***Error! Creating a PotentialRevCrossGPU with no GPU in the execution configuration"
+                  << std::endl;
+        throw std::runtime_error("Error initializing PotentialRevCrossGPU");
+        }
+
+    // initialize autotuner
+    // the full block size and threads_per_particle matrix is searched,
+    // encoded as block_size*10000 + threads_per_particle
+    unsigned int max_tpp = 1;
+    max_tpp = this->m_exec_conf->dev_prop.warpSize;
+
+    std::vector<unsigned int> valid_params;
+    for (unsigned int block_size = 32; block_size <= 1024; block_size += 32)
+        {
+        unsigned int s=1;
+
+        while (s <= max_tpp)
+            {
+            valid_params.push_back(block_size*10000 + s);
+            s = s * 2;
+            }
+        }
+
+    m_tuner.reset(new Autotuner(valid_params, 5, 100000, "pair_revcross", this->m_exec_conf));
+    }
+
+template< class evaluator, cudaError_t gpu_cgpf(const revcross_args_t& pair_args,
+                                                const typename evaluator::param_type *d_params) >
+PotentialRevCrossGPU< evaluator, gpu_cgpf >::~PotentialRevCrossGPU()
+        {
+        this->m_exec_conf->msg->notice(5) << "Destroying PotentialRevCrossGPU" << std::endl;
+        }
+
+template< class evaluator, cudaError_t gpu_cgpf(const revcross_args_t& pair_args,
+                                                const typename evaluator::param_type *d_params) >
+void PotentialRevCrossGPU< evaluator, gpu_cgpf >::computeForces(unsigned int timestep)
+    {
+    // start by updating the neighborlist
+    this->m_nlist->compute(timestep);
+
+    // start the profile
+    if (this->m_prof) this->m_prof->push(this->m_exec_conf, this->m_prof_name);
+
+    // The GPU implementation CANNOT handle a half neighborlist, error out now
+    bool third_law = this->m_nlist->getStorageMode() == NeighborList::half;
+    if (third_law)
+        {
+        this->m_exec_conf->msg->error() << "***Error! PotentialRevCrossGPU cannot handle a half neighborlist"
+                  << std::endl;
+        throw std::runtime_error("Error computing forces in PotentialRevCrossGPU");
+        }
+
+    // access the neighbor list
+    ArrayHandle<unsigned int> d_n_neigh(this->m_nlist->getNNeighArray(), access_location::device, access_mode::read);
+    ArrayHandle<unsigned int> d_nlist(this->m_nlist->getNListArray(), access_location::device, access_mode::read);
+    ArrayHandle<unsigned int> d_head_list(this->m_nlist->getHeadList(), access_location::device, access_mode::read);
+
+    // access the particle data
+    ArrayHandle<Scalar4> d_pos(this->m_pdata->getPositions(), access_location::device, access_mode::read);
+
+    BoxDim box = this->m_pdata->getBox();
+
+    // access parameters
+    ArrayHandle<Scalar> d_ronsq(this->m_ronsq, access_location::device, access_mode::read);
+    ArrayHandle<Scalar> d_rcutsq(this->m_rcutsq, access_location::device, access_mode::read);
+    ArrayHandle<typename evaluator::param_type> d_params(this->m_params, access_location::device, access_mode::read);
+
+    ArrayHandle<Scalar4> d_force(this->m_force, access_location::device, access_mode::overwrite);
+    ArrayHandle<Scalar> d_virial(this->m_virial, access_location::device, access_mode::overwrite);
+    
+    // access flags
+    PDataFlags flags = this->m_pdata->getFlags();
+    bool compute_virial = flags[pdata_flag::pressure_tensor] || flags[pdata_flag::isotropic_virial];
+
+    this->m_tuner->begin();
+    unsigned int param =  this->m_tuner->getParam();
+    unsigned int block_size = param / 10000;
+    unsigned int threads_per_particle = param % 10000;
+
+    gpu_cgpf(revcross_args_t(d_force.data,
+                            this->m_pdata->getN(),
+                            this->m_pdata->getNGhosts(),
+                            d_virial.data,
+                            this->m_virial_pitch,
+                            compute_virial,
+                            d_pos.data,
+                            box,
+                            d_n_neigh.data,
+                            d_nlist.data,
+                            d_head_list.data,
+                            d_rcutsq.data,
+                            d_ronsq.data,
+                            this->m_nlist->getNListArray().getPitch(),
+                            this->m_pdata->getNTypes(),
+                            block_size,
+                            threads_per_particle,
+                            this->m_exec_conf->dev_prop),
+                            d_params.data);
+
+    if (this->m_exec_conf->isCUDAErrorCheckingEnabled())
+        CHECK_CUDA_ERROR();
+
+    this->m_tuner->end();
+
+    if (this->m_prof) this->m_prof->pop(this->m_exec_conf);
+    }
+
+//! Export this three-body potential to python
+/*! \param name Name of the class in the exported python module
+    \tparam T Class type to export. \b Must be an instantiated PotentialRevCrossGPU class template.
+    \tparam Base Base class of \a T. \b Must be PotentialRevCross<evaluator> with the same evaluator as used in \a T.
+*/
+template < class T, class Base > void export_PotentialRevCrossGPU(pybind11::module& m, const std::string& name)
+    {
+     pybind11::class_<T, std::shared_ptr<T> >(m, name.c_str(), pybind11::base<Base>())
+        .def(pybind11::init< std::shared_ptr<SystemDefinition>, std::shared_ptr<NeighborList>, const std::string& >())
+    ;
+    }
+
+#endif // ENABLE_CUDA
+#endif

--- a/hoomd/md/module-md.cc
+++ b/hoomd/md/module-md.cc
@@ -19,6 +19,7 @@
 #include "OneDConstraint.h"
 #include "Enforce2DUpdater.h"
 #include "EvaluatorTersoff.h"
+#include "EvaluatorRevCross.h"
 #include "EvaluatorSquareDensity.h"
 #include "FIREEnergyMinimizer.h"
 #include "ForceComposite.h"
@@ -40,6 +41,7 @@
 #include "PotentialPairDPDThermo.h"
 #include "PotentialPair.h"
 #include "PotentialTersoff.h"
+#include "PotentialRevCross.h"
 #include "PPPMForceCompute.h"
 #include "QuaternionMath.h"
 #include "TableAngleForceCompute.h"
@@ -83,6 +85,7 @@
 #include "PotentialPairDPDThermoGPU.h"
 #include "PotentialPairGPU.h"
 #include "PotentialTersoffGPU.h"
+#include "PotentialRevCrossGPU.h"
 #include "PPPMForceComputeGPU.h"
 #include "TableAngleForceComputeGPU.h"
 #include "TableDihedralForceComputeGPU.h"
@@ -120,6 +123,21 @@ void export_tersoff_params(py::module& m)
         ;
 
     m.def("make_tersoff_params", &make_tersoff_params);
+}
+
+
+//! Function to export the revcross parameter type to python
+void export_revcross_params(py::module& m)
+{
+    py::class_<revcross_params>(m, "revcross_params")
+        .def(py::init<>())
+        .def_readwrite("sigma", &revcross_params::sigma)
+        .def_readwrite("n", &revcross_params::n)
+        .def_readwrite("epsilon", &revcross_params::epsilon)
+        .def_readwrite("lambda3", &revcross_params::lambda3)
+        ;
+
+    m.def("make_revcross_params", &make_revcross_params);
 }
 
 
@@ -263,12 +281,14 @@ PYBIND11_MODULE(_md, m)
     export_PotentialPair<PotentialPairDPD>(m, "PotentialPairDPD");
     export_PotentialPair<PotentialPairMoliere>(m, "PotentialPairMoliere");
     export_PotentialPair<PotentialPairZBL>(m, "PotentialPairZBL");
+    export_PotentialRevCross<PotentialTripletRevCross>(m, "PotentialRevCross");
     export_PotentialTersoff<PotentialTripletTersoff>(m, "PotentialTersoff");
     export_PotentialTersoff<PotentialTripletSquareDensity> (m, "PotentialSquareDensity");
     export_PotentialPair<PotentialPairMie>(m, "PotentialPairMie");
     export_PotentialPair<PotentialPairReactionField>(m, "PotentialPairReactionField");
     export_PotentialPair<PotentialPairDLVO>(m, "PotentialPairDLVO");
     export_PotentialPair<PotentialPairFourier>(m, "PotentialPairFourier");
+    export_revcross_params(m);
     export_tersoff_params(m);
     export_pair_params(m);
     export_AnisoPotentialPair<AnisoPotentialPairGB>(m, "AnisoPotentialPairGB");
@@ -324,6 +344,7 @@ PYBIND11_MODULE(_md, m)
     export_PotentialPairGPU<PotentialPairDPDGPU, PotentialPairDPD>(m, "PotentialPairDPDGPU");
     export_PotentialPairGPU<PotentialPairMoliereGPU, PotentialPairMoliere>(m, "PotentialPairMoliereGPU");
     export_PotentialPairGPU<PotentialPairZBLGPU, PotentialPairZBL>(m, "PotentialPairZBLGPU");
+    export_PotentialRevCrossGPU<PotentialTripletRevCrossGPU, PotentialTripletRevCross>(m, "PotentialRevCrossGPU");
     export_PotentialTersoffGPU<PotentialTripletTersoffGPU, PotentialTripletTersoff>(m, "PotentialTersoffGPU");
     export_PotentialTersoffGPU<PotentialTripletSquareDensityGPU, PotentialTripletSquareDensity> (m, "PotentialSquareDensityGPU");
     export_PotentialPairGPU<PotentialPairForceShiftedLJGPU, PotentialPairForceShiftedLJ>(m, "PotentialPairForceShiftedLJGPU");

--- a/hoomd/md/pair.py
+++ b/hoomd/md/pair.py
@@ -2039,6 +2039,124 @@ class tersoff(pair):
 
         return _md.make_tersoff_params(cutoff_d, tersoff_coeffs, exp_consts, dimer_r, n, gamman, lambda3_cube, ang_consts, alpha);
 
+
+class revcross(pair):
+    R""" Reversible crosslinker three-body potential to model bond swaps.
+
+    Args:
+        r_cut (float): Default cutoff radius (in distance units).
+        nlist (:py:mod:`hoomd.md.nlist`): Neighbor list
+        name (str): Name of the force instance.
+
+    :py:class:`revcross` specifies that the revcross three-body potential should be applied to every
+    non-bonded particle pair in the simulation.  Despite the fact that the revcross potential accounts
+    for the effects of third bodies, it is included in the pair potentials because its is actually just a
+    combination of two body potential terms. It can thus use type-pair parameters similar to those of the pair potentials.
+
+    The revcross potential has been described in detail in REF_Ciarella. It is based on a generalized-Lennard-Jones pairwise
+    attraction to form bonds between interacting particless:
+
+    .. math::
+        :nowrap:
+
+        \begin{equation}
+        V_{ij}(r)  =  4 \varepsilon \left[ \left( \dfrac{ \sigma}{r_{ij}} \right) ^{2n}- \left( \dfrac{ \sigma}{r_{ij}} \right)^{n} \right] \qquad r<r_{cut}
+        \end{equation}
+
+    with the following coefficients:
+
+    - :math:`\varepsilon` - *epsilon* (in energy units)
+    - :math:`\sigma` - *sigma* (in distance units)
+    - :math:`n` - *n* (unitless)
+    - :math:`m` - *m* (unitless)
+    - :math:`r_{\mathrm{cut}}` - *r_cut* (in distance units)
+      - *optional*: defaults to the global r_cut specified in the pair command
+
+    Then an additional three-body repulsion is evaluated to compensate the bond energies imposing single bond per particle condition: 
+
+    .. math::
+        :nowrap:
+            \begin{equation}
+v^{\left( 3b \right)}_{ijk}=\lambda \epsilon\,\hat{v}^{ \left( 2b \right)}_{ij}\left(\vec{r}_{ij}\right) \cdot \hat{v}^{ \left( 2b \right)}_{ik}\left(\vec{r}_{ik}\right)~,
+            \end{equation}
+
+    where the two body potential is rewritten as:
+    .. math::
+        :nowrap:
+            \begin{equation}
+            \hat{v}^{ \left( 2b \right)}_{ij}\left(\vec{r}_{ij}\right) =
+            \begin{cases}
+            & 1 \qquad \qquad \; \; \qquad r\le r_{min}\\
+            & - \dfrac{v_{ij}\left(\vec{r}_{ij}\right)}{\epsilon} \qquad r > r_{min}~.\\
+            \end{cases}
+            \end{equation}
+
+    .. attention::
+
+        The revcross potential models an asymmetric interaction between two different chemical moieties that can form a reversible bond. 
+	This requires the definition of (at least) two different types of particles.
+	A reversible bond is only possible between two different species, otherwise :math:` v^{\left( 3b \right)}_{ijk}` would prevent any bond.
+	In our example we then set the interactions for types A and B with ``potRevC.pair_coeff.set(['A','B'],['A','B'],sigma=0.0,n=0,epsilon=0,lambda3=0)`` and the only non-zero energy only between the different types ``potRevC.pair_coeff.set('A','B',sigma=1,n=100,epsilon=100,lambda3=1) ``. 
+	Notice that the number of the minoritary species corresponds to the maximum number of bonds.
+                                
+
+    This three-body term also tunes the energy required for a bond swap through the coefficient: 
+    - :math:`\lambda` - *lambda3* (unitless)
+    in REF_Ciarella is explained that setting :math:`\lambda=1` corresponds to no energy requirement to initiate bond swap, while this
+    energy barrier scales roughly as :math:`\beta \Delta E_\text{sw} =\beta \varepsilon(\lambda-1)`.
+
+    Note:
+
+        Choosing :math:`\lambda=1` pushes the system towards clusterization because the three-body term is not enough to
+        compensate the energy of multiple bonds, so it may cause unphysical situations. 
+    
+
+    Example::
+
+        nl = md.nlist.cell()
+        potBondSwap = md.pair.revcross(r_cut=1.3,nlist=nl)
+        potBondSwap.pair_coeff.set(['A','B'],['A','B'],sigma=0,n=0,epsilon=0,lambda3=0)
+	# a bond can be made only between A-B and not A-A or B-B
+        potBondSwap.pair_coeff.set('A','B',sigma=1,n=100,epsilon=10,lambda3=1)
+    """
+    def __init__(self, r_cut, nlist, name=None):
+        hoomd.util.print_status_line();
+
+        # tell the base class how we operate
+
+        # initialize the base class
+        pair.__init__(self, r_cut, nlist, name);
+
+        # this potential cannot handle a half neighbor list
+        self.nlist.cpp_nlist.setStorageMode(_md.NeighborList.storageMode.full);
+
+        # create the c++ mirror class
+        if not hoomd.context.exec_conf.isCUDAEnabled():
+            self.cpp_force = _md.PotentialRevCross(hoomd.context.current.system_definition, self.nlist.cpp_nlist, self.name);
+            self.cpp_class = _md.PotentialRevCross;
+        else:
+            self.cpp_force = _md.PotentialRevCrossGPU(hoomd.context.current.system_definition, self.nlist.cpp_nlist, self.name);
+            self.cpp_class = _md.PotentialRevCrossGPU;
+
+        hoomd.context.current.system.addCompute(self.cpp_force, self.force_name);
+
+        # setup the coefficients
+        self.required_coeffs = ['sigma', 'n', 'epsilon', 'lambda3']
+        self.pair_coeff.set_default_coeff('sigma', 2.);
+        self.pair_coeff.set_default_coeff('n', 1.0);
+        self.pair_coeff.set_default_coeff('epsilon', 1.0);
+        self.pair_coeff.set_default_coeff('lambda3', 1.0);
+
+    def process_coeff(self, coeff):
+        sigma = coeff['sigma'];
+        n = coeff['n'];
+        epsilon = coeff['epsilon'];
+        lambda3 = coeff['lambda3'];
+
+        return _md.make_revcross_params(sigma, n, epsilon, lambda3);
+
+
+
 class mie(pair):
     R""" Mie pair potential.
 

--- a/hoomd/md/pair.py
+++ b/hoomd/md/pair.py
@@ -2053,7 +2053,7 @@ class revcross(pair):
     for the effects of third bodies, it is included in the pair potentials because its is actually just a
     combination of two body potential terms. It can thus use type-pair parameters similar to those of the pair potentials.
 
-    The revcross potential has been described in detail in REF_Ciarella. It is based on a generalized-Lennard-Jones pairwise
+    The revcross potential has been described in detail in `S. Ciarella and W.G. Ellenbroek 2019 <https://arxiv.org/abs/1912.08569>`_. It is based on a generalized-Lennard-Jones pairwise
     attraction to form bonds between interacting particless:
 
     .. math::
@@ -2102,7 +2102,7 @@ v^{\left( 3b \right)}_{ijk}=\lambda \epsilon\,\hat{v}^{ \left( 2b \right)}_{ij}\
 
     This three-body term also tunes the energy required for a bond swap through the coefficient: 
     - :math:`\lambda` - *lambda3* (unitless)
-    in REF_Ciarella is explained that setting :math:`\lambda=1` corresponds to no energy requirement to initiate bond swap, while this
+    in `S. Ciarella and W.G. Ellenbroek 2019 <https://arxiv.org/abs/1912.08569>`_ is explained that setting :math:`\lambda=1` corresponds to no energy requirement to initiate bond swap, while this
     energy barrier scales roughly as :math:`\beta \Delta E_\text{sw} =\beta \varepsilon(\lambda-1)`.
 
     Note:

--- a/sphinx-doc/credits.rst
+++ b/sphinx-doc/credits.rst
@@ -395,6 +395,10 @@ William Zygmunt, Luis Rivera-Rivera, University of Michigan
  * Patchy interaction support in HPMC CPU integrators
  * GSD state bug fixes
 
+Simone Ciarella, Wouter Ellenbroek, Eindhoven University of Technology
+
+ * RevCross potential
+
 DEM developers
 --------------
 

--- a/sphinx-doc/module-md-pair.rst
+++ b/sphinx-doc/module-md-pair.rst
@@ -25,6 +25,7 @@ md.pair
     md.pair.moliere
     md.pair.pair
     md.pair.reaction_field
+    md.pair.revcross
     md.pair.slj
     md.pair.square_density
     md.pair.table


### PR DESCRIPTION
## Description
We implement a three-body potential to model associative bond swaps under the name of "RevCross" that can run on both cpu and gpu. In https://arxiv.org/abs/1912.08569 we explain the details of it.

## Motivation and Context
The change that we propose include the "RevCross" potential to the master branch.

## How Has This Been Tested?
The physics of the potential has been tested in https://arxiv.org/abs/1912.08569. The implementation was also compared to its mathematical definition using the attached test_revcross.py.zip for both cpu and gpu versions.
[test_revcross.py.zip](https://github.com/glotzerlab/hoomd-blue/files/3983684/test_revcross.py.zip)

 
## Change log
*New Features*

- MD:

  - Added ``revcross`` potential.

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/hoomd-blue/blob/master/sphinx-doc/credits.rst).
