### PR TITLE
Feature/new nve

### DIFF
--- a/hoomd/dem/__init__.py
+++ b/hoomd/dem/__init__.py
@@ -37,7 +37,7 @@ Integration
 To allow particles to rotate, use integrators which can update
 rotational degrees of freedom:
 
-  * :py:mod:`hoomd.md.methods.nve`
+  * ``hoomd.md.methods.NVE``
   * ``hoomd.md.methods.NVT``
   * ``hoomd.md.methods.npt``
   * :py:mod:`hoomd.md.methods.Langevin`

--- a/hoomd/md/TwoStepNVE.cc
+++ b/hoomd/md/TwoStepNVE.cc
@@ -57,19 +57,6 @@ TwoStepNVE::~TwoStepNVE()
     a distance larger than the limit in a single time step
 */
 
-void TwoStepNVE::setLimit(pybind11::object limit)
-    {
-    if (limit.is_none())
-        {
-        m_limit = false;
-        }
-    else
-        {
-        m_limit=true;
-        m_limit_val=pybind11::cast<Scalar>(limit);
-        }
-    }
-
 pybind11::object TwoStepNVE::getLimit()
     {
     pybind11::object result;
@@ -84,10 +71,19 @@ pybind11::object TwoStepNVE::getLimit()
     return result;
     }
 
-void TwoStepNVE::setZeroForce(pybind11::object zero_force)
+void TwoStepNVE::setLimit(pybind11::object limit)
     {
-    m_zero_force=pybind11::cast<bool>(zero_force);
+    if (limit.is_none())
+        {
+        m_limit = false;
+        }
+    else
+        {
+        m_limit=true;
+        m_limit_val=pybind11::cast<Scalar>(limit);
+        }
     }
+
 
 pybind11::object TwoStepNVE::getZeroForce()
     {
@@ -95,6 +91,11 @@ pybind11::object TwoStepNVE::getZeroForce()
     result = pybind11::cast(m_zero_force);
 
     return result;
+    }
+
+void TwoStepNVE::setZeroForce(pybind11::object zero_force)
+    {
+    m_zero_force=pybind11::cast<bool>(zero_force);
     }
 
 
@@ -373,9 +374,9 @@ void export_TwoStepNVE(py::module& m)
         .def(py::init< std::shared_ptr<SystemDefinition>, 
                        std::shared_ptr<ParticleGroup>, 
                        bool >())
-        .def_property("limit", &TwoStepNVE::setLimit,
-                               &TwoStepNVE::getLimit)
-        .def_property("zero_force", &TwoStepNVE::setZeroForce,
-                                   &TwoStepNVE::getZeroForce)
+        .def_property("limit", &TwoStepNVE::getLimit,
+                               &TwoStepNVE::setLimit)
+        .def_property("zero_force", &TwoStepNVE::getZeroForce,
+                                   &TwoStepNVE::setZeroForce)
         ;
     }

--- a/hoomd/md/TwoStepNVE.cc
+++ b/hoomd/md/TwoStepNVE.cc
@@ -56,18 +56,47 @@ TwoStepNVE::~TwoStepNVE()
     Once the limit is set, future calls to update() will never move a particle
     a distance larger than the limit in a single time step
 */
-void TwoStepNVE::setLimit(Scalar limit)
+
+void TwoStepNVE::setLimit(pybind11::object limit)
     {
-    m_limit = true;
-    m_limit_val = limit;
+    if (limit.is_none())
+        {
+        m_limit = false;
+        }
+    else
+        {
+        m_limit=true;
+        m_limit_val=pybind11::cast<Scalar>(limit);
+        }
     }
 
-/*! Disables the limit, allowing particles to move normally
-*/
-void TwoStepNVE::removeLimit()
+pybind11::object TwoStepNVE::getLimit()
     {
-    m_limit = false;
+    pybind11::object result;
+    if (m_limit)
+        {
+        result = pybind11::cast(m_limit_val);
+        }
+    else
+    {
+    result = pybind11::none();
     }
+    return result;
+    }
+
+void TwoStepNVE::setZeroForce(pybind11::object zero_force)
+    {
+    m_zero_force=pybind11::cast<bool>(zero_force);
+    }
+
+pybind11::object TwoStepNVE::getZeroForce()
+    {
+    pybind11::object result;
+    result = pybind11::cast(m_zero_force);
+
+    return result;
+    }
+
 
 /*! \param timestep Current time step
     \post Particle positions are moved forward to timestep+1 and velocities to timestep+1/2 per the velocity verlet
@@ -341,9 +370,12 @@ void TwoStepNVE::integrateStepTwo(unsigned int timestep)
 void export_TwoStepNVE(py::module& m)
     {
     py::class_<TwoStepNVE, IntegrationMethodTwoStep, std::shared_ptr<TwoStepNVE> >(m, "TwoStepNVE")
-        .def(py::init< std::shared_ptr<SystemDefinition>, std::shared_ptr<ParticleGroup>, bool >())
-        .def("setLimit", &TwoStepNVE::setLimit)
-        .def("removeLimit", &TwoStepNVE::removeLimit)
-        .def("setZeroForce", &TwoStepNVE::setZeroForce)
+        .def(py::init< std::shared_ptr<SystemDefinition>, 
+                       std::shared_ptr<ParticleGroup>, 
+                       bool >())
+        .def_property("limit", &TwoStepNVE::setLimit,
+                               &TwoStepNVE::getLimit)
+        .def_property("zero_force", &TwoStepNVE::setZeroForce,
+                                   &TwoStepNVE::getZeroForce)
         ;
     }

--- a/hoomd/md/TwoStepNVE.h
+++ b/hoomd/md/TwoStepNVE.h
@@ -34,19 +34,20 @@ class PYBIND11_EXPORT TwoStepNVE : public IntegrationMethodTwoStep
         virtual ~TwoStepNVE();
 
         //! Sets the movement limit
-        void setLimit(Scalar limit);
+        void setLimit(pybind11::object limit);
 
-        //! Removes the limit
-        void removeLimit();
+        /// Get the movement limit
+        pybind11::object getLimit();
 
         //! Sets the zero force option
         /*! \param zero_force Set to true to specify that the integration with a zero net force on each of the particles
                               in the group
         */
-        void setZeroForce(bool zero_force)
-            {
-            m_zero_force = zero_force;
-            }
+        void setZeroForce(pybind11::object zero_force);
+
+        /// Get zero force
+        pybind11::object getZeroForce();
+
 
         //! Performs the first step of the integration
         virtual void integrateStepOne(unsigned int timestep);

--- a/hoomd/md/TwoStepNVE.h
+++ b/hoomd/md/TwoStepNVE.h
@@ -33,20 +33,20 @@ class PYBIND11_EXPORT TwoStepNVE : public IntegrationMethodTwoStep
                    bool skip_restart=false);
         virtual ~TwoStepNVE();
 
+        /// Get the movement limit
+        pybind11::object getLimit();
+
         //! Sets the movement limit
         void setLimit(pybind11::object limit);
 
-        /// Get the movement limit
-        pybind11::object getLimit();
+        /// Get zero force
+        pybind11::object getZeroForce();
 
         //! Sets the zero force option
         /*! \param zero_force Set to true to specify that the integration with a zero net force on each of the particles
                               in the group
         */
         void setZeroForce(pybind11::object zero_force);
-
-        /// Get zero force
-        pybind11::object getZeroForce();
 
 
         //! Performs the first step of the integration

--- a/hoomd/md/integrate.py
+++ b/hoomd/md/integrate.py
@@ -104,7 +104,7 @@ class Integrator(_DynamicIntegrator):
 
     - :py:class:`hoomd.md.methods.brownian`
     - :py:class:`hoomd.md.methods.Langevin`
-    - :py:class:`hoomd.md.methods.nve`
+    - ``hoomd.md.methods.NVE``
     - :py:class:`hoomd.md.methods.NVT`
     - :py:class:`hoomd.md.methods.npt`
     - :py:class:`hoomd.md.methods.nph`

--- a/hoomd/md/methods.py
+++ b/hoomd/md/methods.py
@@ -603,23 +603,15 @@ class NVE(_Method):
         integrator = hoomd.md.Integrator(dt=0.005, methods=[nve], forces=[lj])
 
     """
-    def __init__(self, filter, limit=None, zero_force=False):
-        """
-        # set the limit
-        if limit is not None:
-            self.cpp_method.setLimit(limit)
+    def __init__(self, filter, limit=None):
 
-        self.cpp_method.setZeroForce(zero_force)
-
-        self.cpp_method.validateGroup()
-        """
         # store metadata
         param_dict = ParameterDict(
             filter=_ParticleFilter,
             limit=OnlyType(float, allow_none=True),
             zero_force=OnlyType(bool, allow_none=False),
         )
-        param_dict.update(dict(filter=filter, limit=limit, zero_force=zero_force))
+        param_dict.update(dict(filter=filter, limit=limit, zero_force=False))
 
         # set defaults
         self._param_dict.update(param_dict)
@@ -636,56 +628,6 @@ class NVE(_Method):
 
         # Attach param_dict and typeparam_dict
         super().attach(simulation)
-'''
-    def set_params(self, limit=None, zero_force=None):
-        R""" Changes parameters of an existing integrator.
-
-        Args:
-            limit (bool): (if set) New limit value to set. Removes the limit if limit is False
-            zero_force (bool): (if set) New value for the zero force option
-
-        Examples::
-
-            integrator.set_params(limit=0.01)
-            integrator.set_params(limit=False)
-        """
-        self.check_initialization()
-
-        # change the parameters
-        if limit is not None:
-            if limit == False:
-                self.cpp_method.removeLimit()
-            else:
-                self.cpp_method.setLimit(limit)
-            self.limit = limit
-
-        if zero_force is not None:
-            self.cpp_method.setZeroForce(zero_force)
-
-    def randomize_velocities(self, kT, seed):
-        R""" Assign random velocities and angular momenta to particles in the
-        group, sampling from the Maxwell-Boltzmann distribution. This method
-        considers the dimensionality of the system and particle anisotropy, and
-        removes drift (the center of mass velocity).
-
-        .. versionadded:: 2.3
-
-        Args:
-            kT (float): Temperature (in energy units)
-            seed (int): Random number seed
-
-        Note:
-            Randomization is applied at the start of the next call to ```hoomd.run```.
-
-        Example::
-
-            integrator = md.integrate.nve(group=group.all())
-            integrator.randomize_velocities(kT=1.0, seed=42)
-            run(100)
-
-        """
-        self.cpp_method.setRandomizeVelocitiesParams(kT, seed)
-'''
 
 class Langevin(_Method):
     R""" Langevin dynamics.

--- a/hoomd/md/methods.py
+++ b/hoomd/md/methods.py
@@ -574,23 +574,23 @@ class NVE(_Method):
           velocity and any net force on them is ignored.
 
 
-    :py:class:`nve` performs constant volume, constant energy simulations using the standard
+    :py:class:`NVE` performs constant volume, constant energy simulations using the standard
     Velocity-Verlet method. For poor initial conditions that include overlapping atoms, a
     limit can be specified to the movement a particle is allowed to make in one time step.
     After a few thousand time steps with the limit set, the system should be in a safe state
     to continue with unconstrained integration.
 
-    Another use-case for :py:class:`nve` is to fix the velocity of a certain group of particles. This can be achieved by
+    Another use-case for :py:class:`NVE` is to fix the velocity of a certain group of particles. This can be achieved by
     setting the velocity of those particles in the initial condition and setting the *zero_force* option to True
-    for that group. A True value for *zero_force* causes integrate.nve to ignore any net force on each particle and
+    for that group. A True value for *zero_force* causes integrate.NVE to ignore any net force on each particle and
     integrate them forward in time with a constant velocity.
 
     Note:
         With an active limit, Newton's third law is effectively **not** obeyed and the system
-        can gain linear momentum. Activate the :py:class:`hoomd.md.update.zero_momentum` updater during the limited nve
+        can gain linear momentum. Activate the :py:class:`hoomd.md.update.zero_momentum` updater during the limited NVE
         run to prevent this.
 
-    :py:class:`nve` is an integration method. It must be used with ``mode_standard``.
+    :py:class:`NVE` is an integration method. It must be used with ``mode_standard``.
 
     A :py:class:`hoomd.compute.thermo` is automatically specified and associated with *group*.
 
@@ -689,7 +689,7 @@ class Langevin(_Method):
     assumption is valid when underdamped: :math:`\frac{m}{\gamma} \gg \delta t`.
     Use :py:class:`brownian` if your system is not underdamped.
 
-    :py:class:`Langevin` uses the same integrator as :py:class:`nve` with the
+    :py:class:`Langevin` uses the same integrator as :py:class:`NVE` with the
     additional force term :math:`- \gamma \cdot \vec{v} + \vec{F}_\mathrm{R}`.
     The random force :math:`\vec{F}_\mathrm{R}` is drawn from a uniform random
     number distribution.

--- a/hoomd/md/methods.py
+++ b/hoomd/md/methods.py
@@ -604,7 +604,7 @@ class NVE(_Method):
 
     """
     def __init__(self, filter, limit=None, zero_force=False):
-
+        """
         # set the limit
         if limit is not None:
             self.cpp_method.setLimit(limit)
@@ -612,12 +612,12 @@ class NVE(_Method):
         self.cpp_method.setZeroForce(zero_force)
 
         self.cpp_method.validateGroup()
-
+        """
         # store metadata
         param_dict = ParameterDict(
             filter=_ParticleFilter,
             limit=OnlyType(float, allow_none=True),
-            zero_force=OnlyType(bool),
+            zero_force=OnlyType(bool, allow_none=False),
         )
         param_dict.update(dict(filter=filter, limit=limit, zero_force=zero_force))
 
@@ -628,11 +628,10 @@ class NVE(_Method):
 
         # initialize the reflected c++ class
         if not simulation.device.cpp_exec_conf.isCUDAEnabled():
-            my_class = _md.TwoStepNVE
+            self._cpp_obj = _md.TwoStepNVE(simulation.state._cpp_sys_def,
+                                        simulation.state.get_group(self.filter), False)
         else:
-            my_class = _md.TwoStepNVEGPU
-
-        self._cpp_obj = my_class(simulation.state._cpp_sys_def, 
+            self._cpp_obj = _md.TwoStepNVEGPU(simulation.state._cpp_sys_def, 
                                  simulation.state.get_group(self.filter))
 
         # Attach param_dict and typeparam_dict

--- a/hoomd/md/pair.py
+++ b/hoomd/md/pair.py
@@ -975,7 +975,7 @@ class dpd(pair):
     - :math:`r_{\mathrm{cut}}` - *r_cut* (in distance units)
       - *optional*: defaults to the global r_cut specified in the pair command
 
-    To use the DPD thermostat, an :py:class:`hoomd.md.methods.nve` integrator must be applied to the system and
+    To use the DPD thermostat, an :py:class:`hoomd.md.methods.NVE` integrator must be applied to the system and
     the user must specify a temperature.  Use of the dpd thermostat pair force with other integrators will result
     in unphysical behavior. To use pair.dpd with a different conservative potential than :math:`F_C`,
     set A to zero and define the conservative pair potential separately.  Note that DPD thermostats
@@ -1213,7 +1213,7 @@ class dpdlj(pair):
     - :math:`r_{\mathrm{cut}}` - *r_cut* (in distance units)
       - *optional*: defaults to the global r_cut specified in the pair command
 
-    To use the DPD thermostat, an :py:class:`hoomd.md.methods.nve` integrator must be applied to the system and
+    To use the DPD thermostat, an :py:class:`hoomd.md.methods.NVE` integrator must be applied to the system and
     the user must specify a temperature.  Use of the dpd thermostat pair force with other integrators will result
     in unphysical behavior.
 

--- a/hoomd/mpcd/__init__.py
+++ b/hoomd/mpcd/__init__.py
@@ -136,7 +136,7 @@ class integrator(hoomd.integrate._integrator):
     in order for :py:mod:`~hoomd.mpcd.stream` and :py:mod:`~hoomd.mpcd.collide`
     methods to take effect. Embedded MD particles require the creation of an
     appropriate integration method. Typically, this will just be
-    :py:class:`~hoomd.md.methods.nve`.
+    :py:class:`~hoomd.md.methods.NVE`.
 
     In MPCD simulations, *dt* defines the amount of time that the system is advanced
     forward every time step. MPCD streaming and collision steps can be defined to

--- a/hoomd/mpcd/collide.py
+++ b/hoomd/mpcd/collide.py
@@ -74,7 +74,7 @@ class _collision_method(hoomd.meta._metadata):
 
         No integrator is generated for *group*. Usually, you will need to create
         a separate method to integrate the embedded particles. The recommended
-        (and most common) integrator to use is :py:class:`~hoomd.md.methods.nve`.
+        (and most common) integrator to use is :py:class:`~hoomd.md.methods.NVE`.
         It is generally **not** a good idea to use a thermostatting integrator for
         the embedded particles, since the MPCD particles themselves already act
         as a heat bath that will thermalize the embedded particles.
@@ -190,7 +190,7 @@ class at(_collision_method):
     HOOMD particles in *group* can be embedded into the collision step (see
     ``embed``). A separate integration method (:py:mod:`~hoomd.md.methods`)
     must be specified in order to integrate the positions of particles in *group*.
-    The recommended integrator is :py:class:`~hoomd.md.methods.nve`.
+    The recommended integrator is :py:class:`~hoomd.md.methods.NVE`.
 
     Examples::
 
@@ -289,7 +289,7 @@ class srd(_collision_method):
     HOOMD particles in *group* can be embedded into the collision step (see
     ``embed()``). A separate integration method (:py:mod:`~hoomd.md.methods`)
     must be specified in order to integrate the positions of particles in *group*.
-    The recommended integrator is :py:class:`~hoomd.md.methods.nve`.
+    The recommended integrator is :py:class:`~hoomd.md.methods.NVE`.
 
     The SRD method naturally imparts the NVE ensemble to the system comprising
     the MPCD particles and *group*. Accordingly, the system must be properly

--- a/sphinx-doc/module-md-methods.rst
+++ b/sphinx-doc/module-md-methods.rst
@@ -13,7 +13,7 @@ md.integrate
     Langevin
     npt
     nph
-    nve
+    NVE
     NVT
 
 


### PR DESCRIPTION
## Description

porting NVE integrator to v3 API

## Motivation and Context

NVE integrator needs to be changed to be compatible with v3 API.

## How Has This Been Tested?
Test with simple script on local machine is ongoing.
Will have pytest later with other integrators including Brownian, Langevin, NPT, etc. 

## Change log

1. The parameter `limit` and `zero_force` have get, set functions in cc file as included in param_dict.
2. `def_property` was reset to match with how param_dict functions.

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [ ] My name is on the [list of contributors](https://github.com/glotzerlab/hoomd-blue/blob/master/sphinx-doc/credits.rst).
