### PR TITLE
Backport sphere union shape spec

### DIFF
--- a/hoomd/hpmc/IntegratorHPMCMono.h
+++ b/hoomd/hpmc/IntegratorHPMCMono.h
@@ -406,7 +406,7 @@ class IntegratorHPMCMono : public IntegratorHPMC
             for (unsigned int i = 0; i < type_shape_mapping.size(); i++)
                 {
                 Shape shape(q, params[i]);
-                type_shape_mapping[i] = shape.getShapeSpec();
+                type_shape_mapping[i] = getShapeSpec(shape);
                 }
             return type_shape_mapping;
             }

--- a/hoomd/hpmc/ShapeConvexPolygon.h
+++ b/hoomd/hpmc/ShapeConvexPolygon.h
@@ -300,20 +300,6 @@ struct ShapeConvexPolygon
         return OverlapReal(0.0);
         }
 
-    #ifndef __HIPCC__
-    std::string getShapeSpec() const
-        {
-        std::ostringstream shapedef;
-        shapedef << "{\"type\": \"Polygon\", \"rounding_radius\": " << verts.sweep_radius << ", \"vertices\": [";
-        for (unsigned int i = 0; i < verts.N-1; i++)
-            {
-            shapedef << "[" << verts.x[i] << ", " << verts.y[i] << "], ";
-            }
-        shapedef << "[" << verts.x[verts.N-1] << ", " << verts.y[verts.N-1] << "]]}";
-        return shapedef.str();
-        }
-    #endif
-
     //! Return the bounding box of the shape in world coordinates
     DEVICE detail::AABB getAABB(const vec3<Scalar>& pos) const
         {
@@ -530,6 +516,21 @@ DEVICE inline bool test_overlap<ShapeConvexPolygon,ShapeConvexPolygon>(const vec
                                                   quat<OverlapReal>(b.orientation));
     #endif
     }
+
+#ifndef __HIPCC__
+template<>
+inline std::string getShapeSpec(const ShapeConvexPolygon& poly)
+    {
+    std::ostringstream shapedef;
+    shapedef << "{\"type\": \"Polygon\", \"rounding_radius\": " << poly.verts.sweep_radius << ", \"vertices\": [";
+    for (unsigned int i = 0; i < poly.verts.N-1; i++)
+        {
+        shapedef << "[" << poly.verts.x[i] << ", " << poly.verts.y[i] << "], ";
+        }
+    shapedef << "[" << poly.verts.x[poly.verts.N-1] << ", " << poly.verts.y[poly.verts.N-1] << "]]}";
+    return shapedef.str();
+    }
+#endif
 
 }; // end namespace hpmc
 

--- a/hoomd/hpmc/ShapeConvexPolyhedron.h
+++ b/hoomd/hpmc/ShapeConvexPolyhedron.h
@@ -586,20 +586,6 @@ struct ShapeConvexPolyhedron
         return OverlapReal(0.0);
         }
 
-    #ifndef __HIPCC__
-    std::string getShapeSpec() const
-        {
-        std::ostringstream shapedef;
-        shapedef << "{\"type\": \"ConvexPolyhedron\", \"rounding_radius\": " << verts.sweep_radius << ", \"vertices\": [";
-        for (unsigned int i = 0; i < verts.N-1; i++)
-            {
-            shapedef << "[" << verts.x[i] << ", " << verts.y[i] << ", " << verts.z[i] << "], ";
-            }
-        shapedef << "[" << verts.x[verts.N-1] << ", " << verts.y[verts.N-1] << ", " << verts.z[verts.N-1] << "]]}";
-        return shapedef.str();
-        }
-    #endif
-
     //! Return the bounding box of the shape in world coordinates
     DEVICE detail::AABB getAABB(const vec3<Scalar>& pos) const
         {
@@ -717,6 +703,22 @@ DEVICE inline bool test_overlap_intersection(const ShapeConvexPolyhedron& a,
         vec3<OverlapReal>(ac_t),
         err);
     }
+
+#ifndef __HIPCC__
+template<>
+inline std::string getShapeSpec(const ShapeConvexPolyhedron& poly)
+    {
+    std::ostringstream shapedef;
+    auto& verts = poly.verts;
+    shapedef << "{\"type\": \"ConvexPolyhedron\", \"rounding_radius\": " << verts.sweep_radius << ", \"vertices\": [";
+    for (unsigned int i = 0; i < verts.N-1; i++)
+        {
+        shapedef << "[" << verts.x[i] << ", " << verts.y[i] << ", " << verts.z[i] << "], ";
+        }
+    shapedef << "[" << verts.x[verts.N-1] << ", " << verts.y[verts.N-1] << ", " << verts.z[verts.N-1] << "]]}";
+    return shapedef.str();
+    }
+#endif
 
 }; // end namespace hpmc
 

--- a/hoomd/hpmc/ShapeEllipsoid.h
+++ b/hoomd/hpmc/ShapeEllipsoid.h
@@ -96,18 +96,6 @@ struct ShapeEllipsoid
         return OverlapReal(0.0);
         }
 
-    #ifndef __HIPCC__
-    std::string getShapeSpec() const
-        {
-        std::ostringstream shapedef;
-        shapedef << "{\"type\": \"Ellipsoid\", \"a\": " << axes.x <<
-                    ", \"b\": " << axes.y <<
-                    ", \"c\": " << axes.z <<
-                    "}";
-        return shapedef.str();
-        }
-    #endif
-
     //! Support function of the shape (in local coordinates), used in getAABB
     /*! \param n Vector to query support function (must be normalized)
     */
@@ -457,6 +445,19 @@ DEVICE inline bool test_overlap<ShapeEllipsoid,ShapeEllipsoid>(const vec3<Scalar
 
     return ret_val == ELLIPSOID_OVERLAP_TRUE;
     }
+
+#ifndef __HIPCC__
+template<>
+inline std::string getShapeSpec(const ShapeEllipsoid& ellipsoid)
+    {
+    std::ostringstream shapedef;
+    shapedef << "{\"type\": \"Ellipsoid\", \"a\": " << ellipsoid.axes.x <<
+                ", \"b\": " << ellipsoid.axes.y <<
+                ", \"c\": " << ellipsoid.axes.z <<
+                "}";
+    return shapedef.str();
+    }
+#endif
 
 }; // end namespace hpmc
 

--- a/hoomd/hpmc/ShapeFacetedEllipsoid.h
+++ b/hoomd/hpmc/ShapeFacetedEllipsoid.h
@@ -294,13 +294,6 @@ struct ShapeFacetedEllipsoid
         return 0.0;
         }
 
-    #ifndef __HIPCC__
-    std::string getShapeSpec() const
-        {
-        throw std::runtime_error("Shape definition not supported for this shape class.");
-        }
-    #endif
-
     //! Return the bounding box of the shape in world coordinates
     DEVICE detail::AABB getAABB(const vec3<Scalar>& pos) const
         {

--- a/hoomd/hpmc/ShapePolyhedron.h
+++ b/hoomd/hpmc/ShapePolyhedron.h
@@ -178,40 +178,7 @@ struct ShapePolyhedron
         return data.sweep_radius != OverlapReal(0.0);
         }
 
-    #ifndef __HIPCC__
-    std::string getShapeSpec() const
-        {
-        unsigned int n_verts = data.n_verts;
-        unsigned int n_faces = data.n_faces;
-        std::ostringstream shapedef;
-        shapedef << "{\"type\": \"Mesh\", \"vertices\": [";
-        for (unsigned int i = 0; i < n_verts-1; i++)
-            {
-            shapedef << "[" << data.verts[i].x << ", " << data.verts[i].y << ", " << data.verts[i].z << "], ";
-            }
-        shapedef << "[" << data.verts[n_verts-1].x << ", " << data.verts[n_verts-1].y << ", " << data.verts[n_verts-1].z << "]], \"indices\": [";
-        unsigned int nverts_face, offset;
-        for (unsigned int i = 0; i < n_faces; i++)
-            {
-            // Number of vertices of ith face
-            nverts_face = data.face_offs[i + 1] - data.face_offs[i];
-            offset = data.face_offs[i];
-            shapedef << "[";
-            for (unsigned int j = 0; j < nverts_face-1; j++)
-                {
-                shapedef << data.face_verts[offset+j] << ", ";
-                }
-            shapedef << data.face_verts[offset+nverts_face-1];
-            if (i == n_faces-1)
-                shapedef << "]]}";
-            else
-                shapedef << "], ";
-            }
-        return shapedef.str();
-        }
-    #endif
-
-    //! Return the bounding box of the shape in world coordinates
+    /// Return the bounding box of the shape in world coordinates
     DEVICE detail::AABB getAABB(const vec3<Scalar>& pos) const
         {
         return detail::AABB(pos, data.convex_hull_verts.diameter/Scalar(2));
@@ -977,6 +944,46 @@ DEVICE inline bool test_overlap(const vec3<Scalar>& r_ab,
 
     return false;
     }
+
+#ifndef __HIPCC__
+/// Return the shape parameters in the `type_shape` format
+template<>
+inline std::string getShapeSpec(const ShapePolyhedron& s)
+    {
+    auto& data = s.data;
+    unsigned int n_verts = data.n_verts;
+    unsigned int n_faces = data.n_faces;
+    std::ostringstream shapedef;
+    shapedef << "{\"type\": \"Mesh\", \"vertices\": [";
+    for (unsigned int i = 0; i < n_verts-1; i++)
+        {
+        shapedef << "[" << data.verts[i].x << ", " << data.verts[i].y << ", "
+                 << data.verts[i].z << "], ";
+        }
+    shapedef << "[" << data.verts[n_verts-1].x << ", " << data.verts[n_verts-1].y
+             << ", " << data.verts[n_verts-1].z << "]], \"indices\": [";
+
+    unsigned int nverts_face, offset;
+    for (unsigned int i = 0; i < n_faces; i++)
+        {
+        // Number of vertices of ith face
+        nverts_face = data.face_offs[i + 1] - data.face_offs[i];
+        offset = data.face_offs[i];
+        shapedef << "[";
+        for (unsigned int j = 0; j < nverts_face-1; j++)
+            {
+            shapedef << data.face_verts[offset+j] << ", ";
+            }
+        shapedef << data.face_verts[offset+nverts_face-1];
+        if (i == n_faces-1)
+            shapedef << "]]}";
+        else
+            shapedef << "], ";
+        }
+    return shapedef.str();
+    }
+#endif
+
 
 }; // end namespace hpmc
 

--- a/hoomd/hpmc/ShapeSimplePolygon.h
+++ b/hoomd/hpmc/ShapeSimplePolygon.h
@@ -320,6 +320,22 @@ DEVICE inline bool test_overlap<ShapeSimplePolygon,ShapeSimplePolygon>(const vec
                                                quat<OverlapReal>(b.orientation));
     }
 
+#ifndef __HIPCC__
+template<>
+inline std::string getShapeSpec(const ShapeSimplePolygon& poly)
+    {
+    std::ostringstream shapedef;
+    auto& verts = poly.verts;
+    shapedef << "{\"type\": \"Polygon\", \"rounding_radius\": " << poly.verts.sweep_radius << ", \"vertices\": [";
+    for (unsigned int i = 0; i < verts.N-1; i++)
+        {
+        shapedef << "[" << verts.x[i] << ", " << verts.y[i] << "], ";
+        }
+    shapedef << "[" << verts.x[verts.N-1] << ", " << verts.y[verts.N-1] << "]]}";
+    return shapedef.str();
+    }
+#endif
+
 }; // end namespace hpmc
 
 #undef DEVICE

--- a/hoomd/hpmc/ShapeSphere.h
+++ b/hoomd/hpmc/ShapeSphere.h
@@ -164,15 +164,6 @@ struct ShapeSphere
         return detail::OBB(getAABB(pos));
         }
 
-    #ifndef __HIPCC__
-    std::string getShapeSpec() const
-        {
-        std::ostringstream shapedef;
-        shapedef << "{\"type\": \"Sphere\", \"diameter\": " << params.radius*OverlapReal(2.0) << "}";
-        return shapedef.str();
-        }
-    #endif
-
     //! Returns true if this shape splits the overlap check over several threads of a warp using threadIdx.x
     HOSTDEVICE static bool isParallel() { return false; }
 
@@ -470,6 +461,24 @@ DEVICE inline bool test_overlap_intersection(const ShapeSphere& a, const ShapeSp
 
     return detail::check_three_spheres_overlap(Ra,Rb,Rc,ab_t,ac_t);
     }
+
+#ifndef __HIPCC__
+template<class Shape>
+std::string getShapeSpec(const Shape& shape)
+    {
+    // default implementation
+    throw std::runtime_error("Shape definition not supported for this shape class.");
+    }
+
+template<>
+inline std::string getShapeSpec(const ShapeSphere& sphere)
+    {
+    std::ostringstream shapedef;
+    shapedef << "{\"type\": \"Sphere\", \"diameter\": " << sphere.params.radius*OverlapReal(2.0) << "}";
+    return shapedef.str();
+    }
+#endif
+
 
 }; // end namespace hpmc
 

--- a/hoomd/hpmc/ShapeSpheropolygon.h
+++ b/hoomd/hpmc/ShapeSpheropolygon.h
@@ -123,32 +123,6 @@ struct ShapeSpheropolygon
         return OverlapReal(0.0);
         }
 
-    #ifndef __HIPCC__
-    std::string getShapeSpec() const
-        {
-        std::ostringstream shapedef;
-        unsigned int nverts = verts.N;
-        if (nverts == 1)
-            {
-            shapedef << "{\"type\": \"Sphere\", " << "\"diameter\": " << verts.diameter << "}";
-            }
-        else if (nverts == 2)
-            {
-            throw std::runtime_error("Shape definition not supported for 2-vertex spheropolygons");
-            }
-        else
-            {
-            shapedef << "{\"type\": \"Polygon\", \"rounding_radius\": " << verts.sweep_radius << ", \"vertices\": [";
-            for (unsigned int i = 0; i < nverts-1; i++)
-                {
-                shapedef << "[" << verts.x[i] << ", " << verts.y[i] << "], ";
-                }
-            shapedef << "[" << verts.x[nverts-1] << ", " << verts.y[nverts-1] << "]]}";
-            }
-        return shapedef.str();
-        }
-    #endif
-
     //! Return the bounding box of the shape in world coordinates
     DEVICE detail::AABB getAABB(const vec3<Scalar>& pos) const
         {
@@ -209,6 +183,34 @@ DEVICE inline bool test_overlap<ShapeSpheropolygon,ShapeSpheropolygon>(const vec
                                   quat<OverlapReal>(b.orientation),
                                   err);
     }
+
+#ifndef __HIPCC__
+template<>
+inline std::string getShapeSpec(const ShapeSpheropolygon& spoly)
+    {
+    std::ostringstream shapedef;
+    auto& verts = spoly.verts;
+    unsigned int nverts = verts.N;
+    if (nverts == 1)
+        {
+        shapedef << "{\"type\": \"Sphere\", " << "\"diameter\": " << verts.diameter << "}";
+        }
+    else if (nverts == 2)
+        {
+        throw std::runtime_error("Shape definition not supported for 2-vertex spheropolygons");
+        }
+    else
+        {
+        shapedef << "{\"type\": \"Polygon\", \"rounding_radius\": " << verts.sweep_radius << ", \"vertices\": [";
+        for (unsigned int i = 0; i < nverts-1; i++)
+            {
+            shapedef << "[" << verts.x[i] << ", " << verts.y[i] << "], ";
+            }
+        shapedef << "[" << verts.x[nverts-1] << ", " << verts.y[nverts-1] << "]]}";
+        }
+    return shapedef.str();
+    }
+#endif
 
 }; // end namespace hpmc
 

--- a/hoomd/hpmc/ShapeSpheropolyhedron.h
+++ b/hoomd/hpmc/ShapeSpheropolyhedron.h
@@ -91,32 +91,6 @@ struct ShapeSpheropolyhedron
         return OverlapReal(0.0);
         }
 
-    #ifndef __HIPCC__
-    std::string getShapeSpec() const
-        {
-        std::ostringstream shapedef;
-        unsigned int nverts = verts.N;
-        if (nverts == 1)
-            {
-            shapedef << "{\"type\": \"Sphere\", " << "\"diameter\": " << verts.diameter << "}";
-            }
-        else if (nverts == 2)
-            {
-            throw std::runtime_error("Shape definition not supported for 2-vertex spheropolyhedra");
-            }
-        else
-            {
-            shapedef << "{\"type\": \"ConvexPolyhedron\", \"rounding_radius\": " << verts.sweep_radius << ", \"vertices\": [";
-            for (unsigned int i = 0; i < nverts-1; i++)
-                {
-                shapedef << "[" << verts.x[i] << ", " << verts.y[i] << ", " << verts.z[i] << "], ";
-                }
-            shapedef << "[" << verts.x[nverts-1] << ", " << verts.y[nverts-1] << ", " << verts.z[nverts-1] << "]]}";
-            }
-        return shapedef.str();
-        }
-    #endif
-
     //! Return the bounding box of the shape in world coordinates
     DEVICE detail::AABB getAABB(const vec3<Scalar>& pos) const
         {
@@ -235,6 +209,34 @@ DEVICE inline bool test_overlap_intersection(const ShapeSpheropolyhedron& a,
         vec3<OverlapReal>(ac_t),
         err);
     }
+
+#ifndef __HIPCC__
+template<>
+inline std::string getShapeSpec(const ShapeSpheropolyhedron& spoly)
+    {
+    std::ostringstream shapedef;
+    auto& verts = spoly.verts;
+    unsigned int nverts = verts.N;
+    if (nverts == 1)
+        {
+        shapedef << "{\"type\": \"Sphere\", " << "\"diameter\": " << verts.diameter << "}";
+        }
+    else if (nverts == 2)
+        {
+        throw std::runtime_error("Shape definition not supported for 2-vertex spheropolyhedra");
+        }
+    else
+        {
+        shapedef << "{\"type\": \"ConvexPolyhedron\", \"rounding_radius\": " << verts.sweep_radius << ", \"vertices\": [";
+        for (unsigned int i = 0; i < nverts-1; i++)
+            {
+            shapedef << "[" << verts.x[i] << ", " << verts.y[i] << ", " << verts.z[i] << "], ";
+            }
+        shapedef << "[" << verts.x[nverts-1] << ", " << verts.y[nverts-1] << ", " << verts.z[nverts-1] << "]]}";
+        }
+    return shapedef.str();
+    }
+#endif
 
 }; // end namespace hpmc
 

--- a/hoomd/hpmc/ShapeSphinx.h
+++ b/hoomd/hpmc/ShapeSphinx.h
@@ -130,13 +130,6 @@ struct ShapeSphinx
         return Scalar(0.0);
         }
 
-    #ifndef __HIPCC__
-    std::string getShapeSpec() const
-        {
-        throw std::runtime_error("Shape definition not supported for this shape class.");
-        }
-    #endif
-
     //! Return the bounding box of the shape in world coordinates
     DEVICE detail::AABB getAABB(const vec3<Scalar>& pos) const
         {

--- a/hoomd/hpmc/ShapeUnion.h
+++ b/hoomd/hpmc/ShapeUnion.h
@@ -719,10 +719,10 @@ inline std::string getShapeSpec(const ShapeUnion<ShapeSphere>& sphere_union)
         {
         shapedef << "[" << members.mpos[i].x << ", " << members.mpos[i].y << ", " << members.mpos[i].z << "], ";
         }
-    shapedef << "[" << members.mpos[n_centers-1].x << ", " << members.mpos[n_centers-1].y << ", " << members.mpos[n_centers-1].z << "]], \"radii\": [";
+    shapedef << "[" << members.mpos[n_centers-1].x << ", " << members.mpos[n_centers-1].y << ", " << members.mpos[n_centers-1].z << "]], \"diameters\": [";
     for (unsigned int i = 0; i < n_centers-1; i++)
         {
-        shapedef << members.mparams[i].radius << ", ";
+        shapedef << 2.0*members.mparams[i].radius << ", ";
         }
     shapedef << members.mparams[n_centers-1].radius;
     shapedef << "]}";

--- a/hoomd/hpmc/ShapeUnion.h
+++ b/hoomd/hpmc/ShapeUnion.h
@@ -197,13 +197,6 @@ struct ShapeUnion
         return OverlapReal(0.0);
         }
 
-    #ifndef __HIPCC__
-    std::string getShapeSpec() const
-        {
-        throw std::runtime_error("Shape definition not supported for this shape class.");
-        }
-    #endif
-
     //! Return the bounding box of the shape in world coordinates
     DEVICE detail::AABB getAABB(const vec3<Scalar>& pos) const
         {
@@ -712,6 +705,32 @@ DEVICE inline bool test_overlap_intersection(const ShapeUnion<Shape>& a,
 
     return false;
     }
+
+#ifndef __HIPCC__
+template<>
+inline std::string getShapeSpec(const ShapeUnion<ShapeSphere>& sphere_union)
+    {
+    auto& members = sphere_union.members;
+
+    unsigned int n_centers = members.N;
+    std::ostringstream shapedef;
+    shapedef << "{\"type\": \"SphereUnion\", \"centers\": [";
+    for (unsigned int i = 0; i < n_centers-1; i++)
+        {
+        shapedef << "[" << members.mpos[i].x << ", " << members.mpos[i].y << ", " << members.mpos[i].z << "], ";
+        }
+    shapedef << "[" << members.mpos[n_centers-1].x << ", " << members.mpos[n_centers-1].y << ", " << members.mpos[n_centers-1].z << "]], \"radii\": [";
+    for (unsigned int i = 0; i < n_centers-1; i++)
+        {
+        shapedef << members.mparams[i].radius << ", ";
+        }
+    shapedef << members.mparams[n_centers-1].radius;
+    shapedef << "]}";
+
+    return shapedef.str();
+    }
+#endif
+
 } // end namespace hpmc
 
 #undef DEVICE

--- a/hoomd/hpmc/ShapeUnion.h
+++ b/hoomd/hpmc/ShapeUnion.h
@@ -724,7 +724,7 @@ inline std::string getShapeSpec(const ShapeUnion<ShapeSphere>& sphere_union)
         {
         shapedef << 2.0*members.mparams[i].radius << ", ";
         }
-    shapedef << members.mparams[n_centers-1].radius;
+    shapedef << 2.0*members.mparams[n_centers-1].radius;
     shapedef << "]}";
 
     return shapedef.str();


### PR DESCRIPTION
## Description

Backport of GSD `SphereUnion` shape spec export [`hpmc.gsd.dump_shape()`], from #537 . I cherry-picked the commits, so this *should* merge cleanly into `hpmc_integrator_api`.

## Motivation and Context

These commits enable us to use the shape export feature now, rather than waiting for #537 to be feature complete. `SphereUnion` support has made its way into OVITO  (dev build 743) https://gitlab.com/stuko/ovito/-/issues/177

Resolves: N/A

## How Has This Been Tested?

The unit test is not in this branch. A prototype is contained in `hpmc_integrator_api` for further adaptation to the new API / `pytest`.

## Change log

N/A

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/hoomd-blue/blob/master/sphinx-doc/credits.rst).
