### PR TITLE
Add undocumented arguments for frenkel-ladd-energy

### DIFF
--- a/hoomd/hpmc/field.py
+++ b/hoomd/hpmc/field.py
@@ -832,11 +832,13 @@ class frenkel_ladd_energy(_compute):
     R""" Compute the Frenkel-Ladd Energy of a crystal.
 
     Args:
+        mc (:py:mod:`hoomd.hpmc.integrate`): MC integrator.
         ln_gamma (float): log of the translational spring constant
         q_factor (float): scale factor between the translational spring constant and rotational spring constant
         r0 (list): reference lattice positions
         q0 (list): reference lattice orientations
         drift_period (int): period call the remove drift updater
+        symmetry (list): list of equivalent quaternions for the shape.
 
     :py:class:`frenkel_ladd_energy` interacts with :py:class:`.lattice_field`
     and :py:class:`hoomd.hpmc.update.remove_drift`.


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should based on *maint*. -->
<!-- New features should based on *master*. -->

## Description

<!-- Describe your changes in detail. -->
Adds docstrings for the integrator and the symmetric orientations arguments to `frenkel_ladd_energy`.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

<!-- Replace ??? with the issue number that this pull request resolves. -->
The symmetric orientations of a particle are an available parameter for lattice_field and can be passed to frenkel_ladd_energy, but they are undocumented and likely unused. The MC integrator is also an undocumented argument. While the latter is easy for users to recognize since the code will fail without it, users are likely completely unaware of the symmetric orientations argument.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

N/A

## Change log

<!-- Propose a change log entry. -->
None needed.

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/hoomd-blue/blob/master/sphinx-doc/credits.rst).
