### PR TITLE
retain old overlap check settings after adding types

### DIFF
--- a/hoomd/hpmc/IntegratorHPMCMono.h
+++ b/hoomd/hpmc/IntegratorHPMCMono.h
@@ -526,9 +526,31 @@ void IntegratorHPMCMono<Shape>::slotNumTypesChange()
         return;
 
     // re-allocate overlap interaction matrix
+    Index2D old_overlap_idx = m_overlap_idx;
     m_overlap_idx = Index2D(m_pdata->getNTypes());
 
     GPUArray<unsigned int> overlaps(m_overlap_idx.getNumElements(), m_exec_conf);
+
+        {
+        ArrayHandle<unsigned int> h_old_overlaps(m_overlaps, access_location::host, access_mode::read);
+        ArrayHandle<unsigned int> h_overlaps(overlaps, access_location::host, access_mode::overwrite);
+
+        for(unsigned int i = 0; i < m_overlap_idx.getNumElements(); i++)
+            {
+            h_overlaps.data[i] = 1; // Assume we want to check overlaps.
+            }
+
+        // copy over old overlap check flags (this assumes the number of types is greater or equal to the old number of types)
+        for (unsigned int i = 0; i < old_overlap_idx.getW(); ++i)
+            {
+            for (unsigned int j = 0; j < old_overlap_idx.getH(); ++j)
+                {
+                h_overlaps.data[m_overlap_idx(i,j)] = h_old_overlaps.data[old_overlap_idx(i,j)];
+                }
+            }
+        }
+
+>>>>>>> bf5b98c4b... retain old overlap check settings after adding types
     m_overlaps.swap(overlaps);
 
     updateCellWidth();

--- a/hoomd/hpmc/IntegratorHPMCMono.h
+++ b/hoomd/hpmc/IntegratorHPMCMono.h
@@ -550,7 +550,6 @@ void IntegratorHPMCMono<Shape>::slotNumTypesChange()
             }
         }
 
->>>>>>> bf5b98c4b... retain old overlap check settings after adding types
     m_overlaps.swap(overlaps);
 
     updateCellWidth();


### PR DESCRIPTION
## Description

This fixes a bug where the overlap checking matrix gets initialized with zeros for newly added types.

## Motivation and Context

A side effect of this bug is that some depletant simulations failed. The bug was introduced in https://github.com/glotzerlab/hoomd-blue/commit/a4de8f0a919c73a348d8a5b71b530997af562298#diff-c2883a3648e52b0d7f15ec6a3f370a72

Resolves: N/A

## How Has This Been Tested?

standard unit tests, perhaps add a new one

## Change log

```
- Fix bug in HPMC where overlaps were not checked after new particle types are added
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/hoomd-blue/blob/master/sphinx-doc/credits.rst).
