### PR TITLE
Change citations to output at notice level 3 instead of 1.

### DIFF
--- a/hoomd/cite.py
+++ b/hoomd/cite.py
@@ -326,7 +326,7 @@ class bibliography(object):
                     cite_str += 'Please cite the following:\n'
                     cite_str += log_str
                     cite_str += '-'*5 + '\n'
-                    hoomd.context.current.device.cpp_msg.notice(1, cite_str)
+                    hoomd.context.current.device.cpp_msg.notice(3, cite_str)
 
         # print each feature set together
         for feature in citations:
@@ -334,7 +334,9 @@ class bibliography(object):
             cite_str += 'You are using %s. Please cite the following:\n' % feature
             cite_str += ''.join(citations[feature])
             cite_str += '-'*5 + '\n'
-            hoomd.context.current.device.cpp_msg.notice(1, cite_str)
+            # Set the notice level to the lowest level where users won't see it by
+            # default.
+            hoomd.context.current.device.cpp_msg.notice(3, cite_str)
 
         # after adding, we need to update the file
         self.updated = True


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should based on *maint*. -->
<!-- New features should based on *master*. -->

## Description

<!-- Describe your changes in detail. -->

Citations are now only printed at notice level >=3

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

<!-- Replace ??? with the issue number that this pull request resolves. -->
Part of #684.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->
N/A

## Change log

<!-- Propose a change log entry. -->

N/A

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/hoomd-blue/blob/master/sphinx-doc/credits.rst).
