### PR TITLE
Reinstate streams for HPMC kernels

### DIFF
--- a/hoomd/ManagedArray.h
+++ b/hoomd/ManagedArray.h
@@ -132,11 +132,12 @@ class ManagedArray
 
         #ifdef ENABLE_HIP
         //! Attach managed memory to CUDA stream
-        void set_memory_hint() const
+        void attach_to_stream(hipStream_t stream) const
             {
             if (managed && ptr)
                 {
                 #if defined(__HIP_PLATFORM_NVCC__) && (CUDART_VERSION >= 8000)
+		cudaStreamAttachMemAsync(stream, ptr, 0, cudaMemAttachSingle);
                 cudaMemAdvise(ptr, sizeof(T)*N, cudaMemAdviseSetReadMostly, 0);
                 #endif
                 }

--- a/hoomd/hpmc/ComputeFreeVolumeGPU.cuh
+++ b/hoomd/hpmc/ComputeFreeVolumeGPU.cuh
@@ -63,7 +63,8 @@ struct hpmc_free_volume_args_t
                 const Scalar3 _ghost_width,
                 const unsigned int *_d_check_overlaps,
                 Index2D _overlap_idx,
-                const hipDeviceProp_t& _devprop
+                const hipDeviceProp_t& _devprop,
+		const hipStream_t _stream
                 )
                 : n_sample(_n_sample),
                   type(_type),
@@ -93,7 +94,8 @@ struct hpmc_free_volume_args_t
                   ghost_width(_ghost_width),
                   d_check_overlaps(_d_check_overlaps),
                   overlap_idx(_overlap_idx),
-                  devprop(_devprop)
+                  devprop(_devprop),
+		  stream(_stream)
         {
         };
 
@@ -126,6 +128,7 @@ struct hpmc_free_volume_args_t
     const unsigned int *d_check_overlaps;   //!< Interaction matrix
     Index2D overlap_idx;              //!< Interaction matrix indexer
     const hipDeviceProp_t& devprop;    //!< CUDA device properties
+    hipStream_t stream;	               //!< GPU execution stream
     };
 
 template< class Shape >
@@ -431,7 +434,7 @@ hipError_t gpu_hpmc_free_volume(const hpmc_free_volume_args_t& args, const typen
 
     shared_bytes += extra_bytes;
 
-    hipLaunchKernelGGL(HIP_KERNEL_NAME(gpu_hpmc_free_volume_kernel<Shape>), dim3(grid), dim3(threads), shared_bytes, 0, 
+    hipLaunchKernelGGL(HIP_KERNEL_NAME(gpu_hpmc_free_volume_kernel<Shape>), dim3(grid), dim3(threads), shared_bytes, args.stream, 
                                                      args.n_sample,
                                                      args.type,
                                                      args.d_postype,

--- a/hoomd/hpmc/GPUTree.h
+++ b/hoomd/hpmc/GPUTree.h
@@ -260,21 +260,21 @@ class GPUTree
 
         #ifdef ENABLE_HIP
         //! Set CUDA memory hints
-        void set_memory_hint() const
+        void attach_to_stream(hipStream_t stream) const
             {
-            m_center.set_memory_hint();
-            m_lengths.set_memory_hint();
-            m_rotation.set_memory_hint();
-            m_mask.set_memory_hint();
-            m_is_sphere.set_memory_hint();
+            m_center.attach_to_stream(stream);
+            m_lengths.attach_to_stream(stream);
+            m_rotation.attach_to_stream(stream);
+            m_mask.attach_to_stream(stream);
+            m_is_sphere.attach_to_stream(stream);
 
-            m_left.set_memory_hint();
-            m_escape.set_memory_hint();
-            m_ancestors.set_memory_hint();
+            m_left.attach_to_stream(stream);
+            m_escape.attach_to_stream(stream);
+            m_ancestors.attach_to_stream(stream);
 
-            m_leaf_ptr.set_memory_hint();
-            m_leaf_obb_ptr.set_memory_hint();
-            m_particles.set_memory_hint();
+            m_leaf_ptr.attach_to_stream(stream);
+            m_leaf_obb_ptr.attach_to_stream(stream);
+            m_particles.attach_to_stream(stream);
             }
         #endif
 

--- a/hoomd/hpmc/ShapeConvexPolygon.h
+++ b/hoomd/hpmc/ShapeConvexPolygon.h
@@ -59,7 +59,7 @@ struct poly2d_verts : param_base
 
     #ifdef ENABLE_HIP
     //! Set CUDA memory hint
-    void set_memory_hint() const
+    void attach_to_stream(hipStream_t stream) const
         {
         // default implementation does nothing
         }

--- a/hoomd/hpmc/ShapeConvexPolyhedron.h
+++ b/hoomd/hpmc/ShapeConvexPolyhedron.h
@@ -100,12 +100,12 @@ struct poly3d_verts : param_base
 
     #ifdef ENABLE_HIP
     //! Set CUDA memory hints
-    void set_memory_hint() const
+    void attach_to_stream(hipStream_t stream) const
         {
-        x.set_memory_hint();
-        y.set_memory_hint();
-        z.set_memory_hint();
-        hull_verts.set_memory_hint();
+        x.attach_to_stream(stream);
+        y.attach_to_stream(stream);
+        z.attach_to_stream(stream);
+        hull_verts.attach_to_stream(stream);
         }
     #endif
 

--- a/hoomd/hpmc/ShapeEllipsoid.h
+++ b/hoomd/hpmc/ShapeEllipsoid.h
@@ -58,7 +58,7 @@ struct ell_params : param_base
 
     #ifdef ENABLE_HIP
     //! Set CUDA memory hints
-    void set_memory_hint() const
+    void attach_to_stream(hipStream_t stream) const
         {
         // default implementation does nothing
         }

--- a/hoomd/hpmc/ShapeFacetedEllipsoid.h
+++ b/hoomd/hpmc/ShapeFacetedEllipsoid.h
@@ -100,12 +100,12 @@ struct faceted_ellipsoid_params : param_base
 
     #ifdef ENABLE_HIP
     //! Set CUDA memory hints
-    void set_memory_hint() const
+    void attach_to_stream(hipStream_t stream) const
         {
-        n.set_memory_hint();
-        offset.set_memory_hint();
-        verts.set_memory_hint();
-        additional_verts.set_memory_hint();
+        n.attach_to_stream(stream);
+        offset.attach_to_stream(stream);
+        verts.attach_to_stream(stream);
+        additional_verts.attach_to_stream(stream);
         }
     #endif
     } __attribute__((aligned(32)));

--- a/hoomd/hpmc/ShapePolyhedron.h
+++ b/hoomd/hpmc/ShapePolyhedron.h
@@ -119,14 +119,14 @@ struct poly3d_data : param_base
 
     #ifdef ENABLE_HIP
     //! Set CUDA memory hints
-    void set_memory_hint() const
+    void attach_to_stream(hipStream_t stream) const
         {
-        tree.set_memory_hint();
-        convex_hull_verts.set_memory_hint();
-        verts.set_memory_hint();
-        face_offs.set_memory_hint();
-        face_verts.set_memory_hint();
-        face_overlap.set_memory_hint();
+        tree.attach_to_stream(stream);
+        convex_hull_verts.attach_to_stream(stream);
+        verts.attach_to_stream(stream);
+        face_offs.attach_to_stream(stream);
+        face_verts.attach_to_stream(stream);
+        face_overlap.attach_to_stream(stream);
         }
     #endif
     } __attribute__((aligned(32)));

--- a/hoomd/hpmc/ShapeSphere.h
+++ b/hoomd/hpmc/ShapeSphere.h
@@ -114,7 +114,7 @@ struct sph_params : param_base
 
     #ifdef ENABLE_HIP
     //! Set CUDA memory hints
-    void set_memory_hint() const
+    void attach_to_stream(hipStream_t stream) const
         {
         // default implementation does nothing
         }

--- a/hoomd/hpmc/ShapeSphinx.h
+++ b/hoomd/hpmc/ShapeSphinx.h
@@ -48,7 +48,7 @@ struct sphinx3d_params : param_base
 
     #ifdef ENABLE_HIP
     //! Set CUDA memory hints
-    void set_memory_hint() const
+    void attach_to_stream(hipStream_t stream) const
         {
         // default implementation does nothing
         }

--- a/hoomd/hpmc/ShapeUnion.h
+++ b/hoomd/hpmc/ShapeUnion.h
@@ -100,18 +100,18 @@ struct union_params : param_base
 
     #ifdef ENABLE_HIP
     //! Set CUDA memory hints
-    void set_memory_hint() const
+    void attach_to_stream(hipStream_t stream) const
         {
-        tree.set_memory_hint();
+        tree.attach_to_stream(stream);
 
-        mpos.set_memory_hint();
-        morientation.set_memory_hint();
-        mparams.set_memory_hint();
-        moverlap.set_memory_hint();
+        mpos.attach_to_stream(stream);
+        morientation.attach_to_stream(stream);
+        mparams.attach_to_stream(stream);
+        moverlap.attach_to_stream(stream);
 
         // attach member parameters
         for (unsigned int i = 0; i < mparams.size(); ++i)
-            mparams[i].set_memory_hint();
+            mparams[i].attach_to_stream(stream);
         }
     #endif
 


### PR DESCRIPTION
## Description

Implements streams for HPMC kernels, to restrict concurrent access to managed memory regions (shape parameters). This reinstates an older implementation which had been inadvertently removed.

## Motivation and Context

The issue only occurred on pre-Pascal GPUs (Kepler) which do not support concurrent managed access.

Resolves: #583

## How Has This Been Tested?

offline, and standard unit tets

## Change log

N/A

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/hoomd-blue/blob/master/sphinx-doc/credits.rst).
