### PR TITLE
Feature/new nvt method

### DIFF
--- a/hoomd/device.py
+++ b/hoomd/device.py
@@ -338,7 +338,7 @@ class Auto(_device):
         _init_nthreads(nthreads)
 
         self.cpp_exec_conf = _hoomd.ExecutionConfiguration(_hoomd.ExecutionConfiguration.executionMode.AUTO,
-                                                           _hoomd.std_vector_int(),
+                                                           [],
                                                            False,
                                                            False,
                                                            self.comm.cpp_mpi_conf,

--- a/hoomd/md/IntegrationMethodTwoStep.cc
+++ b/hoomd/md/IntegrationMethodTwoStep.cc
@@ -321,5 +321,8 @@ void export_IntegrationMethodTwoStep(py::module& m)
                                              {
                                              return method->getGroup()->getFilter();
                                              })
+        #ifdef ENABLE_MPI
+        .def("setCommunicator", &IntegrationMethodTwoStep::setCommunicator)
+        #endif
         ;
     }

--- a/hoomd/md/TwoStepNVTMTK.cc
+++ b/hoomd/md/TwoStepNVTMTK.cc
@@ -510,5 +510,6 @@ void export_TwoStepNVTMTK(py::module& m)
                        >())
         .def("setT", &TwoStepNVTMTK::setT)
         .def("setTau", &TwoStepNVTMTK::setTau)
+        .def_property("kT", &TwoStepNVTMTK::getT, $TwoStepNVTMTK::setT)
         ;
     }

--- a/hoomd/md/TwoStepNVTMTK.cc
+++ b/hoomd/md/TwoStepNVTMTK.cc
@@ -510,7 +510,7 @@ void export_TwoStepNVTMTK(py::module& m)
                        >())
         .def("setT", &TwoStepNVTMTK::setT)
         .def("setTau", &TwoStepNVTMTK::setTau)
-        .def_property("kT", &TwoStepNVTMTK::getT, $TwoStepNVTMTK::setT)
-        .def_property("tau", &TwoStepNVTMTK::getTau, $TwoStepNVTMTK::setTau)
+        .def_property("kT", &TwoStepNVTMTK::getT, &TwoStepNVTMTK::setT)
+        .def_property("tau", &TwoStepNVTMTK::getTau, &TwoStepNVTMTK::setTau)
         ;
     }

--- a/hoomd/md/TwoStepNVTMTK.cc
+++ b/hoomd/md/TwoStepNVTMTK.cc
@@ -511,5 +511,6 @@ void export_TwoStepNVTMTK(py::module& m)
         .def("setT", &TwoStepNVTMTK::setT)
         .def("setTau", &TwoStepNVTMTK::setTau)
         .def_property("kT", &TwoStepNVTMTK::getT, $TwoStepNVTMTK::setT)
+        .def_property("tau", &TwoStepNVTMTK::getTau, $TwoStepNVTMTK::setTau)
         ;
     }

--- a/hoomd/md/TwoStepNVTMTK.h
+++ b/hoomd/md/TwoStepNVTMTK.h
@@ -57,7 +57,7 @@ class PYBIND11_EXPORT TwoStepNVTMTK : public IntegrationMethodTwoStep
             }
 
         /// Get the current temperature variant
-        std:shared_ptr<Variant> getT()
+        std::shared_ptr<Variant> getT()
             {
             return m_T;
             }

--- a/hoomd/md/TwoStepNVTMTK.h
+++ b/hoomd/md/TwoStepNVTMTK.h
@@ -56,6 +56,12 @@ class PYBIND11_EXPORT TwoStepNVTMTK : public IntegrationMethodTwoStep
             m_T = T;
             }
 
+        /// Get the current temperature variant
+        std:shared_ptr<Variant> getT()
+            {
+            return m_T;
+            }
+
         //! Update the tau value
         /*! \param tau New time constant to set
         */

--- a/hoomd/md/TwoStepNVTMTK.h
+++ b/hoomd/md/TwoStepNVTMTK.h
@@ -70,6 +70,12 @@ class PYBIND11_EXPORT TwoStepNVTMTK : public IntegrationMethodTwoStep
             m_tau = tau;
             }
 
+        /// get the tau value
+        Scalar getTau()
+            {
+            return m_tau;
+            }
+
         //! Set the value of xi (for unit tests)
         void setXi(Scalar new_xi)
             {

--- a/hoomd/md/methods.py
+++ b/hoomd/md/methods.py
@@ -108,14 +108,18 @@ class NVT(_Method):
         # initialize the reflected cpp class
         if not simulation.device.cpp_exec_conf.isCUDAEnabled():
             my_class = _md.TwoStepNVTMTK
+            thermo_cls = _hoomd.ComputeThermo
         else:
             my_class = _md.TwoStepNVTMTKGPU
+            thermo_cls = _hoomd.ComputeThermoGPU
 
         group = simulation.state.get_group(self.filter)
-        self._cpp_obj = my_class(simulation.state._cpp_sys_def,
+        cpp_sys_def = simulation.state._cpp_sys_def
+        self._cpp_obj = my_class(cpp_sys_def,
                                  group,
-                                 hoomd.compute.thermo(group).cpp_compute,
-                                 self.kT)
+                                 thermo_cls(cpp_sys_def, group, ""),
+                                 self.kT,
+                                 "")
         super().attach(simulation)
 
     def thermalize_velocities(self, seed):

--- a/hoomd/md/methods.py
+++ b/hoomd/md/methods.py
@@ -115,9 +115,11 @@ class NVT(_Method):
 
         group = simulation.state.get_group(self.filter)
         cpp_sys_def = simulation.state._cpp_sys_def
+        thermo = thermo_cls(cpp_sys_def, group, "")
         self._cpp_obj = my_class(cpp_sys_def,
                                  group,
-                                 thermo_cls(cpp_sys_def, group, ""),
+                                 thermo,
+                                 self.tau,
                                  self.kT,
                                  "")
         super().attach(simulation)

--- a/hoomd/md/methods.py
+++ b/hoomd/md/methods.py
@@ -825,9 +825,9 @@ class Langevin(_Method):
             kT=create_variant,
             seed=int(seed),
             alpha=none_or(float),
-            tally_reservoir_energy=bool(tally_reservoir_energy),
-            explicit_defaults=dict(kT=kT, alpha=alpha, filter=filter)
+            tally_reservoir_energy=bool(tally_reservoir_energy)
             )
+        param_dict.update(dict(kT=kT, alpha=alpha, filter=filter))
         # set defaults
         self._param_dict.update(param_dict)
 

--- a/hoomd/md/methods.py
+++ b/hoomd/md/methods.py
@@ -91,7 +91,7 @@ class NVT(_Method):
         typeA = group.type('A')
         integrator = integrate.nvt(group=typeA, tau=1.0, kT=hoomd.variant.linear_interp([(0, 4.0), (1e6, 1.0)]))
     """
-    def __init__(self, filter, kT, tau)
+    def __init__(self, filter, kT, tau):
 
         # store metadata
         param_dict = ParameterDict(

--- a/hoomd/md/methods.py
+++ b/hoomd/md/methods.py
@@ -47,25 +47,25 @@ class NVT(_Method):
     R""" NVT Integration via the Nosé-Hoover thermostat.
 
     Args:
-        group (:py:mod:`hoomd.group`): Group of particles on which to apply this
+        filter (:py:mod:`hoomd.filter`): Subset of particles on which to apply this
             method.
         kT (:py:mod:`hoomd.variant` or :py:obj:`float`): Temperature set point
             for the Nosé-Hoover thermostat. (in energy units).
         tau (float): Coupling constant for the Nosé-Hoover thermostat. (in time
             units).
 
-    :py:class:`nvt` performs constant volume, constant temperature simulations
+    :py:class:`NVT` performs constant volume, constant temperature simulations
     using the Nosé-Hoover thermostat, using the MTK equations described in Refs.
     `G. J. Martyna, D. J. Tobias, M. L. Klein  1994
     <http://dx.doi.org/10.1063/1.467468>`_ and `J. Cao, G. J. Martyna 1996
     <http://dx.doi.org/10.1063/1.470959>`_.
 
-    :py:class:`nvt` is an integration method. It must be used in connection with
+    :py:class:`NVT` is an integration method. It must be used in connection with
     :py:class:`mode_standard`.
 
-    :py:class:`nvt` uses the proper number of degrees of freedom to compute the
+    :py:class:`NVT` uses the proper number of degrees of freedom to compute the
     temperature of the system in both 2 and 3 dimensional systems, as long as
-    the number of dimensions is set before the integrate.nvt command is
+    the number of dimensions is set before the integrate.NVT command is
     specified.
 
     :math:`\tau` is related to the Nosé mass :math:`Q` by
@@ -85,11 +85,11 @@ class NVT(_Method):
 
     Examples::
 
-        all = group.all()
-        integrate.nvt(group=all, kT=1.0, tau=0.5)
-        integrator = integrate.nvt(group=all, tau=1.0, kT=0.65)
-        typeA = group.type('A')
-        integrator = integrate.nvt(group=typeA, tau=1.0, kT=hoomd.variant.linear_interp([(0, 4.0), (1e6, 1.0)]))
+        all = filter.All()
+        integrate.NVT(filter=all, kT=1.0, tau=0.5)
+        integrator = integrate.NVT(filter=all, tau=1.0, kT=0.65)
+        typeA = filter.Type('A')
+        integrator = integrate.NVT(filter=typeA, tau=1.0, kT=hoomd.variant.linear_interp([(0, 4.0), (1e6, 1.0)]))
     """
     def __init__(self, filter, kT, tau):
 
@@ -123,37 +123,6 @@ class NVT(_Method):
                                  self.kT,
                                  "")
         super().attach(simulation)
-
-    def thermalize_velocities(self, seed):
-        R""" Assign random velocities and angular momenta to particles in the
-        group, sampling from the Maxwell-Boltzmann distribution. This method
-        considers the dimensionality of the system and particle anisotropy, and
-        removes drift (the center of mass velocity).
-
-        .. versionadded:: 2.3
-
-        Starting in version 2.5, `randomize_velocities` also chooses random values
-        for the internal integrator variables.
-
-        Args:
-            seed (int): Random number seed
-
-        Note:
-            Randomization is applied at the start of the next call to :py:func:`hoomd.run`.
-
-        Example::
-
-            integrator = md.integrate.nvt(group=group.all(), kT=1.0, tau=0.5)
-            integrator.randomize_velocities(seed=42)
-            run(100)
-
-        """
-        if not self.is_attached():
-            raise NotAttachedError("Must be attached before calling thermalize_velocities()")
-
-        step = self._sim.timestep  # need to give operations access to the sim object
-        kT = self.kT._cpp_obj.getValue(timestep)
-        self._cpp_obj.setRandomVelocititesParams(kT, seed)
 
 
 class npt(_Method):

--- a/hoomd/md/methods.py
+++ b/hoomd/md/methods.py
@@ -97,7 +97,8 @@ class NVT(_Method):
         param_dict = ParameterDict(
             filter=OnlyType(_ParticleFilter),
             kT=create_variant,
-            tau=float(tau)
+            tau=float(tau),
+            explicit_defaults=dict(kT=kT, filter=filter)
             )
         # set defaults
         self._param_dict.update(param_dict)
@@ -106,14 +107,14 @@ class NVT(_Method):
 
         # initialize the reflected cpp class
         if not simulation.device.cpp_exec_conf.isCUDAEnabled():
-            my_class = _md.TwoStepNVTMKT
+            my_class = _md.TwoStepNVTMTK
         else:
-            my_class = _md.TwoStepNVTMKTGPU
+            my_class = _md.TwoStepNVTMTKGPU
 
         group = simulation.state.get_group(self.filter)
         self._cpp_obj = my_class(simulation.state._cpp_sys_def,
                                  group,
-                                 hoomd.compute.thermo(group)._cpp_obj,  # placeholder
+                                 hoomd.compute.thermo(group).cpp_compute,
                                  self.kT)
         super().attach(simulation)
 

--- a/hoomd/md/methods.py
+++ b/hoomd/md/methods.py
@@ -98,8 +98,8 @@ class NVT(_Method):
             filter=OnlyType(_ParticleFilter),
             kT=create_variant,
             tau=float(tau),
-            explicit_defaults=dict(kT=kT, filter=filter)
             )
+        param_dict.update(dict(kT=kT, filter=filter))
         # set defaults
         self._param_dict.update(param_dict)
 

--- a/hoomd/md/pytest/CMakeLists.txt
+++ b/hoomd/md/pytest/CMakeLists.txt
@@ -1,6 +1,7 @@
 # copy python modules to the build directory to make it a working python package
 set(files __init__.py
     test_flags.py
+    test_methods.py
     )
 
 install(FILES ${files}

--- a/hoomd/md/pytest/test_methods.py
+++ b/hoomd/md/pytest/test_methods.py
@@ -4,14 +4,14 @@ import numpy
 import itertools
 from copy import deepcopy
 
-_int_methods = [
-    hoomd.md.methods.Langevin(hoomd.filter.All(), kT=1, seed=1),
-    hoomd.md.methods.NVT(hoomd.filter.All(), kT=1, tau=1),
+_method_data = [
+    ("Langevin", hoomd.md.methods.Langevin(hoomd.filter.All(), kT=1, seed=1)),
+    ("NVT", hoomd.md.methods.NVT(hoomd.filter.All(), kT=1, tau=1)),
 ]
 
-@pytest.fixture(scope='function', params=_int_methods)
+@pytest.fixture(scope='function', params=_method_data, ids=(lambda x: x[0]))
 def int_method(request):
-    return deepcopy(request.param)
+    return deepcopy(request.param[1])
 
 def test_attach(simulation_factory, two_particle_snapshot_factory, int_method):
     sim = simulation_factory(two_particle_snapshot_factory(dimensions=3, d=.9))

--- a/hoomd/md/pytest/test_methods.py
+++ b/hoomd/md/pytest/test_methods.py
@@ -2,19 +2,22 @@ import hoomd
 import pytest
 import numpy
 import itertools
+from copy import deepcopy
 
-def attach_and_sim(simulation_factory, two_particle_snapshot_factory, method):
+_int_methods = [
+    hoomd.md.methods.Langevin(hoomd.filter.All(), kT=1, seed=1),
+    hoomd.md.methods.NVT(hoomd.filter.All(), kT=1, tau=1),
+]
+
+@pytest.fixture(scope='function', params=_int_methods)
+def int_method(request):
+    return deepcopy(request.param)
+
+def test_attach(simulation_factory, two_particle_snapshot_factory, int_method):
     sim = simulation_factory(two_particle_snapshot_factory(dimensions=3, d=.9))
     integrator = hoomd.md.Integrator(.05)
-    integrator.methods.append(method)
+    integrator.methods.append(int_method)
     sim.operations.integrator = integrator
     sim.operations.schedule()
     sim.run(10)
 
-def test_attach_nvt(simulation_factory, two_particle_snapshot_factory):
-    nvt = hoomd.md.methods.NVT(hoomd.filter.All(), kT=1, tau=1)
-    attach_and_sim(simulation_factory, two_particle_snapshot_factory, nvt)
-
-def test_attach_langevin(simulation_factory, two_particle_snapshot_factory):
-    lang = hoomd.md.methods.Langevin(hoomd.filter.All(), kT=1, seed=1)
-    attach_and_sim(simulation_factory, two_particle_snapshot_factory, lang)

--- a/hoomd/md/pytest/test_methods.py
+++ b/hoomd/md/pytest/test_methods.py
@@ -3,13 +3,18 @@ import pytest
 import numpy
 import itertools
 
-def test_attach_nvt(simulation_factory, two_particle_snapshot_factory):
+def attach_and_sim(simulation_factory, two_particle_snapshot_factory, method):
     sim = simulation_factory(two_particle_snapshot_factory(dimensions=3, d=.9))
-    f = hoomd.filter.All()
-    nvt = hoomd.md.methods.NVT(f, kT=1, tau=1)
     integrator = hoomd.md.Integrator(.05)
-    integrator.methods.append(nvt)
+    integrator.methods.append(method)
     sim.operations.integrator = integrator
     sim.operations.schedule()
     sim.run(10)
 
+def test_attach_nvt(simulation_factory, two_particle_snapshot_factory):
+    nvt = hoomd.md.methods.NVT(hoomd.filter.All(), kT=1, tau=1)
+    attach_and_sim(simulation_factory, two_particle_snapshot_factory, nvt)
+
+def test_attach_langevin(simulation_factory, two_particle_snapshot_factory):
+    lang = hoomd.md.methods.Langevin(hoomd.filter.All(), kT=1, seed=1)
+    attach_and_sim(simulation_factory, two_particle_snapshot_factory, lang)

--- a/hoomd/md/pytest/test_methods.py
+++ b/hoomd/md/pytest/test_methods.py
@@ -1,0 +1,15 @@
+import hoomd
+import pytest
+import numpy
+import itertools
+
+def test_attach_nvt(simulation_factory, two_particle_snapshot_factory):
+    sim = simulation_factory(two_particle_snapshot_factory(dimensions=3, d=.9))
+    f = hoomd.filter.All()
+    nvt = hoomd.md.methods.NVT(f, kT=1, tau=1)
+    integrator = hoomd.md.Integrator(.05)
+    integrator.methods.append(nvt)
+    sim.operations.integrator = integrator
+    sim.operations.schedule()
+    sim.run(10)
+

--- a/hoomd/operation.py
+++ b/hoomd/operation.py
@@ -21,6 +21,9 @@ from hoomd.parameterdicts import ParameterDict
 
 from copy import deepcopy
 
+class NotAttachedError(RuntimeError):
+    """ Raised when a method that requires attachment is called before attaching """
+    pass
 
 def convert_values_to_log_form(value):
     if value is RequiredArg:

--- a/hoomd/operation.py
+++ b/hoomd/operation.py
@@ -22,7 +22,7 @@ from hoomd.parameterdicts import ParameterDict
 from copy import deepcopy
 
 class NotAttachedError(RuntimeError):
-    """ Raised when a method that requires attachment is called before attaching """
+    """ Raised when something that requires attachment happens before attaching """
     pass
 
 def convert_values_to_log_form(value):


### PR DESCRIPTION
## Description

Porting NVT integration method to the new v3 API. We haven't decided on how to handle the `randomize_velocities()` API in v3 yet, so this draft is to facilitate that discussion.

## Motivation and Context

We need to port everything to the new API, and this is one of those things

## How Has This Been Tested?

No tests or changes to documentation

## Change log

```
Moved NVT integration method to v3 API
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/hoomd-blue/blob/master/sphinx-doc/credits.rst).
