### PR TITLE
Scale nondimensional cutoff irrespective of sigma.

### DIFF
--- a/hoomd/md/EvaluatorPairGB.h
+++ b/hoomd/md/EvaluatorPairGB.h
@@ -186,7 +186,7 @@ class EvaluatorPairGB
 
             // define r_cut to be along the long axis
             Scalar sigma_max = Scalar(2.0)*HOOMD_GB_MAX(params.lperp,params.lpar);
-            Scalar zetacut = (rcut*sigma/sigma_max-sigma+sigma_min)/sigma_min;
+            Scalar zetacut = rcut/sigma_max;
             Scalar zetacutsq = zetacut*zetacut;
 
             // compute the force divided by r in force_divr


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should based on *maint*. -->
<!-- New features should based on *master*. -->

## Description

This PR replaces #601, which attempted to fix the scaling of the cutoff distance in the Gay-Berne potential.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

<!-- Replace ??? with the issue number that this pull request resolves. -->

 The version of the cutoff before #601 was clearly incorrect because it led to attractive potentials for any choice of the cutoff > sigma. The fix in #601 leads to a repulsive potential, but more extensive tests show that this version violates energy conservation for any choice of cutoff when `mode="shift"`, so clearly the cutoff is nonuniform across different orientations. The issue is that the cutoff should not be a function of the current orientations, because we're already comparing to sigma/r (where r is already based on the barycentric coordinates and orientations). So our expectation should be that the user specifies `r_cut` relative to `sigma_max` -- where `sigma_max` is the major axis length-- because that is what you need for the neighborlist to be complete, and then the cutoff just scales that down to the nondimensional value but dividing out `sigma_max`. 

This version properly conserves energy and momentum with and without the shift, and setting `mode="shift"` leads to a purely repulsive potential (always positive energies).

@jglaser I'd appreciate if you could confirm that this makes sense. When we worked on #601 you went a bit too fast for me to follow the reason for the choice that you recommended, but I think the issue is that it only considered the behavior when `r_cut=sigma` without accounting for shifting.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

As in #601, I'm not sure what the best way to test this without the 3.0 API. However, I think it would be good to try to add some validation for this so that we can be confident in our choice.

## Change log

<!-- Propose a change log entry. -->
No need for one since we have one from #601. 

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/hoomd-blue/blob/master/sphinx-doc/credits.rst).
