### PR TITLE
fix visibility setting on dfftlib symbols

### DIFF
--- a/hoomd/extern/dfftlib/src/acml_single_interface.h
+++ b/hoomd/extern/dfftlib/src/acml_single_interface.h
@@ -6,6 +6,8 @@
 
 #include <stdlib.h>
 
+#pragma GCC visibility push(default)
+
 //#define FFT1D_SUPPORTS_THREADS
 
 typedef struct { float real, imag; } float2_dfft;
@@ -64,4 +66,6 @@ void dfft_local_1dfft(
     cpx_t *out,
     plan_t p,
     int dir);
+
+#pragma GCC visibility pop
 #endif

--- a/hoomd/extern/dfftlib/src/bare_fft_interface.h
+++ b/hoomd/extern/dfftlib/src/bare_fft_interface.h
@@ -4,10 +4,10 @@
 #ifndef __DFFT_BARE_FFT_INTERFACE_H__
 #define __DFFT_BARE_FFT_INTERFACE_H__
 
-#pragma GCC visibility push(default)
-
 #include "bare_fft.h"
 #include <stdlib.h>
+
+#pragma GCC visibility push(default)
 
 typedef cpxfloat cpx_t;
 typedef bare_fft_plan plan_t;

--- a/hoomd/extern/dfftlib/src/bare_fft_interface.h
+++ b/hoomd/extern/dfftlib/src/bare_fft_interface.h
@@ -4,6 +4,8 @@
 #ifndef __DFFT_BARE_FFT_INTERFACE_H__
 #define __DFFT_BARE_FFT_INTERFACE_H__
 
+#pragma GCC visibility push(hidden)
+
 #include "bare_fft.h"
 #include <stdlib.h>
 
@@ -49,4 +51,7 @@ void dfft_local_1dfft(
     cpx_t *out,
     plan_t p,
     int dir);
+
+#pragma GCC visibility pop
+
 #endif

--- a/hoomd/extern/dfftlib/src/bare_fft_interface.h
+++ b/hoomd/extern/dfftlib/src/bare_fft_interface.h
@@ -4,7 +4,7 @@
 #ifndef __DFFT_BARE_FFT_INTERFACE_H__
 #define __DFFT_BARE_FFT_INTERFACE_H__
 
-#pragma GCC visibility push(hidden)
+#pragma GCC visibility push(default)
 
 #include "bare_fft.h"
 #include <stdlib.h>

--- a/hoomd/extern/dfftlib/src/cufft_single_interface.h
+++ b/hoomd/extern/dfftlib/src/cufft_single_interface.h
@@ -5,6 +5,8 @@
 #ifndef __DFFT_CUFFT_SINGLE_INTERFACE_H__
 #define __DFFT_CUFFT_SINGLE_INTERFACE_H__
 
+#pragma GCC visibility push(default)
+
 #include <hip/hip_runtime.h>
 
 #if defined(ENABLE_HIP)
@@ -80,4 +82,7 @@ int dfft_cuda_destroy_local_plan(cuda_plan_t *p);
 int dfft_cuda_local_fft( cuda_cpx_t *in, cuda_cpx_t *out, cuda_plan_t p, int dir);
 
 #endif /* NVCC */
+
+#pragma GCC visibility pop
+
 #endif

--- a/hoomd/extern/dfftlib/src/cufft_single_interface.h
+++ b/hoomd/extern/dfftlib/src/cufft_single_interface.h
@@ -5,8 +5,6 @@
 #ifndef __DFFT_CUFFT_SINGLE_INTERFACE_H__
 #define __DFFT_CUFFT_SINGLE_INTERFACE_H__
 
-#pragma GCC visibility push(default)
-
 #include <hip/hip_runtime.h>
 
 #if defined(ENABLE_HIP)
@@ -18,6 +16,8 @@ typedef cufftComplex hipfftComplex;
 typedef cufftHandle hipfftHandle;
 #endif
 #endif
+
+#pragma GCC visibility push(default)
 
 typedef float cuda_scalar_t;
 typedef hipfftComplex cuda_cpx_t;

--- a/hoomd/extern/dfftlib/src/dfft_common.h
+++ b/hoomd/extern/dfftlib/src/dfft_common.h
@@ -5,6 +5,8 @@
 #ifndef __DFFT_COMMON_H__
 #define __DFFT_COMMON_H__
 
+#pragma GCC visibility push(default)
+
 #include <dfft_lib_config.h>
 #include "dfft_local_fft_config.h"
 
@@ -125,4 +127,5 @@ int dfft_create_plan_common(dfft_plan *plan,
  */
 void dfft_destroy_plan_common(dfft_plan plan, int device);
 
+#pragma GCC visibility pop
 #endif

--- a/hoomd/extern/dfftlib/src/dfft_common.h
+++ b/hoomd/extern/dfftlib/src/dfft_common.h
@@ -5,12 +5,12 @@
 #ifndef __DFFT_COMMON_H__
 #define __DFFT_COMMON_H__
 
-#pragma GCC visibility push(default)
-
 #include <dfft_lib_config.h>
 #include "dfft_local_fft_config.h"
 
 #include <mpi.h>
+
+#pragma GCC visibility push(default)
 
 /*
  * Data structure for a distributed FFT

--- a/hoomd/extern/dfftlib/src/dfft_cuda.h
+++ b/hoomd/extern/dfftlib/src/dfft_cuda.h
@@ -45,9 +45,10 @@ EXTERN_DFFT void dfft_cuda_check_errors(dfft_plan *plan, int check_err);
  */
 EXTERN_DFFT int dfft_cuda_execute(cuda_cpx_t *id_in, cuda_cpx_t *d_out, int dir, dfft_plan *p);
 
+#pragma GCC visibility pop
+
 #undef EXTERN_DFFT
 #endif
 #endif // ENABLE_HIP
 
-#pragma GCC visibility pop
 #endif

--- a/hoomd/extern/dfftlib/src/dfft_cuda.h
+++ b/hoomd/extern/dfftlib/src/dfft_cuda.h
@@ -5,8 +5,6 @@
 #ifndef __DFFT_CUDA_H__
 #define __DFFT_CUDA_H__
 
-#pragma GCC visibility push(default)
-
 #include <dfft_lib_config.h>
 
 #ifdef ENABLE_HIP
@@ -19,6 +17,8 @@
 #else
 #define EXTERN_DFFT
 #endif
+
+#pragma GCC visibility push(default)
 
 /*
  * Create a device plan for distributed FFT

--- a/hoomd/extern/dfftlib/src/dfft_cuda.h
+++ b/hoomd/extern/dfftlib/src/dfft_cuda.h
@@ -5,6 +5,8 @@
 #ifndef __DFFT_CUDA_H__
 #define __DFFT_CUDA_H__
 
+#pragma GCC visibility push(default)
+
 #include <dfft_lib_config.h>
 
 #ifdef ENABLE_HIP
@@ -46,4 +48,6 @@ EXTERN_DFFT int dfft_cuda_execute(cuda_cpx_t *id_in, cuda_cpx_t *d_out, int dir,
 #undef EXTERN_DFFT
 #endif
 #endif // ENABLE_HIP
+
+#pragma GCC visibility pop
 #endif

--- a/hoomd/extern/dfftlib/src/dfft_host.h
+++ b/hoomd/extern/dfftlib/src/dfft_host.h
@@ -5,8 +5,6 @@
 #ifndef __DFFT_HOST_H__
 #define __DFFT_HOST_H__
 
-#pragma GCC visibility push(default)
-
 #include <dfft_lib_config.h>
 #ifdef ENABLE_HOST
 
@@ -17,6 +15,8 @@
 #else
 #define EXTERN_DFFT
 #endif
+
+#pragma GCC visibility push(default)
 
 /* 
  *

--- a/hoomd/extern/dfftlib/src/dfft_host.h
+++ b/hoomd/extern/dfftlib/src/dfft_host.h
@@ -5,6 +5,8 @@
 #ifndef __DFFT_HOST_H__
 #define __DFFT_HOST_H__
 
+#pragma GCC visibility push(default)
+
 #include <dfft_lib_config.h>
 #ifdef ENABLE_HOST
 
@@ -40,4 +42,5 @@ EXTERN_DFFT int dfft_execute(cpx_t *h_in, cpx_t *h_out, int dir, dfft_plan p);
 #undef EXTERN_DFFT
 
 #endif // ENABLE_HOST
+#pragma GCC visibility pop
 #endif

--- a/hoomd/extern/dfftlib/src/mkl_single_interface.h
+++ b/hoomd/extern/dfftlib/src/mkl_single_interface.h
@@ -4,6 +4,8 @@
 #ifndef __DFFT_MKL_SINGLE_INTERFACE_H__
 #define __DFFT_MKL_SINGLE_INTERFACE_H__
 
+#pragma GCC visibility push(default)
+
 #include <omp.h>
 #include <mkl.h>
 
@@ -51,4 +53,6 @@ void dfft_local_1dfft(
     cpx_t *out,
     plan_t p,
     int dir);
+
+#pragma GCC visibility pop
 #endif

--- a/hoomd/extern/dfftlib/src/mkl_single_interface.h
+++ b/hoomd/extern/dfftlib/src/mkl_single_interface.h
@@ -4,10 +4,10 @@
 #ifndef __DFFT_MKL_SINGLE_INTERFACE_H__
 #define __DFFT_MKL_SINGLE_INTERFACE_H__
 
-#pragma GCC visibility push(default)
-
 #include <omp.h>
 #include <mkl.h>
+
+#pragma GCC visibility push(default)
 
 #define FFT1D_SUPPORTS_THREADS
 


### PR DESCRIPTION
## Description

Adds `default` visibility to all `dfftlib` symbols

## Motivation and Context

Enables `metadynamics` plugin to work again
https://github.com/jglaser/metadynamics-plugin/tree/next

Resolves: N/A

## How Has This Been Tested?

standard unit tests

## Change log

N/A

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/hoomd-blue/blob/master/sphinx-doc/credits.rst).
