### PR TITLE
Read and write GSD 2.0 files

### DIFF
--- a/hoomd/GSDReader.cc
+++ b/hoomd/GSDReader.cc
@@ -46,36 +46,7 @@ GSDReader::GSDReader(std::shared_ptr<const ExecutionConfiguration> exec_conf,
     // open the GSD file in read mode
     m_exec_conf->msg->notice(3) << "data.gsd_snapshot: open gsd file " << name << endl;
     int retval = gsd_open(&m_handle, name.c_str(), GSD_OPEN_READONLY);
-    if (retval == -1)
-        {
-        m_exec_conf->msg->error() << "data.gsd_snapshot: " << strerror(errno) << " - " << name << endl;
-        throw runtime_error("Error opening GSD file");
-        }
-    else if (retval == -2)
-        {
-        m_exec_conf->msg->error() << "data.gsd_snapshot: " << name << " is not a valid GSD file" << endl;
-        throw runtime_error("Error opening GSD file");
-        }
-    else if (retval == -3)
-        {
-        m_exec_conf->msg->error() << "data.gsd_snapshot: " << "Invalid GSD file version in " << name << endl;
-        throw runtime_error("Error opening GSD file");
-        }
-    else if (retval == -4)
-        {
-        m_exec_conf->msg->error() << "data.gsd_snapshot: " << "Corrupt GSD file: " << name << endl;
-        throw runtime_error("Error opening GSD file");
-        }
-    else if (retval == -5)
-        {
-        m_exec_conf->msg->error() << "data.gsd_snapshot: " << "Out of memory opening: " << name << endl;
-        throw runtime_error("Error opening GSD file");
-        }
-    else if (retval != 0)
-        {
-        m_exec_conf->msg->error() << "data.gsd_snapshot: " << "Unknown error opening: " << name << endl;
-        throw runtime_error("Error opening GSD file");
-        }
+    checkError(retval);
 
     // validate schema
     if (string(m_handle.header.schema) != string("hoomd"))
@@ -154,27 +125,7 @@ bool GSDReader::readChunk(void *data, uint64_t frame, const char *name, size_t e
             throw runtime_error("Error reading GSD file");
             }
         int retval = gsd_read_chunk(&m_handle, data, entry);
-
-        if (retval == -1)
-            {
-            m_exec_conf->msg->error() << "data.gsd_snapshot: " << strerror(errno) << " - " << m_name << endl;
-            throw runtime_error("Error reading GSD file");
-            }
-        else if (retval == -2)
-            {
-            m_exec_conf->msg->error() << "data.gsd_snapshot: " << "Unknown error reading: " << m_name << endl;
-            throw runtime_error("Error reading GSD file");
-            }
-        else if (retval == -3)
-            {
-            m_exec_conf->msg->error() << "data.gsd_snapshot: " << "Invalid GSD file " << m_name << endl;
-            throw runtime_error("Error reading GSD file");
-            }
-        else if (retval != 0)
-            {
-            m_exec_conf->msg->error() << "data.gsd_snapshot: " << "Unknown error reading: " << m_name << endl;
-            throw runtime_error("Error reading GSD file");
-            }
+        checkError(retval);
 
         return true;
         }
@@ -209,27 +160,7 @@ std::vector<std::string> GSDReader::readTypes(uint64_t frame, const char *name)
         size_t actual_size = entry->N * entry->M * gsd_sizeof_type((enum gsd_type)entry->type);
         std::vector<char> data(actual_size);
         int retval = gsd_read_chunk(&m_handle, &data[0], entry);
-
-        if (retval == -1)
-            {
-            m_exec_conf->msg->error() << "data.gsd_snapshot: " << strerror(errno) << " - " << m_name << endl;
-            throw runtime_error("Error reading GSD file");
-            }
-        else if (retval == -2)
-            {
-            m_exec_conf->msg->error() << "data.gsd_snapshot: " << "Unknown error reading: " << m_name << endl;
-            throw runtime_error("Error reading GSD file");
-            }
-        else if (retval == -3)
-            {
-            m_exec_conf->msg->error() << "data.gsd_snapshot: " << "Invalid GSD file " << m_name << endl;
-            throw runtime_error("Error reading GSD file");
-            }
-        else if (retval != 0)
-            {
-            m_exec_conf->msg->error() << "data.gsd_snapshot: " << "Unknown error reading: " << m_name << endl;
-            throw runtime_error("Error reading GSD file");
-            }
+        checkError(retval);
 
         type_mapping.clear();
         for (unsigned int i = 0; i < entry->N; i++)
@@ -367,6 +298,62 @@ pybind11::list GSDReader::readTypeShapesPy(uint64_t frame)
     for (unsigned int i = 0; i < type_mapping.size(); i++)
         type_shapes.append(type_mapping[i]);
     return type_shapes;
+    }
+
+void GSDReader::checkError(int retval)
+    {
+    // checkError prints errors and then throws exceptions for common gsd error codes
+    if (retval == GSD_ERROR_IO)
+        {
+        m_exec_conf->msg->error() << "dump.gsd: " << strerror(errno) << " - " << m_name << endl;
+        throw runtime_error("Error reading GSD file");
+        }
+    else if (retval == GSD_ERROR_INVALID_ARGUMENT)
+        {
+        m_exec_conf->msg->error() << "dump.gsd: Invalid argument" " - " << m_name << endl;
+        throw runtime_error("Error reading GSD file");
+        }
+    else if (retval == GSD_ERROR_NOT_A_GSD_FILE)
+        {
+        m_exec_conf->msg->error() << "dump.gsd: Not a GSD file" " - " << m_name << endl;
+        throw runtime_error("Error reading GSD file");
+        }
+    else if (retval == GSD_ERROR_INVALID_GSD_FILE_VERSION)
+        {
+        m_exec_conf->msg->error() << "dump.gsd: Invalid GSD file version" " - " << m_name << endl;
+        throw runtime_error("Error reading GSD file");
+        }
+    else if (retval == GSD_ERROR_FILE_CORRUPT)
+        {
+        m_exec_conf->msg->error() << "dump.gsd: File corrupt" " - " << m_name << endl;
+        throw runtime_error("Error reading GSD file");
+        }
+    else if (retval == GSD_ERROR_MEMORY_ALLOCATION_FAILED)
+        {
+        m_exec_conf->msg->error() << "dump.gsd: Memory allocation failed" " - " << m_name << endl;
+        throw runtime_error("Error reading GSD file");
+        }
+    else if (retval == GSD_ERROR_NAMELIST_FULL)
+        {
+        m_exec_conf->msg->error() << "dump.gsd: Namelist full" " - " << m_name << endl;
+        throw runtime_error("Error reading GSD file");
+        }
+    else if (retval == GSD_ERROR_FILE_MUST_BE_WRITABLE)
+        {
+        m_exec_conf->msg->error() << "dump.gsd: File must be writeable" " - " << m_name << endl;
+        throw runtime_error("Error reading GSD file");
+        }
+    else if (retval == GSD_ERROR_FILE_MUST_BE_READABLE)
+        {
+        m_exec_conf->msg->error() << "dump.gsd: File must be readable" " - " << m_name << endl;
+        throw runtime_error("Error reading GSD file");
+        }
+    else if (retval != GSD_SUCCESS)
+        {
+        m_exec_conf->msg->error() << "dump.gsd: " << "Unknown error " << retval << " reading: "
+                                  << m_name << endl;
+        throw runtime_error("Error reading GSD file");
+        }
     }
 
 void export_GSDReader(py::module& m)

--- a/hoomd/GSDReader.h
+++ b/hoomd/GSDReader.h
@@ -102,6 +102,9 @@ class PYBIND11_EXPORT GSDReader
         void readHeader();
         void readParticles();
         void readTopology();
+
+        /// Check and raise an exception if an error occurs
+        void checkError(int retval);
     };
 
 //! Exports GSDReader to python

--- a/hoomd/extern/gsd.c
+++ b/hoomd/extern/gsd.c
@@ -1085,13 +1085,13 @@ inline static int gsd_flush_write_buffer(struct gsd_handle* handle)
         return GSD_ERROR_INVALID_ARGUMENT;
     }
 
-    if (handle->write_buffer.size == 0)
+    if (handle->write_buffer.size == 0 && handle->buffer_index.size == 0)
     {
         // nothing to do
         return GSD_SUCCESS;
     }
 
-    if (handle->buffer_index.size == 0)
+    if (handle->write_buffer.size > 0 && handle->buffer_index.size == 0)
     {
         // error: bytes in buffer, but no index for them
         return GSD_ERROR_INVALID_ARGUMENT;
@@ -1922,11 +1922,11 @@ int gsd_write_chunk(struct gsd_handle* handle,
                     const void* data)
 {
     // validate input
-    if (data == NULL)
+    if (N > 0 && data == NULL)
     {
         return GSD_ERROR_INVALID_ARGUMENT;
     }
-    if (N == 0 || M == 0 || gsd_sizeof_type(type) == 0)
+    if (M == 0)
     {
         return GSD_ERROR_INVALID_ARGUMENT;
     }
@@ -1988,7 +1988,14 @@ int gsd_write_chunk(struct gsd_handle* handle,
         *index_entry = entry;
 
         // add the data to the write buffer
-        gsd_byte_buffer_append(&handle->write_buffer, data, size);
+        if (size > 0)
+        {
+            retval = gsd_byte_buffer_append(&handle->write_buffer, data, size);
+            if (retval != GSD_SUCCESS)
+            {
+                return retval;
+           }
+        }
     }
     else
     {

--- a/hoomd/extern/gsd.c
+++ b/hoomd/extern/gsd.c
@@ -1,8 +1,12 @@
-// Copyright (c) 2016-2019 The Regents of the University of Michigan
-// This file is part of the General Simulation Data (GSD) project, released under the BSD 2-Clause License.
+// Copyright (c) 2016-2020 The Regents of the University of Michigan
+// This file is part of the General Simulation Data (GSD) project, released under the BSD 2-Clause
+// License.
 
 #include <sys/stat.h>
 #ifdef _WIN32
+
+#pragma warning(push)
+#pragma warning(disable : 4996)
 
 #define GSD_USE_MMAP 0
 #include <io.h>
@@ -10,8 +14,8 @@
 #else // linux / mac
 
 #define _XOPEN_SOURCE 500
-#include <unistd.h>
 #include <sys/mman.h>
+#include <unistd.h>
 #define GSD_USE_MMAP 1
 
 #endif
@@ -20,17 +24,62 @@
 #include <limits.h>
 #endif
 
-#include <stdlib.h>
-#include <stdio.h>
-#include <fcntl.h>
 #include <errno.h>
+#include <fcntl.h>
 #include <stddef.h>
+#include <stdio.h>
+#include <stdlib.h>
 
 #include "gsd.h"
 
-/*! \file gsd.c
-    \brief Implements the GSD C API
+/** @file gsd.c
+    @brief Implements the GSD C API
 */
+
+/// Magic value identifying a GSD file
+const uint64_t GSD_MAGIC_ID = 0x65DF65DF65DF65DF;
+
+/// Initial index size
+enum
+{
+    GSD_INITIAL_INDEX_SIZE = 128
+};
+
+/// Initial namelist size
+enum
+{
+    GSD_INITIAL_NAME_BUFFER_SIZE = 1024
+};
+
+/// Size of initial frame index
+enum
+{
+    GSD_INITIAL_FRAME_INDEX_SIZE = 16
+};
+
+/// Size of write buffer
+enum
+{
+    GSD_WRITE_BUFFER_SIZE = 16 * 1024 * 1024
+};
+
+/// Size of copy buffer
+enum
+{
+    GSD_COPY_BUFFER_SIZE = 128 * 1024
+};
+
+/// Size of hash map
+enum
+{
+    GSD_NAME_MAP_SIZE = 57557
+};
+
+/// Current GSD file specification
+enum
+{
+    GSD_CURRENT_FILE_VERSION = 2
+};
 
 // define windows wrapper functions
 #ifdef _WIN32
@@ -45,1168 +94,2360 @@ int S_IWUSR = _S_IWRITE;
 int S_IRGRP = _S_IREAD;
 int S_IWGRP = _S_IWRITE;
 
-ssize_t pread(int fd, void *buf, size_t count, int64_t offset)
-    {
+inline ssize_t pread(int fd, void* buf, size_t count, int64_t offset)
+{
     // Note: _read only accepts unsigned int values
     if (count > UINT_MAX)
-        return -1;
+        return GSD_ERROR_IO;
 
     int64_t oldpos = _telli64(fd);
     _lseeki64(fd, offset, SEEK_SET);
     ssize_t result = _read(fd, buf, (unsigned int)count);
     _lseeki64(fd, oldpos, SEEK_SET);
     return result;
-    }
+}
 
-ssize_t pwrite(int fd, const void *buf, size_t count, int64_t offset)
-    {
+inline ssize_t pwrite(int fd, const void* buf, size_t count, int64_t offset)
+{
     // Note: _write only accepts unsigned int values
     if (count > UINT_MAX)
-        return -1;
+        return GSD_ERROR_IO;
 
     int64_t oldpos = _telli64(fd);
     _lseeki64(fd, offset, SEEK_SET);
     ssize_t result = _write(fd, buf, (unsigned int)count);
     _lseeki64(fd, oldpos, SEEK_SET);
     return result;
-    }
+}
 
 #endif
 
-static ssize_t __pwrite_retry(int fd, const void *buf, size_t count, int64_t offset)
-    {
+/** Zero memory
+
+    @param d pointer to memory region
+    @param size_to_zero size of the area to zero in bytes
+*/
+inline static void gsd_util_zero_memory(void* d, size_t size_to_zero)
+{
+    memset(d, 0, size_to_zero);
+}
+
+/** @internal
+    @brief Write large data buffer to file
+
+    The system call pwrite() fails to write very large data buffers. This method calls pwrite() as
+    many times as necessary to completely write a large buffer.
+
+    @param fd File descriptor.
+    @param buf Data buffer.
+    @param count Number of bytes to write.
+    @param offset Location in the file to start writing.
+
+    @returns The total number of bytes written or a negative value on error.
+*/
+inline static ssize_t gsd_io_pwrite_retry(int fd, const void* buf, size_t count, int64_t offset)
+{
     size_t total_bytes_written = 0;
-    const char *ptr = (char *)buf;
+    const char* ptr = (char*)buf;
 
     // perform multiple pwrite calls to complete a large write successfully
     while (total_bytes_written < count)
-        {
+    {
         size_t to_write = count - total_bytes_written;
-        #if defined(_WIN32) || defined(__APPLE__)
+#if defined(_WIN32) || defined(__APPLE__)
         // win32 and apple raise an error for writes greater than INT_MAX
-        if (to_write > INT_MAX/2) to_write = INT_MAX/2;
-        #endif
+        if (to_write > INT_MAX / 2)
+            to_write = INT_MAX / 2;
+#endif
 
         errno = 0;
-        ssize_t bytes_written = pwrite(fd, ptr + total_bytes_written, to_write, offset + total_bytes_written);
+        ssize_t bytes_written
+            = pwrite(fd, ptr + total_bytes_written, to_write, offset + total_bytes_written);
         if (bytes_written == -1 || (bytes_written == 0 && errno != 0))
-            return -1;
-
-        total_bytes_written += bytes_written;
+        {
+            return GSD_ERROR_IO;
         }
 
-    return total_bytes_written;
+        total_bytes_written += bytes_written;
     }
 
-static ssize_t __pread_retry(int fd, void *buf, size_t count, int64_t offset)
-    {
+    return total_bytes_written;
+}
+
+/** @internal
+    @brief Read large data buffer to file
+
+    The system call pread() fails to read very large data buffers. This method calls pread() as many
+    times as necessary to completely read a large buffer.
+
+    @param fd File descriptor.
+    @param buf Data buffer.
+    @param count Number of bytes to read.
+    @param offset Location in the file to start reading.
+
+    @returns The total number of bytes read or a negative value on error.
+*/
+inline static ssize_t gsd_io_pread_retry(int fd, void* buf, size_t count, int64_t offset)
+{
     size_t total_bytes_read = 0;
-    char *ptr = (char *)buf;
+    char* ptr = (char*)buf;
 
     // perform multiple pread calls to complete a large write successfully
     while (total_bytes_read < count)
-        {
+    {
         size_t to_read = count - total_bytes_read;
-        #if defined(_WIN32) || defined(__APPLE__)
+#if defined(_WIN32) || defined(__APPLE__)
         // win32 and apple raise errors for reads greater than INT_MAX
-        if (to_read > INT_MAX/2) to_read = INT_MAX/2;
-        #endif
+        if (to_read > INT_MAX / 2)
+            to_read = INT_MAX / 2;
+#endif
 
         errno = 0;
         ssize_t bytes_read = pread(fd, ptr + total_bytes_read, to_read, offset + total_bytes_read);
         if (bytes_read == -1 || (bytes_read == 0 && errno != 0))
-            return -1;
+        {
+            return GSD_ERROR_IO;
+        }
 
         total_bytes_read += bytes_read;
 
         // handle end of file
         if (bytes_read == 0)
+        {
             return total_bytes_read;
         }
-
-    return total_bytes_read;
     }
 
-/*! \internal
-    \brief Utility function to expand the memory space for the index block
-    \param handle handle to the open gsd file
+    return total_bytes_read;
+}
+
+/** @internal
+    @brief Allocate a name/id map
+
+    @param map Map to allocate.
+    @param size Number of entries in the map.
+
+    @returns GSD_SUCCESS on success, GSD_* error codes on error.
 */
-static int __gsd_expand_index(struct gsd_handle *handle)
+inline static int gsd_name_id_map_allocate(struct gsd_name_id_map* map, size_t size)
+{
+    if (map == NULL || map->v || size == 0 || map->size != 0)
     {
+        return GSD_ERROR_INVALID_ARGUMENT;
+    }
+
+    map->v = calloc(size, sizeof(struct gsd_name_id_pair));
+    if (map->v == NULL)
+    {
+        return GSD_ERROR_MEMORY_ALLOCATION_FAILED;
+    }
+
+    map->size = size;
+
+    return GSD_SUCCESS;
+}
+
+/** @internal
+    @brief Free a name/id map
+
+    @param map Map to free.
+
+    @returns GSD_SUCCESS on success, GSD_* error codes on error.
+*/
+inline static int gsd_name_id_map_free(struct gsd_name_id_map* map)
+{
+    if (map == NULL || map->v == NULL || map->size == 0)
+    {
+        return GSD_ERROR_INVALID_ARGUMENT;
+    }
+
+    // free all of the linked lists
+    size_t i;
+    for (i = 0; i < map->size; i++)
+    {
+        free(map->v[i].name);
+
+        struct gsd_name_id_pair* cur = map->v[i].next;
+        while (cur != NULL)
+        {
+            struct gsd_name_id_pair* prev = cur;
+            cur = cur->next;
+            free(prev->name);
+            free(prev);
+        }
+    }
+
+    // free the main map
+    free(map->v);
+
+    map->v = 0;
+    map->size = 0;
+
+    return GSD_SUCCESS;
+}
+
+/** @internal
+    @brief Hash a string
+
+    @param str String to hash
+
+    @returns Hashed value of the string.
+*/
+inline static unsigned long gsd_hash_str(const unsigned char* str)
+{
+    unsigned long hash = 5381; // NOLINT
+    int c;
+
+    while ((c = *str++))
+    {
+        hash = ((hash << 5) + hash) + c; /* hash * 33 + c NOLINT */
+    }
+
+    return hash;
+}
+
+/** @internal
+    @brief Insert a string into a name/id map
+
+    @param map Map to insert into.
+    @param str String to insert.
+    @param id ID to associate with the string.
+
+    @returns GSD_SUCCESS on success, GSD_* error codes on error.
+*/
+inline static int gsd_name_id_map_insert(struct gsd_name_id_map* map, const char* str, uint16_t id)
+{
+    if (map == NULL || map->v == NULL || map->size == 0)
+    {
+        return GSD_ERROR_INVALID_ARGUMENT;
+    }
+
+    size_t hash = gsd_hash_str((const unsigned char*)str) % map->size;
+
+    // base case: no conflict
+    if (map->v[hash].name == NULL)
+    {
+        map->v[hash].name = calloc(strlen(str) + 1, sizeof(char));
+        if (map->v[hash].name == NULL)
+        {
+            return GSD_ERROR_MEMORY_ALLOCATION_FAILED;
+        }
+        memcpy(map->v[hash].name, str, strlen(str) + 1);
+        map->v[hash].id = id;
+        map->v[hash].next = NULL;
+    }
+    else
+    {
+        // go to the end of the conflict list
+        struct gsd_name_id_pair* insert_point = map->v + hash;
+
+        while (insert_point->next != NULL)
+        {
+            insert_point = insert_point->next;
+        }
+
+        // allocate and insert a new entry
+        insert_point->next = malloc(sizeof(struct gsd_name_id_pair));
+        if (insert_point->next == NULL)
+        {
+            return GSD_ERROR_MEMORY_ALLOCATION_FAILED;
+        }
+
+        insert_point->next->name = calloc(strlen(str) + 1, sizeof(char));
+        if (insert_point->next->name == NULL)
+        {
+            return GSD_ERROR_MEMORY_ALLOCATION_FAILED;
+        }
+        memcpy(insert_point->next->name, str, strlen(str) + 1);
+        insert_point->next->id = id;
+        insert_point->next->next = NULL;
+    }
+
+    return GSD_SUCCESS;
+}
+
+/** @internal
+    @brief Find an ID in a name/id mapping
+
+    @param map Map to search.
+    @param str String to search.
+
+    @returns The ID if found, or UINT16_MAX if not found.
+*/
+inline static uint16_t gsd_name_id_map_find(struct gsd_name_id_map* map, const char* str)
+{
+    if (map == NULL || map->v == NULL || map->size == 0)
+    {
+        return UINT16_MAX;
+    }
+
+    size_t hash = gsd_hash_str((const unsigned char*)str) % map->size;
+
+    struct gsd_name_id_pair* cur = map->v + hash;
+
+    while (cur != NULL)
+    {
+        if (cur->name == NULL)
+        {
+            // not found
+            return UINT16_MAX;
+        }
+
+        if (strcmp(str, cur->name) == 0)
+        {
+            // found
+            return cur->id;
+        }
+
+        // keep looking
+        cur = cur->next;
+    }
+
+    // not found in any conflict
+    return UINT16_MAX;
+}
+
+/** @internal
+    @brief Utility function to validate index entry
+    @param handle handle to the open gsd file
+    @param idx index of entry to validate
+
+    @returns 1 if the entry is valid, 0 if it is not
+*/
+inline static int gsd_is_entry_valid(struct gsd_handle* handle, size_t idx)
+{
+    const struct gsd_index_entry entry = handle->file_index.data[idx];
+
+    // check for valid type
+    if (gsd_sizeof_type((enum gsd_type)entry.type) == 0)
+    {
+        return 0;
+    }
+
+    // validate that we don't read past the end of the file
+    size_t size = entry.N * entry.M * gsd_sizeof_type((enum gsd_type)entry.type);
+    if ((entry.location + size) > (uint64_t)handle->file_size)
+    {
+        return 0;
+    }
+
+    // check for valid frame (frame cannot be more than the number of index entries)
+    if (entry.frame >= handle->header.index_allocated_entries)
+    {
+        return 0;
+    }
+
+    // check for valid id
+    if (entry.id >= (handle->file_names.n_names + handle->frame_names.n_names))
+    {
+        return 0;
+    }
+
+    // check for valid flags
+    if (entry.flags != 0)
+    {
+        return 0;
+    }
+
+    return 1;
+}
+
+/** @internal
+    @brief Allocate a write buffer
+
+    @param buf Buffer to allocate.
+    @param reserve Number of bytes to allocate.
+
+    @returns GSD_SUCCESS on success, GSD_* error codes on error.
+*/
+inline static int gsd_byte_buffer_allocate(struct gsd_byte_buffer* buf, size_t reserve)
+{
+    if (buf == NULL || buf->data || reserve == 0 || buf->reserved != 0 || buf->size != 0)
+    {
+        return GSD_ERROR_INVALID_ARGUMENT;
+    }
+
+    buf->data = calloc(reserve, sizeof(char));
+    if (buf->data == NULL)
+    {
+        return GSD_ERROR_MEMORY_ALLOCATION_FAILED;
+    }
+
+    buf->size = 0;
+    buf->reserved = reserve;
+
+    return GSD_SUCCESS;
+}
+
+/** @internal
+    @brief Append bytes to a byte buffer
+
+    @param buf Buffer to append to.
+    @param data Data to append.
+    @param size Number of bytes in *data*.
+
+    @returns GSD_SUCCESS on success, GSD_* error codes on error.
+*/
+inline static int gsd_byte_buffer_append(struct gsd_byte_buffer* buf, const char* data, size_t size)
+{
+    if (buf == NULL || buf->data == NULL || size == 0 || buf->reserved == 0)
+    {
+        return GSD_ERROR_INVALID_ARGUMENT;
+    }
+
+    if (buf->size + size > buf->reserved)
+    {
+        // reallocate by doubling
+        size_t new_reserved = buf->reserved * 2;
+        while (buf->size + size >= new_reserved)
+        {
+            new_reserved = new_reserved * 2;
+        }
+
+        char* old_data = buf->data;
+        buf->data = realloc(buf->data, sizeof(char) * new_reserved);
+        if (buf->data == NULL)
+        {
+            // this free should not be necessary, but clang-tidy disagrees
+            free(old_data);
+            return GSD_ERROR_MEMORY_ALLOCATION_FAILED;
+        }
+
+        // zero the new memory, but only the portion after the end of the new section to be appended
+        gsd_util_zero_memory(buf->data + (buf->size + size),
+                             sizeof(char) * (new_reserved - (buf->size + size)));
+        buf->reserved = new_reserved;
+    }
+
+    memcpy(buf->data + buf->size, data, size);
+    buf->size += size;
+
+    return GSD_SUCCESS;
+}
+
+/** @internal
+    @brief Free the memory allocated by the write buffer or unmap the mapped memory.
+
+    @param buf Buffer to free.
+
+    @returns GSD_SUCCESS on success, GSD_* error codes on error.
+*/
+inline static int gsd_byte_buffer_free(struct gsd_byte_buffer* buf)
+{
+    if (buf == NULL || buf->data == NULL)
+    {
+        return GSD_ERROR_INVALID_ARGUMENT;
+    }
+
+    free(buf->data);
+
+    gsd_util_zero_memory(buf, sizeof(struct gsd_byte_buffer));
+    return GSD_SUCCESS;
+}
+
+/** @internal
+    @brief Allocate a buffer of index entries
+
+    @param buf Buffer to allocate.
+    @param reserve Number of entries to allocate.
+
+    @post The buffer's data element has *reserve* elements allocated in memory.
+
+    @returns GSD_SUCCESS on success, GSD_* error codes on error.
+*/
+inline static int gsd_index_buffer_allocate(struct gsd_index_buffer* buf, size_t reserve)
+{
+    if (buf == NULL || buf->mapped_data || buf->data || reserve == 0 || buf->reserved != 0
+        || buf->size != 0)
+    {
+        return GSD_ERROR_INVALID_ARGUMENT;
+    }
+
+    buf->data = calloc(reserve, sizeof(struct gsd_index_entry));
+    if (buf->data == NULL)
+    {
+        return GSD_ERROR_MEMORY_ALLOCATION_FAILED;
+    }
+
+    buf->size = 0;
+    buf->reserved = reserve;
+    buf->mapped_data = NULL;
+    buf->mapped_len = 0;
+
+    return GSD_SUCCESS;
+}
+
+/** @internal
+    @brief Map index entries from the file
+
+    @param buf Buffer to map.
+    @param handle GSD file handle to map.
+
+    @post The buffer's data element contains the index data from the file.
+
+    On some systems, this will use mmap to efficiently access the file. On others, it may result in
+    an allocation and read of the entire index from the file.
+
+    @returns GSD_SUCCESS on success, GSD_* error codes on error.
+*/
+inline static int gsd_index_buffer_map(struct gsd_index_buffer* buf, struct gsd_handle* handle)
+{
+    if (buf == NULL || buf->mapped_data || buf->data || buf->reserved != 0 || buf->size != 0)
+    {
+        return GSD_ERROR_INVALID_ARGUMENT;
+    }
+
+    // validate that the index block exists inside the file
+    if (handle->header.index_location
+            + sizeof(struct gsd_index_entry) * handle->header.index_allocated_entries
+        > (uint64_t)handle->file_size)
+    {
+        return GSD_ERROR_FILE_CORRUPT;
+    }
+
+#if GSD_USE_MMAP
+    // map the index in read only mode
+    size_t page_size = getpagesize();
+    size_t index_size = sizeof(struct gsd_index_entry) * handle->header.index_allocated_entries;
+    size_t offset = (handle->header.index_location / page_size) * page_size;
+    buf->mapped_data = mmap(NULL,
+                            index_size + (handle->header.index_location - offset),
+                            PROT_READ,
+                            MAP_SHARED,
+                            handle->fd,
+                            offset);
+
+    if (buf->mapped_data == MAP_FAILED)
+    {
+        return GSD_ERROR_IO;
+    }
+
+    buf->data = (struct gsd_index_entry*)(((char*)buf->mapped_data)
+                                          + (handle->header.index_location - offset));
+
+    buf->mapped_len = index_size + (handle->header.index_location - offset);
+    buf->reserved = handle->header.index_allocated_entries;
+#else
+    // mmap not supported, read the data from the disk
+    int retval = gsd_index_buffer_allocate(buf, handle->header.index_allocated_entries);
+    if (retval != GSD_SUCCESS)
+    {
+        return retval;
+    }
+
+    ssize_t bytes_read = gsd_io_pread_retry(handle->fd,
+                                            buf->data,
+                                            sizeof(struct gsd_index_entry)
+                                                * handle->header.index_allocated_entries,
+                                            handle->header.index_location);
+
+    if (bytes_read == -1
+        || bytes_read != sizeof(struct gsd_index_entry) * handle->header.index_allocated_entries)
+    {
+        return GSD_ERROR_IO;
+    }
+#endif
+
+    // determine the number of index entries in the list
+    // file is corrupt if first index entry is invalid
+    if (buf->data[0].location != 0 && !gsd_is_entry_valid(handle, 0))
+    {
+        return GSD_ERROR_FILE_CORRUPT;
+    }
+
+    if (buf->data[0].location == 0)
+    {
+        buf->size = 0;
+    }
+    else
+    {
+        // determine the number of index entries (marked by location = 0)
+        // binary search for the first index entry with location 0
+        size_t L = 0;
+        size_t R = buf->reserved;
+
+        // progressively narrow the search window by halves
+        do
+        {
+            size_t m = (L + R) / 2;
+
+            // file is corrupt if any index entry is invalid or frame does not increase
+            // monotonically
+            if (buf->data[m].location != 0
+                && (!gsd_is_entry_valid(handle, m) || buf->data[m].frame < buf->data[L].frame))
+            {
+                return GSD_ERROR_FILE_CORRUPT;
+            }
+
+            if (buf->data[m].location != 0)
+            {
+                L = m;
+            }
+            else
+            {
+                R = m;
+            }
+        } while ((R - L) > 1);
+
+        // this finds R = the first index entry with location = 0
+        buf->size = R;
+    }
+
+    return GSD_SUCCESS;
+}
+
+/** @internal
+    @brief Free the memory allocated by the index buffer or unmap the mapped memory.
+
+    @param buf Buffer to free.
+
+    @returns GSD_SUCCESS on success, GSD_* error codes on error.
+*/
+inline static int gsd_index_buffer_free(struct gsd_index_buffer* buf)
+{
+    if (buf == NULL || buf->data == NULL)
+    {
+        return GSD_ERROR_INVALID_ARGUMENT;
+    }
+
+#if GSD_USE_MMAP
+    if (buf->mapped_data)
+    {
+        int retval = munmap(buf->mapped_data, buf->mapped_len);
+
+        if (retval != 0)
+        {
+            return GSD_ERROR_IO;
+        }
+    }
+    else
+#endif
+    {
+        free(buf->data);
+    }
+
+    gsd_util_zero_memory(buf, sizeof(struct gsd_index_buffer));
+    return GSD_SUCCESS;
+}
+
+/** @internal
+    @brief Add a new index entry and provide a pointer to it.
+
+    @param buf Buffer to add too.
+    @param entry [out] Pointer to set to the new entry.
+
+    Double the size of the reserved space as needed to hold the new entry. Does not accept mapped
+    indices.
+
+    @returns GSD_SUCCESS on success, GSD_* error codes on error.
+*/
+inline static int gsd_index_buffer_add(struct gsd_index_buffer* buf, struct gsd_index_entry** entry)
+{
+    if (buf == NULL || buf->mapped_data || entry == NULL || buf->reserved == 0)
+    {
+        return GSD_ERROR_INVALID_ARGUMENT;
+    }
+
+    if (buf->size == buf->reserved)
+    {
+        // grow the array
+        size_t new_reserved = buf->reserved * 2;
+        buf->data = realloc(buf->data, sizeof(struct gsd_index_entry) * new_reserved);
+        if (buf->data == NULL)
+        {
+            return GSD_ERROR_MEMORY_ALLOCATION_FAILED;
+        }
+
+        // zero the new memory
+        gsd_util_zero_memory(buf->data + buf->reserved,
+                             sizeof(struct gsd_index_entry) * (new_reserved - buf->reserved));
+        buf->reserved = new_reserved;
+    }
+
+    size_t insert_pos = buf->size;
+    buf->size++;
+    *entry = buf->data + insert_pos;
+
+    return GSD_SUCCESS;
+}
+
+inline static int gsd_cmp_index_entry(const struct gsd_index_entry* a,
+                                      const struct gsd_index_entry* b)
+{
+    int result = 0;
+
+    if (a->frame < b->frame)
+    {
+        result = -1;
+    }
+
+    if (a->frame > b->frame)
+    {
+        result = 1;
+    }
+
+    if (a->frame == b->frame)
+    {
+        if (a->id < b->id)
+        {
+            result = -1;
+        }
+
+        if (a->id > b->id)
+        {
+            result = 1;
+        }
+
+        if (a->id == b->id)
+        {
+            result = 0;
+        }
+    }
+
+    return result;
+}
+
+/** @internal
+    @brief Compute heap parent node.
+    @param i Node index.
+*/
+inline static size_t gsd_heap_parent(size_t i)
+{
+    return (i - 1) / 2;
+}
+
+/** @internal
+    @brief Compute heap left child.
+    @param i Node index.
+*/
+inline static size_t gsd_heap_left_child(size_t i)
+{
+    return 2 * i + 1;
+}
+
+/** @internal
+    @brief Swap the nodes *a* and *b* in the buffer
+    @param buf Buffer.
+    @param a First index to swap.
+    @param b Second index to swap.
+*/
+inline static void gsd_heap_swap(struct gsd_index_buffer* buf, size_t a, size_t b)
+{
+    struct gsd_index_entry tmp = buf->data[a];
+    buf->data[a] = buf->data[b];
+    buf->data[b] = tmp;
+}
+
+/** @internal
+    @brief Shift heap node downward
+    @param buf Buffer.
+    @param start First index of the valid heap in *buf*.
+    @param end Last index of the valid hep in *buf*.
+*/
+inline static void gsd_heap_shift_down(struct gsd_index_buffer* buf, size_t start, size_t end)
+{
+    size_t root = start;
+
+    while (gsd_heap_left_child(root) <= end)
+    {
+        size_t child = gsd_heap_left_child(root);
+        size_t swap = root;
+
+        if (gsd_cmp_index_entry(buf->data + swap, buf->data + child) < 0)
+        {
+            swap = child;
+        }
+        if (child + 1 <= end && gsd_cmp_index_entry(buf->data + swap, buf->data + child + 1) < 0)
+        {
+            swap = child + 1;
+        }
+
+        if (swap == root)
+        {
+            return;
+        }
+
+        gsd_heap_swap(buf, root, swap);
+        root = swap;
+    }
+}
+
+/** @internal
+    @brief Convert unordered index buffer to a heap
+    @param buf Buffer.
+*/
+inline static void gsd_heapify(struct gsd_index_buffer* buf)
+{
+    ssize_t start = gsd_heap_parent(buf->size - 1);
+
+    while (start >= 0)
+    {
+        gsd_heap_shift_down(buf, start, buf->size - 1);
+        start--;
+    }
+}
+
+/** @internal
+    @brief Sort the index buffer.
+
+    @param buf Buffer to sort.
+
+    Sorts an in-memory index buffer. Does not accept mapped indices.
+
+    @returns GSD_SUCCESS on success, GSD_* error codes on error.
+*/
+inline static int gsd_index_buffer_sort(struct gsd_index_buffer* buf)
+{
+    if (buf == NULL || buf->mapped_data || buf->reserved == 0)
+    {
+        return GSD_ERROR_INVALID_ARGUMENT;
+    }
+
+    // arrays of size 0 or 1 are already sorted
+    if (buf->size <= 1)
+    {
+        return GSD_SUCCESS;
+    }
+
+    gsd_heapify(buf);
+
+    size_t end = buf->size - 1;
+    while (end > 0)
+    {
+        gsd_heap_swap(buf, end, 0);
+        end = end - 1;
+        gsd_heap_shift_down(buf, 0, end);
+    }
+
+    return GSD_SUCCESS;
+}
+
+/** @internal
+    @brief Utility function to expand the memory space for the index block in the file.
+
+    @param handle Handle to the open gsd file.
+    @param size_required The new index must be able to hold at least this many elements.
+
+    @returns GSD_SUCCESS on success, GSD_* error codes on error.
+*/
+inline static int gsd_expand_file_index(struct gsd_handle* handle, size_t size_required)
+{
+    if (handle->open_flags == GSD_OPEN_READONLY)
+    {
+        return GSD_ERROR_FILE_MUST_BE_WRITABLE;
+    }
+
     // multiply the index size each time it grows
     // this allows the index to grow rapidly to accommodate new frames
     const int multiplication_factor = 2;
 
     // save the old size and update the new size
-    size_t old_size = handle->header.index_allocated_entries;
-    handle->header.index_allocated_entries = old_size * multiplication_factor;
+    size_t size_old = handle->header.index_allocated_entries;
+    size_t size_new = size_old * multiplication_factor;
 
-    if (handle->open_flags == GSD_OPEN_READWRITE)
+    while (size_new <= size_required)
+    {
+        size_new *= multiplication_factor;
+    }
+
+    // Mac systems deadlock when writing from a mapped region into the tail end of that same region
+    // unmap the index first and copy it over by chunks
+    int retval = gsd_index_buffer_free(&handle->file_index);
+    if (retval != 0)
+    {
+        return retval;
+    }
+
+    // allocate the copy buffer
+    char* buf = malloc(GSD_COPY_BUFFER_SIZE);
+
+    // write the current index to the end of the file
+    int64_t new_index_location = lseek(handle->fd, 0, SEEK_END);
+    int64_t old_index_location = handle->header.index_location;
+    size_t total_bytes_written = 0;
+    size_t old_index_bytes = size_old * sizeof(struct gsd_index_entry);
+    while (total_bytes_written < old_index_bytes)
+    {
+        size_t bytes_to_copy = GSD_COPY_BUFFER_SIZE;
+        if (old_index_bytes - total_bytes_written < GSD_COPY_BUFFER_SIZE)
         {
-        // allocate the new larger index block
-        handle->index = (struct gsd_index_entry *)realloc(handle->index, sizeof(struct gsd_index_entry) * old_size * multiplication_factor);
-        if (handle->index == NULL)
-            return -1;
-
-        // zero the new memory
-        memset(handle->index + old_size, 0, sizeof(struct gsd_index_entry) * (old_size * multiplication_factor - old_size));
-
-        // now, put the new larger index at the end of the file
-        handle->header.index_location = lseek(handle->fd, 0, SEEK_END);
-        ssize_t bytes_written = __pwrite_retry(handle->fd,
-                                               handle->index,
-                                               sizeof(struct gsd_index_entry) * handle->header.index_allocated_entries,
-                                               handle->header.index_location);
-
-        if (bytes_written == -1 || bytes_written != sizeof(struct gsd_index_entry) * handle->header.index_allocated_entries)
-            return -1;
-
-        // set the new file size
-        handle->file_size = handle->header.index_location + bytes_written;
+            bytes_to_copy = old_index_bytes - total_bytes_written;
         }
-    else if (handle->open_flags == GSD_OPEN_APPEND)
+
+        ssize_t bytes_read = gsd_io_pread_retry(handle->fd,
+                                                buf,
+                                                bytes_to_copy,
+                                                old_index_location + total_bytes_written);
+
+        if (bytes_read == -1 || bytes_read != bytes_to_copy)
         {
-        // in append mode, we don't have the whole index stored in memory. Instead, we need to copy it in chunks
-        // from the file's old position to the new position
-        const size_t buf_size = 1024*16;
-        char buf[1024*16];
-
-        int64_t new_index_location = lseek(handle->fd, 0, SEEK_END);
-        int64_t old_index_location = handle->header.index_location;
-        size_t total_bytes_written = 0;
-        size_t old_index_bytes = old_size * sizeof(struct gsd_index_entry);
-        while (total_bytes_written < old_index_bytes)
-            {
-            size_t bytes_to_copy = buf_size;
-            if (old_index_bytes - total_bytes_written < buf_size)
-                bytes_to_copy = old_index_bytes - total_bytes_written;
-
-            ssize_t bytes_read = __pread_retry(handle->fd,
-                                               buf,
-                                               bytes_to_copy,
-                                               old_index_location + total_bytes_written);
-
-            if (bytes_read == -1 || bytes_read != bytes_to_copy)
-                return -1;
-
-            ssize_t bytes_written = __pwrite_retry(handle->fd,
-                                                   buf,
-                                                   bytes_to_copy,
-                                                   new_index_location + total_bytes_written);
-
-            if (bytes_written == -1 || bytes_written != bytes_to_copy)
-                return -1;
-            total_bytes_written += bytes_written;
-            }
-
-        // fill the new index space with 0s
-        memset(buf, 0, buf_size);
-        size_t new_index_bytes = old_size * sizeof(struct gsd_index_entry) * multiplication_factor;
-        while (total_bytes_written < new_index_bytes)
-            {
-            size_t bytes_to_copy = buf_size;
-            if (new_index_bytes - total_bytes_written < buf_size)
-                bytes_to_copy = new_index_bytes - total_bytes_written;
-
-            ssize_t bytes_written = __pwrite_retry(handle->fd,
-                                                   buf,
-                                                   bytes_to_copy,
-                                                   new_index_location + total_bytes_written);
-
-            if (bytes_written == -1 || bytes_written != bytes_to_copy)
-                return -1;
-            total_bytes_written += bytes_written;
-            }
-
-        // update to the new index location in the header
-        handle->header.index_location = new_index_location;
-        handle->file_size = handle->header.index_location + total_bytes_written;
+            free(buf);
+            return GSD_ERROR_IO;
         }
+
+        ssize_t bytes_written = gsd_io_pwrite_retry(handle->fd,
+                                                    buf,
+                                                    bytes_to_copy,
+                                                    new_index_location + total_bytes_written);
+
+        if (bytes_written == -1 || bytes_written != bytes_to_copy)
+        {
+            free(buf);
+            return GSD_ERROR_IO;
+        }
+
+        total_bytes_written += bytes_written;
+    }
+
+    // fill the new index space with 0s
+    gsd_util_zero_memory(buf, GSD_COPY_BUFFER_SIZE);
+
+    size_t new_index_bytes = size_new * sizeof(struct gsd_index_entry);
+    while (total_bytes_written < new_index_bytes)
+    {
+        size_t bytes_to_copy = GSD_COPY_BUFFER_SIZE;
+        if (new_index_bytes - total_bytes_written < GSD_COPY_BUFFER_SIZE)
+        {
+            bytes_to_copy = new_index_bytes - total_bytes_written;
+        }
+
+        ssize_t bytes_written = gsd_io_pwrite_retry(handle->fd,
+                                                    buf,
+                                                    bytes_to_copy,
+                                                    new_index_location + total_bytes_written);
+
+        if (bytes_written == -1 || bytes_written != bytes_to_copy)
+        {
+            free(buf);
+            return GSD_ERROR_IO;
+        }
+
+        total_bytes_written += bytes_written;
+    }
 
     // sync the expanded index
-    int retval = fsync(handle->fd);
+    retval = fsync(handle->fd);
     if (retval != 0)
-        return -1;
+    {
+        free(buf);
+        return GSD_ERROR_IO;
+    }
+
+    // free the copy buffer
+    free(buf);
+
+    // update the header
+    handle->header.index_location = new_index_location;
+    handle->file_size = handle->header.index_location + total_bytes_written;
+    handle->header.index_allocated_entries = size_new;
 
     // write the new header out
-    ssize_t bytes_written = __pwrite_retry(handle->fd, &(handle->header), sizeof(struct gsd_header), 0);
-    if (bytes_written == -1 || bytes_written != sizeof(struct gsd_header))
-        return -1;
+    ssize_t bytes_written
+        = gsd_io_pwrite_retry(handle->fd, &(handle->header), sizeof(struct gsd_header), 0);
+    if (bytes_written != sizeof(struct gsd_header))
+    {
+        return GSD_ERROR_IO;
+    }
 
     // sync the updated header
     retval = fsync(handle->fd);
     if (retval != 0)
-        return -1;
-
-    return 0;
+    {
+        return GSD_ERROR_IO;
     }
 
-/*! \internal
-    \brief utility function to search the namelist and return the id assigned to the name
-    \param handle handle to the open gsd file
-    \param name string name
-    \param append Set to true to allow appending new names into the index, false to disallow
-
-    \return the id assigned to the name, or UINT16_MAX if not found and append is false
-*/
-uint16_t __gsd_get_id(struct gsd_handle *handle, const char *name, uint8_t append)
+    // remap the file index
+    retval = gsd_index_buffer_map(&handle->file_index, handle);
+    if (retval != 0)
     {
-    // search for the name in the namelist
+        return retval;
+    }
+
+    return GSD_SUCCESS;
+}
+
+/** @internal
+    @brief Flush the write buffer.
+
+    gsd_write_frame() writes small data chunks into the write buffer. It adds index entries for
+    these chunks to gsd_handle::buffer_index with locations offset from the start of the write
+    buffer. gsd_flush_write_buffer() writes the buffer to the end of the file, moves the index
+    entries to gsd_handle::frame_index and updates the location to reference the beginning of the
+    file.
+
+    @param handle Handle to flush the write buffer.
+    @returns GSD_SUCCESS on success or GSD_* error codes on error
+*/
+inline static int gsd_flush_write_buffer(struct gsd_handle* handle)
+{
+    if (handle == NULL)
+    {
+        return GSD_ERROR_INVALID_ARGUMENT;
+    }
+
+    if (handle->write_buffer.size == 0)
+    {
+        // nothing to do
+        return GSD_SUCCESS;
+    }
+
+    if (handle->buffer_index.size == 0)
+    {
+        // error: bytes in buffer, but no index for them
+        return GSD_ERROR_INVALID_ARGUMENT;
+    }
+
+    // write the buffer to the end of the file
+    uint64_t offset = handle->file_size;
+    ssize_t bytes_written = gsd_io_pwrite_retry(handle->fd,
+                                                handle->write_buffer.data,
+                                                handle->write_buffer.size,
+                                                offset);
+
+    if (bytes_written == -1 || bytes_written != handle->write_buffer.size)
+    {
+        return GSD_ERROR_IO;
+    }
+
+    handle->file_size += handle->write_buffer.size;
+
+    // reset write_buffer for new data
+    handle->write_buffer.size = 0;
+
+    // move buffer_index entries to file_index
     size_t i;
-    for (i = 0; i < handle->namelist_num_entries; i++)
+    for (i = 0; i < handle->buffer_index.size; i++)
+    {
+        struct gsd_index_entry* new_index;
+        int retval = gsd_index_buffer_add(&handle->frame_index, &new_index);
+        if (retval != GSD_SUCCESS)
         {
-        if (0 == strncmp(name, handle->namelist[i].name, sizeof(handle->namelist[i].name)))
-            return i;
+            return retval;
         }
 
-    // append the name if allowed
-    if (append &&
-        (handle->open_flags == GSD_OPEN_READWRITE || handle->open_flags == GSD_OPEN_APPEND) &&
-        handle->namelist_num_entries < handle->header.namelist_allocated_entries)
+        *new_index = handle->buffer_index.data[i];
+        new_index->location += offset;
+    }
+
+    // clear the buffer index for new entries
+    handle->buffer_index.size = 0;
+
+    return GSD_SUCCESS;
+}
+
+/** @internal
+    @brief Flush the name buffer.
+
+    gsd_write_frame() adds new names to the frame_names buffer. gsd_flush_name_buffer() flushes
+    this buffer at the end of a frame write and commits the new names to the file. If necessary,
+    the namelist is written to a new location in the file.
+
+    @param handle Handle to flush the write buffer.
+    @returns GSD_SUCCESS on success or GSD_* error codes on error
+*/
+inline static int gsd_flush_name_buffer(struct gsd_handle* handle)
+{
+    if (handle == NULL)
+    {
+        return GSD_ERROR_INVALID_ARGUMENT;
+    }
+
+    if (handle->frame_names.n_names == 0)
+    {
+        // nothing to do
+        return GSD_SUCCESS;
+    }
+
+    if (handle->frame_names.data.size == 0)
+    {
+        // error: bytes in buffer, but no names for them
+        return GSD_ERROR_INVALID_ARGUMENT;
+    }
+
+    size_t old_reserved = handle->file_names.data.reserved;
+    size_t old_size = handle->file_names.data.size;
+
+    // add the new names to the file name list and zero the frame list
+    int retval = gsd_byte_buffer_append(&handle->file_names.data,
+                                        handle->frame_names.data.data,
+                                        handle->frame_names.data.size);
+    if (retval != GSD_SUCCESS)
+    {
+        return retval;
+    }
+
+    handle->file_names.n_names += handle->frame_names.n_names;
+    handle->frame_names.n_names = 0;
+    handle->frame_names.data.size = 0;
+    gsd_util_zero_memory(handle->frame_names.data.data, handle->frame_names.data.reserved);
+
+    // reserved space must be a multiple of the GSD name size
+    if (handle->file_names.data.reserved % GSD_NAME_SIZE != 0)
+    {
+        return GSD_ERROR_INVALID_ARGUMENT;
+    }
+
+    if (handle->file_names.data.reserved > old_reserved)
+    {
+        // write the new name list to the end of the file
+        uint64_t offset = handle->file_size;
+        ssize_t bytes_written = gsd_io_pwrite_retry(handle->fd,
+                                                    handle->file_names.data.data,
+                                                    handle->file_names.data.reserved,
+                                                    offset);
+
+        if (bytes_written == -1 || bytes_written != handle->file_names.data.reserved)
         {
-        strncpy(handle->namelist[handle->namelist_num_entries].name, name, sizeof(struct gsd_namelist_entry)-1);
-        handle->namelist[handle->namelist_num_entries].name[sizeof(struct gsd_namelist_entry)-1] = 0;
-
-        // update the namelist on disk
-        ssize_t bytes_written = __pwrite_retry(handle->fd,
-                                               &(handle->namelist[handle->namelist_num_entries]),
-                                               sizeof(struct gsd_namelist_entry),
-                                               handle->header.namelist_location
-                                                   + sizeof(struct gsd_namelist_entry)*handle->namelist_num_entries);
-
-        if (bytes_written == -1 || bytes_written != sizeof(struct gsd_namelist_entry))
-            return UINT16_MAX;
-
-        handle->namelist_num_entries++;
-
-        // mark that synchronization is needed
-        handle->needs_sync = true;
-
-        return handle->namelist_num_entries-1;
+            return GSD_ERROR_IO;
         }
+
+        // sync the updated name list
+        retval = fsync(handle->fd);
+        if (retval != 0)
+        {
+            return GSD_ERROR_IO;
+        }
+
+        handle->file_size += handle->file_names.data.reserved;
+        handle->header.namelist_location = offset;
+        handle->header.namelist_allocated_entries
+            = handle->file_names.data.reserved / GSD_NAME_SIZE;
+
+        // write the new header out
+        bytes_written
+            = gsd_io_pwrite_retry(handle->fd, &(handle->header), sizeof(struct gsd_header), 0);
+        if (bytes_written != sizeof(struct gsd_header))
+        {
+            return GSD_ERROR_IO;
+        }
+    }
     else
+    {
+        // write the new name list to the old index location
+        uint64_t offset = handle->header.namelist_location;
+        ssize_t bytes_written = gsd_io_pwrite_retry(handle->fd,
+                                                    handle->file_names.data.data + old_size,
+                                                    handle->file_names.data.reserved - old_size,
+                                                    offset + old_size);
+        if (bytes_written != (handle->file_names.data.reserved - old_size))
         {
-        // otherwise, return not found
-        return UINT16_MAX;
+            return GSD_ERROR_IO;
         }
     }
 
-/*! \param fd file descriptor to initialize
-
-    Truncate the file and write a new gsd header.
-*/
-int __gsd_initialize_file(int fd, const char *application, const char *schema, uint32_t schema_version)
+    // sync the updated name list or header
+    retval = fsync(handle->fd);
+    if (retval != 0)
     {
+        return GSD_ERROR_IO;
+    }
+
+    return GSD_SUCCESS;
+}
+
+/** @internal
+    @brief utility function to append a name to the namelist
+
+    @param id [out] ID of the new name
+    @param handle handle to the open gsd file
+    @param name string name
+
+    Append a name to the names in the current frame. gsd_end_frame() will add this list to the
+    file names.
+
+    @return
+      - GSD_SUCCESS (0) on success. Negative value on failure:
+      - GSD_ERROR_IO: IO error (check errno).
+      - GSD_ERROR_MEMORY_ALLOCATION_FAILED: Unable to allocate memory.
+      - GSD_ERROR_FILE_MUST_BE_WRITABLE: File must not be read only.
+*/
+inline static int gsd_append_name(uint16_t* id, struct gsd_handle* handle, const char* name)
+{
+    if (handle->open_flags == GSD_OPEN_READONLY)
+    {
+        return GSD_ERROR_FILE_MUST_BE_WRITABLE;
+    }
+
+    if (handle->file_names.n_names + handle->frame_names.n_names == UINT16_MAX)
+    {
+        // no more names may be added
+        return GSD_ERROR_NAMELIST_FULL;
+    }
+
+    // Provide the ID of the new name
+    *id = (uint16_t)(handle->file_names.n_names + handle->frame_names.n_names);
+
+    if (handle->header.gsd_version < gsd_make_version(2, 0))
+    {
+        // v1 files always allocate GSD_NAME_SIZE bytes for each name and put a NULL terminator
+        // at address 63
+        char name_v1[GSD_NAME_SIZE];
+        strncpy(name_v1, name, GSD_NAME_SIZE - 1);
+        name_v1[GSD_NAME_SIZE - 1] = 0;
+        gsd_byte_buffer_append(&handle->frame_names.data, name_v1, GSD_NAME_SIZE);
+        handle->frame_names.n_names++;
+
+        // update the name/id mapping with the truncated name
+        int retval = gsd_name_id_map_insert(&handle->name_map, name_v1, *id);
+        if (retval != GSD_SUCCESS)
+        {
+            return retval;
+        }
+    }
+    else
+    {
+        gsd_byte_buffer_append(&handle->frame_names.data, name, strlen(name) + 1);
+        handle->frame_names.n_names++;
+
+        // update the name/id mapping
+        int retval = gsd_name_id_map_insert(&handle->name_map, name, *id);
+        if (retval != GSD_SUCCESS)
+        {
+            return retval;
+        }
+    }
+
+    return GSD_SUCCESS;
+}
+
+/** @internal
+    @brief Truncate the file and write a new gsd header.
+
+    @param fd file descriptor to initialize
+    @param application Generating application name (truncated to 63 chars)
+    @param schema Schema name for data to be written in this GSD file (truncated to 63 chars)
+    @param schema_version Version of the scheme data to be written (make with gsd_make_version())
+*/
+inline static int
+gsd_initialize_file(int fd, const char* application, const char* schema, uint32_t schema_version)
+{
     // check if the file was created
     if (fd == -1)
-        return -1;
+    {
+        return GSD_ERROR_IO;
+    }
 
     int retval = ftruncate(fd, 0);
     if (retval != 0)
-        return retval;
+    {
+        return GSD_ERROR_IO;
+    }
 
     // populate header fields
     struct gsd_header header;
-    memset(&header, 0, sizeof(header));
+    gsd_util_zero_memory(&header, sizeof(header));
 
-    header.magic = 0x65DF65DF65DF65DF;
-    header.gsd_version = gsd_make_version(1,0);
-    strncpy(header.application, application, sizeof(header.application)-1);
-    header.application[sizeof(header.application)-1] = 0;
-    strncpy(header.schema, schema, sizeof(header.schema)-1);
-    header.schema[sizeof(header.schema)-1] = 0;
+    header.magic = GSD_MAGIC_ID;
+    header.gsd_version = gsd_make_version(GSD_CURRENT_FILE_VERSION, 0);
+    strncpy(header.application, application, sizeof(header.application) - 1);
+    header.application[sizeof(header.application) - 1] = 0;
+    strncpy(header.schema, schema, sizeof(header.schema) - 1);
+    header.schema[sizeof(header.schema) - 1] = 0;
     header.schema_version = schema_version;
     header.index_location = sizeof(header);
-    header.index_allocated_entries = 128;
-    header.namelist_location = header.index_location + sizeof(struct gsd_index_entry)*header.index_allocated_entries;
-    header.namelist_allocated_entries = 128;
-    memset(header.reserved, 0, sizeof(header.reserved));
+    header.index_allocated_entries = GSD_INITIAL_INDEX_SIZE;
+    header.namelist_location
+        = header.index_location + sizeof(struct gsd_index_entry) * header.index_allocated_entries;
+    header.namelist_allocated_entries = GSD_INITIAL_NAME_BUFFER_SIZE / GSD_NAME_SIZE;
+    gsd_util_zero_memory(header.reserved, sizeof(header.reserved));
 
     // write the header out
-    ssize_t bytes_written = __pwrite_retry(fd, &header, sizeof(header), 0);
-    if (bytes_written == -1 || bytes_written != sizeof(header))
-        return -1;
+    ssize_t bytes_written = gsd_io_pwrite_retry(fd, &header, sizeof(header), 0);
+    if (bytes_written != sizeof(header))
+    {
+        return GSD_ERROR_IO;
+    }
 
     // allocate and zero default index memory
-    struct gsd_index_entry index[128];
-    memset(index, 0, sizeof(index));
+    struct gsd_index_entry index[GSD_INITIAL_INDEX_SIZE];
+    gsd_util_zero_memory(index, sizeof(index));
 
     // write the empty index out
-    bytes_written = __pwrite_retry(fd, index, sizeof(index), sizeof(header));
-    if (bytes_written == -1 || bytes_written != sizeof(index))
-        return -1;
+    bytes_written = gsd_io_pwrite_retry(fd, index, sizeof(index), sizeof(header));
+    if (bytes_written != sizeof(index))
+    {
+        return GSD_ERROR_IO;
+    }
 
     // allocate and zero the namelist memory
-    struct gsd_namelist_entry namelist[128];
-    memset(namelist, 0, sizeof(namelist));
+    char names[GSD_INITIAL_NAME_BUFFER_SIZE];
+    gsd_util_zero_memory(names, sizeof(char) * GSD_INITIAL_NAME_BUFFER_SIZE);
 
     // write the namelist out
-    bytes_written = __pwrite_retry(fd, namelist, sizeof(namelist), sizeof(header)+sizeof(index));
-    if (bytes_written == -1 || bytes_written != sizeof(namelist))
-        return -1;
+    bytes_written = gsd_io_pwrite_retry(fd, names, sizeof(names), sizeof(header) + sizeof(index));
+    if (bytes_written != sizeof(names))
+    {
+        return GSD_ERROR_IO;
+    }
 
     // sync file
     retval = fsync(fd);
     if (retval != 0)
-        return -1;
-
-    return 0;
+    {
+        return GSD_ERROR_IO;
     }
 
-/*! \internal
-    \brief Utility function to validate index entry
-    \param handle handle to the open gsd file
-    \param idx index of entry to validate
+    return GSD_SUCCESS;
+}
 
-    \returns 1 if the entry is valid, 0 if it is not
+/** @internal
+    @brief Read in the file index and initialize the handle.
+
+    @param handle Handle to read the header
+
+    @pre handle->fd is an open file.
+    @pre handle->open_flags is set.
 */
-static int __is_entry_valid(struct gsd_handle *handle, size_t idx)
-    {
-    const struct gsd_index_entry entry = handle->index[idx];
-
-    // check for valid type
-    if (gsd_sizeof_type((enum gsd_type)entry.type) == 0)
-        {
-        return 0;
-        }
-
-    // validate that we don't read past the end of the file
-    size_t size = entry.N * entry.M * gsd_sizeof_type((enum gsd_type)entry.type);
-    if ((entry.location + size) > handle->file_size)
-        {
-        return 0;
-        }
-
-    // check for valid frame (frame cannot be more than the number of index entries)
-    if (entry.frame >= handle->header.index_allocated_entries)
-        {
-        return 0;
-        }
-
-    // check for valid id
-    if (entry.id >= handle->namelist_num_entries)
-        {
-        return 0;
-        }
-
-    // check for valid flags
-    if (entry.flags != 0)
-        {
-        return 0;
-        }
-
-    return 1;
-    }
-
-/*! \param handle Handle to read the header
-
-    \pre handle->fd is an open file.
-    \pre handle->open_flags is set.
-
-    Read in the file index.
-*/
-int __gsd_read_header(struct gsd_handle* handle)
-    {
+inline static int gsd_initialize_handle(struct gsd_handle* handle)
+{
     // check if the file was created
     if (handle->fd == -1)
-        return -1;
+    {
+        return GSD_ERROR_IO;
+    }
 
     // read the header
-    ssize_t bytes_read = __pread_retry(handle->fd, &handle->header, sizeof(struct gsd_header), 0);
+    ssize_t bytes_read
+        = gsd_io_pread_retry(handle->fd, &handle->header, sizeof(struct gsd_header), 0);
     if (bytes_read == -1)
-        {
-        return -1;
-        }
+    {
+        return GSD_ERROR_IO;
+    }
     if (bytes_read != sizeof(struct gsd_header))
-        {
-        return -2;
-        }
+    {
+        return GSD_ERROR_NOT_A_GSD_FILE;
+    }
 
     // validate the header
-    if (handle->header.magic != 0x65DF65DF65DF65DF)
-        return -2;
+    if (handle->header.magic != GSD_MAGIC_ID)
+    {
+        return GSD_ERROR_NOT_A_GSD_FILE;
+    }
 
-    if (handle->header.gsd_version < gsd_make_version(1,0) && handle->header.gsd_version != gsd_make_version(0,3))
-        return -3;
-    if (handle->header.gsd_version >= gsd_make_version(2,0))
-        return -3;
+    if (handle->header.gsd_version < gsd_make_version(1, 0)
+        && handle->header.gsd_version != gsd_make_version(0, 3))
+    {
+        return GSD_ERROR_INVALID_GSD_FILE_VERSION;
+    }
+
+    if (handle->header.gsd_version >= gsd_make_version(3, 0))
+    {
+        return GSD_ERROR_INVALID_GSD_FILE_VERSION;
+    }
 
     // determine the file size
     handle->file_size = lseek(handle->fd, 0, SEEK_END);
 
-    // map the file in read only mode
-    #if GSD_USE_MMAP
-    if (handle->open_flags == GSD_OPEN_READONLY)
-        {
-        size_t page_size = getpagesize();
-        size_t index_size = sizeof(struct gsd_index_entry) * handle->header.index_allocated_entries;
-        size_t offset = (handle->header.index_location / page_size) * page_size;
-        handle->mapped_data = mmap(NULL, index_size+(handle->header.index_location - offset), PROT_READ, MAP_SHARED, handle->fd, offset);
-        handle->index = (struct gsd_index_entry *) (((char *)handle->mapped_data) + (handle->header.index_location - offset));
-
-        if (handle->mapped_data == MAP_FAILED)
-            return -1;
-        }
-    else if (handle->open_flags == GSD_OPEN_READWRITE)
-    #endif
-        {
-        // read the indices into our own memory
-        handle->mapped_data = NULL;
-
-        // validate that the index block exists inside the file
-        if (handle->header.index_location + sizeof(struct gsd_index_entry) * handle->header.index_allocated_entries > handle->file_size)
-            return -4;
-
-        // read the index block
-        handle->index = (struct gsd_index_entry *)malloc(sizeof(struct gsd_index_entry) * handle->header.index_allocated_entries);
-        if (handle->index == NULL)
-            return -5;
-
-        bytes_read = __pread_retry(handle->fd,
-                                   handle->index,
-                                   sizeof(struct gsd_index_entry) * handle->header.index_allocated_entries,
-                                   handle->header.index_location);
-
-        if (bytes_read == -1 || bytes_read != sizeof(struct gsd_index_entry) * handle->header.index_allocated_entries)
-            return -1;
-        }
-    #if GSD_USE_MMAP
-    else if (handle->open_flags == GSD_OPEN_APPEND)
-        {
-        // in append mode, we want to avoid reading the entire index in memory, but we also don't want to bother
-        // keeping the mapping up to date. Map the index for now to determine index_num_entries, but then
-        // unmap it and use different logic to manage a cache of only unwritten index entries
-
-        // mmap may fail if offset is not a multiple of the page size, so we
-        // always memory map from the beginning of the file and then access the
-        // index pointer by its offset.
-        size_t page_size = getpagesize();
-        size_t index_size = sizeof(struct gsd_index_entry) * handle->header.index_allocated_entries;
-        size_t offset = (handle->header.index_location / page_size) * page_size;
-        handle->mapped_data = mmap(NULL, index_size+(handle->header.index_location - offset), PROT_READ, MAP_SHARED, handle->fd, offset);
-        handle->index = (struct gsd_index_entry *) (((char *)handle->mapped_data) + (handle->header.index_location - offset));
-
-        if (handle->mapped_data == MAP_FAILED)
-            return -1;
-        }
-    #endif
-
-    // since the namelist is small, we always allocate memory for it rather than memory mapping
     // validate that the namelist block exists inside the file
-    if (handle->header.namelist_location + sizeof(struct gsd_namelist_entry) * handle->header.namelist_allocated_entries > handle->file_size)
-        return -4;
+    if (handle->header.namelist_location
+            + (GSD_NAME_SIZE * handle->header.namelist_allocated_entries)
+        > (uint64_t)handle->file_size)
+    {
+        return GSD_ERROR_FILE_CORRUPT;
+    }
+
+    // allocate the hash map
+    int retval = gsd_name_id_map_allocate(&handle->name_map, GSD_NAME_MAP_SIZE);
+    if (retval != GSD_SUCCESS)
+    {
+        return retval;
+    }
 
     // read the namelist block
-    handle->namelist = (struct gsd_namelist_entry *)malloc(sizeof(struct gsd_namelist_entry) * handle->header.namelist_allocated_entries);
-    if (handle->namelist == NULL)
-        return -5;
+    size_t namelist_n_bytes = GSD_NAME_SIZE * handle->header.namelist_allocated_entries;
+    retval = gsd_byte_buffer_allocate(&handle->file_names.data, namelist_n_bytes);
+    if (retval != GSD_SUCCESS)
+    {
+        return retval;
+    }
+    bytes_read = gsd_io_pread_retry(handle->fd,
+                                    handle->file_names.data.data,
+                                    namelist_n_bytes,
+                                    handle->header.namelist_location);
 
-    bytes_read = __pread_retry(handle->fd,
-                               handle->namelist,
-                               sizeof(struct gsd_namelist_entry) * handle->header.namelist_allocated_entries,
-                               handle->header.namelist_location);
+    if (bytes_read == -1 || bytes_read != namelist_n_bytes)
+    {
+        return GSD_ERROR_IO;
+    }
 
-    if (bytes_read == -1 || bytes_read != sizeof(struct gsd_namelist_entry) * handle->header.namelist_allocated_entries)
-        return -1;
+    // The name buffer must end in a NULL terminator or else the file is corrupt
+    if (handle->file_names.data.data[handle->file_names.data.reserved - 1] != 0)
+    {
+        return GSD_ERROR_FILE_CORRUPT;
+    }
 
-    // determine the number of namelist entries (marked by an empty string)
-    // base case: the namelist is full
-    handle->namelist_num_entries = handle->header.namelist_allocated_entries;
+    // Add the names to the hash map. Also determine the number of used bytes in the namelist.
+    size_t name_start = 0;
+    handle->file_names.n_names = 0;
+    while (name_start < handle->file_names.data.reserved)
+    {
+        char* name = handle->file_names.data.data + name_start;
 
-    // general case, find the first namelist entry that is the empty string
-    size_t i;
-    for (i = 0; i < handle->header.namelist_allocated_entries; i++)
+        // an empty name notes the end of the list
+        if (name[0] == 0)
         {
-        if (handle->namelist[i].name[0] == 0)
-            {
-            handle->namelist_num_entries = i;
             break;
-            }
         }
 
-    // file is corrupt if first index entry is invalid
-    if (handle->index[0].location != 0 && !__is_entry_valid(handle, 0))
+        retval
+            = gsd_name_id_map_insert(&handle->name_map, name, (uint16_t)handle->file_names.n_names);
+        if (retval != GSD_SUCCESS)
         {
-        return -4;
+            return retval;
         }
+        handle->file_names.n_names++;
 
-    if (handle->index[0].location == 0)
+        if (handle->header.gsd_version < gsd_make_version(2, 0))
         {
-        handle->index_num_entries = 0;
+            // gsd v1 stores names in fixed 64 byte segments
+            name_start += GSD_NAME_SIZE;
         }
-    else
+        else
         {
-        // determine the number of index entries (marked by location = 0)
-        // binary search for the first index entry with location 0
-        size_t L = 0;
-        size_t R = handle->header.index_allocated_entries;
-
-        // progressively narrow the search window by halves
-        do
-            {
-            size_t m = (L+R)/2;
-
-            // file is corrupt if any index entry is invalid or frame does not increase monotonically
-            if (handle->index[m].location != 0 &&
-                (!__is_entry_valid(handle, m) || handle->index[m].frame < handle->index[L].frame))
-                {
-                return -4;
-                }
-
-            if (handle->index[m].location != 0)
-                L = m;
-            else
-                R = m;
-            } while ((R-L) > 1);
-
-        // this finds R = the first index entry with location = 0
-        handle->index_num_entries = R;
+            size_t len = strnlen(name, handle->file_names.data.reserved - name_start);
+            name_start += len + 1;
         }
+    }
+
+    handle->file_names.data.size = name_start;
+
+    // read in the file index
+    retval = gsd_index_buffer_map(&handle->file_index, handle);
+    if (retval != GSD_SUCCESS)
+    {
+        return retval;
+    }
 
     // determine the current frame counter
-    if (handle->index_num_entries == 0)
-        {
+    if (handle->file_index.size == 0)
+    {
         handle->cur_frame = 0;
-        }
+    }
     else
-        {
-        handle->cur_frame = handle->index[handle->index_num_entries-1].frame + 1;
-        }
-
-    // at this point, all valid index entries have been written to disk
-    handle->index_written_entries = handle->index_num_entries;
-
-    if (handle->open_flags == GSD_OPEN_APPEND)
-        {
-        #if GSD_USE_MMAP
-        // in append mode, we need to tear down the temporary mapping and allocate a temporary buffer
-        // to hold indices for a single frame
-        size_t page_size = getpagesize();
-        size_t index_size = sizeof(struct gsd_index_entry) * handle->header.index_allocated_entries;
-        size_t offset = (handle->header.index_location / page_size) * page_size;
-        int retval = munmap(handle->mapped_data, index_size+(handle->header.index_location - offset));
-        handle->index = NULL;
-
-        if (retval != 0)
-            return -1;
-        #else
-        free(handle->index);
-        #endif
-
-        handle->append_index_size = 1;
-        handle->index = (struct gsd_index_entry *)malloc(sizeof(struct gsd_index_entry) * handle->append_index_size);
-        if (handle->index == NULL)
-            return -5;
-
-        handle->mapped_data = NULL;
-        }
-
-    return 0;
+    {
+        handle->cur_frame = handle->file_index.data[handle->file_index.size - 1].frame + 1;
     }
 
-/*! \param major major version
-    \param minor minor version
+    // if this is a write mode, allocate the initial frame index and the name buffer
+    if (handle->open_flags != GSD_OPEN_READONLY)
+    {
+        retval = gsd_index_buffer_allocate(&handle->frame_index, GSD_INITIAL_FRAME_INDEX_SIZE);
+        if (retval != GSD_SUCCESS)
+        {
+            return retval;
+        }
 
-    \return a packed version number aaaa.bbbb suitable for storing in a gsd file version entry.
-*/
+        retval = gsd_index_buffer_allocate(&handle->buffer_index, GSD_INITIAL_FRAME_INDEX_SIZE);
+        if (retval != GSD_SUCCESS)
+        {
+            return retval;
+        }
+
+        retval = gsd_byte_buffer_allocate(&handle->write_buffer, GSD_WRITE_BUFFER_SIZE);
+        if (retval != GSD_SUCCESS)
+        {
+            return retval;
+        }
+
+        handle->frame_names.n_names = 0;
+        retval = gsd_byte_buffer_allocate(&handle->frame_names.data, GSD_NAME_SIZE);
+        if (retval != GSD_SUCCESS)
+        {
+            return retval;
+        }
+    }
+
+    return GSD_SUCCESS;
+}
+
 uint32_t gsd_make_version(unsigned int major, unsigned int minor)
-    {
-    return major << 16 | minor;
-    }
+{
+    return major << (sizeof(uint32_t) * 4) | minor;
+}
 
-/*! \param fname File name
-    \param application Generating application name (truncated to 63 chars)
-    \param schema Schema name for data to be written in this GSD file (truncated to 63 chars)
-    \param schema_version Version of the scheme data to be written (make with gsd_make_version())
-
-    \post Create an empty gsd file in a file of the given name. Overwrite any existing file at that location.
-
-    The generated gsd file is not opened. Call gsd_open() to open it for writing.
-
-    \return 0 on success, -1 on a file IO failure - see errno for details
-*/
-int gsd_create(const char *fname, const char *application, const char *schema, uint32_t schema_version)
-    {
+int gsd_create(const char* fname,
+               const char* application,
+               const char* schema,
+               uint32_t schema_version)
+{
     int extra_flags = 0;
-    #ifdef _WIN32
+#ifdef _WIN32
     extra_flags = _O_BINARY;
-    #endif
+#endif
 
     // create the file
-    int fd = open(fname, O_RDWR | O_CREAT | O_TRUNC | extra_flags,  S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP);
-    int retval = __gsd_initialize_file(fd, application, schema, schema_version);
+    int fd = open(fname,
+                  O_RDWR | O_CREAT | O_TRUNC | extra_flags,
+                  S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP);
+    int retval = gsd_initialize_file(fd, application, schema, schema_version);
     close(fd);
     return retval;
-    }
+}
 
-/*! \param handle Handle to open
-    \param fname File name
-    \param application Generating application name (truncated to 63 chars)
-    \param schema Schema name for data to be written in this GSD file (truncated to 63 chars)
-    \param schema_version Version of the scheme data to be written (make with gsd_make_version())
-    \param flags Either GSD_OPEN_READWRITE, or GSD_OPEN_APPEND
-    \param exclusive_create Set to non-zero to force exclusive creation of the file
-
-    \post Create an empty gsd file in a file of the given name. Overwrite any existing file at that location.
-
-    Open the generated gsd file in *handle*.
-
-    The file descriptor is closed if there when an error opening the file.
-
-    \return 0 on success. Negative value on failure:
-        * -1: IO error (check errno)
-        * -2: Not a GSD file
-        * -3: Invalid GSD file version
-        * -4: Corrupt file
-        * -5: Unable to allocate memory
-        * -6: Invalid argument
-*/
 int gsd_create_and_open(struct gsd_handle* handle,
-                        const char *fname,
-                        const char *application,
-                        const char *schema,
+                        const char* fname,
+                        const char* application,
+                        const char* schema,
                         uint32_t schema_version,
                         const enum gsd_open_flag flags,
                         int exclusive_create)
-    {
+{
+    // zero the handle
+    gsd_util_zero_memory(handle, sizeof(struct gsd_handle));
+
     int extra_flags = 0;
-    #ifdef _WIN32
+#ifdef _WIN32
     extra_flags = _O_BINARY;
-    #endif
+#endif
 
     // set the open flags in the handle
     if (flags == GSD_OPEN_READWRITE)
-        {
+    {
         handle->open_flags = GSD_OPEN_READWRITE;
-        }
+    }
     else if (flags == GSD_OPEN_READONLY)
-        {
-        return -6;
-        }
+    {
+        return GSD_ERROR_FILE_MUST_BE_WRITABLE;
+    }
     else if (flags == GSD_OPEN_APPEND)
-        {
+    {
         handle->open_flags = GSD_OPEN_APPEND;
-        }
+    }
 
     // set the exclusive create bit
     if (exclusive_create)
+    {
         extra_flags |= O_EXCL;
-
-    // create the file
-    handle->fd = open(fname, O_RDWR | O_CREAT | O_TRUNC | extra_flags,  S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP);
-    int retval = __gsd_initialize_file(handle->fd, application, schema, schema_version);
-    if (retval != 0)
-        {
-        close(handle->fd);
-        return retval;
-        }
-
-    retval = __gsd_read_header(handle);
-    if (retval != 0)
-        {
-        close(handle->fd);
-        }
-    return retval;
     }
 
-/*! \param handle Handle to open
-    \param fname File name to open
-    \param flags Either GSD_OPEN_READWRITE, GSD_OPEN_READONLY, or GSD_OPEN_APPEND
-
-    \pre The file name \a fname is a GSD file.
-
-    \post Open a GSD file and populates the handle for use by API calls.
-
-    The file descriptor is closed if there when an error opening the file.
-
-    \return 0 on success. Negative value on failure:
-        * -1: IO error (check errno)
-        * -2: Not a GSD file
-        * -3: Invalid GSD file version
-        * -4: Corrupt file
-        * -5: Unable to allocate memory
-*/
-int gsd_open(struct gsd_handle* handle, const char *fname, const enum gsd_open_flag flags)
+    // create the file
+    handle->fd = open(fname,
+                      O_RDWR | O_CREAT | O_TRUNC | extra_flags,
+                      S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP);
+    int retval = gsd_initialize_file(handle->fd, application, schema, schema_version);
+    if (retval != 0)
     {
-    // allocate the handle
-    memset(handle, 0, sizeof(struct gsd_handle));
-    handle->index = NULL;
-    handle->namelist = NULL;
-    handle->cur_frame = 0;
+        close(handle->fd);
+        return retval;
+    }
+
+    retval = gsd_initialize_handle(handle);
+    if (retval != 0)
+    {
+        close(handle->fd);
+    }
+    return retval;
+}
+
+int gsd_open(struct gsd_handle* handle, const char* fname, const enum gsd_open_flag flags)
+{
+    // zero the handle
+    gsd_util_zero_memory(handle, sizeof(struct gsd_handle));
 
     int extra_flags = 0;
-    #ifdef _WIN32
+#ifdef _WIN32
     extra_flags = _O_BINARY;
-    #endif
+#endif
 
     // open the file
     if (flags == GSD_OPEN_READWRITE)
-        {
+    {
         handle->fd = open(fname, O_RDWR | extra_flags);
         handle->open_flags = GSD_OPEN_READWRITE;
-        }
+    }
     else if (flags == GSD_OPEN_READONLY)
-        {
+    {
         handle->fd = open(fname, O_RDONLY | extra_flags);
         handle->open_flags = GSD_OPEN_READONLY;
-        }
+    }
     else if (flags == GSD_OPEN_APPEND)
-        {
+    {
         handle->fd = open(fname, O_RDWR | extra_flags);
         handle->open_flags = GSD_OPEN_APPEND;
-        }
-
-    int retval = __gsd_read_header(handle);
-    if (retval != 0)
-        {
-        close(handle->fd);
-        }
-    return retval;
     }
 
-/*! \param handle Handle to an open GSD file
-
-    Truncate the gsd file, then write a new header. Truncating a file removes all frames and data chunks. The
-    application, schema, and schema version are not modified. Truncating may be useful when writing restart files
-    to reduce the metadata load on Lustre file servers.
-
-    \return 0 on success. Negative value on failure:
-        * -1: IO error (check errno)
-        * -2: Invalid input
-        * -3: Invalid GSD file version
-        * -4: Corrupt file
-        * -5: Unable to allocate memory
-*/
-int gsd_truncate(struct gsd_handle* handle)
+    int retval = gsd_initialize_handle(handle);
+    if (retval != 0)
     {
+        close(handle->fd);
+    }
+    return retval;
+}
+
+int gsd_truncate(struct gsd_handle* handle)
+{
     if (handle == NULL)
-        return -2;
+    {
+        return GSD_ERROR_INVALID_ARGUMENT;
+    }
     if (handle->open_flags == GSD_OPEN_READONLY)
-        return -2;
+    {
+        return GSD_ERROR_FILE_MUST_BE_WRITABLE;
+    }
+
+    int retval = 0;
 
     // deallocate indices
-    if (handle->namelist != NULL)
+    if (handle->frame_names.data.reserved > 0)
+    {
+        retval = gsd_byte_buffer_free(&handle->frame_names.data);
+        if (retval != GSD_SUCCESS)
         {
-        free(handle->namelist);
-        handle->namelist = NULL;
+            return retval;
         }
+    }
 
-    if (handle->index != NULL)
+    if (handle->file_names.data.reserved > 0)
+    {
+        retval = gsd_byte_buffer_free(&handle->file_names.data);
+        if (retval != GSD_SUCCESS)
         {
-        free(handle->index);
-        handle->index = NULL;
+            return retval;
         }
+    }
+
+    retval = gsd_name_id_map_free(&handle->name_map);
+    if (retval != GSD_SUCCESS)
+    {
+        return retval;
+    }
+
+    retval = gsd_index_buffer_free(&handle->file_index);
+    if (retval != GSD_SUCCESS)
+    {
+        return retval;
+    }
+
+    if (handle->frame_index.reserved > 0)
+    {
+        retval = gsd_index_buffer_free(&handle->frame_index);
+        if (retval != GSD_SUCCESS)
+        {
+            return retval;
+        }
+    }
+
+    if (handle->buffer_index.reserved > 0)
+    {
+        retval = gsd_index_buffer_free(&handle->buffer_index);
+        if (retval != GSD_SUCCESS)
+        {
+            return retval;
+        }
+    }
+
+    if (handle->write_buffer.reserved > 0)
+    {
+        retval = gsd_byte_buffer_free(&handle->write_buffer);
+        if (retval != GSD_SUCCESS)
+        {
+            return retval;
+        }
+    }
 
     // keep a copy of the old header
     struct gsd_header old_header = handle->header;
-    int retval = __gsd_initialize_file(handle->fd,
-                                       old_header.application,
-                                       old_header.schema,
-                                       old_header.schema_version);
+    retval = gsd_initialize_file(handle->fd,
+                                 old_header.application,
+                                 old_header.schema,
+                                 old_header.schema_version);
 
-    if (retval != 0)
+    if (retval != GSD_SUCCESS)
+    {
         return retval;
-
-    return __gsd_read_header(handle);
     }
 
-/*! \param handle Handle to an open GSD file
+    return gsd_initialize_handle(handle);
+}
 
-    \pre \a handle was opened by gsd_open().
-    \pre gsd_end_frame() has been called since the last call to gsd_write_chunk().
-
-    \post The file is closed.
-    \post \a handle is freed and can no longer be used.
-
-    \warning Do not write chunks to the file with gsd_write_chunk() and then immediately close the file with gsd_close().
-    This will result in data loss. Data chunks written by gsd_write_chunk() are not updated in the index until
-    gsd_end_frame() is called. This is by design to prevent partial frames in files.
-
-    \return 0 on success, -1 on a file IO failure - see errno for details, and -2 on invalid input
-*/
 int gsd_close(struct gsd_handle* handle)
-    {
+{
     if (handle == NULL)
-        return -2;
+    {
+        return GSD_ERROR_INVALID_ARGUMENT;
+    }
 
     // save the fd so we can use it after freeing the handle
     int fd = handle->fd;
 
-    // zero and free memory allocated in the handle
-    #if GSD_USE_MMAP
-    if (handle->mapped_data != NULL)
+    int retval = gsd_index_buffer_free(&handle->file_index);
+    if (retval != GSD_SUCCESS)
+    {
+        return retval;
+    }
+
+    if (handle->frame_index.reserved > 0)
+    {
+        retval = gsd_index_buffer_free(&handle->frame_index);
+        if (retval != GSD_SUCCESS)
         {
-        size_t page_size = getpagesize();
-        size_t index_size = sizeof(struct gsd_index_entry) * handle->header.index_allocated_entries;
-        size_t offset = (handle->header.index_location / page_size) * page_size;
-        int retval = munmap(handle->mapped_data, index_size+(handle->header.index_location - offset));
-        handle->mapped_data = NULL;
-        handle->index = NULL;
-
-        if (retval != 0)
-            return -1;
-
-        memset(handle, 0, sizeof(struct gsd_handle));
+            return retval;
         }
-    else
-    #endif
+    }
+
+    if (handle->buffer_index.reserved > 0)
+    {
+        retval = gsd_index_buffer_free(&handle->buffer_index);
+        if (retval != GSD_SUCCESS)
         {
-        if (handle->index != NULL)
-            {
-            free(handle->index);
-            handle->index = NULL;
-
-            memset(handle, 0, sizeof(struct gsd_handle));
-            }
+            return retval;
         }
+    }
 
-    if (handle->namelist != NULL)
+    if (handle->write_buffer.reserved > 0)
+    {
+        retval = gsd_byte_buffer_free(&handle->write_buffer);
+        if (retval != GSD_SUCCESS)
         {
-        free(handle->namelist);
-        handle->namelist = NULL;
+            return retval;
         }
+    }
+
+    retval = gsd_name_id_map_free(&handle->name_map);
+    if (retval != GSD_SUCCESS)
+    {
+        return retval;
+    }
+
+    if (handle->frame_names.data.reserved > 0)
+    {
+        handle->frame_names.n_names = 0;
+        retval = gsd_byte_buffer_free(&handle->frame_names.data);
+        if (retval != GSD_SUCCESS)
+        {
+            return retval;
+        }
+    }
+
+    if (handle->file_names.data.reserved > 0)
+    {
+        handle->file_names.n_names = 0;
+        retval = gsd_byte_buffer_free(&handle->file_names.data);
+        if (retval != GSD_SUCCESS)
+        {
+            return retval;
+        }
+    }
 
     // close the file
-    int retval = close(fd);
+    retval = close(fd);
     if (retval != 0)
-        return -1;
-
-    return 0;
+    {
+        return GSD_ERROR_IO;
     }
 
-/*! \param handle Handle to an open GSD file
+    return GSD_SUCCESS;
+}
 
-    \pre \a handle was opened by gsd_open().
-    \pre gsd_write_chunk() has been called at least once since the last call to gsd_end_frame().
-
-    \post The current frame counter is increased by 1 and cached indexes are written to disk.
-
-    \return 0 on success, -1 on a file IO failure - see errno for details, and -2 on invalid input
-*/
 int gsd_end_frame(struct gsd_handle* handle)
-    {
+{
     if (handle == NULL)
-        return -2;
+    {
+        return GSD_ERROR_INVALID_ARGUMENT;
+    }
     if (handle->open_flags == GSD_OPEN_READONLY)
-        return -2;
+    {
+        return GSD_ERROR_FILE_MUST_BE_WRITABLE;
+    }
 
-    // all data chunks have already been written to the file and the index updated in memory. To end a frame, all we
-    // need to do is increment the frame counter
+    // increment the frame counter
     handle->cur_frame++;
 
-    // and write unwritten index entries to the file (if there are any to write)
-    uint64_t entries_to_write = handle->index_num_entries - handle->index_written_entries;
-    if (entries_to_write > 0)
-        {
-        // write just those unwritten entries to the end of the index block
-        int64_t write_pos = handle->header.index_location + sizeof(struct gsd_index_entry)*handle->index_written_entries;
-
-        // in append mode, the start of the write is at the start of the index in memory
-        // in readwrite mode, the entire index is in memory, so start at index_written_entries
-        struct gsd_index_entry* data = handle->index;
-        if (handle->open_flags != GSD_OPEN_APPEND)
-            data += handle->index_written_entries;
-
-        ssize_t bytes_written = __pwrite_retry(handle->fd,
-                                              data,
-                                              sizeof(struct gsd_index_entry)*entries_to_write,
-                                              write_pos);
-
-        if (bytes_written == -1 || bytes_written != sizeof(struct gsd_index_entry)*entries_to_write)
-            return -1;
-
-        handle->index_written_entries += entries_to_write;
-        }
-
-    // this sync is triggered by the namelist update
-    if (handle->needs_sync)
-        {
-        int retval = fsync(handle->fd);
-        if (retval != 0)
-            return -1;
-        handle->needs_sync = false;
-        }
-
-    return 0;
+    // flush the namelist buffer
+    int retval = gsd_flush_name_buffer(handle);
+    if (retval != GSD_SUCCESS)
+    {
+        return retval;
     }
 
-/*! \param handle Handle to an open GSD file
-    \param name Name of the data chunk (truncated to 63 chars)
-    \param type type ID that identifies the type of data in \a data
-    \param N Number of rows in the data
-    \param M Number of columns in the data
-    \param flags set to 0, non-zero values reserved for future use
-    \param data Data buffer
+    // flush the write buffer
+    retval = gsd_flush_write_buffer(handle);
+    if (retval != GSD_SUCCESS)
+    {
+        return retval;
+    }
 
-    \pre \a handle was opened by gsd_open().
-    \pre \a name is a unique name for data chunks in the given frame.
-    \pre data is allocated and contains at least `N * M * gsd_sizeof_type(type)` bytes.
+    // write the frame index to the file
+    if (handle->frame_index.size > 0)
+    {
+        // ensure there is enough space in the index
+        if ((handle->file_index.size + handle->frame_index.size) > handle->file_index.reserved)
+        {
+            gsd_expand_file_index(handle, handle->file_index.size + handle->frame_index.size);
+        }
 
-    \post The given data chunk is written to the end of the file and its location is updated in the in-memory index.
+        // sort the index before writing
+        retval = gsd_index_buffer_sort(&handle->frame_index);
+        if (retval != 0)
+        {
+            return retval;
+        }
 
-    \return 0 on success, -1 on a file IO failure - see errno for details, -2 on invalid input, and -3 when out of names
-*/
+        // write the frame index entries to the file
+        int64_t write_pos = handle->header.index_location
+                            + sizeof(struct gsd_index_entry) * handle->file_index.size;
+
+        size_t bytes_to_write = sizeof(struct gsd_index_entry) * handle->frame_index.size;
+        ssize_t bytes_written
+            = gsd_io_pwrite_retry(handle->fd, handle->frame_index.data, bytes_to_write, write_pos);
+
+        if (bytes_written == -1 || bytes_written != bytes_to_write)
+        {
+            return GSD_ERROR_IO;
+        }
+
+#if !GSD_USE_MMAP
+        // add the entries to the file index
+        memcpy(handle->file_index.data + handle->file_index.size,
+               handle->frame_index.data,
+               sizeof(struct gsd_index_entry) * handle->frame_index.size);
+#endif
+
+        // update size of file index
+        handle->file_index.size += handle->frame_index.size;
+
+        // clear the frame index
+        handle->frame_index.size = 0;
+    }
+
+    return GSD_SUCCESS;
+}
+
 int gsd_write_chunk(struct gsd_handle* handle,
-                    const char *name,
+                    const char* name,
                     enum gsd_type type,
                     uint64_t N,
                     uint32_t M,
                     uint8_t flags,
-                    const void *data)
-    {
+                    const void* data)
+{
     // validate input
     if (data == NULL)
-        return -2;
-    if (M == 0)
-        return -2;
+    {
+        return GSD_ERROR_INVALID_ARGUMENT;
+    }
+    if (N == 0 || M == 0 || gsd_sizeof_type(type) == 0)
+    {
+        return GSD_ERROR_INVALID_ARGUMENT;
+    }
     if (handle->open_flags == GSD_OPEN_READONLY)
-        return -2;
+    {
+        return GSD_ERROR_FILE_MUST_BE_WRITABLE;
+    }
+    if (flags != 0)
+    {
+        return GSD_ERROR_INVALID_ARGUMENT;
+    }
 
-    // populate fields in the index_entry data
-    struct gsd_index_entry index_entry;
-    memset(&index_entry, 0, sizeof(index_entry));
-    index_entry.frame = handle->cur_frame;
-    index_entry.id = __gsd_get_id(handle, name, 1);
-    if (index_entry.id == UINT16_MAX)
-        return -3;
-    index_entry.type = (uint8_t)type;
-    index_entry.N = N;
-    index_entry.M = M;
+    uint16_t id = gsd_name_id_map_find(&handle->name_map, name);
+    if (id == UINT16_MAX)
+    {
+        // not found, append to the index
+        int retval = gsd_append_name(&id, handle, name);
+        if (retval != GSD_SUCCESS)
+        {
+            return retval;
+        }
+
+        if (id == UINT16_MAX)
+        {
+            // this should never happen
+            return GSD_ERROR_NAMELIST_FULL;
+        }
+    }
+
+    struct gsd_index_entry entry;
+    // populate fields in the entry's data
+    gsd_util_zero_memory(&entry, sizeof(struct gsd_index_entry));
+    entry.frame = handle->cur_frame;
+    entry.id = id;
+    entry.type = (uint8_t)type;
+    entry.N = N;
+    entry.M = M;
     size_t size = N * M * gsd_sizeof_type(type);
 
-    // find the location at the end of the file for the chunk
-    index_entry.location = handle->file_size;
-
-    // write the data
-    ssize_t bytes_written = __pwrite_retry(handle->fd, data, size, index_entry.location);
-    if (bytes_written == -1 || bytes_written != size)
-        return -1;
-
-    // update the file_size in the handle
-    handle->file_size += bytes_written;
-
-    // update the index entry in the index
-    // need to expand the index if it is already full
-    if (handle->index_num_entries >= handle->header.index_allocated_entries)
+    // decide whether to write this chunk to the buffer or straight to disk
+    if (size < handle->write_buffer.reserved / 2)
+    {
+        // flush the buffer if this entry won't fit
+        if (size > (handle->write_buffer.reserved - handle->write_buffer.size))
         {
-        int retval = __gsd_expand_index(handle);
-        if (retval != 0)
-            return -1;
+            gsd_flush_write_buffer(handle);
         }
 
-    // once we get here, there is a free slot to add this entry to the index
-    size_t slot = handle->index_num_entries;
+        entry.location = handle->write_buffer.size;
 
-    // in append mode, only unwritten entries are stored in memory
-    if (handle->open_flags == GSD_OPEN_APPEND)
+        // add an entry to the buffer index
+        struct gsd_index_entry* index_entry;
+
+        int retval = gsd_index_buffer_add(&handle->buffer_index, &index_entry);
+        if (retval != GSD_SUCCESS)
         {
-        slot -= handle->index_written_entries;
-        if (slot >= handle->append_index_size)
-            {
-            handle->append_index_size *= 2;
-            handle->index = (struct gsd_index_entry *)realloc(handle->index, handle->append_index_size*sizeof(struct gsd_index_entry));
-            if (handle->index == NULL)
-                return -1;
-            }
+            return retval;
         }
-    handle->index[slot] = index_entry;
-    handle->index_num_entries++;
+        *index_entry = entry;
 
-    return 0;
+        // add the data to the write buffer
+        gsd_byte_buffer_append(&handle->write_buffer, data, size);
+    }
+    else
+    {
+        // add an entry to the frame index
+        struct gsd_index_entry* index_entry;
+
+        int retval = gsd_index_buffer_add(&handle->frame_index, &index_entry);
+        if (retval != GSD_SUCCESS)
+        {
+            return retval;
+        }
+        *index_entry = entry;
+
+        // find the location at the end of the file for the chunk
+        index_entry->location = handle->file_size;
+
+        // write the data
+        ssize_t bytes_written = gsd_io_pwrite_retry(handle->fd, data, size, index_entry->location);
+        if (bytes_written == -1 || bytes_written != size)
+        {
+            return GSD_ERROR_IO;
+        }
+
+        // update the file_size in the handle
+        handle->file_size += bytes_written;
     }
 
-/*! \param handle Handle to an open GSD file
+    return GSD_SUCCESS;
+}
 
-    \pre \a handle was opened by gsd_open().
-
-    \return The number of frames in the file, or 0 on error
-*/
 uint64_t gsd_get_nframes(struct gsd_handle* handle)
-    {
+{
     if (handle == NULL)
+    {
         return 0;
-    return handle->cur_frame;
     }
+    return handle->cur_frame;
+}
 
-/*! \param handle Handle to an open GSD file
-    \param frame Frame to look for chunk
-    \param name Name of the chunk to find
-
-    \pre \a handle was opened by gsd_open() in read or readwrite mode.
-
-    \return A pointer to the found chunk, or NULL if not found
-*/
-const struct gsd_index_entry* gsd_find_chunk(struct gsd_handle* handle, uint64_t frame, const char *name)
-    {
+const struct gsd_index_entry*
+gsd_find_chunk(struct gsd_handle* handle, uint64_t frame, const char* name)
+{
     if (handle == NULL)
+    {
         return NULL;
+    }
     if (name == NULL)
+    {
         return NULL;
+    }
     if (frame >= gsd_get_nframes(handle))
+    {
         return NULL;
+    }
     if (handle->open_flags == GSD_OPEN_APPEND)
+    {
         return NULL;
+    }
 
     // find the id for the given name
-    uint16_t match_id = __gsd_get_id(handle, name, 0);
+    uint16_t match_id = gsd_name_id_map_find(&handle->name_map, name);
     if (match_id == UINT16_MAX)
+    {
         return NULL;
+    }
 
-    // binary search for the first index entry at the requested frame
-    size_t L = 0;
-    size_t R = handle->index_num_entries;
+    if (handle->header.gsd_version >= gsd_make_version(2, 0))
+    {
+        // gsd 2.0 files sort the entire index
+        // binary search for the index entry
+        ssize_t L = 0;
+        ssize_t R = handle->file_index.size - 1;
+        struct gsd_index_entry T;
+        T.frame = frame;
+        T.id = match_id;
 
-    // progressively narrow the search window by halves
-    do
+        while (L <= R)
         {
-        size_t m = (L+R)/2;
-
-        if (frame < handle->index[m].frame)
-            R = m;
-        else
-            L = m;
-        } while ((R-L) > 1);
-
-    // this finds L = the rightmost index with the desired frame
-    int64_t cur_index;
-
-    // search all index entries with the matching frame
-    for (cur_index = L; (cur_index >= 0) && (handle->index[cur_index].frame == frame); cur_index--)
-        {
-        // if the frame matches, check the id
-        if (match_id == handle->index[cur_index].id)
+            size_t m = (L + R) / 2;
+            int cmp = gsd_cmp_index_entry(handle->file_index.data + m, &T);
+            if (cmp == -1)
             {
-            return &(handle->index[cur_index]);
+                L = m + 1;
+            }
+            else if (cmp == 1)
+            {
+                R = m - 1;
+            }
+            else
+            {
+                return &(handle->file_index.data[m]);
             }
         }
+    }
+    else
+    {
+        // gsd 1.0 file: use binary search to find the frame and linear search to find the entry
+        size_t L = 0;
+        size_t R = handle->file_index.size;
+
+        // progressively narrow the search window by halves
+        do
+        {
+            size_t m = (L + R) / 2;
+
+            if (frame < handle->file_index.data[m].frame)
+            {
+                R = m;
+            }
+            else
+            {
+                L = m;
+            }
+        } while ((R - L) > 1);
+
+        // this finds L = the rightmost index with the desired frame
+        int64_t cur_index;
+
+        // search all index entries with the matching frame
+        for (cur_index = L; (cur_index >= 0) && (handle->file_index.data[cur_index].frame == frame);
+             cur_index--)
+        {
+            // if the frame matches, check the id
+            if (match_id == handle->file_index.data[cur_index].id)
+            {
+                return &(handle->file_index.data[cur_index]);
+            }
+        }
+    }
 
     // if we got here, we didn't find the specified chunk
     return NULL;
-    }
+}
 
-/*! \param handle Handle to an open GSD file
-    \param data Data buffer to read into
-    \param chunk Chunk to read
-
-    \pre \a handle was opened by gsd_open() in read or readwrite mode.
-    \pre \a chunk was found by gsd_find_chunk().
-    \pre \a data points to an allocated buffer with at least `N * M * gsd_sizeof_type(type)` bytes.
-
-    \return 0 on success, -1 on a file IO failure - see errno for details, and -2 on invalid input
-*/
 int gsd_read_chunk(struct gsd_handle* handle, void* data, const struct gsd_index_entry* chunk)
-    {
+{
     if (handle == NULL)
-        return -2;
+    {
+        return GSD_ERROR_INVALID_ARGUMENT;
+    }
     if (data == NULL)
-        return -2;
+    {
+        return GSD_ERROR_INVALID_ARGUMENT;
+    }
     if (chunk == NULL)
-        return -2;
+    {
+        return GSD_ERROR_INVALID_ARGUMENT;
+    }
     if (handle->open_flags == GSD_OPEN_APPEND)
-        return -2;
+    {
+        return GSD_ERROR_FILE_MUST_BE_READABLE;
+    }
 
     size_t size = chunk->N * chunk->M * gsd_sizeof_type((enum gsd_type)chunk->type);
     if (size == 0)
-        return -3;
+    {
+        return GSD_ERROR_FILE_CORRUPT;
+    }
     if (chunk->location == 0)
-        return -3;
+    {
+        return GSD_ERROR_FILE_CORRUPT;
+    }
 
     // validate that we don't read past the end of the file
-    if ((chunk->location + size) > handle->file_size)
-        {
-        return -3;
-        }
-
-    ssize_t bytes_read = __pread_retry(handle->fd, data, size, chunk->location);
-    if (bytes_read == -1 || bytes_read != size)
-        {
-        return -1;
-        }
-
-    return 0;
+    if ((chunk->location + size) > (uint64_t)handle->file_size)
+    {
+        return GSD_ERROR_FILE_CORRUPT;
     }
 
-/*! \param type Type ID to query
-
-    \return Size of the given type, or 0 for an unknown type ID.
-*/
-size_t gsd_sizeof_type(enum gsd_type type)
+    ssize_t bytes_read = gsd_io_pread_retry(handle->fd, data, size, chunk->location);
+    if (bytes_read == -1 || bytes_read != size)
     {
+        return GSD_ERROR_IO;
+    }
+
+    return GSD_SUCCESS;
+}
+
+size_t gsd_sizeof_type(enum gsd_type type)
+{
+    size_t val = 0;
     if (type == GSD_TYPE_UINT8)
-        return 1;
+    {
+        val = sizeof(uint8_t);
+    }
     else if (type == GSD_TYPE_UINT16)
-        return 2;
+    {
+        val = sizeof(uint16_t);
+    }
     else if (type == GSD_TYPE_UINT32)
-        return 4;
+    {
+        val = sizeof(uint32_t);
+    }
     else if (type == GSD_TYPE_UINT64)
-        return 8;
+    {
+        val = sizeof(uint64_t);
+    }
     else if (type == GSD_TYPE_INT8)
-        return 1;
+    {
+        val = sizeof(int8_t);
+    }
     else if (type == GSD_TYPE_INT16)
-        return 2;
+    {
+        val = sizeof(int16_t);
+    }
     else if (type == GSD_TYPE_INT32)
-        return 4;
+    {
+        val = sizeof(int32_t);
+    }
     else if (type == GSD_TYPE_INT64)
-        return 8;
+    {
+        val = sizeof(int64_t);
+    }
     else if (type == GSD_TYPE_FLOAT)
-        return 4;
+    {
+        val = sizeof(float);
+    }
     else if (type == GSD_TYPE_DOUBLE)
-        return 8;
+    {
+        val = sizeof(double);
+    }
     else
+    {
         return 0;
     }
+    return val;
+}
 
-/*! \param handle Handle to an open GSD file
-    \param match String to match
-    \param prev Search starting point
-
-    \pre \a handle was opened by gsd_open()
-    \pre \a prev was returned by a previous call to gsd_find_matching_chunk_name
-
-    To find the first matching chunk name, pass NULL for prev. Pass in the previous found string to find the next
-    after that, and so on. Chunk names match if they begin with the string in \a match. Chunk names returned
-    by this function may be present in at least one frame.
-
-    \return Pointer to a string, NULL if no more matching chunks are found found, or NULL if \a prev is invalid
-*/
-const char *gsd_find_matching_chunk_name(struct gsd_handle* handle, const char* match, const char *prev)
-    {
+const char*
+gsd_find_matching_chunk_name(struct gsd_handle* handle, const char* match, const char* prev)
+{
     if (handle == NULL)
+    {
         return NULL;
+    }
     if (match == NULL)
+    {
         return NULL;
-    if (handle->namelist_num_entries == 0)
+    }
+    if (handle->file_names.n_names == 0)
+    {
         return NULL;
+    }
+
+    // return nothing found if the name buffer is corrupt
+    if (handle->file_names.data.data[handle->file_names.data.reserved - 1] != 0)
+    {
+        return NULL;
+    }
 
     // determine search start index
-    size_t start;
+    const char* search_str;
     if (prev == NULL)
-        {
-        start = 0;
-        }
+    {
+        search_str = handle->file_names.data.data;
+    }
     else
+    {
+        // return not found if prev is not in range
+        if (prev < handle->file_names.data.data)
         {
-        if (prev < handle->namelist[0].name)
             return NULL;
-
-        ptrdiff_t d = prev - handle->namelist[0].name;
-        if (d % sizeof(struct gsd_namelist_entry) != 0)
+        }
+        if (prev >= (handle->file_names.data.data + handle->file_names.data.reserved))
+        {
             return NULL;
-        start = d / sizeof(struct gsd_namelist_entry) + 1;
         }
 
-    size_t match_len = strnlen(match, sizeof(handle->namelist[0].name));
-    size_t i;
-    for (i = start; i < handle->namelist_num_entries; i++)
+        if (handle->header.gsd_version < gsd_make_version(2, 0))
         {
-        if (0 == strncmp(match, handle->namelist[i].name, match_len))
-            return handle->namelist[i].name;
+            search_str = prev + GSD_NAME_SIZE;
         }
+        else
+        {
+            search_str = prev + strlen(prev) + 1;
+        }
+    }
+
+    size_t match_len = strlen(match);
+
+    while (search_str < (handle->file_names.data.data + handle->file_names.data.reserved))
+    {
+        if (search_str[0] != 0 && 0 == strncmp(match, search_str, match_len))
+        {
+            return search_str;
+        }
+
+        if (handle->header.gsd_version < gsd_make_version(2, 0))
+        {
+            search_str += GSD_NAME_SIZE;
+        }
+        else
+        {
+            search_str += strlen(search_str) + 1;
+        }
+    }
 
     // searched past the end of the list, return NULL
     return NULL;
+}
+
+int gsd_upgrade(struct gsd_handle* handle)
+{
+    if (handle == NULL)
+    {
+        return GSD_ERROR_INVALID_ARGUMENT;
+    }
+    if (handle->open_flags == GSD_OPEN_READONLY)
+    {
+        return GSD_ERROR_INVALID_ARGUMENT;
+    }
+    if (handle->frame_index.size > 0 || handle->frame_names.n_names > 0)
+    {
+        return GSD_ERROR_INVALID_ARGUMENT;
     }
 
+    if (handle->header.gsd_version < gsd_make_version(2, 0))
+    {
+        if (handle->file_index.size > 0)
+        {
+            // make a copy of the file index
+            struct gsd_index_buffer buf;
+            gsd_util_zero_memory(&buf, sizeof(struct gsd_index_buffer));
+            int retval = gsd_index_buffer_allocate(&buf, handle->file_index.size);
+            if (retval != GSD_SUCCESS)
+            {
+                return retval;
+            }
+            memcpy(buf.data,
+                   handle->file_index.data,
+                   sizeof(struct gsd_index_entry) * handle->file_index.size);
+            buf.size = handle->file_index.size;
+
+            // sort the copy and write it back out to the file
+            retval = gsd_index_buffer_sort(&buf);
+            if (retval != GSD_SUCCESS)
+            {
+                gsd_index_buffer_free(&buf);
+                return retval;
+            }
+
+            ssize_t bytes_written = gsd_io_pwrite_retry(handle->fd,
+                                                        buf.data,
+                                                        sizeof(struct gsd_index_entry) * buf.size,
+                                                        handle->header.index_location);
+
+            if (bytes_written == -1 || bytes_written != sizeof(struct gsd_index_entry) * buf.size)
+            {
+                gsd_index_buffer_free(&buf);
+                return GSD_ERROR_IO;
+            }
+
+            retval = gsd_index_buffer_free(&buf);
+            if (retval != GSD_SUCCESS)
+            {
+                return retval;
+            }
+
+            // sync the updated index
+            retval = fsync(handle->fd);
+            if (retval != 0)
+            {
+                return GSD_ERROR_IO;
+            }
+        }
+
+        if (handle->file_names.n_names > 0)
+        {
+            // compact the name list without changing its size or position on the disk
+            struct gsd_byte_buffer new_name_buf;
+            gsd_util_zero_memory(&new_name_buf, sizeof(struct gsd_byte_buffer));
+            int retval = gsd_byte_buffer_allocate(&new_name_buf, handle->file_names.data.reserved);
+            if (retval != GSD_SUCCESS)
+            {
+                return retval;
+            }
+
+            const char* name = gsd_find_matching_chunk_name(handle, "", NULL);
+            while (name != NULL)
+            {
+                retval = gsd_byte_buffer_append(&new_name_buf, name, strlen(name) + 1);
+                if (retval != GSD_SUCCESS)
+                {
+                    gsd_byte_buffer_free(&new_name_buf);
+                    return retval;
+                }
+                name = gsd_find_matching_chunk_name(handle, "", name);
+            }
+
+            if (new_name_buf.reserved != handle->file_names.data.reserved)
+            {
+                gsd_byte_buffer_free(&new_name_buf);
+                return GSD_ERROR_FILE_CORRUPT;
+            }
+
+            // write the new names out to disk
+            ssize_t bytes_written = gsd_io_pwrite_retry(handle->fd,
+                                                        new_name_buf.data,
+                                                        new_name_buf.reserved,
+                                                        handle->header.namelist_location);
+
+            if (bytes_written == -1 || bytes_written != new_name_buf.reserved)
+            {
+                gsd_byte_buffer_free(&new_name_buf);
+                return GSD_ERROR_IO;
+            }
+
+            // swap in the re-organized name buffer
+            retval = gsd_byte_buffer_free(&handle->file_names.data);
+            if (retval != GSD_SUCCESS)
+            {
+                gsd_byte_buffer_free(&new_name_buf);
+                return retval;
+            }
+            handle->file_names.data = new_name_buf;
+
+            // sync the updated name list
+            retval = fsync(handle->fd);
+            if (retval != 0)
+            {
+                gsd_byte_buffer_free(&new_name_buf);
+                return GSD_ERROR_IO;
+            }
+        }
+
+        // label the file as a v2.0 file
+        handle->header.gsd_version = gsd_make_version(GSD_CURRENT_FILE_VERSION, 0);
+
+        // write the new header out
+        ssize_t bytes_written
+            = gsd_io_pwrite_retry(handle->fd, &(handle->header), sizeof(struct gsd_header), 0);
+        if (bytes_written != sizeof(struct gsd_header))
+        {
+            return GSD_ERROR_IO;
+        }
+
+        // sync the updated header
+        int retval = fsync(handle->fd);
+        if (retval != 0)
+        {
+            return GSD_ERROR_IO;
+        }
+
+        // remap the file index
+        retval = gsd_index_buffer_free(&handle->file_index);
+        if (retval != 0)
+        {
+            return retval;
+        }
+
+        retval = gsd_index_buffer_map(&handle->file_index, handle);
+        if (retval != 0)
+        {
+            return retval;
+        }
+    }
+
+    return GSD_SUCCESS;
+}
 
 // undefine windows wrapper macros
 #ifdef _WIN32
@@ -1215,5 +2456,6 @@ const char *gsd_find_matching_chunk_name(struct gsd_handle* handle, const char* 
 #undef read
 #undef open
 #undef ftruncate
+#pragma warning(pop)
 
 #endif

--- a/hoomd/extern/gsd.h
+++ b/hoomd/extern/gsd.h
@@ -478,6 +478,8 @@ int gsd_end_frame(struct gsd_handle* handle);
     @note If the GSD file is version 1.0, the chunk name is truncated to 63 bytes. GSD version
     2.0 files support arbitrarily long names.
 
+    @note *N* == 0 is allowed. When *N* is 0, *data* may be NULL.
+
     @return
       - GSD_SUCCESS (0) on success. Negative value on failure:
       - GSD_ERROR_IO: IO error (check errno).

--- a/hoomd/extern/gsd.h
+++ b/hoomd/extern/gsd.h
@@ -1,12 +1,13 @@
-// Copyright (c) 2016-2019 The Regents of the University of Michigan
-// This file is part of the General Simulation Data (GSD) project, released under the BSD 2-Clause License.
+// Copyright (c) 2016-2020 The Regents of the University of Michigan
+// This file is part of the General Simulation Data (GSD) project, released under the BSD 2-Clause
+// License.
 
-#ifndef __GSD_H__
-#define __GSD_H__
+#ifndef GSD_H
+#define GSD_H
 
+#include <stdbool.h>
 #include <stdint.h>
 #include <string.h>
-#include <stdbool.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -16,151 +17,573 @@ extern "C" {
     \brief Declare GSD data types and C API
 */
 
-//! Identifiers for the gsd data chunk element types
+/// Identifiers for the gsd data chunk element types
 enum gsd_type
-    {
-    GSD_TYPE_UINT8=1,
+{
+    /// Unsigned 8-bit integer.
+    GSD_TYPE_UINT8 = 1,
+
+    /// Unsigned 16-bit integer.
     GSD_TYPE_UINT16,
+
+    /// Unsigned 32-bit integer.
     GSD_TYPE_UINT32,
+
+    /// Unsigned 53-bit integer.
     GSD_TYPE_UINT64,
+
+    /// Signed 8-bit integer.
     GSD_TYPE_INT8,
+
+    /// Signed 16-bit integer.
     GSD_TYPE_INT16,
+
+    /// Signed 32-bit integer.
     GSD_TYPE_INT32,
+
+    /// Signed 64-bit integer.
     GSD_TYPE_INT64,
+
+    /// 32-bit floating point number.
     GSD_TYPE_FLOAT,
+
+    /// 64-bit floating point number.
     GSD_TYPE_DOUBLE
-    };
+};
 
-//! Flag for GSD file open options
+/// Flag for GSD file open options
 enum gsd_open_flag
-    {
-    GSD_OPEN_READWRITE=1,
+{
+    /// Open for both reading and writing
+    GSD_OPEN_READWRITE = 1,
+
+    /// Open only for reading
     GSD_OPEN_READONLY,
+
+    /// Open only for writing
     GSD_OPEN_APPEND
-    };
+};
 
-//! GSD file header
-/*! The GSD file header.
+/// Error return values
+enum gsd_error
+{
+    /// Success.
+    GSD_SUCCESS = 0,
 
-    \warning All members are **read-only** to the caller.
+    /// IO error. Check ``errno`` for details
+    GSD_ERROR_IO = -1,
+
+    /// Invalid argument passed to function.
+    GSD_ERROR_INVALID_ARGUMENT = -2,
+
+    /// The file is not a GSD file.
+    GSD_ERROR_NOT_A_GSD_FILE = -3,
+
+    /// The GSD file version cannot be read.
+    GSD_ERROR_INVALID_GSD_FILE_VERSION = -4,
+
+    /// The GSD file is corrupt.
+    GSD_ERROR_FILE_CORRUPT = -5,
+
+    /// GSD failed to allocated memory.
+    GSD_ERROR_MEMORY_ALLOCATION_FAILED = -6,
+
+    /// The GSD file cannot store any additional unique data chunk names.
+    GSD_ERROR_NAMELIST_FULL = -7,
+
+    /** This API call requires that the GSD file opened in with the mode GSD_OPEN_APPEND or
+        GSD_OPEN_READWRITE.
+    */
+    GSD_ERROR_FILE_MUST_BE_WRITABLE = -8,
+
+    /** This API call requires that the GSD file opened the mode GSD_OPEN_READ or
+        GSD_OPEN_READWRITE.
+    */
+    GSD_ERROR_FILE_MUST_BE_READABLE = -9,
+};
+
+enum
+{
+    /** v1 file: Size of a GSD name in memory. v2 file: The name buffer size is a multiple of
+        GSD_NAME_SIZE.
+    */
+    GSD_NAME_SIZE = 64
+};
+
+enum
+{
+    /// Reserved bytes in the header structure
+    GSD_RESERVED_BYTES = 80
+};
+
+/** GSD file header
+
+    The in-memory and on-disk storage of the GSD file header. Stored in the first 256 bytes of the
+    file.
+
+    @warning All members are **read-only** to the caller.
 */
 struct gsd_header
-    {
+{
+    /// Magic number marking that this is a GSD file.
     uint64_t magic;
+
+    /// Location of the chunk index in the file.
     uint64_t index_location;
+
+    /// Number of index entries that will fit in the space allocated.
     uint64_t index_allocated_entries;
+
+    /// Location of the name list in the file.
     uint64_t namelist_location;
+
+    /// Number of bytes in the namelist divided by GSD_NAME_SIZE.
     uint64_t namelist_allocated_entries;
-    uint32_t schema_version;            //!< Schema version: 0xaaaabbbb => aaaa.bbbb
-    uint32_t gsd_version;               //!< File format version: 0xaaaabbbb => aaaa.bbbb
-    char application[64];               //!< Name of generating application
-    char schema[64];                    //!< Name of data schema
-    char reserved[80];
-    };
 
-//! Index entry
-/*! An index entry for a single chunk of data.
+    /// Schema version: from gsd_make_version().
+    uint32_t schema_version;
 
-    \warning All members are **read-only** to the caller.
+    /// GSD file format version from gsd_make_version().
+    uint32_t gsd_version;
+
+    /// Name of the application that generated this file.
+    char application[GSD_NAME_SIZE];
+
+    /// Name of data schema.
+    char schema[GSD_NAME_SIZE];
+
+    /// Reserved for future use.
+    char reserved[GSD_RESERVED_BYTES];
+};
+
+/** Index entry
+
+    An index entry for a single chunk of data.
+
+    @warning All members are **read-only** to the caller.
 */
 struct gsd_index_entry
-    {
-    uint64_t frame;     //!< Frame index of the chunk
-    uint64_t N;         //!< Number of rows in the chunk
+{
+    /// Frame index of the chunk.
+    uint64_t frame;
+
+    /// Number of rows in the chunk.
+    uint64_t N;
+
+    /// Location of the chunk in the file.
     int64_t location;
-    uint32_t M;         //!< Number of columns in the chunk
+
+    /// Number of columns in the chunk.
+    uint32_t M;
+
+    /// Index of the chunk name in the name list.
     uint16_t id;
-    uint8_t type;       //!< Data type of the chunk
+
+    /// Data type of the chunk: one of gsd_type.
+    uint8_t type;
+
+    /// Flags (for internal use).
     uint8_t flags;
-    };
+};
 
-//! Namelist entry
-/*! An entry in the list of data chunk names
+/** Name/id mapping
 
-    \warning All members are **read-only** to the caller.
+    A string name paired with an ID. Used for storing sorted name/id mappings in a hash map.
 */
-struct gsd_namelist_entry
-    {
-    char name[64];      //!< Entry name
-    };
+struct gsd_name_id_pair
+{
+    /// Pointer to name (actual name storage is allocated in gsd_handle)
+    char* name;
 
-//! File handle
-/*! A handle to an open GSD file.
+    /// Next name/id pair with the same hash
+    struct gsd_name_id_pair* next;
 
-    This handle is obtained when opening a GSD file and is passed into every method that operates on the file.
+    /// Entry id
+    uint16_t id;
+};
 
-    \warning All members are **read-only** to the caller.
+/** Name/id hash map
+
+    A hash map of string names to integer identifiers.
+*/
+struct gsd_name_id_map
+{
+    /// Name/id mappings
+    struct gsd_name_id_pair* v;
+
+    /// Number of entries in the mapping
+    size_t size;
+};
+
+/** Array of index entries
+
+    May point to a mapped location of index entries in the file or an in-memory buffer.
+*/
+struct gsd_index_buffer
+{
+    /// Indices in the buffer
+    struct gsd_index_entry* data;
+
+    /// Number of entries in the buffer
+    size_t size;
+
+    /// Number of entries available in the buffer
+    size_t reserved;
+
+    /// Pointer to mapped data (NULL if not mapped)
+    void* mapped_data;
+
+    /// Number of bytes mapped
+    size_t mapped_len;
+};
+
+/** Byte buffer
+
+    Used to buffer of small data chunks held for a buffered write at the end of a frame. Also
+    used to hold the names.
+*/
+struct gsd_byte_buffer
+{
+    /// Data
+    char* data;
+
+    /// Number of bytes in the buffer
+    size_t size;
+
+    /// Number of bytes available in the buffer
+    size_t reserved;
+};
+
+/** Name buffer
+
+    Holds a list of string names in order separated by NULL terminators. In v1 files, each name is
+    64 bytes. In v2 files, only one NULL terminator is placed between each name.
+*/
+struct gsd_name_buffer
+{
+    /// Data
+    struct gsd_byte_buffer data;
+
+    /// Number of names in the list
+    size_t n_names;
+};
+
+/** File handle
+
+    A handle to an open GSD file.
+
+    This handle is obtained when opening a GSD file and is passed into every method that operates
+    on the file.
+
+    @warning All members are **read-only** to the caller.
 */
 struct gsd_handle
-    {
+{
+    /// File descriptor
     int fd;
-    struct gsd_header header;           //!< GSD file header
-    void *mapped_data;
-    size_t append_index_size;
-    struct gsd_index_entry *index;
-    struct gsd_namelist_entry *namelist;
-    uint64_t namelist_num_entries;
-    uint64_t index_written_entries;
-    uint64_t index_num_entries;
-    uint64_t cur_frame;
-    int64_t file_size;                  //!< File size (in bytes)
-    enum gsd_open_flag open_flags;      //!< Flags passed to gsd_open()
-    bool needs_sync; //!< Whether the handle requires an fsync call (new data was written)
-    };
 
-//! Specify a version
+    /// The file header
+    struct gsd_header header;
+
+    /// Mapped data chunk index
+    struct gsd_index_buffer file_index;
+
+    /// Index entries to append to the current frame
+    struct gsd_index_buffer frame_index;
+
+    /// Buffered index entries to append to the current frame
+    struct gsd_index_buffer buffer_index;
+
+    /// Buffered write data
+    struct gsd_byte_buffer write_buffer;
+
+    /// List of names stored in the file
+    struct gsd_name_buffer file_names;
+
+    /// List of names added in the current frame
+    struct gsd_name_buffer frame_names;
+
+    /// The index of the last frame in the file
+    uint64_t cur_frame;
+
+    /// Size of the file (in bytes)
+    int64_t file_size;
+
+    /// Flags passed to gsd_open() when opening this handle
+    enum gsd_open_flag open_flags;
+
+    /// Access the names in the namelist
+    struct gsd_name_id_map name_map;
+};
+
+/** Specify a version
+
+    @param major major version
+    @param minor minor version
+
+    @return a packed version number aaaa.bbbb suitable for storing in a gsd file version entry.
+*/
 uint32_t gsd_make_version(unsigned int major, unsigned int minor);
 
-//! Create a GSD file
-int gsd_create(const char *fname, const char *application, const char *schema, uint32_t schema_version);
+/** Create a GSD file
 
-//! Create and open a GSD file
+    @param fname File name.
+    @param application Generating application name (truncated to 63 chars).
+    @param schema Schema name for data to be written in this GSD file (truncated to 63 chars).
+    @param schema_version Version of the scheme data to be written (make with gsd_make_version()).
+
+    @post Create an empty gsd file in a file of the given name. Overwrite any existing file at that
+    location.
+
+    The generated gsd file is not opened. Call gsd_open() to open it for writing.
+
+    @return
+      - GSD_SUCCESS (0) on success. Negative value on failure:
+      - GSD_ERROR_IO: IO error (check errno).
+*/
+int gsd_create(const char* fname,
+               const char* application,
+               const char* schema,
+               uint32_t schema_version);
+
+/** Create and open a GSD file
+
+    @param handle Handle to open.
+    @param fname File name.
+    @param application Generating application name (truncated to 63 chars).
+    @param schema Schema name for data to be written in this GSD file (truncated to 63 chars).
+    @param schema_version Version of the scheme data to be written (make with gsd_make_version()).
+    @param flags Either GSD_OPEN_READWRITE, or GSD_OPEN_APPEND.
+    @param exclusive_create Set to non-zero to force exclusive creation of the file.
+
+    @post Create an empty gsd file with the given name. Overwrite any existing file at that
+    location.
+
+    Open the generated gsd file in *handle*.
+
+    The file descriptor is closed if there when an error opening the file.
+
+    @return
+      - GSD_SUCCESS (0) on success. Negative value on failure:
+      - GSD_ERROR_IO: IO error (check errno).
+      - GSD_ERROR_NOT_A_GSD_FILE: Not a GSD file.
+      - GSD_ERROR_INVALID_GSD_FILE_VERSION: Invalid GSD file version.
+      - GSD_ERROR_FILE_CORRUPT: Corrupt file.
+      - GSD_ERROR_MEMORY_ALLOCATION_FAILED: Unable to allocate memory.
+*/
 int gsd_create_and_open(struct gsd_handle* handle,
-                        const char *fname,
-                        const char *application,
-                        const char *schema,
+                        const char* fname,
+                        const char* application,
+                        const char* schema,
                         uint32_t schema_version,
-                        const enum gsd_open_flag flags,
+                        enum gsd_open_flag flags,
                         int exclusive_create);
 
-//! Open a GSD file
-int gsd_open(struct gsd_handle* handle, const char *fname, const enum gsd_open_flag flags);
+/** Open a GSD file
 
-//! Truncate a GSD file
+    @param handle Handle to open.
+    @param fname File name to open.
+    @param flags Either GSD_OPEN_READWRITE, GSD_OPEN_READONLY, or GSD_OPEN_APPEND.
+
+    @pre The file name *fname* is a GSD file.
+
+    @post Open a GSD file and populates the handle for use by API calls.
+
+    The file descriptor is closed if there is an error opening the file.
+
+    @return
+      - GSD_SUCCESS (0) on success. Negative value on failure:
+      - GSD_ERROR_IO: IO error (check errno).
+      - GSD_ERROR_NOT_A_GSD_FILE: Not a GSD file.
+      - GSD_ERROR_INVALID_GSD_FILE_VERSION: Invalid GSD file version.
+      - GSD_ERROR_FILE_CORRUPT: Corrupt file.
+      - GSD_ERROR_MEMORY_ALLOCATION_FAILED: Unable to allocate memory.
+*/
+int gsd_open(struct gsd_handle* handle, const char* fname, enum gsd_open_flag flags);
+
+/** Truncate a GSD file
+
+    @param handle Open GSD file to truncate.
+
+    After truncating, a file will have no frames and no data chunks. The file size will be that of a
+    newly created gsd file. The application, schema, and schema version metadata will be kept.
+    Truncate does not close and reopen the file, so it is suitable for writing restart files on
+    Lustre file systems without any metadata access.
+
+    @return
+      - GSD_SUCCESS (0) on success. Negative value on failure:
+      - GSD_ERROR_IO: IO error (check errno).
+      - GSD_ERROR_NOT_A_GSD_FILE: Not a GSD file.
+      - GSD_ERROR_INVALID_GSD_FILE_VERSION: Invalid GSD file version.
+      - GSD_ERROR_FILE_CORRUPT: Corrupt file.
+      - GSD_ERROR_MEMORY_ALLOCATION_FAILED: Unable to allocate memory.
+*/
 int gsd_truncate(struct gsd_handle* handle);
 
-//! Close a GSD file
+/** Close a GSD file
+
+    @param handle GSD file to close.
+
+    @pre *handle* was opened by gsd_open().
+    @pre gsd_end_frame() has been called since the last call to gsd_write_chunk().
+
+    @post The file is closed.
+    @post *handle* is freed and can no longer be used.
+
+    @warning Ensure that all gsd_write_chunk() calls are committed with gsd_end_frame() before
+    closing the file.
+
+    @return
+      - GSD_SUCCESS (0) on success. Negative value on failure:
+      - GSD_ERROR_IO: IO error (check errno).
+      - GSD_ERROR_INVALID_ARGUMENT: *handle* is NULL.
+*/
 int gsd_close(struct gsd_handle* handle);
 
-//! Move on to the next frame
+/** Commit the current frame and increment the frame counter.
+
+    @param handle Handle to an open GSD file
+
+    @pre *handle* was opened by gsd_open().
+    @pre gsd_write_chunk() has been called at least once since the last call to gsd_end_frame().
+
+    @post The current frame counter is increased by 1 and cached indexes are written to disk.
+
+    @return
+      - GSD_SUCCESS (0) on success. Negative value on failure:
+      - GSD_ERROR_IO: IO error (check errno).
+      - GSD_ERROR_INVALID_ARGUMENT: *handle* is NULL.
+      - GSD_ERROR_FILE_MUST_BE_WRITABLE: The file was opened read-only.
+      - GSD_ERROR_MEMORY_ALLOCATION_FAILED: Unable to allocate memory.
+*/
 int gsd_end_frame(struct gsd_handle* handle);
 
-//! Write a data chunk to the current frame
+/** Write a data chunk to the current frame
+
+    @param handle Handle to an open GSD file.
+    @param name Name of the data chunk.
+    @param type type ID that identifies the type of data in *data*.
+    @param N Number of rows in the data.
+    @param M Number of columns in the data.
+    @param flags set to 0, non-zero values reserved for future use.
+    @param data Data buffer.
+
+    @pre *handle* was opened by gsd_open().
+    @pre *name* is a unique name for data chunks in the given frame.
+    @pre data is allocated and contains at least `N * M * gsd_sizeof_type(type)` bytes.
+
+    @post The given data chunk is written to the end of the file and its location is updated in the
+    in-memory index.
+
+    @note If the GSD file is version 1.0, the chunk name is truncated to 63 bytes. GSD version
+    2.0 files support arbitrarily long names.
+
+    @return
+      - GSD_SUCCESS (0) on success. Negative value on failure:
+      - GSD_ERROR_IO: IO error (check errno).
+      - GSD_ERROR_INVALID_ARGUMENT: *handle* is NULL, *N* == 0, *M* == 0, *type* is invalid, or
+        *flags* != 0.
+      - GSD_ERROR_FILE_MUST_BE_WRITABLE: The file was opened read-only.
+      - GSD_ERROR_NAMELIST_FULL: The file cannot store any additional unique chunk names.
+      - GSD_ERROR_MEMORY_ALLOCATION_FAILED: failed to allocate memory.
+*/
 int gsd_write_chunk(struct gsd_handle* handle,
-                    const char *name,
+                    const char* name,
                     enum gsd_type type,
                     uint64_t N,
                     uint32_t M,
                     uint8_t flags,
-                    const void *data);
+                    const void* data);
 
-//! Find a chunk in the GSD file
-const struct gsd_index_entry* gsd_find_chunk(struct gsd_handle* handle, uint64_t frame, const char *name);
+/** Find a chunk in the GSD file
 
-//! Read a chunk from the GSD file
+    @param handle Handle to an open GSD file
+    @param frame Frame to look for chunk
+    @param name Name of the chunk to find
+
+    @pre *handle* was opened by gsd_open() in read or readwrite mode.
+
+    The found entry contains size and type metadata and can be passed to gsd_read_chunk() to read
+    the data.
+
+    @return A pointer to the found chunk, or NULL if not found.
+*/
+const struct gsd_index_entry*
+gsd_find_chunk(struct gsd_handle* handle, uint64_t frame, const char* name);
+
+/** Read a chunk from the GSD file
+
+    @param handle Handle to an open GSD file.
+    @param data Data buffer to read into.
+    @param chunk Chunk to read.
+
+    @pre *handle* was opened in read or readwrite mode.
+    @pre *chunk* was found by gsd_find_chunk().
+    @pre *data* points to an allocated buffer with at least `N * M * gsd_sizeof_type(type)` bytes.
+
+    @return
+      - GSD_SUCCESS (0) on success. Negative value on failure:
+      - GSD_ERROR_IO: IO error (check errno).
+      - GSD_ERROR_INVALID_ARGUMENT: *handle* is NULL, *data* is NULL, or *chunk* is NULL.
+      - GSD_ERROR_FILE_MUST_BE_READABLE: The file was opened in append mode.
+      - GSD_ERROR_FILE_CORRUPT: The GSD file is corrupt.
+*/
 int gsd_read_chunk(struct gsd_handle* handle, void* data, const struct gsd_index_entry* chunk);
 
-//! Get the number of frames in the GSD file
+/** Get the number of frames in the GSD file
+
+    @param handle Handle to an open GSD file
+
+    @pre *handle* was opened by gsd_open().
+
+    @return The number of frames in the file, or 0 on error.
+*/
 uint64_t gsd_get_nframes(struct gsd_handle* handle);
 
-//! Query size of a GSD type ID
+/** Query size of a GSD type ID.
+
+    @param type Type ID to query.
+
+    @return Size of the given type in bytes, or 0 for an unknown type ID.
+*/
 size_t gsd_sizeof_type(enum gsd_type type);
 
-//! Search for chunk names in a gsd file
-const char *gsd_find_matching_chunk_name(struct gsd_handle* handle, const char* match, const char *prev);
+/** Search for chunk names in a gsd file.
+
+    @param handle Handle to an open GSD file.
+    @param match String to match.
+    @param prev Search starting point.
+
+    @pre *handle* was opened by gsd_open()
+    @pre *prev* was returned by a previous call to gsd_find_matching_chunk_name()
+
+    To find the first matching chunk name, pass NULL for prev. Pass in the previous found string to
+    find the next after that, and so on. Chunk names match if they begin with the string in *match*.
+    Chunk names returned by this function may be present in at least one frame.
+
+    @return Pointer to a string, NULL if no more matching chunks are found found, or NULL if *prev*
+    is invalid
+*/
+const char*
+gsd_find_matching_chunk_name(struct gsd_handle* handle, const char* match, const char* prev);
+
+/** Upgrade a GSD file to the latest specification.
+
+    @param handle Handle to an open GSD file
+
+    @pre *handle* was opened by gsd_open() with a writable mode.
+    @pre There are no pending data to write to the file in gsd_end_frame()
+
+    @return
+      - GSD_SUCCESS (0) on success. Negative value on failure:
+      - GSD_ERROR_IO: IO error (check errno).
+      - GSD_ERROR_INVALID_ARGUMENT: *handle* is NULL
+      - GSD_ERROR_FILE_MUST_BE_WRITABLE: The file was opened in read-only mode.
+*/
+int gsd_upgrade(struct gsd_handle* handle);
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif  // #ifndef __GSD_H__
+#endif // #ifndef GSD_H


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should based on *maint*. -->
<!-- New features should based on *master*. -->

## Description

<!-- Describe your changes in detail. -->
Update the embedded GSD code to v2.0.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
GSD 2.0 introduces arbitrary long chunk names and better performance when reading and writing many chunks in a GSD file. This enables support of GSD as a logging backend for many small loggable quantities coming in HOOMD v3.0.

I am releasing GSD 2.0 now so that users will be able to effectively beta test HOOMD 3.0 prior to the release.

<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves: #578

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
GSD 2.0 is extensively tested in its own package. HOOMD includes some minimal GSD unit tests.

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
* Read and write GSD 2.0 files. 
  * HOOMD >=2.9 can read and write GSD files created by HOOMD <= 2.8 or GSD 1.x. But HOOMD 2.8 cannot read GSD files created by HOOMD >=2.9 or GSD >= 2.0.
  * OVITO >=3.0.0-dev652 reads GSD 2.0 files.
  * A future release of the ``gsd-vmd`` plugin will read GSD 2.0 files.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/hoomd-blue/blob/master/sphinx-doc/credits.rst).
