### PR TITLE
Removed unused imports and unreachable code.

### DIFF
--- a/hoomd/dem/utils.py
+++ b/hoomd/dem/utils.py
@@ -4,8 +4,7 @@
 R"""Various helper utilities for geometry.
 """
 
-from collections import Counter, defaultdict, deque
-from itertools import chain
+from collections import defaultdict
 import numpy as np
 
 def _normalize(vector):

--- a/hoomd/device.py
+++ b/hoomd/device.py
@@ -28,9 +28,6 @@ Attributes:
 
 import os
 import time
-import socket
-import atexit
-import getpass
 import hoomd
 from hoomd import _hoomd
 

--- a/hoomd/hpmc/util.py
+++ b/hoomd/hpmc/util.py
@@ -14,7 +14,6 @@ except ImportError:
 
 import hoomd
 import sys
-import colorsys as cs
 import re
 
 #replace range with xrange for python3 compatibility

--- a/hoomd/hpmc/validation/disks_implicit.py
+++ b/hoomd/hpmc/validation/disks_implicit.py
@@ -22,7 +22,6 @@ params = list(itertools.product(seed_list, phi_c_list, eta_p_r_list))
 context.current.device.cpp_msg.notice(1,"{} parameters\n".format(len(params)))
 
 # choose a random state point
-import random
 p = int(option.get_user()[0])
 (seed, phi_c, eta_p_r) = params[p % len(params)]
 

--- a/hoomd/hpmc/validation/spheres_implicit.py
+++ b/hoomd/hpmc/validation/spheres_implicit.py
@@ -24,7 +24,6 @@ params = list(itertools.product(seed_list, phi_c_list, eta_p_r_list))
 context.current.device.cpp_msg.notice(1,"{} parameters\n".format(len(params)))
 
 # choose a random state point
-import random
 p = int(option.get_user()[0])
 (seed, phi_c, eta_p_r) = params[p % len(params)]
 

--- a/hoomd/hpmc/validation/spheres_implicit_repulsive.py
+++ b/hoomd/hpmc/validation/spheres_implicit_repulsive.py
@@ -24,7 +24,6 @@ params = list(itertools.product(seed_list, phi_c_list, eta_p_r_list))
 context.current.device.cpp_msg.notice(1,"{} parameters\n".format(len(params)))
 
 # choose a random state point
-import random
 p = int(option.get_user()[0])
 (seed, phi_c, eta_p_r) = params[p % len(params)]
 

--- a/hoomd/init.py
+++ b/hoomd/init.py
@@ -14,10 +14,8 @@ import hoomd;
 
 import math;
 import sys;
-import gc;
 import os;
 import re;
-import platform;
 
 ## Tests if the system has been initialized
 #

--- a/hoomd/jit/patch.py
+++ b/hoomd/jit/patch.py
@@ -5,8 +5,6 @@ from hoomd import _hoomd
 from hoomd.jit import _jit
 import hoomd
 
-import tempfile
-import shutil
 import subprocess
 import os
 

--- a/hoomd/mpcd/stream.py
+++ b/hoomd/mpcd/stream.py
@@ -217,7 +217,6 @@ class _streaming_method(hoomd.meta._metadata):
         else:
             hoomd.context.current.device.cpp_msg.error("mpcd.stream: boundary condition " + bc + " not recognized.\n")
             raise ValueError("Unrecognized streaming boundary condition")
-            return None
 
 class bulk(_streaming_method):
     """ Bulk fluid streaming geometry.

--- a/hoomd/util.py
+++ b/hoomd/util.py
@@ -9,7 +9,6 @@ R""" Utilities.
 import sys;
 import traceback;
 import os.path;
-import linecache;
 import re;
 import hoomd;
 from hoomd import _hoomd;


### PR DESCRIPTION
## Description

Removes unused import statements and one instance of unreachable code. This should help a bit with later stages of Python codebase cleanup before releasing v3. I located these instances with the tool `vulture`.

## How Has This Been Tested?

Existing tests pass.

## Change log

```
Removed unused package imports.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/hoomd-blue/blob/master/sphinx-doc/credits.rst).
