### PR TITLE
Feature/quasi2d

### DIFF
--- a/.azp/test.yml
+++ b/.azp/test.yml
@@ -7,14 +7,6 @@ pr:
 # repository.
 trigger: none
 
-# Instead, trigger periodic builds on active branches.
-schedules:
-- cron: "0 2-20/6 * * *"
-  displayName: Periodic build
-  branches:
-    include:
-    - "*"
-
 variables:
   image_root: glotzerlab/ci:2021.03
 

--- a/.azp/validate.yml
+++ b/.azp/validate.yml
@@ -9,14 +9,6 @@ pr:
 # repository.
 trigger: none
 
-# Instead, trigger periodic builds on active branches.
-schedules:
-- cron: "0 2-20/6 * * *"
-  displayName: Periodic build
-  branches:
-    include:
-    - "*"
-
 variables:
   image_root: glotzerlab/ci:2021.03
 

--- a/hoomd/hpmc/integrate.py
+++ b/hoomd/hpmc/integrate.py
@@ -925,6 +925,12 @@ class ConvexPolyhedron(HPMCIntegrator):
             (distance units).
 
         a (float): Default maximum size of rotation trial moves.
+        quasi2d(int): Run a quasi 2d simulation in three dimensions. This means
+                      that all moves will only occur in the XY plane. A value
+                      of 0 is False, a value of 1 indicates that out-of-plane
+                      rotations will be allowed but translations forbidden, and
+                      a value of 2 indicates that all rotations will be
+                      in-plane rotations.
 
         translation_move_probability (float): Fraction of moves that are
             translation moves.
@@ -995,7 +1001,8 @@ class ConvexPolyhedron(HPMCIntegrator):
                  d=0.1,
                  a=0.1,
                  translation_move_probability=0.5,
-                 nselect=4):
+                 nselect=4,
+                 quasi2d=0):
 
         # initialize base class
         super().__init__(d, a, translation_move_probability, nselect)


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should based on *maint*. -->
<!-- New features should based on *master*. -->

## Description

<!-- Describe your changes in detail. -->

This is an initial draft of how we could enable quasi-2D simulations. It is currently implemented as a simple hack of the internals where translation moves are modified to only sample in-plane even in 3D simulations when a particular flag is set, but this implementation could be cleaned up.  I'd appreciate any thoughts at a high level on how this should work, once that's resolved I can work on cleaning up the code. I do not think that there's a need for in-depth code review yet, but enabling this should be pretty straightforward.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

<!-- Replace ??? with the issue number that this pull request resolves. -->

@joaander and I discussed this briefly a few months ago, the goal is to enable simulations where particles can optionally rotate out of plane but are otherwise constrained to the plane. Currently this is enabled by an integer flag whose value (>0 vs >1) is used to indicate whether or not out of plane rotations are permitted.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
Enable simulations of 3D objects constrained to move in a plane, with out-of-plane rotations optionally enabled.
```

## Checklist:

- [ ] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [ ] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [ ] My name is on the [list of contributors](https://github.com/glotzerlab/hoomd-blue/blob/master/sphinx-doc/credits.rst).
