### PR TITLE
Hackathon/hoomd device auto to function

### DIFF
--- a/hoomd/ExecutionConfiguration.cc
+++ b/hoomd/ExecutionConfiguration.cc
@@ -648,6 +648,13 @@ int ExecutionConfiguration::getNumCapableGPUs()
         }
     return count;
     }
+#else
+/*! \return The count of available GPUs as 0, not compiled with GPU support
+*/
+int ExecutionConfiguration::getNumCapableGPUs()
+    {
+    return 0;
+    }
 #endif
 
 /*! Print out GPU stats if running on the GPU, otherwise determine and print out the CPU stats
@@ -851,6 +858,7 @@ void export_ExecutionConfiguration(py::module& m)
         .def("isCUDAEnabled", &ExecutionConfiguration::isCUDAEnabled)
         .def("setCUDAErrorChecking", &ExecutionConfiguration::setCUDAErrorChecking)
         .def("getNumActiveGPUs", &ExecutionConfiguration::getNumActiveGPUs)
+        .def("getNumCapableGPUs", &ExecutionConfiguration::getNumCapableGPUs)
 #if defined(ENABLE_HIP)
         .def("hipProfileStart", &ExecutionConfiguration::hipProfileStart)
         .def("hipProfileStop", &ExecutionConfiguration::hipProfileStop)

--- a/hoomd/ExecutionConfiguration.cc
+++ b/hoomd/ExecutionConfiguration.cc
@@ -80,16 +80,6 @@ ExecutionConfiguration::ExecutionConfiguration(executionMode mode,
     scanGPUs(ignore_display);
     int dev_count = getNumCapableGPUs();
 
-    // auto select a mode
-    if (exec_mode == AUTO)
-        {
-        // if there are available GPUs, initialize them. Otherwise, default to running on the CPU
-        if (dev_count > 0)
-            exec_mode = GPU;
-        else
-            exec_mode = CPU;
-        }
-
     #ifdef __HIP_PLATFORM_NVCC__
     m_concurrent = exec_mode==GPU;
     #else
@@ -97,8 +87,6 @@ ExecutionConfiguration::ExecutionConfiguration(executionMode mode,
     #endif
 
     m_in_multigpu_block = false;
-
-    // now, exec_mode should be either CPU or GPU - proceed with initialization
 
     // initialize the GPU if that mode was requested
     if (exec_mode == GPU)
@@ -883,7 +871,6 @@ void export_ExecutionConfiguration(py::module& m)
     py::enum_<ExecutionConfiguration::executionMode>(executionconfiguration,"executionMode")
         .value("GPU", ExecutionConfiguration::executionMode::GPU)
         .value("CPU", ExecutionConfiguration::executionMode::CPU)
-        .value("AUTO", ExecutionConfiguration::executionMode::AUTO)
         .export_values()
     ;
     }

--- a/hoomd/ExecutionConfiguration.h
+++ b/hoomd/ExecutionConfiguration.h
@@ -211,6 +211,9 @@ struct PYBIND11_EXPORT ExecutionConfiguration
     //! Get the name of the executing GPU (or the empty string)
     std::string getGPUName(unsigned int idev=0) const;
 
+    //! Returns the count of capable GPUs
+    static int getNumCapableGPUs();
+
 #if defined(ENABLE_HIP)
     //! Get the device properties of a logical GPU
     hipDeviceProp_t getDeviceProperties(unsigned int idev) const
@@ -357,9 +360,6 @@ private:
 
     //! Returns true if the given GPU is available for computation
     bool isGPUAvailable(int gpu_id);
-
-    //! Returns the count of capable GPUs
-    int getNumCapableGPUs();
 
     //! Return the number of GPUs that can be checked for availability
     unsigned int getNumTotalGPUs()

--- a/hoomd/ExecutionConfiguration.h
+++ b/hoomd/ExecutionConfiguration.h
@@ -78,11 +78,10 @@ struct PYBIND11_EXPORT ExecutionConfiguration
         {
         GPU,    //!< Execute on the GPU
         CPU,    //!< Execute on the CPU
-        AUTO,   //!< Auto select between GPU and CPU
         };
 
     //! Constructor
-    ExecutionConfiguration(executionMode mode=AUTO,
+    ExecutionConfiguration(executionMode mode=CPU,
                            std::vector<int> gpu_id = std::vector<int>(),
                            bool min_cpu=false,
                            bool ignore_display=false,

--- a/hoomd/device.py
+++ b/hoomd/device.py
@@ -332,17 +332,7 @@ def auto(communicator=None, msg_file=None, shared_msg_file=None, notice_level=2)
         a GPU or CPU device, depending on availability, GPU is preferred
     """
 
-    device=_device(communicator, notice_level, msg_file, shared_msg_file)
-    device.cpp_exec_conf = _hoomd.ExecutionConfiguration(_hoomd.ExecutionConfiguration.executionMode.AUTO,
-                                                           [],
-                                                           False,
-                                                           False,
-                                                           device.comm.cpp_mpi_conf,
-                                                           device.cpp_msg)
-    
-    # Set class according to C++ object
-    if device.cpp_exec_conf.isCUDAEnabled():
-        device.__class__=GPU
+    if _hoomd.ExecutionConfiguration.getNumCapableGPUs()>0:
+        return GPU(None, communicator, msg_file, shared_msg_file, notice_level)
     else:
-        device.__class__=CPU
-    return device
+        return CPU(None, communicator, msg_file, shared_msg_file, notice_level)

--- a/hoomd/device.py
+++ b/hoomd/device.py
@@ -316,7 +316,7 @@ class CPU(_device):
                                                            self.cpp_msg)
 
 
-class Auto(_device):
+def auto(nthreads=None, communicator=None, msg_file=None, shared_msg_file=None, notice_level=2):
     """
     Allow simulation hardware to be chosen automatically by HOOMD-blue
 
@@ -328,18 +328,16 @@ class Auto(_device):
         shared_msg_file (str): (MPI only) Name of shared file to write message to (append partition #)
         notice_level (int): Minimum level of notice messages to print
 
-    TODO: convert this to a function that produces a GPU or CPU device.
+
+    Returns:
+        a GPU or CPU device, depending on availability
     """
 
-    def __init__(self, nthreads=None, communicator=None, msg_file=None, shared_msg_file=None, notice_level=2):
+    # Copying the logic found in ExecutionConfiguration.cc
+    if _hoomd.ExecutionConfiguration.getNumCapableGPUs() > 0:
+        # use GPU
+        return GPU(None, communicator, notice_level, msg_file, shared_msg_file)
+    else:
+        # use CPU
+        return CPU(nthreads, communicator, notice_level, msg_file, shared_msg_file)
 
-        _device.__init__(self, communicator, notice_level, msg_file, shared_msg_file)
-
-        _init_nthreads(nthreads)
-
-        self.cpp_exec_conf = _hoomd.ExecutionConfiguration(_hoomd.ExecutionConfiguration.executionMode.AUTO,
-                                                           [],
-                                                           False,
-                                                           False,
-                                                           self.comm.cpp_mpi_conf,
-                                                           self.cpp_msg)

--- a/hoomd/device.py
+++ b/hoomd/device.py
@@ -345,4 +345,4 @@ def auto(communicator=None, msg_file=None, shared_msg_file=None, notice_level=2)
         self.__class__=GPU
     else:
         self.__class__=CPU
-
+    return self

--- a/hoomd/device.py
+++ b/hoomd/device.py
@@ -332,17 +332,17 @@ def auto(communicator=None, msg_file=None, shared_msg_file=None, notice_level=2)
         a GPU or CPU device, depending on availability, GPU is preferred
     """
 
-    self=_device(communicator, notice_level, msg_file, shared_msg_file)
-    self.cpp_exec_conf = _hoomd.ExecutionConfiguration(_hoomd.ExecutionConfiguration.executionMode.AUTO,
+    device=_device(communicator, notice_level, msg_file, shared_msg_file)
+    device.cpp_exec_conf = _hoomd.ExecutionConfiguration(_hoomd.ExecutionConfiguration.executionMode.AUTO,
                                                            [],
                                                            False,
                                                            False,
-                                                           self.comm.cpp_mpi_conf,
-                                                           self.cpp_msg)
+                                                           device.comm.cpp_mpi_conf,
+                                                           device.cpp_msg)
     
     # Set class according to C++ object
-    if self.cpp_exec_conf.isCUDAEnabled():
-        self.__class__=GPU
+    if device.cpp_exec_conf.isCUDAEnabled():
+        device.__class__=GPU
     else:
-        self.__class__=CPU
-    return self
+        device.__class__=CPU
+    return device


### PR DESCRIPTION
## Description

The auto function now returns a CPU or GPU device object rather than existing as it's own class. Create a standard device, and then match the python class to the mode of the C++ enum which was created.

## Motivation and Context

Resolves: #717 
## How Has This Been Tested?

More testing is needed. We weren't able to test further because we couldn't get a GPU device working when called directly. Will investigate.
