### PR TITLE
Test on macOS 10.15 instead of 10.13

### DIFF
--- a/.azp/test.yml
+++ b/.azp/test.yml
@@ -107,10 +107,10 @@ stages:
 
     strategy:
       matrix:
-        10_13:
-          mac_image: macOS-10.13
-        10_14_mpi_tbb:
+        10_14:
           mac_image: macOS-10.14
+        10_15_mpi_tbb:
+          mac_image: macOS-10.15
           enable_mpi: on
           enable_tbb: on
 


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail. -->
Add macOS 10.15 to azure test matrix and remove 10.13.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Ensure that gsd works on macOS 10.15. Azure is removing 10.13 agents on March 23.

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/hoomd-blue/blob/master/sphinx-doc/credits.rst).
