### PR TITLE
llvm 10 support

### DIFF
--- a/.azp/test.yml
+++ b/.azp/test.yml
@@ -49,8 +49,8 @@ stages:
           container_image: clang10_py38
           enable_mpi: on
           enable_tbb: on
-          build_jit: off
-          llvm_version: '9'
+          build_jit: on
+          llvm_version: '10'
 
         clang9_py38_mpi_tbb:
           container_image: clang9_py38

--- a/hoomd/jit/CMakeLists.txt
+++ b/hoomd/jit/CMakeLists.txt
@@ -43,9 +43,9 @@ add_library(HOOMD::_${PACKAGE_NAME} ALIAS _${PACKAGE_NAME})
 
 add_library (_${PACKAGE_NAME}_llvm SHARED ${_${PACKAGE_NAME}_llvm_sources})
 if (CMAKE_CXX_STANDARD LESS 14)
+    set_property(TARGET _${PACKAGE_NAME} PROPERTY CXX_STANDARD 14)
     set_property(TARGET _${PACKAGE_NAME}_llvm PROPERTY CXX_STANDARD 14)
 endif()
-set_property(TARGET _${PACKAGE_NAME} PROPERTY CXX_STANDARD 14)
 
 if (ENABLE_HIP)
     # no device linking

--- a/hoomd/jit/CMakeLists.txt
+++ b/hoomd/jit/CMakeLists.txt
@@ -43,6 +43,7 @@ add_library(HOOMD::_${PACKAGE_NAME} ALIAS _${PACKAGE_NAME})
 
 add_library (_${PACKAGE_NAME}_llvm SHARED ${_${PACKAGE_NAME}_llvm_sources})
 set_property(TARGET _${PACKAGE_NAME}_llvm PROPERTY CXX_STANDARD 14)
+set_property(TARGET _${PACKAGE_NAME} PROPERTY CXX_STANDARD 14)
 
 if (ENABLE_HIP)
     # no device linking

--- a/hoomd/jit/CMakeLists.txt
+++ b/hoomd/jit/CMakeLists.txt
@@ -42,7 +42,9 @@ pybind11_add_module(_${PACKAGE_NAME} SHARED ${_${PACKAGE_NAME}_sources} ${_${PAC
 add_library(HOOMD::_${PACKAGE_NAME} ALIAS _${PACKAGE_NAME})
 
 add_library (_${PACKAGE_NAME}_llvm SHARED ${_${PACKAGE_NAME}_llvm_sources})
-set_property(TARGET _${PACKAGE_NAME}_llvm PROPERTY CXX_STANDARD 14)
+if (CMAKE_CXX_STANDARD LESS 14)
+    set_property(TARGET _${PACKAGE_NAME}_llvm PROPERTY CXX_STANDARD 14)
+endif()
 set_property(TARGET _${PACKAGE_NAME} PROPERTY CXX_STANDARD 14)
 
 if (ENABLE_HIP)

--- a/hoomd/jit/CMakeLists.txt
+++ b/hoomd/jit/CMakeLists.txt
@@ -43,8 +43,8 @@ add_library(HOOMD::_${PACKAGE_NAME} ALIAS _${PACKAGE_NAME})
 
 add_library (_${PACKAGE_NAME}_llvm SHARED ${_${PACKAGE_NAME}_llvm_sources})
 if (CMAKE_CXX_STANDARD LESS 14)
-    set_property(TARGET _${PACKAGE_NAME} PROPERTY CXX_STANDARD 14)
     set_property(TARGET _${PACKAGE_NAME}_llvm PROPERTY CXX_STANDARD 14)
+    set_property(TARGET _${PACKAGE_NAME} PROPERTY CXX_STANDARD 14)
 endif()
 
 if (ENABLE_HIP)

--- a/hoomd/jit/CMakeLists.txt
+++ b/hoomd/jit/CMakeLists.txt
@@ -42,6 +42,7 @@ pybind11_add_module(_${PACKAGE_NAME} SHARED ${_${PACKAGE_NAME}_sources} ${_${PAC
 add_library(HOOMD::_${PACKAGE_NAME} ALIAS _${PACKAGE_NAME})
 
 add_library (_${PACKAGE_NAME}_llvm SHARED ${_${PACKAGE_NAME}_llvm_sources})
+set_property(TARGET _${PACKAGE_NAME}_llvm PROPERTY CXX_STANDARD 14)
 
 if (ENABLE_HIP)
     # no device linking

--- a/hoomd/jit/KaleidoscopeJIT.h
+++ b/hoomd/jit/KaleidoscopeJIT.h
@@ -14,8 +14,8 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_KALEIDOSCOPEJIT_H
 #define LLVM_EXECUTIONENGINE_ORC_KALEIDOSCOPEJIT_H
 
+#include <utility>
 #include "llvm/Config/llvm-config.h"
-
 #include "llvm/ExecutionEngine/ExecutionEngine.h"
 #include "llvm/ExecutionEngine/RTDyldMemoryManager.h"
 #include "llvm/ExecutionEngine/Orc/CompileUtils.h"


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should based on *maint*. -->
<!-- New features should based on *master*. -->

## Description
This PR cherry picks two commits from the `depletants_new` branch that enable the use of llvm 10.

Resolves: None

## How Has This Been Tested?

No new unit test required.

## Change log

<!-- Propose a change log entry. -->
```
Enabled llvm10 support.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/hoomd-blue/blob/master/sphinx-doc/credits.rst).
