### PR TITLE
Fix HOOMD-blue as a submodule

### DIFF
--- a/CMake/git/GetGitRevisionDescription.cmake
+++ b/CMake/git/GetGitRevisionDescription.cmake
@@ -47,6 +47,15 @@ function(get_git_head_revision _refspecvar _hashvar)
         set(${_hashvar} "GITDIR-NOTFOUND" PARENT_SCOPE)
         return()
     endif()
+
+    # check if this is a submodule
+    if(NOT IS_DIRECTORY ${GIT_DIR})
+        file(READ ${GIT_DIR} submodule)
+        string(REGEX REPLACE "gitdir: (.*)\n$" "\\1" GIT_DIR_RELATIVE ${submodule})
+        get_filename_component(SUBMODULE_DIR ${GIT_DIR} PATH)
+        get_filename_component(GIT_DIR ${SUBMODULE_DIR}/${GIT_DIR_RELATIVE} ABSOLUTE)
+    endif()
+
     set(GIT_DATA "${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/git-data")
     if(NOT EXISTS "${GIT_DATA}")
         file(MAKE_DIRECTORY "${GIT_DATA}")

--- a/sphinx-doc/credits.rst
+++ b/sphinx-doc/credits.rst
@@ -293,6 +293,10 @@ Geert Kapteijns, University of Amsterdam
 
   * Bug fixes.
 
+Charlie Slominski, Caltech
+
+  * HOOMD-blue as a submodule
+
 HPMC developers
 ---------------
 


### PR DESCRIPTION
## Description

This enables HOOMD-blue to build when it is used as a submodule in another project.

## Motivation and Context

This is convenient because the state of HOOMD-blue can be saved within a higher-level package.

I have restored the code block from here:
https://github.com/EmperorArthur/VBA-M/commit/c2a6f980cbcf02e96f23a48f836346664fbe0753

Resolves: #577

## How Has This Been Tested?

I checked build and tests when used as a submodule and as its own git repo.

## Change log

HOOMD-blue can now be used as a git submodule

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/hoomd-blue/blob/master/sphinx-doc/credits.rst).

