### PR TITLE
Initialize ddfab explicitly to prevent compiler warning.

### DIFF
--- a/hoomd/md/HarmonicDihedralForceCompute.cc
+++ b/hoomd/md/HarmonicDihedralForceCompute.cc
@@ -241,7 +241,7 @@ void HarmonicDihedralForceCompute::computeForces(unsigned int timestep)
         int multi = (int)m_multi[dihedral_type];
         Scalar p = Scalar(1.0);
         Scalar dfab = Scalar(0.0);
-        Scalar ddfab;
+        Scalar ddfab = Scalar(0.0);
 
         for (int j = 0; j < multi; j++)
             {


### PR DESCRIPTION
## Description

This PR fixes a small compiler warning.

Warning Output:
```
../hoomd/md/HarmonicDihedralForceCompute.cc: In member function 'virtual void HarmonicDihedralForceCompute::computeForces(unsigned int)':
../hoomd/md/HarmonicDihedralForceCompute.cc:265:14: warning: 'ddfab' may be used uninitialized in this function [-Wmaybe-uninitialized]
         dfab = dfab*cos_phi_0 - ddfab*sin_phi_0;
         ~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

Compiler version: `gcc (Ubuntu 7.4.0-1ubuntu1~18.04.1) 7.4.0`

## Motivation and Context

The rest of HOOMD built without warnings, and initializing variables is usually good.

## How Has This Been Tested?

Rebuilding HOOMD showed no warnings.

## Change log

Probably not necessary for a small fix.
<!-- Propose a change log entry. -->
```
Reduced compiler warnings.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/hoomd-blue/blob/master/sphinx-doc/credits.rst).
