### PR TITLE
Fix memory leak with period=None operations

### DIFF
--- a/hoomd/dump.py
+++ b/hoomd/dump.py
@@ -642,6 +642,7 @@ class gsd(hoomd.analyze._analyzer):
             if time_step is None:
                 time_step = hoomd.context.current.system.getCurrentTimeStep()
             self.cpp_analyzer.analyze(time_step);
+            hoomd.context.current.analyzers.remove(self)
 
         # store metadata
         self.filename = filename

--- a/hoomd/update.py
+++ b/hoomd/update.py
@@ -386,6 +386,7 @@ class box_resize(_updater):
 
         if period is None:
             self.cpp_updater.update(hoomd.context.current.system.getCurrentTimeStep());
+            hoomd.context.current.updaters.remove(self)
         else:
             self.setupUpdater(period, phase);
 


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should based on *maint*. -->
<!-- New features should based on *master*. -->

## Description

<!-- Describe your changes in detail. -->
Do not save references to objects when called with `period=None`.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
This prevents increasing memory usage.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
I have not tested the changes.

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
* Fix a bug where repeatedly using objects with ``period=None`` would use significant amounts of memory.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/hoomd-blue/blob/master/sphinx-doc/credits.rst).
