### PR TITLE
Add Analyzer setCommunicator method to pybind export

### DIFF
--- a/hoomd/Analyzer.cc
+++ b/hoomd/Analyzer.cc
@@ -43,5 +43,8 @@ void export_Analyzer(py::module& m)
         .def(py::init< std::shared_ptr<SystemDefinition> >())
         .def("analyze", &Analyzer::analyze)
         .def("setProfiler", &Analyzer::setProfiler)
+# ifdef ENABLE_MPI
+        .def("setCommunicator", &Analyzer::setCommunicator)
+# endif
         ;
     }

--- a/hoomd/Analyzer.cc
+++ b/hoomd/Analyzer.cc
@@ -43,8 +43,8 @@ void export_Analyzer(py::module& m)
         .def(py::init< std::shared_ptr<SystemDefinition> >())
         .def("analyze", &Analyzer::analyze)
         .def("setProfiler", &Analyzer::setProfiler)
-# ifdef ENABLE_MPI
+    #ifdef ENABLE_MPI
         .def("setCommunicator", &Analyzer::setCommunicator)
-# endif
+    #endif
         ;
     }

--- a/hoomd/Analyzer.h
+++ b/hoomd/Analyzer.h
@@ -20,6 +20,7 @@
 #include "Profiler.h"
 #include "SystemDefinition.h"
 #include "SharedSignal.h"
+#include "Communicator.h"
 
 #include <memory>
 

--- a/hoomd/Updater.cc
+++ b/hoomd/Updater.cc
@@ -3,7 +3,6 @@
 
 // Maintainer: joaander
 #include "Updater.h"
-#include "Communicator.h"
 
 namespace py = pybind11;
 

--- a/hoomd/Updater.h
+++ b/hoomd/Updater.h
@@ -9,6 +9,7 @@
 #include "SystemDefinition.h"
 #include "Profiler.h"
 #include "SharedSignal.h"
+#include "Communicator.h"
 
 #include <memory>
 


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should based on *maint*. -->
<!-- New features should based on *master*. -->

## Description
Fixes bug where `Analyzer`s did not expose their `setCommunicator` method to Python.
<!-- Describe your changes in detail. -->

## Motivation and Context
Required for `Analyzer`s to work currently.
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Has not, but `GSD` objects work now.
<!--- Please describe in detail how you tested your changes. -->

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```

```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [ ] My name is on the [list of contributors](https://github.com/glotzerlab/hoomd-blue/blob/master/sphinx-doc/credits.rst).
