### PR TITLE
Fix bug in the state of hoomd.md._Force objects

### DIFF
--- a/hoomd/operation.py
+++ b/hoomd/operation.py
@@ -249,7 +249,7 @@ class _Operation(_HOOMDGetSetAttrBase, metaclass=Loggable):
     def state(self):
         self._update_param_dict()
         state = self._typeparam_states()
-        state['params'] = dict(self._param_dict)
+        state['__params__'] = dict(self._param_dict)
         return dict_map(state, convert_values_to_log_form)
 
     @classmethod
@@ -320,16 +320,16 @@ class _Operation(_HOOMDGetSetAttrBase, metaclass=Loggable):
     def _from_state_with_state_dict(cls, state, **kwargs):
 
         # Initialize object using params from state and passed arguments
-        params = state['params']
+        params = state['__params__']
         params.update(kwargs)
         obj = cls(**params)
-        del state['params']
+        del state['__params__']
 
         # Add typeparameter information
         for name, tp_dict in state.items():
-            if '__default' in tp_dict.keys():
-                obj._typeparam_dict[name].default = tp_dict['__default']
-                del tp_dict['__default']
+            if '__default__' in tp_dict.keys():
+                obj._typeparam_dict[name].default = tp_dict['__default__']
+                del tp_dict['__default__']
             # Parse the stringified tuple back into tuple
             if obj._typeparam_dict[name]._len_keys > 1:
                 tp_dict = str_to_tuple_keys(tp_dict)

--- a/hoomd/typeparam.py
+++ b/hoomd/typeparam.py
@@ -57,7 +57,7 @@ class TypeParameter:
         state = self.to_dict()
         if self.param_dict._len_keys > 1:
             state = {str(key): value for key, value in state.items()}
-        state['__default'] = self.default
+        state['__default__'] = self.default
         return state
 
     def __deepcopy__(self, memo):


### PR DESCRIPTION
## Description

Fixes a bug in the state of `hoomd.md._Force` objects. We previously stored the `_param_dict`
information in the state key `param`. We rename the new state key to `__state__`. Likewise for
consistency, we rename the `__default` key in a type parameters state `dict` to `__default__`.

This also addresses a bug where we convert any non-specified values (i.e. they are set to
`RequiredArg`) to `None` in the state. This can raise errors when using `from_state`. We now filter
out any `RequiredArg` from the type parameters.
<!-- Describe your changes in detail. -->

## Motivation and Context

Needed to properly use state.

## How Has This Been Tested?

Should be covered in part through existing tests. The `from_state` methods of objects should be
tested more.

## Change log

<!-- Propose a change log entry. -->
```

```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [ ] My name is on the [list of contributors](https://github.com/glotzerlab/hoomd-blue/blob/master/sphinx-doc/credits.rst).
