### PR TITLE
Rescale Gay-Berne cutoff relative to sigma rather than sigma_max.

### DIFF
--- a/hoomd/md/EvaluatorPairGB.h
+++ b/hoomd/md/EvaluatorPairGB.h
@@ -186,7 +186,7 @@ class EvaluatorPairGB
 
             // define r_cut to be along the long axis
             Scalar sigma_max = Scalar(2.0)*HOOMD_GB_MAX(params.lperp,params.lpar);
-            Scalar zetacut = (rcut-sigma_max+sigma_min)/sigma_min;
+            Scalar zetacut = (rcut*sigma/sigma_max-sigma+sigma_min)/sigma_min;
             Scalar zetacutsq = zetacut*zetacut;
 
             // compute the force divided by r in force_divr

--- a/sphinx-doc/credits.rst
+++ b/sphinx-doc/credits.rst
@@ -213,6 +213,7 @@ Vyas Ramasubramani, University of Michigan
  * Enable simulation of floppy bodies that can be integrated separately but are ignored by the NeighborList
  * Enabled use of shared memory for Evaluator structs
  * Added per-type shape information to anisotropic pair potentials
+ * Fix cutoff rescaling in Gay-Berne potential
 
 Nathan Horst
 


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should based on *maint*. -->
<!-- New features should based on *master*. -->

## Description

The Gay-Berne potential as currently implemented is not purely repulsive even when the cutoff is set correctly (2^(1/6)*sigma) because the provided r_cut is not scaled by sigma at the current orientation. This PR corrects that by scaling r_cut into the appropriate range before shifting it into the sigma_min range for testing the current distance.

## Motivation and Context

This change brings our definition of the Gay-Berne potential in line with the potential as defined in the literature (see Allen and Germano, "Expressions for forces and torques in molecular simulations using rigid bodies").

## How Has This Been Tested?

I ran some very small simulations of 8 ellipsoids where you can clearly see that when particles are near collision they have some attraction, even when `r_cut = 2^(1/6)*(2*lperp)`. Rather than simply bouncing off of each other, they oscillate around some equilibrium distance until jolted by another particle.

I would recommend adding a test that verifies that all per-particle energies are negative, but I would prefer to wait until HOOMD 3.0 for that since it will be much easier to accomplish with the new logging API. I can make an issue for that if you'd like.

## Change log

<!-- Propose a change log entry. -->
```
Fix scaling of cutoff in Gay-Berne potential to scale the current maximum distance based on the orientations of the particles, ensuring ellipsoidal energy isocontours.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/hoomd-blue/blob/master/sphinx-doc/credits.rst).
