### PR TITLE
Updated deprecated collections API.

### DIFF
--- a/hoomd/meta.py
+++ b/hoomd/meta.py
@@ -17,13 +17,13 @@ Example::
 """
 
 import hoomd;
-import json, collections;
+import json
 import time
 import datetime
 import copy
 
 from collections import OrderedDict
-from collections import Mapping
+from collections.abc import Mapping
 
 ## \internal
 # \brief A Mixin to facilitate storage of simulation metadata
@@ -85,7 +85,7 @@ def dump_metadata(filename=None,user=None,indent=4):
     metadata = dict()
 
     if user is not None:
-        if not isinstance(user, collections.Mapping):
+        if not isinstance(user, Mapping):
             hoomd.context.msg.warning("Extra meta data needs to be a mapping type. Ignoring.\n")
         else:
             metadata['user'] = _metadata_from_dict(user);


### PR DESCRIPTION
## Description

Fixes DeprecationWarning appearing from `collections` module. This is appearing for me any time that HOOMD is imported (including when importing all MoSDeF tools that support HOOMD). I found it annoying to see this in Jupyter notebooks that are being rendered for documentation. I made this pull request to `maint` because I think it can be included in the next bugfix release.

Screenshot:
![image](https://user-images.githubusercontent.com/3943761/75848589-98f45c80-5db0-11ea-8b0d-e3a460671fda.png)


## How Has This Been Tested?

Existing tests pass. The warning no longer appears.

## Change log

<!-- Propose a change log entry. -->
```
Updated collections API to hide DeprecationWarning.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/hoomd-blue/blob/master/sphinx-doc/credits.rst).
