### PR TITLE
Trigger compute caching and add new triggers

### DIFF
--- a/hoomd/Trigger.cc
+++ b/hoomd/Trigger.cc
@@ -17,15 +17,14 @@ class TriggerPy : public Trigger
         using Trigger::Trigger;
 
         // trampoline method
-        bool operator()(uint64_t timestep) override
+        bool compute(uint64_t timestep) override
             {
-            PYBIND11_OVERLOAD_NAME(bool,         // Return type
+            PYBIND11_OVERLOAD_PURE(bool,         // Return type
                                    Trigger,      // Parent class
-                                   "__call__",   // name of function in python
-                                   operator(),   // Name of function in C++
+                                   compute,
                                    timestep      // Argument(s)
                               );
-        }
+            }
     };
 
 void export_Trigger(pybind11::module& m)
@@ -33,6 +32,7 @@ void export_Trigger(pybind11::module& m)
     pybind11::class_<Trigger, TriggerPy, std::shared_ptr<Trigger> >(m,"Trigger")
         .def(pybind11::init<>())
         .def("__call__", &Trigger::operator())
+        .def("compute", &Trigger::compute)
         ;
 
     pybind11::class_<PeriodicTrigger, Trigger, std::shared_ptr<PeriodicTrigger> >(m, "PeriodicTrigger")

--- a/hoomd/Trigger.cc
+++ b/hoomd/Trigger.cc
@@ -42,5 +42,54 @@ void export_Trigger(pybind11::module& m)
         .def_property("period", &PeriodicTrigger::getPeriod, &PeriodicTrigger::setPeriod)
         ;
 
+    pybind11::class_<UntilTrigger, Trigger, std::shared_ptr<UntilTrigger>
+                    >(m, "UntilTrigger")
+        .def(pybind11::init<uint64_t>(), pybind11::arg("until"))
+        .def_property("until", &UntilTrigger::getUntil, &UntilTrigger::setUntil)
+        ;
+
+    pybind11::class_<AfterTrigger, Trigger, std::shared_ptr<AfterTrigger>
+                    >(m, "AfterTrigger")
+        .def(pybind11::init<uint64_t>(), pybind11::arg("after"))
+        .def_property("after", &AfterTrigger::getAfter, &AfterTrigger::setAfter)
+        ;
+
+    pybind11::class_<NotTrigger, Trigger, std::shared_ptr<NotTrigger>
+                    >(m, "NotTrigger")
+        .def(pybind11::init<std::shared_ptr<Trigger> >(),
+             pybind11::arg("trigger"))
+        .def_property("trigger",
+                      &NotTrigger::getTrigger,
+                      &NotTrigger::setTrigger)
+        ;
+
+    pybind11::class_<AndTrigger, Trigger, std::shared_ptr<AndTrigger>
+                    >(m, "AndTrigger")
+        .def(pybind11::init<std::shared_ptr<Trigger>,
+                            std::shared_ptr<Trigger> >(),
+             pybind11::arg("trigger1"),
+             pybind11::arg("trigger2"))
+        .def_property("trigger1",
+                      &AndTrigger::getTrigger1,
+                      &AndTrigger::setTrigger1)
+        .def_property("trigger2",
+                      &AndTrigger::getTrigger2,
+                      &AndTrigger::setTrigger2)
+        ;
+
+    pybind11::class_<OrTrigger, Trigger, std::shared_ptr<OrTrigger>
+                    >(m, "OrTrigger")
+        .def(pybind11::init<std::shared_ptr<Trigger>,
+                            std::shared_ptr<Trigger> >(),
+             pybind11::arg("trigger1"),
+             pybind11::arg("trigger2"))
+        .def_property("trigger1",
+                      &OrTrigger::getTrigger1,
+                      &OrTrigger::setTrigger1)
+        .def_property("trigger2",
+                      &OrTrigger::getTrigger2,
+                      &OrTrigger::setTrigger2)
+        ;
+
     m.def("_test_trigger_call", &testTriggerCall);
     }

--- a/hoomd/Trigger.cc
+++ b/hoomd/Trigger.cc
@@ -2,6 +2,10 @@
 // This file is part of the HOOMD-blue project, released under the BSD 3-Clause License.
 
 #include "Trigger.h"
+#include <pybind11/stl.h>
+#include <pybind11/stl_bind.h>
+
+PYBIND11_MAKE_OPAQUE(std::vector<std::shared_ptr<Trigger> >);
 
 //* Method to enable unit testing of C++ trigger calls from pytest
 bool testTriggerCall(std::shared_ptr<Trigger> t, uint64_t step)
@@ -35,23 +39,42 @@ void export_Trigger(pybind11::module& m)
         .def("compute", &Trigger::compute)
         ;
 
-    pybind11::class_<PeriodicTrigger, Trigger, std::shared_ptr<PeriodicTrigger> >(m, "PeriodicTrigger")
-        .def(pybind11::init< uint64_t, uint64_t >(), pybind11::arg("period"), pybind11::arg("phase"))
+    pybind11::class_<PeriodicTrigger, Trigger,
+                     std::shared_ptr<PeriodicTrigger> >(m, "PeriodicTrigger")
+        .def(pybind11::init< uint64_t, uint64_t >(),
+             pybind11::arg("period"),
+             pybind11::arg("phase"))
         .def(pybind11::init< uint64_t >(), pybind11::arg("period"))
-        .def_property("phase", &PeriodicTrigger::getPhase, &PeriodicTrigger::setPhase)
-        .def_property("period", &PeriodicTrigger::getPeriod, &PeriodicTrigger::setPeriod)
+        .def_property("phase",
+                      &PeriodicTrigger::getPhase,
+                      &PeriodicTrigger::setPhase)
+        .def_property("period",
+                      &PeriodicTrigger::getPeriod,
+                      &PeriodicTrigger::setPeriod)
         ;
 
-    pybind11::class_<UntilTrigger, Trigger, std::shared_ptr<UntilTrigger>
-                    >(m, "UntilTrigger")
-        .def(pybind11::init<uint64_t>(), pybind11::arg("until"))
-        .def_property("until", &UntilTrigger::getUntil, &UntilTrigger::setUntil)
+    pybind11::class_<BeforeTrigger, Trigger, std::shared_ptr<BeforeTrigger>
+                    >(m, "BeforeTrigger")
+        .def(pybind11::init<uint64_t>(), pybind11::arg("timestep"))
+        .def_property("timestep",
+                      &BeforeTrigger::getTimestep,
+                      &BeforeTrigger::setTimestep)
+        ;
+
+    pybind11::class_<OnTrigger, Trigger, std::shared_ptr<OnTrigger>
+                    >(m, "OnTrigger")
+        .def(pybind11::init<uint64_t>(), pybind11::arg("timestep"))
+        .def_property("timestep",
+                      &OnTrigger::getTimestep,
+                      &OnTrigger::setTimestep)
         ;
 
     pybind11::class_<AfterTrigger, Trigger, std::shared_ptr<AfterTrigger>
                     >(m, "AfterTrigger")
-        .def(pybind11::init<uint64_t>(), pybind11::arg("after"))
-        .def_property("after", &AfterTrigger::getAfter, &AfterTrigger::setAfter)
+        .def(pybind11::init<uint64_t>(), pybind11::arg("timestep"))
+        .def_property("timestep",
+                      &AfterTrigger::getTimestep,
+                      &AfterTrigger::setTimestep)
         ;
 
     pybind11::class_<NotTrigger, Trigger, std::shared_ptr<NotTrigger>
@@ -63,32 +86,21 @@ void export_Trigger(pybind11::module& m)
                       &NotTrigger::setTrigger)
         ;
 
+    pybind11::bind_vector<std::vector<std::shared_ptr<Trigger> >
+                         >(m, "trigger_list");
+
     pybind11::class_<AndTrigger, Trigger, std::shared_ptr<AndTrigger>
                     >(m, "AndTrigger")
-        .def(pybind11::init<std::shared_ptr<Trigger>,
-                            std::shared_ptr<Trigger> >(),
-             pybind11::arg("trigger1"),
-             pybind11::arg("trigger2"))
-        .def_property("trigger1",
-                      &AndTrigger::getTrigger1,
-                      &AndTrigger::setTrigger1)
-        .def_property("trigger2",
-                      &AndTrigger::getTrigger2,
-                      &AndTrigger::setTrigger2)
+        .def(pybind11::init<pybind11::object>(),
+             pybind11::arg("triggers"))
+        .def_property_readonly("triggers", &AndTrigger::getTriggers)
         ;
 
     pybind11::class_<OrTrigger, Trigger, std::shared_ptr<OrTrigger>
                     >(m, "OrTrigger")
-        .def(pybind11::init<std::shared_ptr<Trigger>,
-                            std::shared_ptr<Trigger> >(),
-             pybind11::arg("trigger1"),
-             pybind11::arg("trigger2"))
-        .def_property("trigger1",
-                      &OrTrigger::getTrigger1,
-                      &OrTrigger::setTrigger1)
-        .def_property("trigger2",
-                      &OrTrigger::getTrigger2,
-                      &OrTrigger::setTrigger2)
+        .def(pybind11::init<pybind11::object>(),
+             pybind11::arg("triggers"))
+        .def_property_readonly("triggers", &OrTrigger::getTriggers)
         ;
 
     m.def("_test_trigger_call", &testTriggerCall);

--- a/hoomd/Trigger.h
+++ b/hoomd/Trigger.h
@@ -130,8 +130,7 @@ class PYBIND11_EXPORT BeforeTrigger : public Trigger
     void setTimestep(uint64_t timestep) {m_timestep = timestep;}
 
     protected:
-        /// Always trigger timestep this timestep
-        uint64_t m_timestep;
+        uint64_t m_timestep;  /// trigger timestep < m_timestep
     };
 
 /** On trigger
@@ -156,8 +155,7 @@ class PYBIND11_EXPORT OnTrigger : public Trigger
     void setTimestep(uint64_t timestep) {m_timestep = timestep;}
 
     protected:
-        /// Always trigger timestep this timestep
-        uint64_t m_timestep;
+        uint64_t m_timestep;  /// only trigger on this timestep
     };
 
 /** After trigger
@@ -182,8 +180,7 @@ class PYBIND11_EXPORT AfterTrigger : public Trigger
     void setTimestep(uint64_t timestep) {m_timestep = timestep;}
 
     protected:
-        /// Always trigger timestep this timestep
-        uint64_t m_timestep;
+        uint64_t m_timestep;  /// trigger timestep > m_timestep
     };
 
 /** Not trigger
@@ -208,7 +205,7 @@ class PYBIND11_EXPORT NotTrigger : public Trigger
         void setTrigger(std::shared_ptr<Trigger> trigger) {m_trigger = trigger;}
 
     protected:
-        std::shared_ptr<Trigger> m_trigger;
+        std::shared_ptr<Trigger> m_trigger; ///  trigger to be negated
     };
 
 /** And trigger
@@ -246,6 +243,7 @@ class PYBIND11_EXPORT AndTrigger : public Trigger
             }
 
     protected:
+        /// Vector of triggers to do a n-way AND
         std::vector<std::shared_ptr<Trigger> > m_triggers;
     };
 
@@ -271,8 +269,7 @@ class PYBIND11_EXPORT OrTrigger : public Trigger
 
         bool compute(uint64_t timestep)
             {
-            return std::any_of(
-                m_triggers.begin(), m_triggers.end(),
+            return std::any_of(m_triggers.begin(), m_triggers.end(),
                 [timestep](std::shared_ptr<Trigger> t)
                     {
                     return t->operator()(timestep);
@@ -285,6 +282,7 @@ class PYBIND11_EXPORT OrTrigger : public Trigger
             }
 
     protected:
+        /// Vector of triggers to do a n-way OR
         std::vector<std::shared_ptr<Trigger> > m_triggers;
     };
 

--- a/hoomd/Trigger.h
+++ b/hoomd/Trigger.h
@@ -103,5 +103,176 @@ class PYBIND11_EXPORT PeriodicTrigger : public Trigger
         uint64_t m_phase;
     };
 
+/** Until trigger
+ *
+ *  Trigger every time step until `timestep >= m_until`.
+*/
+class PYBIND11_EXPORT UntilTrigger : public Trigger
+    {
+    public:
+
+    UntilTrigger(uint64_t until) : Trigger(), m_until(until) {}
+
+    bool compute(uint64_t timestep)
+        {
+        if (timestep < m_until)
+            {
+            return true;
+            }
+        else
+            {
+            return false;
+            }
+        }
+
+    /// Get the point where triggering will stop
+    uint64_t getUntil() {return m_until;}
+
+    /// Set the point where triggering will stop
+    void setUntil(uint64_t until) {m_until = until;}
+
+    protected:
+        /// Always trigger until this timestep
+        uint64_t m_until;
+    };
+
+/** After trigger
+ *
+ *  Trigger every time step after and including `timestep > m_after`.
+*/
+class PYBIND11_EXPORT AfterTrigger : public Trigger
+    {
+    public:
+
+    AfterTrigger(uint64_t after) : Trigger(), m_after(after) {}
+
+    bool compute(uint64_t timestep)
+        {
+        if (timestep > m_after)
+            {
+            return true;
+            }
+        else
+            {
+            return false;
+            }
+        }
+
+    /// Get the point where triggering will stop
+    uint64_t getAfter() {return m_after;}
+
+    /// Set the point where triggering will stop
+    void setAfter(uint64_t after) {m_after = after;}
+
+    protected:
+        /// Always trigger after this timestep
+        uint64_t m_after;
+    };
+
+/** Not trigger
+ *
+ *  Negates any given trigger.
+*/
+class PYBIND11_EXPORT NotTrigger : public Trigger
+    {
+    public:
+        NotTrigger(std::shared_ptr<Trigger> trigger) :
+            Trigger(), m_trigger(trigger) {}
+
+        bool compute(uint64_t timestep)
+            {
+            return !(m_trigger->compute(timestep));
+            }
+
+        /// Get the trigger thats negated
+        std::shared_ptr<Trigger> getTrigger() {return m_trigger;}
+
+        /// Set the trigger to negate
+        void setTrigger(std::shared_ptr<Trigger> trigger) {m_trigger = trigger;}
+
+    protected:
+        std::shared_ptr<Trigger> m_trigger;
+    };
+
+/** And trigger
+ *
+ *  The logical AND between two triggers.
+*/
+class PYBIND11_EXPORT AndTrigger : public Trigger
+    {
+    public:
+        AndTrigger(std::shared_ptr<Trigger> trigger1,
+                   std::shared_ptr<Trigger> trigger2) :
+            Trigger(), m_trigger1(trigger1), m_trigger2(trigger2) {}
+
+        bool compute(uint64_t timestep)
+            {
+            return m_trigger1->compute(timestep) &&
+                   m_trigger2->compute(timestep);
+            }
+
+        /// Get the first trigger
+        std::shared_ptr<Trigger> getTrigger1() {return m_trigger1;}
+
+        /// Set the second trigger
+        void setTrigger1(std::shared_ptr<Trigger> trigger)
+            {
+            m_trigger1 = trigger;
+            }
+
+        /// Get the second trigger
+        std::shared_ptr<Trigger> getTrigger2() {return m_trigger2;}
+
+        /// Set the second trigger
+        void setTrigger2(std::shared_ptr<Trigger> trigger)
+            {
+            m_trigger2 = trigger;
+            }
+
+    protected:
+        std::shared_ptr<Trigger> m_trigger1;
+        std::shared_ptr<Trigger> m_trigger2;
+    };
+
+/** Or trigger
+ *
+ *  The logical OR between two triggers.
+*/
+class PYBIND11_EXPORT OrTrigger : public Trigger
+    {
+    public:
+        OrTrigger(std::shared_ptr<Trigger> trigger1,
+                   std::shared_ptr<Trigger> trigger2) :
+            Trigger(), m_trigger1(trigger1), m_trigger2(trigger2) {}
+
+        bool compute(uint64_t timestep)
+            {
+            return m_trigger1->compute(timestep) ||
+                   m_trigger2->compute(timestep);
+            }
+
+        /// Get the first trigger
+        std::shared_ptr<Trigger> getTrigger1() {return m_trigger1;}
+
+        /// Set the second trigger
+        void setTrigger1(std::shared_ptr<Trigger> trigger)
+            {
+            m_trigger1 = trigger;
+            }
+
+        /// Get the second trigger
+        std::shared_ptr<Trigger> getTrigger2() {return m_trigger2;}
+
+        /// Set the second trigger
+        void setTrigger2(std::shared_ptr<Trigger> trigger)
+            {
+            m_trigger2 = trigger;
+            }
+
+    protected:
+        std::shared_ptr<Trigger> m_trigger1;
+        std::shared_ptr<Trigger> m_trigger2;
+    };
+
 /// Export Trigger classes to Python
 void export_Trigger(pybind11::module& m);

--- a/hoomd/Trigger.h
+++ b/hoomd/Trigger.h
@@ -123,10 +123,10 @@ class PYBIND11_EXPORT BeforeTrigger : public Trigger
         return timestep < m_timestep;
         }
 
-    /// Get the point where triggering will stop
+    /// Get the timestep before which the trigger is active.
     uint64_t getTimestep() {return m_timestep;}
 
-    /// Set the point where triggering will stop
+    /// Set the timestep before which the trigger is active.
     void setTimestep(uint64_t timestep) {m_timestep = timestep;}
 
     protected:
@@ -149,10 +149,10 @@ class PYBIND11_EXPORT OnTrigger : public Trigger
         return timestep == m_timestep;
         }
 
-    /// Get the point where triggering will stop
+    /// Get the timestep when the trigger is active.
     uint64_t getTimestep() {return m_timestep;}
 
-    /// Set the point where triggering will stop
+    /// Set the timestep when the trigger is active.
     void setTimestep(uint64_t timestep) {m_timestep = timestep;}
 
     protected:
@@ -175,10 +175,10 @@ class PYBIND11_EXPORT AfterTrigger : public Trigger
         return timestep > m_timestep;
         }
 
-    /// Get the point where triggering will stop
+    /// Get the timestep after which the trigger is active.
     uint64_t getTimestep() {return m_timestep;}
 
-    /// Set the point where triggering will stop
+    /// Set the timestep after which the trigger is active.
     void setTimestep(uint64_t timestep) {m_timestep = timestep;}
 
     protected:
@@ -213,7 +213,7 @@ class PYBIND11_EXPORT NotTrigger : public Trigger
 
 /** And trigger
  *
- *  The logical AND between n triggers.
+ *  The logical AND between multiple triggers.
 */
 class PYBIND11_EXPORT AndTrigger : public Trigger
     {
@@ -251,7 +251,7 @@ class PYBIND11_EXPORT AndTrigger : public Trigger
 
 /** Or trigger
  *
- *  The logical OR between n triggers.
+ *  The logical OR between multiple triggers.
 */
 class PYBIND11_EXPORT OrTrigger : public Trigger
     {

--- a/hoomd/operation.py
+++ b/hoomd/operation.py
@@ -10,7 +10,7 @@ _TriggeredOperation is _Operation for objects that are triggered.
 """
 
 from hoomd.util import is_iterable, dict_map, str_to_tuple_keys
-from hoomd.trigger import PeriodicTrigger, Trigger
+from hoomd.trigger import Periodic, Trigger
 from hoomd.variant import Variant, Constant
 from hoomd.filter import _ParticleFilter
 from hoomd.logger import Loggable
@@ -294,9 +294,9 @@ def trigger_preprocessing(value):
     if isinstance(value, Trigger):
         return value
     if isinstance(value, int):
-        return PeriodicTrigger(period=value, phase=0)
+        return Periodic(period=value, phase=0)
     elif hasattr(value, '__len__') and len(value) == 2:
-        return PeriodicTrigger(period=value[0], phase=value[1])
+        return Periodic(period=value[0], phase=value[1])
     else:
         raise ValueError("Value {} could not be converted to a Trigger.")
 

--- a/hoomd/pytest/test_trigger.py
+++ b/hoomd/pytest/test_trigger.py
@@ -7,10 +7,10 @@ import hoomd.trigger
 
 
 def test_periodic_properties():
-    """ Test construction and properties of PeriodicTrigger
+    """ Test construction and properties of Periodic
     """
 
-    a = hoomd.trigger.PeriodicTrigger(123)
+    a = hoomd.trigger.Periodic(123)
 
     assert a.period == 123
     assert a.phase == 0
@@ -25,14 +25,14 @@ def test_periodic_properties():
     assert a.period == 10000000000
     assert a.phase == 6000000000
 
-    b = hoomd.trigger.PeriodicTrigger(phase=3, period=456)
+    b = hoomd.trigger.Periodic(phase=3, period=456)
 
     assert b.period == 456
     assert b.phase == 3
 
 
 def test_periodic_eval():
-    a = hoomd.trigger.PeriodicTrigger(period=456, phase=18)
+    a = hoomd.trigger.Periodic(period=456, phase=18)
 
     for i in range(10000):
         assert a(i) == ((i - 18) % 456 == 0)
@@ -40,7 +40,7 @@ def test_periodic_eval():
     for i in range(10000000000, 10000010000):
         assert a(i) == ((i - 18) % 456 == 0)
 
-    b = hoomd.trigger.PeriodicTrigger(period=10000000000, phase=6000000000)
+    b = hoomd.trigger.Periodic(period=10000000000, phase=6000000000)
 
     assert b(6000000000)
     assert not b(6000000001)

--- a/hoomd/pytest/test_trigger.py
+++ b/hoomd/pytest/test_trigger.py
@@ -53,7 +53,7 @@ def test_custom():
         def __init__(self):
             hoomd.trigger.Trigger.__init__(self)
 
-        def __call__(self, timestep):
+        def compute(self, timestep):
             return (timestep**(1 / 2)).is_integer()
 
     c = CustomTrigger()

--- a/hoomd/pytest/test_triggeredops.py
+++ b/hoomd/pytest/test_triggeredops.py
@@ -1,12 +1,12 @@
 from hoomd.pytest.dummy import DummyCppObj, DummySimulation, DummyTrigger
 from hoomd.pytest.dummy import DummyOperation, DummyTriggeredOp
 from hoomd.syncedlist import SyncedList
-from hoomd.trigger import PeriodicTrigger
+from hoomd.trigger import Periodic
 
 
 def test_initialization():
     triggered_op = DummyTriggeredOp(trigger=1)
-    assert type(triggered_op.trigger) == PeriodicTrigger
+    assert type(triggered_op.trigger) == Periodic
     assert triggered_op.trigger.period == 1
     assert triggered_op.trigger.phase == 0
 

--- a/hoomd/trigger.py
+++ b/hoomd/trigger.py
@@ -1,8 +1,9 @@
 # Copyright (c) 2009-2019 The Regents of the University of Michigan
-# This file is part of the HOOMD-blue project, released under the BSD 3-Clause
 # License.
+# This file is part of the HOOMD-blue project, released under the BSD 3-Clause
 
 from hoomd import _hoomd
+from inspect import isclass
 
 
 class Trigger(_hoomd.Trigger):
@@ -14,20 +15,28 @@ class Periodic(_hoomd.PeriodicTrigger, Trigger):
         _hoomd.PeriodicTrigger.__init__(self, period, phase)
 
 
-class Until(_hoomd.UntilTrigger, Trigger):
-    def __init__(self, until):
-        if until < 0:
-            raise ValueError("until must be positive.")
+class Before(_hoomd.BeforeTrigger, Trigger):
+    def __init__(self, timestep):
+        if timestep < 0:
+            raise ValueError("timestep must be positive.")
         else:
-            _hoomd.UntilTrigger.__init__(self, until)
+            _hoomd.BeforeTrigger.__init__(self, timestep)
+
+
+class On(_hoomd.OnTrigger, Trigger):
+    def __init__(self, timestep):
+        if timestep < 0:
+            raise ValueError("timestep must be positive.")
+        else:
+            _hoomd.OnTrigger.__init__(self, timestep)
 
 
 class After(_hoomd.AfterTrigger, Trigger):
-    def __init__(self, after):
-        if after < 0:
-            raise ValueError("after must be positive.")
+    def __init__(self, timestep):
+        if timestep < 0:
+            raise ValueError("timestep must be positive.")
         else:
-            _hoomd.AfterTrigger.__init__(self, after)
+            _hoomd.AfterTrigger.__init__(self, timestep)
 
 
 class Not(_hoomd.NotTrigger, Trigger):
@@ -36,10 +45,14 @@ class Not(_hoomd.NotTrigger, Trigger):
 
 
 class And(_hoomd.AndTrigger, Trigger):
-    def __init__(self, trigger1, trigger2):
-        _hoomd.AndTrigger.__init__(self, trigger1, trigger2)
+    def __init__(self, triggers):
+        if not hasattr(triggers, '__iter__') or isclass(triggers):
+            raise ValueError("triggers must an iterable of Triggers.")
+        _hoomd.AndTrigger.__init__(self, triggers)
 
 
 class Or(_hoomd.OrTrigger, Trigger):
-    def __init__(self, trigger1, trigger2):
-        _hoomd.OrTrigger.__init__(self, trigger1, trigger2)
+    def __init__(self, triggers):
+        if not hasattr(triggers, '__iter__') or isclass(triggers):
+            raise ValueError("triggers must an iterable of Triggers.")
+        _hoomd.OrTrigger.__init__(self, triggers)

--- a/hoomd/trigger.py
+++ b/hoomd/trigger.py
@@ -12,3 +12,34 @@ class Trigger(_hoomd.Trigger):
 class PeriodicTrigger(_hoomd.PeriodicTrigger, Trigger):
     def __init__(self, period, phase=0):
         _hoomd.PeriodicTrigger.__init__(self, period, phase)
+
+
+class UntilTrigger(_hoomd.UntilTrigger, Trigger):
+    def __init__(self, until):
+        if until < 0:
+            raise ValueError("until must be positive.")
+        else:
+            _hoomd.UntilTrigger.__init__(self, until)
+
+
+class AfterTrigger(_hoomd.AfterTrigger, Trigger):
+    def __init__(self, after):
+        if after < 0:
+            raise ValueError("after must be positive.")
+        else:
+            _hoomd.AfterTrigger.__init__(self, after)
+
+
+class NotTrigger(_hoomd.NotTrigger, Trigger):
+    def __init__(self, trigger):
+        _hoomd.NotTrigger.__init__(self, trigger)
+
+
+class AndTrigger(_hoomd.AndTrigger, Trigger):
+    def __init__(self, trigger1, trigger2):
+        _hoomd.AndTrigger.__init__(self, trigger1, trigger2)
+
+
+class OrTrigger(_hoomd.OrTrigger, Trigger):
+    def __init__(self, trigger1, trigger2):
+        _hoomd.OrTrigger.__init__(self, trigger1, trigger2)

--- a/hoomd/trigger.py
+++ b/hoomd/trigger.py
@@ -46,13 +46,15 @@ class Not(_hoomd.NotTrigger, Trigger):
 
 class And(_hoomd.AndTrigger, Trigger):
     def __init__(self, triggers):
-        if not hasattr(triggers, '__iter__') or isclass(triggers):
+        triggers = list(triggers)
+        if not all(isinstance(t, Trigger) for t in triggers):
             raise ValueError("triggers must an iterable of Triggers.")
         _hoomd.AndTrigger.__init__(self, triggers)
 
 
 class Or(_hoomd.OrTrigger, Trigger):
     def __init__(self, triggers):
-        if not hasattr(triggers, '__iter__') or isclass(triggers):
+        triggers = list(triggers)
+        if not all(isinstance(t, Trigger) for t in triggers):
             raise ValueError("triggers must an iterable of Triggers.")
         _hoomd.OrTrigger.__init__(self, triggers)

--- a/hoomd/trigger.py
+++ b/hoomd/trigger.py
@@ -9,12 +9,12 @@ class Trigger(_hoomd.Trigger):
     pass
 
 
-class PeriodicTrigger(_hoomd.PeriodicTrigger, Trigger):
+class Periodic(_hoomd.PeriodicTrigger, Trigger):
     def __init__(self, period, phase=0):
         _hoomd.PeriodicTrigger.__init__(self, period, phase)
 
 
-class UntilTrigger(_hoomd.UntilTrigger, Trigger):
+class Until(_hoomd.UntilTrigger, Trigger):
     def __init__(self, until):
         if until < 0:
             raise ValueError("until must be positive.")
@@ -22,7 +22,7 @@ class UntilTrigger(_hoomd.UntilTrigger, Trigger):
             _hoomd.UntilTrigger.__init__(self, until)
 
 
-class AfterTrigger(_hoomd.AfterTrigger, Trigger):
+class After(_hoomd.AfterTrigger, Trigger):
     def __init__(self, after):
         if after < 0:
             raise ValueError("after must be positive.")
@@ -30,16 +30,16 @@ class AfterTrigger(_hoomd.AfterTrigger, Trigger):
             _hoomd.AfterTrigger.__init__(self, after)
 
 
-class NotTrigger(_hoomd.NotTrigger, Trigger):
+class Not(_hoomd.NotTrigger, Trigger):
     def __init__(self, trigger):
         _hoomd.NotTrigger.__init__(self, trigger)
 
 
-class AndTrigger(_hoomd.AndTrigger, Trigger):
+class And(_hoomd.AndTrigger, Trigger):
     def __init__(self, trigger1, trigger2):
         _hoomd.AndTrigger.__init__(self, trigger1, trigger2)
 
 
-class OrTrigger(_hoomd.OrTrigger, Trigger):
+class Or(_hoomd.OrTrigger, Trigger):
     def __init__(self, trigger1, trigger2):
         _hoomd.OrTrigger.__init__(self, trigger1, trigger2)

--- a/hoomd/trigger.py
+++ b/hoomd/trigger.py
@@ -1,6 +1,6 @@
 # Copyright (c) 2009-2019 The Regents of the University of Michigan
-# License.
 # This file is part of the HOOMD-blue project, released under the BSD 3-Clause
+# License.
 
 from hoomd import _hoomd
 from inspect import isclass
@@ -18,7 +18,7 @@ class Periodic(_hoomd.PeriodicTrigger, Trigger):
 class Before(_hoomd.BeforeTrigger, Trigger):
     def __init__(self, timestep):
         if timestep < 0:
-            raise ValueError("timestep must be positive.")
+            raise ValueError("timestep must be greater than or equal to 0.")
         else:
             _hoomd.BeforeTrigger.__init__(self, timestep)
 

--- a/hoomd/util.py
+++ b/hoomd/util.py
@@ -9,7 +9,7 @@ R""" Utilities.
 from numpy import ndarray
 from inspect import isclass
 from copy import deepcopy
-from hoomd.trigger import PeriodicTrigger
+from hoomd.trigger import Periodic
 
 ## \internal
 # \brief Compatibility definition of a basestring for python 2/3
@@ -252,7 +252,7 @@ def array_to_strings(value):
 
 def trigger_preprocessing(trigger):
     if isinstance(trigger, int):
-        return PeriodicTrigger(period=int(trigger), phase=0)
+        return Periodic(period=int(trigger), phase=0)
     else:
         return trigger
 

--- a/sphinx-doc/module-hoomd-triggers.rst
+++ b/sphinx-doc/module-hoomd-triggers.rst
@@ -6,8 +6,13 @@ hoomd.trigger
 .. autosummary::
     :nosignatures:
 
-    hoomd.trigger.PeriodicTrigger
+    hoomd.trigger.After
+    hoomd.trigger.And
+    hoomd.trigger.Not
+    hoomd.trigger.Or
+    hoomd.trigger.Periodic
     hoomd.trigger.Trigger
+    hoomd.trigger.Until
 
 .. rubric:: Details
 

--- a/sphinx-doc/module-hoomd-triggers.rst
+++ b/sphinx-doc/module-hoomd-triggers.rst
@@ -7,12 +7,13 @@ hoomd.trigger
     :nosignatures:
 
     hoomd.trigger.After
+    hoomd.trigger.Before
     hoomd.trigger.And
     hoomd.trigger.Not
+    hoomd.trigger.On
     hoomd.trigger.Or
     hoomd.trigger.Periodic
     hoomd.trigger.Trigger
-    hoomd.trigger.Until
 
 .. rubric:: Details
 

--- a/sphinx-doc/module-hoomd-triggers.rst
+++ b/sphinx-doc/module-hoomd-triggers.rst
@@ -7,8 +7,8 @@ hoomd.trigger
     :nosignatures:
 
     hoomd.trigger.After
-    hoomd.trigger.Before
     hoomd.trigger.And
+    hoomd.trigger.Before
     hoomd.trigger.Not
     hoomd.trigger.On
     hoomd.trigger.Or


### PR DESCRIPTION
## Description

Implements caching for the last time step and result of a trigger automatically. Now `compute` is the virtual method that must be defined for all derived `Trigger`s.

Also adds the following triggers:

1. `After` - returns true after given step false otherwise
2. `Until` - returns true until given step false otherwise
3. `Not` - negates a single trigger
4. `And` - returns the logical AND of two triggers
5. `Or` - returns the logical OR of two triggers


## How Has This Been Tested?
locally in a jupyter notebook
