### PR TITLE
Union shape spec

### DIFF
--- a/hoomd/hpmc/IntegratorHPMCMono.h
+++ b/hoomd/hpmc/IntegratorHPMCMono.h
@@ -413,7 +413,7 @@ class IntegratorHPMCMono : public IntegratorHPMC
             for (unsigned int i = 0; i < type_shape_mapping.size(); i++)
                 {
                 Shape shape(q, params[i]);
-                type_shape_mapping[i] = shape.getShapeSpec();
+                type_shape_mapping[i] = getShapeSpec(shape);
                 }
             return type_shape_mapping;
             }

--- a/hoomd/hpmc/ShapeConvexPolygon.h
+++ b/hoomd/hpmc/ShapeConvexPolygon.h
@@ -77,7 +77,7 @@ struct PolygonVertices : ShapeParams
         }
 
     #ifdef ENABLE_HIP
-    //! Set CUDA memory hint
+    /// Set CUDA memory hint
     void set_memory_hint() const
         {
         }
@@ -370,7 +370,7 @@ struct ShapeConvexPolygon
         return OverlapReal(0.0);
         }
 
-    //! Return the bounding box of the shape in world coordinates
+    /// Return the bounding box of the shape in world coordinates
     DEVICE detail::AABB getAABB(const vec3<Scalar>& pos) const
         {
         // generate a tight AABB

--- a/hoomd/hpmc/ShapeConvexPolygon.h
+++ b/hoomd/hpmc/ShapeConvexPolygon.h
@@ -370,22 +370,7 @@ struct ShapeConvexPolygon
         return OverlapReal(0.0);
         }
 
-    #ifndef __HIPCC__
-    /// Return the shape parameters in the `type_shape` format
-    std::string getShapeSpec() const
-        {
-        std::ostringstream shapedef;
-        shapedef << "{\"type\": \"Polygon\", \"rounding_radius\": " << verts.sweep_radius << ", \"vertices\": [";
-        for (unsigned int i = 0; i < verts.N-1; i++)
-            {
-            shapedef << "[" << verts.x[i] << ", " << verts.y[i] << "], ";
-            }
-        shapedef << "[" << verts.x[verts.N-1] << ", " << verts.y[verts.N-1] << "]]}";
-        return shapedef.str();
-        }
-    #endif
-
-    /// Return the bounding box of the shape in world coordinates
+    //! Return the bounding box of the shape in world coordinates
     DEVICE detail::AABB getAABB(const vec3<Scalar>& pos) const
         {
         // generate a tight AABB
@@ -609,6 +594,21 @@ DEVICE inline bool test_overlap<ShapeConvexPolygon,ShapeConvexPolygon>(const vec
                                                   quat<OverlapReal>(b.orientation));
     #endif
     }
+
+#ifndef __HIPCC__
+template<>
+inline std::string getShapeSpec(const ShapeConvexPolygon& poly)
+    {
+    std::ostringstream shapedef;
+    shapedef << "{\"type\": \"Polygon\", \"rounding_radius\": " << poly.verts.sweep_radius << ", \"vertices\": [";
+    for (unsigned int i = 0; i < poly.verts.N-1; i++)
+        {
+        shapedef << "[" << poly.verts.x[i] << ", " << poly.verts.y[i] << "], ";
+        }
+    shapedef << "[" << poly.verts.x[poly.verts.N-1] << ", " << poly.verts.y[poly.verts.N-1] << "]]}";
+    return shapedef.str();
+    }
+#endif
 
 }; // end namespace hpmc
 

--- a/hoomd/hpmc/ShapeConvexPolyhedron.h
+++ b/hoomd/hpmc/ShapeConvexPolyhedron.h
@@ -726,7 +726,7 @@ struct ShapeConvexPolyhedron
         return OverlapReal(0.0);
         }
 
-    //! Return the bounding box of the shape in world coordinates
+    /// Return the bounding box of the shape in world coordinates
     DEVICE detail::AABB getAABB(const vec3<Scalar>& pos) const
         {
         // generate a tight AABB around the polyhedron

--- a/hoomd/hpmc/ShapeConvexPolyhedron.h
+++ b/hoomd/hpmc/ShapeConvexPolyhedron.h
@@ -726,22 +726,7 @@ struct ShapeConvexPolyhedron
         return OverlapReal(0.0);
         }
 
-    #ifndef __HIPCC__
-    /// Return the shape parameters in the `type_shape` format
-    std::string getShapeSpec() const
-        {
-        std::ostringstream shapedef;
-        shapedef << "{\"type\": \"ConvexPolyhedron\", \"rounding_radius\": " << verts.sweep_radius << ", \"vertices\": [";
-        for (unsigned int i = 0; i < verts.N-1; i++)
-            {
-            shapedef << "[" << verts.x[i] << ", " << verts.y[i] << ", " << verts.z[i] << "], ";
-            }
-        shapedef << "[" << verts.x[verts.N-1] << ", " << verts.y[verts.N-1] << ", " << verts.z[verts.N-1] << "]]}";
-        return shapedef.str();
-        }
-    #endif
-
-    /// Return the bounding box of the shape in world coordinates
+    //! Return the bounding box of the shape in world coordinates
     DEVICE detail::AABB getAABB(const vec3<Scalar>& pos) const
         {
         // generate a tight AABB around the polyhedron
@@ -862,6 +847,22 @@ DEVICE inline bool test_overlap_intersection(const ShapeConvexPolyhedron& a,
         vec3<OverlapReal>(ac_t),
         err);
     }
+
+#ifndef __HIPCC__
+template<>
+inline std::string getShapeSpec(const ShapeConvexPolyhedron& poly)
+    {
+    std::ostringstream shapedef;
+    auto& verts = poly.verts;
+    shapedef << "{\"type\": \"ConvexPolyhedron\", \"rounding_radius\": " << verts.sweep_radius << ", \"vertices\": [";
+    for (unsigned int i = 0; i < verts.N-1; i++)
+        {
+        shapedef << "[" << verts.x[i] << ", " << verts.y[i] << ", " << verts.z[i] << "], ";
+        }
+    shapedef << "[" << verts.x[verts.N-1] << ", " << verts.y[verts.N-1] << ", " << verts.z[verts.N-1] << "]]}";
+    return shapedef.str();
+    }
+#endif
 
 }; // end namespace hpmc
 

--- a/hoomd/hpmc/ShapeEllipsoid.h
+++ b/hoomd/hpmc/ShapeEllipsoid.h
@@ -119,21 +119,8 @@ struct ShapeEllipsoid
         return OverlapReal(0.0);
         }
 
-    #ifndef __HIPCC__
-    /// Return the shape parameters in the `type_shape` format
-    std::string getShapeSpec() const
-        {
-        std::ostringstream shapedef;
-        shapedef << "{\"type\": \"Ellipsoid\", \"a\": " << axes.x <<
-                    ", \"b\": " << axes.y <<
-                    ", \"c\": " << axes.z <<
-                    "}";
-        return shapedef.str();
-        }
-    #endif
-
-    /** Support function of the shape (in local coordinates), used in getAABB
-        @param n Vector to query support function (must be normalized)
+    //! Support function of the shape (in local coordinates), used in getAABB
+    /*! \param n Vector to query support function (must be normalized)
     */
     DEVICE vec3<Scalar> sfunc(vec3<Scalar> n) const
         {
@@ -474,6 +461,19 @@ DEVICE inline bool test_overlap<ShapeEllipsoid,ShapeEllipsoid>(const vec3<Scalar
 
     return ret_val == ELLIPSOID_OVERLAP_TRUE;
     }
+
+#ifndef __HIPCC__
+template<>
+inline std::string getShapeSpec(const ShapeEllipsoid& ellipsoid)
+    {
+    std::ostringstream shapedef;
+    shapedef << "{\"type\": \"Ellipsoid\", \"a\": " << ellipsoid.axes.x <<
+                ", \"b\": " << ellipsoid.axes.y <<
+                ", \"c\": " << ellipsoid.axes.z <<
+                "}";
+    return shapedef.str();
+    }
+#endif
 
 }; // end namespace hpmc
 

--- a/hoomd/hpmc/ShapeEllipsoid.h
+++ b/hoomd/hpmc/ShapeEllipsoid.h
@@ -119,8 +119,8 @@ struct ShapeEllipsoid
         return OverlapReal(0.0);
         }
 
-    //! Support function of the shape (in local coordinates), used in getAABB
-    /*! \param n Vector to query support function (must be normalized)
+    /** Support function of the shape (in local coordinates), used in getAABB
+        @param n Vector to query support function (must be normalized)
     */
     DEVICE vec3<Scalar> sfunc(vec3<Scalar> n) const
         {

--- a/hoomd/hpmc/ShapeFacetedEllipsoid.h
+++ b/hoomd/hpmc/ShapeFacetedEllipsoid.h
@@ -513,15 +513,7 @@ struct ShapeFacetedEllipsoid
         return 0.0;
         }
 
-    #ifndef __HIPCC__
-    /// Return the shape parameters in the `type_shape` format
-    std::string getShapeSpec() const
-        {
-        throw std::runtime_error("Shape definition not supported for this shape class.");
-        }
-    #endif
-
-    /// Return the bounding box of the shape in world coordinates
+    //! Return the bounding box of the shape in world coordinates
     DEVICE detail::AABB getAABB(const vec3<Scalar>& pos) const
         {
         // use support function of the ellipsoid to determine the furthest extent in each direction

--- a/hoomd/hpmc/ShapeFacetedEllipsoid.h
+++ b/hoomd/hpmc/ShapeFacetedEllipsoid.h
@@ -513,7 +513,7 @@ struct ShapeFacetedEllipsoid
         return 0.0;
         }
 
-    //! Return the bounding box of the shape in world coordinates
+    /// Return the bounding box of the shape in world coordinates
     DEVICE detail::AABB getAABB(const vec3<Scalar>& pos) const
         {
         // use support function of the ellipsoid to determine the furthest extent in each direction

--- a/hoomd/hpmc/ShapeSimplePolygon.h
+++ b/hoomd/hpmc/ShapeSimplePolygon.h
@@ -320,6 +320,22 @@ DEVICE inline bool test_overlap<ShapeSimplePolygon,ShapeSimplePolygon>(const vec
                                                quat<OverlapReal>(b.orientation));
     }
 
+#ifndef __HIPCC__
+template<>
+inline std::string getShapeSpec(const ShapeSimplePolygon& poly)
+    {
+    std::ostringstream shapedef;
+    auto& verts = poly.verts;
+    shapedef << "{\"type\": \"Polygon\", \"rounding_radius\": " << poly.verts.sweep_radius << ", \"vertices\": [";
+    for (unsigned int i = 0; i < verts.N-1; i++)
+        {
+        shapedef << "[" << verts.x[i] << ", " << verts.y[i] << "], ";
+        }
+    shapedef << "[" << verts.x[verts.N-1] << ", " << verts.y[verts.N-1] << "]]}";
+    return shapedef.str();
+    }
+#endif
+
 }; // end namespace hpmc
 
 #undef DEVICE

--- a/hoomd/hpmc/ShapeSphere.h
+++ b/hoomd/hpmc/ShapeSphere.h
@@ -211,19 +211,7 @@ struct ShapeSphere
         return detail::OBB(getAABB(pos));
         }
 
-    #ifndef __HIPCC__
-    /// Return the shape parameters in the `type_shape` format
-    std::string getShapeSpec() const
-        {
-        std::ostringstream shapedef;
-        shapedef << "{\"type\": \"Sphere\", \"diameter\": " << params.radius*OverlapReal(2.0) << "}";
-        return shapedef.str();
-        }
-    #endif
-
-    /** Returns true if this shape splits the overlap check over several threads of a warp using
-        threadIdx.x
-    */
+    //! Returns true if this shape splits the overlap check over several threads of a warp using threadIdx.x
     HOSTDEVICE static bool isParallel() { return false; }
 
     /// Returns true if the overlap check supports sweeping both shapes by a sphere of given radius
@@ -522,6 +510,24 @@ DEVICE inline bool test_overlap_intersection(const ShapeSphere& a, const ShapeSp
 
     return detail::check_three_spheres_overlap(Ra,Rb,Rc,ab_t,ac_t);
     }
+
+#ifndef __HIPCC__
+template<class Shape>
+std::string getShapeSpec(const Shape& shape)
+    {
+    // default implementation
+    throw std::runtime_error("Shape definition not supported for this shape class.");
+    }
+
+template<>
+inline std::string getShapeSpec(const ShapeSphere& sphere)
+    {
+    std::ostringstream shapedef;
+    shapedef << "{\"type\": \"Sphere\", \"diameter\": " << sphere.params.radius*OverlapReal(2.0) << "}";
+    return shapedef.str();
+    }
+#endif
+
 
 }; // end namespace hpmc
 

--- a/hoomd/hpmc/ShapeSphere.h
+++ b/hoomd/hpmc/ShapeSphere.h
@@ -211,7 +211,7 @@ struct ShapeSphere
         return detail::OBB(getAABB(pos));
         }
 
-    //! Returns true if this shape splits the overlap check over several threads of a warp using threadIdx.x
+    /// Returns true if this shape splits the overlap check over several threads of a warp using threadIdx.x
     HOSTDEVICE static bool isParallel() { return false; }
 
     /// Returns true if the overlap check supports sweeping both shapes by a sphere of given radius

--- a/hoomd/hpmc/ShapeSpheropolygon.h
+++ b/hoomd/hpmc/ShapeSpheropolygon.h
@@ -123,32 +123,6 @@ struct ShapeSpheropolygon
         return OverlapReal(0.0);
         }
 
-    #ifndef __HIPCC__
-    std::string getShapeSpec() const
-        {
-        std::ostringstream shapedef;
-        unsigned int nverts = verts.N;
-        if (nverts == 1)
-            {
-            shapedef << "{\"type\": \"Sphere\", " << "\"diameter\": " << verts.diameter << "}";
-            }
-        else if (nverts == 2)
-            {
-            throw std::runtime_error("Shape definition not supported for 2-vertex spheropolygons");
-            }
-        else
-            {
-            shapedef << "{\"type\": \"Polygon\", \"rounding_radius\": " << verts.sweep_radius << ", \"vertices\": [";
-            for (unsigned int i = 0; i < nverts-1; i++)
-                {
-                shapedef << "[" << verts.x[i] << ", " << verts.y[i] << "], ";
-                }
-            shapedef << "[" << verts.x[nverts-1] << ", " << verts.y[nverts-1] << "]]}";
-            }
-        return shapedef.str();
-        }
-    #endif
-
     //! Return the bounding box of the shape in world coordinates
     DEVICE detail::AABB getAABB(const vec3<Scalar>& pos) const
         {
@@ -209,6 +183,34 @@ DEVICE inline bool test_overlap<ShapeSpheropolygon,ShapeSpheropolygon>(const vec
                                   quat<OverlapReal>(b.orientation),
                                   err);
     }
+
+#ifndef __HIPCC__
+template<>
+inline std::string getShapeSpec(const ShapeSpheropolygon& spoly)
+    {
+    std::ostringstream shapedef;
+    auto& verts = spoly.verts;
+    unsigned int nverts = verts.N;
+    if (nverts == 1)
+        {
+        shapedef << "{\"type\": \"Sphere\", " << "\"diameter\": " << verts.diameter << "}";
+        }
+    else if (nverts == 2)
+        {
+        throw std::runtime_error("Shape definition not supported for 2-vertex spheropolygons");
+        }
+    else
+        {
+        shapedef << "{\"type\": \"Polygon\", \"rounding_radius\": " << verts.sweep_radius << ", \"vertices\": [";
+        for (unsigned int i = 0; i < nverts-1; i++)
+            {
+            shapedef << "[" << verts.x[i] << ", " << verts.y[i] << "], ";
+            }
+        shapedef << "[" << verts.x[nverts-1] << ", " << verts.y[nverts-1] << "]]}";
+        }
+    return shapedef.str();
+    }
+#endif
 
 }; // end namespace hpmc
 

--- a/hoomd/hpmc/ShapeSpheropolyhedron.h
+++ b/hoomd/hpmc/ShapeSpheropolyhedron.h
@@ -91,32 +91,6 @@ struct ShapeSpheropolyhedron
         return OverlapReal(0.0);
         }
 
-    #ifndef __HIPCC__
-    std::string getShapeSpec() const
-        {
-        std::ostringstream shapedef;
-        unsigned int nverts = verts.N;
-        if (nverts == 1)
-            {
-            shapedef << "{\"type\": \"Sphere\", " << "\"diameter\": " << verts.diameter << "}";
-            }
-        else if (nverts == 2)
-            {
-            throw std::runtime_error("Shape definition not supported for 2-vertex spheropolyhedra");
-            }
-        else
-            {
-            shapedef << "{\"type\": \"ConvexPolyhedron\", \"rounding_radius\": " << verts.sweep_radius << ", \"vertices\": [";
-            for (unsigned int i = 0; i < nverts-1; i++)
-                {
-                shapedef << "[" << verts.x[i] << ", " << verts.y[i] << ", " << verts.z[i] << "], ";
-                }
-            shapedef << "[" << verts.x[nverts-1] << ", " << verts.y[nverts-1] << ", " << verts.z[nverts-1] << "]]}";
-            }
-        return shapedef.str();
-        }
-    #endif
-
     //! Return the bounding box of the shape in world coordinates
     DEVICE detail::AABB getAABB(const vec3<Scalar>& pos) const
         {
@@ -235,6 +209,34 @@ DEVICE inline bool test_overlap_intersection(const ShapeSpheropolyhedron& a,
         vec3<OverlapReal>(ac_t),
         err);
     }
+
+#ifndef __HIPCC__
+template<>
+inline std::string getShapeSpec(const ShapeSpheropolyhedron& spoly)
+    {
+    std::ostringstream shapedef;
+    auto& verts = spoly.verts;
+    unsigned int nverts = verts.N;
+    if (nverts == 1)
+        {
+        shapedef << "{\"type\": \"Sphere\", " << "\"diameter\": " << verts.diameter << "}";
+        }
+    else if (nverts == 2)
+        {
+        throw std::runtime_error("Shape definition not supported for 2-vertex spheropolyhedra");
+        }
+    else
+        {
+        shapedef << "{\"type\": \"ConvexPolyhedron\", \"rounding_radius\": " << verts.sweep_radius << ", \"vertices\": [";
+        for (unsigned int i = 0; i < nverts-1; i++)
+            {
+            shapedef << "[" << verts.x[i] << ", " << verts.y[i] << ", " << verts.z[i] << "], ";
+            }
+        shapedef << "[" << verts.x[nverts-1] << ", " << verts.y[nverts-1] << ", " << verts.z[nverts-1] << "]]}";
+        }
+    return shapedef.str();
+    }
+#endif
 
 }; // end namespace hpmc
 

--- a/hoomd/hpmc/ShapeSphinx.h
+++ b/hoomd/hpmc/ShapeSphinx.h
@@ -211,7 +211,7 @@ struct ShapeSphinx
         return Scalar(0.0);
         }
 
-    //! Return the bounding box of the shape in world coordinates
+    /// Return the bounding box of the shape in world coordinates
     DEVICE detail::AABB getAABB(const vec3<Scalar>& pos) const
         {
         return detail::AABB(pos, getCircumsphereDiameter()/Scalar(2.0));

--- a/hoomd/hpmc/ShapeSphinx.h
+++ b/hoomd/hpmc/ShapeSphinx.h
@@ -211,15 +211,7 @@ struct ShapeSphinx
         return Scalar(0.0);
         }
 
-    #ifndef __HIPCC__
-    /// Return the shape parameters in the `type_shape` format
-    std::string getShapeSpec() const
-        {
-        throw std::runtime_error("Shape definition not supported for this shape class.");
-        }
-    #endif
-
-    /// Return the bounding box of the shape in world coordinates
+    //! Return the bounding box of the shape in world coordinates
     DEVICE detail::AABB getAABB(const vec3<Scalar>& pos) const
         {
         return detail::AABB(pos, getCircumsphereDiameter()/Scalar(2.0));

--- a/hoomd/hpmc/ShapeUnion.h
+++ b/hoomd/hpmc/ShapeUnion.h
@@ -910,7 +910,7 @@ inline std::string getShapeSpec(const ShapeUnion<ShapeSphere>& sphere_union)
         {
         shapedef << 2.0*members.mparams[i].radius << ", ";
         }
-    shapedef << members.mparams[n_centers-1].radius;
+    shapedef << 2.0*members.mparams[n_centers-1].radius;
     shapedef << "]}";
 
     return shapedef.str();

--- a/hoomd/hpmc/ShapeUnion.h
+++ b/hoomd/hpmc/ShapeUnion.h
@@ -905,10 +905,10 @@ inline std::string getShapeSpec(const ShapeUnion<ShapeSphere>& sphere_union)
         {
         shapedef << "[" << members.mpos[i].x << ", " << members.mpos[i].y << ", " << members.mpos[i].z << "], ";
         }
-    shapedef << "[" << members.mpos[n_centers-1].x << ", " << members.mpos[n_centers-1].y << ", " << members.mpos[n_centers-1].z << "]], \"radii\": [";
+    shapedef << "[" << members.mpos[n_centers-1].x << ", " << members.mpos[n_centers-1].y << ", " << members.mpos[n_centers-1].z << "]], \"diameters\": [";
     for (unsigned int i = 0; i < n_centers-1; i++)
         {
-        shapedef << members.mparams[i].radius << ", ";
+        shapedef << 2.0*members.mparams[i].radius << ", ";
         }
     shapedef << members.mparams[n_centers-1].radius;
     shapedef << "]}";

--- a/hoomd/hpmc/ShapeUnion.h
+++ b/hoomd/hpmc/ShapeUnion.h
@@ -362,7 +362,7 @@ struct ShapeUnion
         return OverlapReal(0.0);
         }
 
-    //! Return the bounding box of the shape in world coordinates
+    /// Return the bounding box of the shape in world coordinates
     DEVICE detail::AABB getAABB(const vec3<Scalar>& pos) const
         {
         // rotate local AABB into world coordinates

--- a/hoomd/hpmc/integrate.py
+++ b/hoomd/hpmc/integrate.py
@@ -1397,6 +1397,21 @@ class SphereUnion(_HPMCIntegrator):
                                         )
         self._add_typeparam(typeparam_shape)
 
+    @Loggable.log(flag='multi')
+    def type_shapes(self):
+        """Get all the types of shapes in the current simulation.
+
+        Examples:
+            The type will be 'SphereUnion' regardless of dimensionality.
+
+            >>> mc.type_shapes
+            [{'type': 'SphereUnion', 'centers': [[0, 0, 0], [0, 0, 1]], 'diameters': [1, 0.5]},
+             {'type': 'SphereUnion', 'centers': [[1, 2, 3], [4, 5, 6]], 'diameters': [0.5, 1]}]
+
+        Returns:
+            A list of dictionaries, one for each particle type in the system.
+        """
+        return super()._return_type_shapes()
 
 class ConvexSpheropolyhedronUnion(_HPMCIntegrator):
     R""" HPMC integration for unions of convex polyhedra (3D).

--- a/hoomd/hpmc/test-py/hpmc_gsd_state.py
+++ b/hoomd/hpmc/test-py/hpmc_gsd_state.py
@@ -371,5 +371,18 @@ class hpmc_gsd_check_restore_state(unittest.TestCase):
         with self.assertRaises(RuntimeError):
             self.mc = hpmc.integrate.convex_polyhedron(seed=2234, d=0.3, a=0.4, restore_state=True);
 
+    def test_sphere_union(self):
+        cube_verts = [[-0.5, -0.5, -0.5], [-0.5, -0.5, 0.5], [-0.5, 0.5, -0.5], [-0.5, 0.5, 0.5],
+                      [0.5, -0.5, -0.5], [0.5, -0.5, 0.5], [0.5, 0.5, -0.5], [0.5, 0.5, 0.5]]
+        cube_diameters = np.array([1.0]*8)
+        tetra_verts = [[0.5, 0.5, 0.5], [0.5, -0.5, -0.5], [-0.5, 0.5, -0.5], [-0.5, -0.5, 0.5]]
+        tetra_diameters = np.array([0.5]*4)
+        shape_params = dict(A=dict(centers=cube_verts, diameters=cube_diameters),
+                            B=dict(centers=tetra_verts, diameters=tetra_diameters))
+        expected_shapespec = [dict(type='SphereUnion', centers=cube_verts, diameters=cube_diameters),
+                              dict(type='SphereUnion', centers=tetra_verts, diameters=tetra_diameters)]
+        self.setup_system(cls=hpmc.integrate.sphere_union, shape_params=shape_params, \
+                          expected_shapespec=expected_shapespec, filename=self.tmp_file, dim=3);
+
 if __name__ == '__main__':
     unittest.main(argv = ['test.py', '-v'])


### PR DESCRIPTION
## Description

This is a rebase of #582 to implement the revised sphere union spec for gsd

https://github.com/glotzerlab/gsd/pull/65
https://github.com/glotzerlab/gsd/pull/66

## Motivation and Context

Visualize sphere unions with ovito.

## How Has This Been Tested?

I implemented a unit test. It doesn't run yet, as other parts of HPMC have not been converted to the new API yet. In particular `import hoomd` fails. In the unit test, I have used the old syntax so that whoever is converting hpmc.integrate.sphere_union() to the new one doesn't forget to port this test.

## Change log

```
Implement GSD shape spec for hpmc.integrate.SphereUnion()
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/hoomd-blue/blob/master/sphinx-doc/credits.rst).
