### PR TITLE
Fix profiling

### DIFF
--- a/hoomd/Profiler.h
+++ b/hoomd/Profiler.h
@@ -162,7 +162,7 @@ PYBIND11_EXPORT std::ostream& operator<<(std::ostream &o, Profiler& prof);
 
 inline void Profiler::push(std::shared_ptr<const ExecutionConfiguration> exec_conf, const std::string& name)
     {
-#if defined(ENABLE_HIP) && !defined(ENABLE_NVTOOLS)
+#if defined(ENABLE_HIP)
     // nvtools profiling disables synchronization so that async CPU/GPU overlap can be seen
     if(exec_conf->isCUDAEnabled())
         {
@@ -175,7 +175,7 @@ inline void Profiler::push(std::shared_ptr<const ExecutionConfiguration> exec_co
 
 inline void Profiler::pop(std::shared_ptr<const ExecutionConfiguration> exec_conf, uint64_t flop_count, uint64_t byte_count)
     {
-#if defined(ENABLE_HIP) && !defined(ENABLE_NVTOOLS)
+#if defined(ENABLE_HIP)
     // nvtools profiling disables synchronization so that async CPU/GPU overlap can be seen
     if(exec_conf->isCUDAEnabled())
         {

--- a/hoomd/util.py
+++ b/hoomd/util.py
@@ -58,7 +58,7 @@ def cuda_profile_start():
         raise RuntimeError("Cannot start profiling before initialization\n");
 
     if hoomd.context.current.device.cpp_exec_conf.isCUDAEnabled():
-        hoomd.context.current.device.cpp_exec_conf.cudaProfileStart();
+        hoomd.context.current.device.cpp_exec_conf.hipProfileStart();
 
 def cuda_profile_stop():
     """ Stop CUDA profiling.
@@ -72,4 +72,4 @@ def cuda_profile_stop():
         raise RuntimeError('Error stopping profile');
 
     if hoomd.context.current.device.cpp_exec_conf.isCUDAEnabled():
-        hoomd.context.current.device.cpp_exec_conf.cudaProfileStop();
+        hoomd.context.current.device.cpp_exec_conf.hipProfileStop();


### PR DESCRIPTION
## Description

- Fixes the util.cuda_profile_start()/stop() command
- Also fixes an issue with nvToolsExt where profiling ranges are out of sync with the GPU execution stream

## Motivation and Context

N/A

## How Has This Been Tested?

offline

## Change log

```
- fix profiling of NVTX ranges
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/hoomd-blue/blob/master/sphinx-doc/credits.rst).
