### PR TITLE
Refactor ExecutionConfiguration and device.*

### DIFF
--- a/hoomd/ExecutionConfiguration.cc
+++ b/hoomd/ExecutionConfiguration.cc
@@ -454,7 +454,7 @@ void ExecutionConfiguration::setupStats()
             if (error != cudaSuccess)
                 {
                 msg->errorAllRanks() << "" << endl;
-                throw runtime_error("Failed to get device properties: " + string(hipGetErrorString(error)));
+                throw runtime_error("Failed to get device properties: " + string(cudaGetErrorString(error)));
                 }
 
             if (cuda_prop.concurrentManagedAccess)
@@ -467,6 +467,8 @@ void ExecutionConfiguration::setupStats()
                 // AMD does not support concurrent access
                 m_concurrent = false;
                 }
+
+            m_active_device_descriptions.push_back(describeGPU(idev, m_dev_prop[idev]));
             }
 
         // initialize dev_prop with device properties of first device for now
@@ -476,10 +478,7 @@ void ExecutionConfiguration::setupStats()
 
     if (exec_mode == CPU)
         {
-        ostringstream s;
-
-        s << "HOOMD-blue is running on the CPU" << endl;
-        msg->collectiveNoticeStr(1,s.str());
+        m_active_device_descriptions.push_back("CPU");
         }
     }
 
@@ -663,6 +662,8 @@ void export_ExecutionConfiguration(py::module& m)
         .def("setMemoryTracing", &ExecutionConfiguration::setMemoryTracing)
         .def("getMemoryTracer", &ExecutionConfiguration::getMemoryTracer)
         .def_static("getCapableDevices", &ExecutionConfiguration::getCapableDevices)
+        .def_static("getScanMessages", &ExecutionConfiguration::getScanMessages)
+        .def("getActiveDevices", &ExecutionConfiguration::getActiveDevices)
     ;
 
     py::enum_<ExecutionConfiguration::executionMode>(executionconfiguration,"executionMode")

--- a/hoomd/ExecutionConfiguration.cc
+++ b/hoomd/ExecutionConfiguration.cc
@@ -43,8 +43,6 @@ std::vector<std::string> ExecutionConfiguration::s_capable_gpu_descriptions;
 
 /*! \param mode Execution mode to set (cpu or gpu)
     \param gpu_id List of GPU IDs on which to run, or empty for automatic selection
-    \param min_cpu If set to true, hipDeviceBlockingSync is set to keep the CPU usage of HOOMD to a minimum
-    \param ignore_display If set to true, try to ignore GPUs attached to the display
     \param mpi_config MPI configuration object
     \param _msg Messenger to use for status message printing
 
@@ -53,8 +51,6 @@ std::vector<std::string> ExecutionConfiguration::s_capable_gpu_descriptions;
 */
 ExecutionConfiguration::ExecutionConfiguration(executionMode mode,
                                                std::vector<int> gpu_id,
-                                               bool min_cpu,
-                                               bool ignore_display,
                                                std::shared_ptr<MPIConfiguration> mpi_config,
                                                std::shared_ptr<Messenger> _msg
                                                )
@@ -78,7 +74,7 @@ ExecutionConfiguration::ExecutionConfiguration(executionMode mode,
         s << *it << " ";
         }
 
-    msg->notice(5) << "Constructing ExecutionConfiguration: ( " << s.str() << ") " <<  min_cpu << " " << ignore_display << endl;
+    msg->notice(5) << "Constructing ExecutionConfiguration: ( " << s.str() << ") " << endl;
     exec_mode = mode;
 
 #if defined(ENABLE_HIP)
@@ -641,7 +637,7 @@ int ExecutionConfiguration::guessLocalRank(bool &found)
 void export_ExecutionConfiguration(py::module& m)
     {
     py::class_<ExecutionConfiguration, std::shared_ptr<ExecutionConfiguration> > executionconfiguration(m,"ExecutionConfiguration");
-    executionconfiguration.def(py::init< ExecutionConfiguration::executionMode, std::vector<int>, bool, bool,
+    executionconfiguration.def(py::init< ExecutionConfiguration::executionMode, std::vector<int>,
         std::shared_ptr<MPIConfiguration>, std::shared_ptr<Messenger> >())
         .def("getMPIConfig", &ExecutionConfiguration::getMPIConfig)
         .def("isCUDAEnabled", &ExecutionConfiguration::isCUDAEnabled)

--- a/hoomd/ExecutionConfiguration.cc
+++ b/hoomd/ExecutionConfiguration.cc
@@ -204,33 +204,6 @@ ExecutionConfiguration::ExecutionConfiguration(executionMode mode,
             throw runtime_error("Error initializing execution configuration");
             }
         }
-
-    if (hoomd_launch_timing && m_mpi_config->getNRanksGlobal() > 1)
-        {
-        // compute the number of seconds to get an exec conf
-        timeval t;
-        gettimeofday(&t, NULL);
-        unsigned int conf_time = t.tv_sec - hoomd_launch_time;
-
-        // get the min and max times
-        unsigned int start_time_min, start_time_max, mpi_init_time_min, mpi_init_time_max, conf_time_min, conf_time_max;
-        MPI_Reduce(&hoomd_start_time, &start_time_min, 1, MPI_UNSIGNED, MPI_MIN, 0, m_mpi_config->getHOOMDWorldCommunicator());
-        MPI_Reduce(&hoomd_start_time, &start_time_max, 1, MPI_UNSIGNED, MPI_MAX, 0, m_mpi_config->getHOOMDWorldCommunicator());
-
-        MPI_Reduce(&hoomd_mpi_init_time, &mpi_init_time_min, 1, MPI_UNSIGNED, MPI_MIN, 0, m_mpi_config->getHOOMDWorldCommunicator());
-        MPI_Reduce(&hoomd_mpi_init_time, &mpi_init_time_max, 1, MPI_UNSIGNED, MPI_MAX, 0, m_mpi_config->getHOOMDWorldCommunicator());
-
-        MPI_Reduce(&conf_time, &conf_time_min, 1, MPI_UNSIGNED, MPI_MIN, 0, m_mpi_config->getHOOMDWorldCommunicator());
-        MPI_Reduce(&conf_time, &conf_time_max, 1, MPI_UNSIGNED, MPI_MAX, 0, m_mpi_config->getHOOMDWorldCommunicator());
-
-        // write them out to a file
-        if (m_mpi_config->getRankGlobal() == 0)
-            {
-            msg->notice(2) << "start_time:    [" << start_time_min << ", " << start_time_max << "]" << std::endl;
-            msg->notice(2) << "mpi_init_time: [" << mpi_init_time_min << ", " << mpi_init_time_max << "]" << std::endl;
-            msg->notice(2) << "conf_time:     [" << conf_time_min << ", " << conf_time_max << "]" << std::endl;
-            }
-        }
     #endif
 
     #ifdef ENABLE_TBB

--- a/hoomd/ExecutionConfiguration.cc
+++ b/hoomd/ExecutionConfiguration.cc
@@ -615,8 +615,6 @@ int ExecutionConfiguration::getNumCapableGPUs()
 */
 void ExecutionConfiguration::setupStats()
     {
-    n_cpu = 1;
-
     #if defined(ENABLE_HIP)
     if (exec_mode == GPU)
         {
@@ -632,9 +630,6 @@ void ExecutionConfiguration::setupStats()
         dev_prop = m_dev_prop[0];
 
         printGPUStats();
-
-        // GPU runs only use 1 CPU core
-        n_cpu = 1;
         }
     #endif
 
@@ -817,7 +812,6 @@ void export_ExecutionConfiguration(py::module& m)
         .def("hipProfileStop", &ExecutionConfiguration::hipProfileStop)
 #endif
         .def("getGPUName", &ExecutionConfiguration::getGPUName)
-        .def_readonly("n_cpu", &ExecutionConfiguration::n_cpu)
         .def_readonly("msg", &ExecutionConfiguration::msg)
 #if defined(ENABLE_HIP)
         .def("getComputeCapability", &ExecutionConfiguration::getComputeCapabilityAsString)

--- a/hoomd/ExecutionConfiguration.cc
+++ b/hoomd/ExecutionConfiguration.cc
@@ -52,7 +52,7 @@ ExecutionConfiguration::ExecutionConfiguration(executionMode mode,
                                                std::shared_ptr<MPIConfiguration> mpi_config,
                                                std::shared_ptr<Messenger> _msg
                                                )
-    : m_hip_error_checking(false), m_mpi_config(mpi_config), msg(_msg)
+    : msg(_msg), m_hip_error_checking(false), m_mpi_config(mpi_config)
     {
     if (! m_mpi_config)
         {
@@ -247,19 +247,6 @@ ExecutionConfiguration::~ExecutionConfiguration()
     #endif
     }
 
-std::string ExecutionConfiguration::getGPUName(unsigned int idev) const
-    {
-    #if defined(ENABLE_HIP)
-    if (exec_mode == GPU)
-        return string(m_dev_prop[idev].name);
-    else
-        return string();
-    #else
-    return string();
-    #endif
-    }
-
-
 #if defined(ENABLE_HIP)
 /*! \returns Compute capability of GPU 0 as a string
     \note Silently returns an empty string if no GPUs are specified
@@ -435,7 +422,7 @@ void ExecutionConfiguration::printGPUStats()
     Each GPU that CUDA reports to exist is scrutinized to determine if it is actually capable of running HOOMD
     When one is found to be lacking, it is marked as unavailable and a short notice is printed as to why.
 
-    \post m_gpu_list, m_gpu_available and m_system_compute_exclusive are all filled out
+    \post m_gpu_list, m_gpu_available
 */
 void ExecutionConfiguration::scanGPUs(bool ignore_display)
     {
@@ -542,12 +529,6 @@ void ExecutionConfiguration::scanGPUs(bool ignore_display)
             m_gpu_list.push_back(dev);
             }
         }
-
-    // the system is fully compute-exclusive if all capable GPUs are compute-exclusive
-    if (n_exclusive_gpus == getNumCapableGPUs())
-        m_system_compute_exclusive = true;
-    else
-        m_system_compute_exclusive = false;
     }
 
 
@@ -780,13 +761,10 @@ void export_ExecutionConfiguration(py::module& m)
         .def("isCUDAEnabled", &ExecutionConfiguration::isCUDAEnabled)
         .def("setCUDAErrorChecking", &ExecutionConfiguration::setCUDAErrorChecking)
         .def("getNumActiveGPUs", &ExecutionConfiguration::getNumActiveGPUs)
+        .def_readonly("msg", &ExecutionConfiguration::msg)
 #if defined(ENABLE_HIP)
         .def("hipProfileStart", &ExecutionConfiguration::hipProfileStart)
         .def("hipProfileStop", &ExecutionConfiguration::hipProfileStop)
-#endif
-        .def("getGPUName", &ExecutionConfiguration::getGPUName)
-        .def_readonly("msg", &ExecutionConfiguration::msg)
-#if defined(ENABLE_HIP)
         .def("getComputeCapability", &ExecutionConfiguration::getComputeCapabilityAsString)
 #endif
         .def("getPartition", &ExecutionConfiguration::getPartition)

--- a/hoomd/ExecutionConfiguration.h
+++ b/hoomd/ExecutionConfiguration.h
@@ -314,14 +314,18 @@ class PYBIND11_EXPORT ExecutionConfiguration
     /// Get a list of the capable devices
     static std::vector<std::string> getCapableDevices()
         {
+        #ifdef ENABLE_HIP
         scanGPUs();
+        #endif
         return s_capable_gpu_descriptions;
         }
 
     /// Get a list of the capable devices
     static std::vector<std::string> getScanMessages()
         {
+        #ifdef ENABLE_HIP
         scanGPUs();
+        #endif
         return s_gpu_scan_messages;
         }
 

--- a/hoomd/ExecutionConfiguration.h
+++ b/hoomd/ExecutionConfiguration.h
@@ -81,8 +81,6 @@ class PYBIND11_EXPORT ExecutionConfiguration
     //! Constructor
     ExecutionConfiguration(executionMode mode=AUTO,
                            std::vector<int> gpu_id = std::vector<int>(),
-                           bool min_cpu=false,
-                           bool ignore_display=false,
                            std::shared_ptr<MPIConfiguration> mpi_config=std::shared_ptr<MPIConfiguration>(),
                            std::shared_ptr<Messenger> _msg=std::shared_ptr<Messenger>()
                            );

--- a/hoomd/ExecutionConfiguration.h
+++ b/hoomd/ExecutionConfiguration.h
@@ -51,10 +51,6 @@
 class CachedAllocator;
 #endif
 
-// values used in measuring hoomd launch timing
-extern unsigned int hoomd_launch_time, hoomd_start_time, hoomd_mpi_init_time;
-extern bool hoomd_launch_timing;
-
 //! Defines the execution configuration for the simulation
 /*! \ingroup data_structs
     ExecutionConfiguration is a data structure needed to support the hybrid CPU/GPU code. It initializes the CUDA GPU
@@ -116,7 +112,6 @@ struct PYBIND11_EXPORT ExecutionConfiguration
 #endif
 
     executionMode exec_mode;    //!< Execution mode specified in the constructor
-    unsigned int n_cpu;         //!< Number of CPUS hoomd is executing on
     bool m_hip_error_checking;                //!< Set to true if GPU error checking is enabled
 
     std::shared_ptr<MPIConfiguration> m_mpi_config; //!< The MPI object holding the MPI communicator

--- a/hoomd/ExecutionConfiguration.h
+++ b/hoomd/ExecutionConfiguration.h
@@ -320,6 +320,18 @@ class PYBIND11_EXPORT ExecutionConfiguration
         return s_capable_gpu_descriptions;
         }
 
+    /// Get a list of the capable devices
+    static std::vector<std::string> getScanMessages()
+        {
+        scanGPUs();
+        return s_gpu_scan_messages;
+        }
+
+    /// Get the active devices
+    std::vector<std::string> getActiveDevices()
+        {
+        return m_active_device_descriptions;
+        }
 private:
     //! Guess local rank of this processor, used for GPU initialization
     /*! \returns Local rank guessed from common environment variables
@@ -373,6 +385,9 @@ private:
 
     /// Description of the GPU devices
     static std::vector<std::string> s_capable_gpu_descriptions;
+
+    /// Descriptions of the active devices
+    std::vector<std::string> m_active_device_descriptions;
 
     bool m_concurrent;                      //!< True if all GPUs have concurrentManagedAccess flag
 

--- a/hoomd/ExecutionConfiguration.h
+++ b/hoomd/ExecutionConfiguration.h
@@ -313,6 +313,13 @@ class PYBIND11_EXPORT ExecutionConfiguration
         return m_in_multigpu_block;
         }
 
+    /// Get a list of the capable devices
+    static std::vector<std::string> getCapableDevices()
+        {
+        scanGPUs();
+        return s_capable_gpu_descriptions;
+        }
+
 private:
     //! Guess local rank of this processor, used for GPU initialization
     /*! \returns Local rank guessed from common environment variables
@@ -328,14 +335,12 @@ private:
     /// Provide a string that describes a GPU device
     static std::string describeGPU(int id, hipDeviceProp_t prop);
 
-    /// Print out stats on the chosen GPUs
-    void printGPUStats();
-
     /** Scans through all GPUs reported by CUDA and marks if they are available
 
         Determine which GPUs are available for use by HOOMD.
 
-        \post Populate s_gpu_scan_complete, s_gpu_scan_messages, s_gpu_list, and s_gpu_descriptions.
+        @post Populate s_gpu_scan_complete, s_gpu_scan_messages, s_gpu_list, and
+        s_capable_gpu_descriptions.
     */
     static void scanGPUs();
 
@@ -367,7 +372,7 @@ private:
     static std::vector< int > s_capable_gpu_ids;
 
     /// Description of the GPU devices
-    static std::vector<std::string> s_gpu_descriptions;
+    static std::vector<std::string> s_capable_gpu_descriptions;
 
     bool m_concurrent;                      //!< True if all GPUs have concurrentManagedAccess flag
 

--- a/hoomd/conftest.py
+++ b/hoomd/conftest.py
@@ -180,7 +180,7 @@ def only_cpu(request):
             if request.getfixturevalue('device').mode != 'cpu':
                 pytest.skip('Test is run only on CPU(s).')
         else:
-            raise ValueError('only_gpu requires the *device* fixture')
+            raise ValueError('only_cpu requires the *device* fixture')
 
 @pytest.fixture(scope='function', autouse=True)
 def numpy_random_seed():

--- a/hoomd/conftest.py
+++ b/hoomd/conftest.py
@@ -28,17 +28,6 @@ def device(request):
     return d
 
 
-@pytest.fixture(scope='session', params=devices)
-def device_class(request):
-    """Parameterized Device class fixture.
-
-    Use the `device_class` fixture in tests that need to pass parameters to the
-    device creation.
-    """
-    return request.param
-
-
-
 @pytest.fixture(scope='session')
 def simulation_factory(device):
     """Make a Simulation object from a snapshot.

--- a/hoomd/conftest.py
+++ b/hoomd/conftest.py
@@ -156,7 +156,8 @@ def skip_mpi(request):
 def only_gpu(request):
     if request.node.get_closest_marker('gpu'):
         if 'device' in request.fixturenames:
-            if request.getfixturevalue('device').mode != 'gpu':
+            if not isinstance(request.getfixturevalue('device'),
+                              hoomd.device.GPU):
                 pytest.skip('Test is run only on GPU(s).')
         else:
             raise ValueError('only_gpu requires the *device* fixture')
@@ -166,10 +167,12 @@ def only_gpu(request):
 def only_cpu(request):
     if request.node.get_closest_marker('cpu'):
         if 'device' in request.fixturenames:
-            if request.getfixturevalue('device').mode != 'cpu':
+            if not isinstance(request.getfixturevalue('device'),
+                              hoomd.device.CPU):
                 pytest.skip('Test is run only on CPU(s).')
         else:
             raise ValueError('only_cpu requires the *device* fixture')
+
 
 @pytest.fixture(scope='function', autouse=True)
 def numpy_random_seed():
@@ -188,18 +191,14 @@ def pytest_configure(config):
     config.addinivalue_line(
         "markers",
         "validation: Long running tests that validate simulation output")
-    config.addinivalue_line(
-        "markers",
-        "gpu: Tests that should only run on the gpu.")
+    config.addinivalue_line("markers",
+                            "gpu: Tests that should only run on the gpu.")
     config.addinivalue_line(
         "markers",
         "cupy_optional: tests that should pass with and without CuPy.")
-    config.addinivalue_line(
-        "markers",
-        "cpu: Tests that only run on the CPU.")
-    config.addinivalue_line(
-        "markers",
-        "gpu: Tests that only run on the GPU.")
+    config.addinivalue_line("markers", "cpu: Tests that only run on the CPU.")
+    config.addinivalue_line("markers", "gpu: Tests that only run on the GPU.")
+
 
 def abort(exitstatus):
     # get a default mpi communicator

--- a/hoomd/conftest.py
+++ b/hoomd/conftest.py
@@ -76,7 +76,7 @@ def two_particle_snapshot_factory(device):
     """
 
     def make_snapshot(particle_types=['A'], dimensions=3, d=1, L=20):
-        s = Snapshot(device.comm)
+        s = Snapshot(device.communicator)
         N = 2
 
         if s.exists:
@@ -115,7 +115,7 @@ def lattice_snapshot_factory(device):
     """
 
     def make_snapshot(particle_types=['A'], dimensions=3, a=1, n=7, r=0):
-        s = Snapshot(device.comm)
+        s = Snapshot(device.communicator)
 
         if s.exists:
             box = [n * a, n * a, n * a, 0, 0, 0]
@@ -157,7 +157,7 @@ def lattice_snapshot_factory(device):
 def skip_mpi(request):
     if request.node.get_closest_marker('serial'):
         if 'device' in request.fixturenames:
-            if request.getfixturevalue('device').comm.num_ranks > 1:
+            if request.getfixturevalue('device').communicator.num_ranks > 1:
                 pytest.skip('Test does not support MPI execution')
         else:
             raise ValueError('skip_mpi requires the *device* fixture')

--- a/hoomd/custom/custom_operation.py
+++ b/hoomd/custom/custom_operation.py
@@ -58,6 +58,9 @@ class _CustomOperation(_TriggeredOperation, metaclass=_AbstractLoggable):
             return super().__getattr__(attr)
         except AttributeError:
             try:
+                if not hasattr(self, '_action'):
+                    raise RuntimeError(
+                        "{} object has no attribute _action".format(type(self)))
                 return getattr(self._action, attr)
             except AttributeError:
                 raise AttributeError(

--- a/hoomd/device.py
+++ b/hoomd/device.py
@@ -59,17 +59,6 @@ class _Device:
         return self._comm
 
     @property
-    def mode(self):
-        """str: The execution mode [read only].
-
-        `mode` is either ``cpu`` or ``gpu`` depending on the type of the device.
-        """
-        if self.cpp_exec_conf.isCUDAEnabled():
-            return 'gpu'
-        else:
-            return 'cpu'
-
-    @property
     def notice_level(self):
         """int: Minimum level of messages to print.
 

--- a/hoomd/device.py
+++ b/hoomd/device.py
@@ -48,7 +48,7 @@ class _Device:
                                           shared_msg_file)
 
         # c++ execution configuration mirror class
-        self.cpp_exec_conf = None
+        self._cpp_exec_conf = None
 
         # name of the message file
         self._msg_file = msg_file
@@ -98,7 +98,7 @@ class _Device:
     @property
     def devices(self):
         """List[str]: Descriptions of the active hardware devices."""
-        return self.cpp_exec_conf.getActiveDevices()
+        return self._cpp_exec_conf.getActiveDevices()
 
     @property
     def num_cpu_threads(self):
@@ -106,7 +106,7 @@ class _Device:
         if not _hoomd.is_TBB_available():
             return 1
         else:
-            return self.cpp_exec_conf.getNumThreads()
+            return self._cpp_exec_conf.getNumThreads()
 
     @num_cpu_threads.setter
     def num_cpu_threads(self, num_cpu_threads):
@@ -115,7 +115,7 @@ class _Device:
                 "HOOMD was compiled without thread support, ignoring request "
                 "to set number of threads.\n")
         else:
-            self.cpp_exec_conf.setNumThreads(int(num_cpu_threads))
+            self._cpp_exec_conf.setNumThreads(int(num_cpu_threads))
 
 
 def _create_messenger(mpi_config, notice_level, msg_file, shared_msg_file):
@@ -219,7 +219,7 @@ class GPU(_Device):
             gpu_ids = []
 
         # convert None options to defaults
-        self.cpp_exec_conf = _hoomd.ExecutionConfiguration(
+        self._cpp_exec_conf = _hoomd.ExecutionConfiguration(
             _hoomd.ExecutionConfiguration.executionMode.GPU, gpu_ids,
             self.communicator.cpp_mpi_conf, self._cpp_msg)
 
@@ -232,12 +232,12 @@ class GPU(_Device):
 
         Memory tracebacks are useful for developers when debugging GPU code.
         """
-        return self.cpp_exec_conf.getMemoryTracer() is not None
+        return self._cpp_exec_conf.getMemoryTracer() is not None
 
     @memory_traceback.setter
     def memory_traceback(self, mem_traceback):
 
-        self.cpp_exec_conf.setMemoryTracing(mem_traceback)
+        self._cpp_exec_conf.setMemoryTracing(mem_traceback)
 
     @property
     def gpu_error_checking(self):
@@ -247,11 +247,11 @@ class GPU(_Device):
         noticed immediately. Set to `True` to increase the accuracy of the GPU
         error messages at the cost of significantly reduced performance.
         """
-        return self.cpp_exec_conf.isCUDAErrorCheckingEnabled()
+        return self._cpp_exec_conf.isCUDAErrorCheckingEnabled()
 
     @gpu_error_checking.setter
     def gpu_error_checking(self, new_bool):
-        self.cpp_exec_conf.setCUDAErrorChecking(new_bool)
+        self._cpp_exec_conf.setCUDAErrorChecking(new_bool)
 
     @staticmethod
     def is_available():
@@ -297,10 +297,10 @@ class GPU(_Device):
                 sim.run(1000)
         """
         try:
-            self.cpp_exec_conf.hipProfileStart()
+            self._cpp_exec_conf.hipProfileStart()
             yield None
         finally:
-            self.cpp_exec_conf.hipProfileStop()
+            self._cpp_exec_conf.hipProfileStop()
 
 
 class CPU(_Device):
@@ -336,7 +336,7 @@ class CPU(_Device):
 
         super().__init__(communicator, notice_level, msg_file, shared_msg_file)
 
-        self.cpp_exec_conf = _hoomd.ExecutionConfiguration(
+        self._cpp_exec_conf = _hoomd.ExecutionConfiguration(
             _hoomd.ExecutionConfiguration.executionMode.CPU, [],
             self.communicator.cpp_mpi_conf, self._cpp_msg)
 
@@ -365,7 +365,7 @@ class Auto(_Device):
 
         _init_nthreads(nthreads)
 
-        self.cpp_exec_conf = _hoomd.ExecutionConfiguration(_hoomd.ExecutionConfiguration.executionMode.AUTO,
+        self._cpp_exec_conf = _hoomd.ExecutionConfiguration(_hoomd.ExecutionConfiguration.executionMode.AUTO,
                                                            [],
                                                            self.communicator.cpp_mpi_conf,
                                                            self._cpp_msg)

--- a/hoomd/device.py
+++ b/hoomd/device.py
@@ -5,7 +5,6 @@
 
 import contextlib
 import os
-import warnings
 import hoomd
 from hoomd import _hoomd
 
@@ -44,19 +43,15 @@ class _Device:
             self._comm = communicator
 
         # c++ messenger object
-        self._cpp_msg = _create_messenger(self.comm.cpp_mpi_conf, notice_level,
-                                          msg_file, shared_msg_file)
+        self._cpp_msg = _create_messenger(self.communicator.cpp_mpi_conf,
+                                          notice_level, msg_file,
+                                          shared_msg_file)
 
         # c++ execution configuration mirror class
         self.cpp_exec_conf = None
 
         # name of the message file
         self._msg_file = msg_file
-
-    @property
-    def comm(self):
-        warnings.warn("Use communicator.", DeprecationWarning)
-        return self._comm
 
     @property
     def communicator(self):
@@ -237,7 +232,7 @@ class GPU(_Device):
         # convert None options to defaults
         self.cpp_exec_conf = _hoomd.ExecutionConfiguration(
             _hoomd.ExecutionConfiguration.executionMode.GPU, gpu_ids,
-            self.comm.cpp_mpi_conf, self._cpp_msg)
+            self.communicator.cpp_mpi_conf, self._cpp_msg)
 
         if num_cpu_threads is not None:
             self.num_cpu_threads = num_cpu_threads
@@ -354,7 +349,7 @@ class CPU(_Device):
 
         self.cpp_exec_conf = _hoomd.ExecutionConfiguration(
             _hoomd.ExecutionConfiguration.executionMode.CPU, [],
-            self.comm.cpp_mpi_conf, self._cpp_msg)
+            self.communicator.cpp_mpi_conf, self._cpp_msg)
 
         if num_cpu_threads is not None:
             self.num_cpu_threads = num_cpu_threads
@@ -383,5 +378,5 @@ class Auto(_Device):
 
         self.cpp_exec_conf = _hoomd.ExecutionConfiguration(_hoomd.ExecutionConfiguration.executionMode.AUTO,
                                                            [],
-                                                           self.comm.cpp_mpi_conf,
+                                                           self.communicator.cpp_mpi_conf,
                                                            self._cpp_msg)

--- a/hoomd/device.py
+++ b/hoomd/device.py
@@ -1,9 +1,8 @@
 # Copyright (c) 2009-2019 The Regents of the University of Michigan
-# This file is part of the HOOMD-blue project, released under the BSD 3-Clause License.
+# This file is part of the HOOMD-blue project, released under the BSD 3-Clause
+# License.
 
-# Maintainer: tommy-waltmann / All Developers are free to add commands for new features
-
-r""" Devices available to run simulations
+"""Devices available to run simulations
 
 A device object represents the hardware (whether CPU, GPU, or Auto) the simulation will run on. Creating a device
 object will automatically add it to the simulation context. A device in mode Auto is chosen by default for the user,
@@ -256,8 +255,6 @@ class GPU(_device):
         # convert None options to defaults
         self.cpp_exec_conf = _hoomd.ExecutionConfiguration(_hoomd.ExecutionConfiguration.executionMode.GPU,
                                                            gpu_ids,
-                                                           False,
-                                                           False,
                                                            self.comm.cpp_mpi_conf,
                                                            self.cpp_msg)
     @staticmethod
@@ -286,8 +283,6 @@ class GPU(_device):
                 (if any).
         """
         return list(_hoomd.ExecutionConfiguration.getScanMessages())
-
-    @staticmethod
 
     @contextlib.contextmanager
     def enable_profiling(self):
@@ -333,8 +328,6 @@ class CPU(_device):
 
         self.cpp_exec_conf = _hoomd.ExecutionConfiguration(_hoomd.ExecutionConfiguration.executionMode.CPU,
                                                            [],
-                                                           False,
-                                                           False,
                                                            self.comm.cpp_mpi_conf,
                                                            self.cpp_msg)
 
@@ -362,7 +355,5 @@ class Auto(_device):
 
         self.cpp_exec_conf = _hoomd.ExecutionConfiguration(_hoomd.ExecutionConfiguration.executionMode.AUTO,
                                                            [],
-                                                           False,
-                                                           False,
                                                            self.comm.cpp_mpi_conf,
                                                            self.cpp_msg)

--- a/hoomd/device.py
+++ b/hoomd/device.py
@@ -73,13 +73,6 @@ class _device(hoomd.meta._metadata):
 
         return self._comm
 
-    # \brief Return the name of the GPU used in GPU mode.
-    @property
-    def gpu_ids(self):
-
-        n_gpu = self.cpp_exec_conf.getNumActiveGPUs()
-        return [self.cpp_exec_conf.getGPUName(i) for i in range(n_gpu)]
-
     # \brief Return the execution mode
     @property
     def mode(self):

--- a/hoomd/device.py
+++ b/hoomd/device.py
@@ -349,8 +349,7 @@ class CPU(_Device):
                  shared_msg_file=None,
                  notice_level=2):
 
-        super().__init__(communicator, notice_level, msg_file, shared_msg_file,
-                         num_cpu_threads)
+        super().__init__(communicator, notice_level, msg_file, shared_msg_file)
 
         self.cpp_exec_conf = _hoomd.ExecutionConfiguration(
             _hoomd.ExecutionConfiguration.executionMode.CPU, [],

--- a/hoomd/device.py
+++ b/hoomd/device.py
@@ -167,7 +167,7 @@ class GPU(_Device):
 
     Args:
         gpu_ids (List[int]): List of GPU ids to use. Set to `None` to let the
-        driver auto-select a GPU.
+            driver auto-select a GPU.
 
         num_cpu_threads (int): Number of TBB threads. Set to `None` to
             auto-select.
@@ -323,7 +323,7 @@ class CPU(_Device):
 
     Args:
         num_cpu_threads (int): Number of TBB threads. Set to `None` to
-        auto-select.
+            auto-select.
 
         communicator (`hoomd.comm.Communicator`): MPI communicator object.
             When `None`, create a default communicator that uses all MPI ranks.

--- a/hoomd/device.py
+++ b/hoomd/device.py
@@ -183,6 +183,15 @@ class _device(hoomd.meta._metadata):
             self.cpp_msg.openStd()
 
 
+    @property
+    def devices(self):
+        """Descriptions of the active CPU or GPU devices.
+
+        Returns:
+            List[str]: Descriptions of the active hardware devices.
+        """
+        return self.cpp_exec_conf.getActiveDevices()
+
 ## Initializes the Messenger
 # \internal
 def _create_messenger(mpi_config, notice_level, msg_file, shared_msg_file):
@@ -267,6 +276,16 @@ class GPU(_device):
             List[str]: Descriptions of the available devices (if any).
         """
         return list(_hoomd.ExecutionConfiguration.getCapableDevices())
+
+    @staticmethod
+    def get_unavailable_device_reasons():
+        """Get messages describing the reasons why devices are unavailable.
+
+        Returns:
+            List[str]: Messages indicating why some devices are unavailable
+                (if any).
+        """
+        return list(_hoomd.ExecutionConfiguration.getScanMessages())
 
     @staticmethod
 

--- a/hoomd/device.py
+++ b/hoomd/device.py
@@ -259,6 +259,17 @@ class GPU(_device):
         """
         return _hoomd.isCUDAAvailable();
 
+    @staticmethod
+    def get_available_devices():
+        """Get the available GPU devices.
+
+        Returns:
+            List[str]: Descriptions of the available devices (if any).
+        """
+        return list(_hoomd.ExecutionConfiguration.getCapableDevices())
+
+    @staticmethod
+
     @contextlib.contextmanager
     def enable_profiling(self):
         """Enable GPU profiling.

--- a/hoomd/hpmc/integrate.py
+++ b/hoomd/hpmc/integrate.py
@@ -157,7 +157,7 @@ class _HPMCIntegrator(_BaseIntegrator):
                                                            self.seed)
         else:
             if simulation.device.mode == 'gpu':
-                simulation.device.cpp_msg.warning(
+                simulation.device._cpp_msg.warning(
                     "Falling back on CPU. No GPU implementation for shape.\n")
             self._cpp_obj = getattr(_hpmc, self._cpp_cls)(sys_def, self.seed)
             self._cpp_cell = None

--- a/hoomd/hpmc/integrate.py
+++ b/hoomd/hpmc/integrate.py
@@ -146,7 +146,7 @@ class _HPMCIntegrator(_BaseIntegrator):
     def attach(self, simulation):
         '''initialize the reflected c++ class'''
         sys_def = simulation.state._cpp_sys_def
-        if (simulation.device.mode == 'gpu'
+        if (isinstance(simulation.device, hoomd.device.GPU)
                 and (self._cpp_cls + 'GPU') in _hpmc.__dict__):
             self._cpp_cell = _hoomd.CellListGPU(sys_def)
             if simulation._system_communicator is not None:
@@ -156,7 +156,7 @@ class _HPMCIntegrator(_BaseIntegrator):
                                                            self._cpp_cell,
                                                            self.seed)
         else:
-            if simulation.device.mode == 'gpu':
+            if isinstance(simulation.device, hoomd.device.GPU):
                 simulation.device._cpp_msg.warning(
                     "Falling back on CPU. No GPU implementation for shape.\n")
             self._cpp_obj = getattr(_hpmc, self._cpp_cls)(sys_def, self.seed)

--- a/hoomd/md/IntegratorTwoStep.cc
+++ b/hoomd/md/IntegratorTwoStep.cc
@@ -130,7 +130,7 @@ void IntegratorTwoStep::update(unsigned int timestep)
 
     // compute the net force on all particles
 #ifdef ENABLE_HIP
-    if (m_exec_conf->exec_mode == ExecutionConfiguration::GPU)
+    if (m_exec_conf->isCUDAEnabled())
         computeNetForceGPU(timestep+1);
     else
 #endif
@@ -425,7 +425,7 @@ void IntegratorTwoStep::prepRun(unsigned int timestep)
 
         // compute the net force on all particles
 #ifdef ENABLE_HIP
-    if (m_exec_conf->exec_mode == ExecutionConfiguration::GPU)
+    if (m_exec_conf->isCUDAEnabled())
         computeNetForceGPU(timestep);
     else
 #endif

--- a/hoomd/md/angle.py
+++ b/hoomd/md/angle.py
@@ -29,7 +29,7 @@ class _Angle(_Force):
             simulation.device._cpp_msg.warning("No angles are defined.\n")
 
         # create the c++ mirror class
-        if not simulation.device.cpp_exec_conf.isCUDAEnabled():
+        if isinstance(simulation.device, hoomd.device.CPU):
             cpp_cls = getattr(_md, self._cpp_class_name)
         else:
             cpp_cls = getattr(_md, self._cpp_class_name + "GPU")

--- a/hoomd/md/angle.py
+++ b/hoomd/md/angle.py
@@ -26,7 +26,7 @@ class _Angle(_Force):
     def attach(self, simulation):
         # check that some angles are defined
         if simulation.state._cpp_sys_def.getAngleData().getNGlobal() == 0:
-            simulation.device.cpp_msg.warning("No angles are defined.\n")
+            simulation.device._cpp_msg.warning("No angles are defined.\n")
 
         # create the c++ mirror class
         if not simulation.device.cpp_exec_conf.isCUDAEnabled():

--- a/hoomd/md/bond.py
+++ b/hoomd/md/bond.py
@@ -36,7 +36,7 @@ class _Bond(_Force):
     """
     def attach(self, simulation):
         """Create the c++ mirror class."""
-        if not simulation.device.cpp_exec_conf.isCUDAEnabled():
+        if isinstance(simulation.device, hoomd.device.CPU):
             cpp_cls = getattr(_md, self._cpp_class_name)
         else:
             cpp_cls = getattr(_md, self._cpp_class_name + "GPU")

--- a/hoomd/md/dihedral.py
+++ b/hoomd/md/dihedral.py
@@ -39,7 +39,7 @@ class _Dihedral(_Force):
     def attach(self, simulation):
         # check that some dihedrals are defined
         if simulation.state._cpp_sys_def.getDihedralData().getNGlobal() == 0:
-            simulation.device.cpp_msg.warning("No dihedrals are defined.\n")
+            simulation.device._cpp_msg.warning("No dihedrals are defined.\n")
 
         # create the c++ mirror class
         if not simulation.device.cpp_exec_conf.isCUDAEnabled():

--- a/hoomd/md/dihedral.py
+++ b/hoomd/md/dihedral.py
@@ -42,7 +42,7 @@ class _Dihedral(_Force):
             simulation.device._cpp_msg.warning("No dihedrals are defined.\n")
 
         # create the c++ mirror class
-        if not simulation.device.cpp_exec_conf.isCUDAEnabled():
+        if isinstance(simulation.device, hoomd.device.CPU):
             cpp_class = getattr(_md, self._cpp_class_name)
         else:
             cpp_class = getattr(_md, self._cpp_class_name + "GPU")

--- a/hoomd/md/force.py
+++ b/hoomd/md/force.py
@@ -310,7 +310,7 @@ class Active(_Force):
 
 
         # initialize the reflected c++ class
-        if not simulation.device.cpp_exec_conf.isCUDAEnabled():
+        if isinstance(simulation.device, hoomd.device.CPU):
             my_class = _md.ActiveForceCompute
         else:
             my_class = _md.ActiveForceComputeGPU

--- a/hoomd/md/methods.py
+++ b/hoomd/md/methods.py
@@ -84,7 +84,7 @@ class NVT(_Method):
     def attach(self, simulation):
 
         # initialize the reflected cpp class
-        if not simulation.device.cpp_exec_conf.isCUDAEnabled():
+        if isinstance(simulation.device, hoomd.device.CPU):
             my_class = _md.TwoStepNVTMTK
             thermo_cls = _hoomd.ComputeThermo
         else:
@@ -607,11 +607,11 @@ class NVE(_Method):
     def attach(self, simulation):
 
         # initialize the reflected c++ class
-        if not simulation.device.cpp_exec_conf.isCUDAEnabled():
+        if isinstance(simulation.device, hoomd.device.CPU):
             self._cpp_obj = _md.TwoStepNVE(simulation.state._cpp_sys_def,
                                         simulation.state.get_group(self.filter), False)
         else:
-            self._cpp_obj = _md.TwoStepNVEGPU(simulation.state._cpp_sys_def, 
+            self._cpp_obj = _md.TwoStepNVEGPU(simulation.state._cpp_sys_def,
                                  simulation.state.get_group(self.filter))
 
         # Attach param_dict and typeparam_dict
@@ -737,7 +737,7 @@ class Langevin(_Method):
     def attach(self, simulation):
 
         # initialize the reflected c++ class
-        if not simulation.device.cpp_exec_conf.isCUDAEnabled():
+        if isinstance(simulation.device, hoomd.device.CPU):
             my_class = _md.TwoStepLangevin
         else:
             my_class = _md.TwoStepLangevinGPU
@@ -852,7 +852,7 @@ class Brownian(_Method):
     def attach(self, simulation):
 
         # initialize the reflected c++ class
-        if not simulation.device.cpp_exec_conf.isCUDAEnabled():
+        if isinstance(simulation.device, hoomd.device.CPU):
             self._cpp_obj = _md.TwoStepBD(simulation.state._cpp_sys_def,
                                           simulation.state.get_group(self.filter),
                                           self.kT, self.seed)

--- a/hoomd/md/nlist.py
+++ b/hoomd/md/nlist.py
@@ -167,7 +167,7 @@ class Cell(_NList):
             ParameterDict(deterministic=bool(deterministic)))
 
     def attach(self, simulation):
-        if not simulation.device.cpp_exec_conf.isCUDAEnabled():
+        if isinstance(simulation.device, hoomd.device.CPU):
             cell_cls = _hoomd.CellList
             nlist_cls = _md.NeighborListBinned
         else:

--- a/hoomd/md/pair.py
+++ b/hoomd/md/pair.py
@@ -180,7 +180,7 @@ class _Pair(force._Force):
         # create the c++ mirror class
         if not self.nlist.is_attached:
             self.nlist.attach(simulation)
-        if not simulation.device.cpp_exec_conf.isCUDAEnabled():
+        if isinstance(simulation.device, hoomd.device.CPU):
             cls = getattr(_md, self._cpp_class_name)
             self.nlist._cpp_obj.setStorageMode(
                 _md.NeighborList.storageMode.half)

--- a/hoomd/md/pytest/test_flags.py
+++ b/hoomd/md/pytest/test_flags.py
@@ -29,7 +29,7 @@ def test_per_particle_virial(simulation_factory, lattice_snapshot_factory):
     # virials should be None at first
     virials = lj.virials
 
-    if sim.device.comm.rank == 0:
+    if sim.device.communicator.rank == 0:
         assert virials is None
 
     # virials should be non-zero after setting flags
@@ -37,7 +37,7 @@ def test_per_particle_virial(simulation_factory, lattice_snapshot_factory):
 
     virials = lj.virials
 
-    if sim.device.comm.rank == 0:
+    if sim.device.communicator.rank == 0:
         assert numpy.sum(virials * virials) > 0.0
 
 

--- a/hoomd/md/special_pair.py
+++ b/hoomd/md/special_pair.py
@@ -24,7 +24,7 @@ class _SpecialPair(_Force):
     def attach(self, simulation):
         # check that some bonds are defined
         if simulation.state._cpp_sys_def.getPairData().getNGlobal() == 0:
-            simulation.device.cpp_msg.error("No pairs are defined.\n")
+            simulation.device._cpp_msg.error("No pairs are defined.\n")
 
         # create the c++ mirror class
         if not simulation.device.mode == "gpu":

--- a/hoomd/md/special_pair.py
+++ b/hoomd/md/special_pair.py
@@ -18,6 +18,7 @@ from hoomd.md import _md
 from hoomd.md.force import _Force
 from hoomd.typeparam import TypeParameter
 from hoomd.parameterdicts import TypeParameterDict
+import hoomd
 
 
 class _SpecialPair(_Force):
@@ -27,7 +28,7 @@ class _SpecialPair(_Force):
             simulation.device._cpp_msg.error("No pairs are defined.\n")
 
         # create the c++ mirror class
-        if not simulation.device.mode == "gpu":
+        if isinstance(simulation.device, hoomd.device.CPU):
             cpp_cls = getattr(_md, self._cpp_class_name)
         else:
             cpp_cls = getattr(_md, self._cpp_class_name + "GPU")

--- a/hoomd/module.cc
+++ b/hoomd/module.cc
@@ -191,10 +191,6 @@ bool is_TBB_available()
     }
 
 
-// values used in measuring hoomd launch timing
-unsigned int hoomd_launch_time, hoomd_start_time, hoomd_mpi_init_time;
-bool hoomd_launch_timing=false;
-
 #ifdef ENABLE_MPI
 //! Environment variables needed for setting up MPI
 char env_enable_mpi_cuda[] = "MV2_USE_CUDA=1";
@@ -208,33 +204,12 @@ int initialize_mpi()
     putenv(env_enable_mpi_cuda);
     #endif
 
-    // benchmark hoomd launch times
-    if (getenv("HOOMD_LAUNCH_TIME"))
-        {
-        // get the time that mpirun was called
-        hoomd_launch_time = atoi(getenv("HOOMD_LAUNCH_TIME"));
-
-        // compute the number of seconds to get here
-        timeval t;
-        gettimeofday(&t, NULL);
-        hoomd_start_time = t.tv_sec - hoomd_launch_time;
-        hoomd_launch_timing = true;
-        }
-
     // initialize MPI if it has not been initialized by another program
     int external_init = 0;
     MPI_Initialized(&external_init);
     if (!external_init)
         {
         MPI_Init(0, (char ***) NULL);
-        }
-
-    if (hoomd_launch_timing)
-        {
-        // compute the number of seconds to get past mpi_init
-        timeval t;
-        gettimeofday(&t, NULL);
-        hoomd_mpi_init_time = t.tv_sec - hoomd_launch_time;
         }
 
     return external_init;

--- a/hoomd/mpcd/test/cell_list_mpi_test.cc
+++ b/hoomd/mpcd/test/cell_list_mpi_test.cc
@@ -1363,9 +1363,7 @@ UP_TEST( mpcd_cell_list_dimensions )
     // mpi in 1d
         {
         std::shared_ptr<ExecutionConfiguration> exec_conf(new ExecutionConfiguration(ExecutionConfiguration::CPU,
-                                                                                     std::vector<int>(),
-                                                                                     false,
-                                                                                     false));
+                                                                                     std::vector<int>()));
         exec_conf->getMPIConfig()->splitPartitions(2);
         celllist_dimension_test<mpcd::CellList>(exec_conf, true, false, false);
         celllist_dimension_test<mpcd::CellList>(exec_conf, false, true, false);
@@ -1374,9 +1372,7 @@ UP_TEST( mpcd_cell_list_dimensions )
     // mpi in 2d
         {
         std::shared_ptr<ExecutionConfiguration> exec_conf(new ExecutionConfiguration(ExecutionConfiguration::CPU,
-                                                                                     std::vector<int>(),
-                                                                                     false,
-                                                                                     false));
+                                                                                     std::vector<int>()));
         exec_conf->getMPIConfig()->splitPartitions(4);
         celllist_dimension_test<mpcd::CellList>(exec_conf, true, true, false);
         celllist_dimension_test<mpcd::CellList>(exec_conf, true, false, true);
@@ -1385,9 +1381,7 @@ UP_TEST( mpcd_cell_list_dimensions )
     // mpi in 3d
         {
         std::shared_ptr<ExecutionConfiguration> exec_conf(new ExecutionConfiguration(ExecutionConfiguration::CPU,
-                                                                                     std::vector<int>(),
-                                                                                     false,
-                                                                                     false));
+                                                                                     std::vector<int>()));
         exec_conf->getMPIConfig()->splitPartitions(8);
         celllist_dimension_test<mpcd::CellList>(exec_conf, true, true, true);
         }
@@ -1412,9 +1406,7 @@ UP_TEST( mpcd_cell_list_gpu_dimensions )
     // mpi in 1d
         {
         std::shared_ptr<ExecutionConfiguration> exec_conf(new ExecutionConfiguration(ExecutionConfiguration::GPU,
-                                                                                     std::vector<int>(),
-                                                                                     false,
-                                                                                     false));
+                                                                                     std::vector<int>()));
         exec_conf->getMPIConfig()->splitPartitions(2);
         celllist_dimension_test<mpcd::CellListGPU>(exec_conf, true, false, false);
         celllist_dimension_test<mpcd::CellListGPU>(exec_conf, false, true, false);
@@ -1423,9 +1415,7 @@ UP_TEST( mpcd_cell_list_gpu_dimensions )
     // mpi in 2d
         {
         std::shared_ptr<ExecutionConfiguration> exec_conf(new ExecutionConfiguration(ExecutionConfiguration::GPU,
-                                                                                     std::vector<int>(),
-                                                                                     false,
-                                                                                     false));
+                                                                                     std::vector<int>()));
         exec_conf->getMPIConfig()->splitPartitions(4);
         celllist_dimension_test<mpcd::CellListGPU>(exec_conf, true, true, false);
         celllist_dimension_test<mpcd::CellListGPU>(exec_conf, true, false, true);
@@ -1434,9 +1424,7 @@ UP_TEST( mpcd_cell_list_gpu_dimensions )
     // mpi in 3d
         {
         std::shared_ptr<ExecutionConfiguration> exec_conf(new ExecutionConfiguration(ExecutionConfiguration::GPU,
-                                                                                     std::vector<int>(),
-                                                                                     false,
-                                                                                     false));
+                                                                                     std::vector<int>()));
         exec_conf->getMPIConfig()->splitPartitions(8);
         celllist_dimension_test<mpcd::CellListGPU>(exec_conf, true, true, true);
         }

--- a/hoomd/operation.py
+++ b/hoomd/operation.py
@@ -92,7 +92,7 @@ class _HOOMDGetSetAttrBase:
             return self._getattr_typeparam(attr)
         else:
             raise AttributeError("Object {} has no attribute {}".format(
-                self, attr))
+                type(self), attr))
 
     def _getattr_param(self, attr):
         """Hook for getting an attribute from `_param_dict`."""

--- a/hoomd/pytest/test_csv.py
+++ b/hoomd/pytest/test_csv.py
@@ -34,7 +34,7 @@ def expected_values():
 def test_header_generation(device, logger):
     output = StringIO("")
     csv_writer = hoomd.output.CSV(0, logger, output)
-    csv_writer._comm = device.comm
+    csv_writer._comm = device.communicator
     for i in range(10):
         csv_writer.write()
     output_str = output.getvalue()
@@ -59,7 +59,7 @@ def test_header_generation(device, logger):
 def test_values(device, logger, expected_values):
     output = StringIO("")
     csv_writer = hoomd.output.CSV(0, logger, output)
-    csv_writer._comm = device.comm
+    csv_writer._comm = device.communicator
     for i in range(10):
         csv_writer.write()
     lines = output.getvalue().split('\n')
@@ -88,7 +88,7 @@ def test_values(device, logger, expected_values):
 def test_mpi_write_only(device, logger):
     output = StringIO("")
     csv_writer = hoomd.output.CSV(0, logger, output)
-    csv_writer._comm = device.comm
+    csv_writer._comm = device.communicator
     csv_writer.write()
 
     comm = MPI.COMM_WORLD
@@ -103,7 +103,7 @@ def test_header_attributes(device, logger):
     output = StringIO("")
     csv_writer = hoomd.output.CSV(
         0, logger, output, header_sep='-', max_header_len=13)
-    csv_writer._comm = device.comm
+    csv_writer._comm = device.communicator
     csv_writer.write()
     lines = output.getvalue().split('\n')
     headers = lines[0].split()
@@ -116,7 +116,7 @@ def test_delimiter(device, logger):
     output = StringIO("")
     csv_writer = hoomd.output.CSV(
         0, logger, output, delimiter=',')
-    csv_writer._comm = device.comm
+    csv_writer._comm = device.communicator
     csv_writer.write()
     lines = output.getvalue().split('\n')
     assert all(len(row.split(',')) == 3 for row in lines[:-1])
@@ -127,7 +127,7 @@ def test_max_precision(device, logger):
     output = StringIO("")
     csv_writer = hoomd.output.CSV(0, logger, output, pretty=False,
                                   max_precision=5)
-    csv_writer._comm = device.comm
+    csv_writer._comm = device.communicator
     for i in range(10):
         csv_writer.write()
 
@@ -136,7 +136,7 @@ def test_max_precision(device, logger):
     output = StringIO("")
     csv_writer = hoomd.output.CSV(0, logger, output, pretty=False,
                                   max_precision=15)
-    csv_writer._comm = device.comm
+    csv_writer._comm = device.communicator
     for i in range(10):
         csv_writer.write()
 

--- a/hoomd/pytest/test_device.py
+++ b/hoomd/pytest/test_device.py
@@ -1,7 +1,9 @@
-def test_device():
-    assert True
+import pytest
 
+@pytest.mark.gpu
+def test_gpu_profile(device):
 
-def test_gpu_profile(device_gpu):
-    with device_gpu.enable_profiling():
+    print(device)
+
+    with device.enable_profiling():
         pass

--- a/hoomd/pytest/test_example.py
+++ b/hoomd/pytest/test_example.py
@@ -19,19 +19,23 @@ def test_serial(device):
     """
     assert True
 
-def test_cpu_only(device_cpu):
-    """ Some tests need a device but only operate correctly on the CPU. Use the ``device_cpu`` fixture to get only
-    CPU devices.
+@pytest.mark.cpu
+def test_cpu_only(device):
+    """ Some tests need a device but only operate correctly on the CPU.
+
+    Use the ``cpu`` mark to skip these tests on the GPU.
     """
 
-    assert device_cpu.mode == 'cpu'
+    assert device.mode == 'cpu'
 
-def test_gpu_only(device_gpu):
-    """ Some tests need a device but only operate correctly on the GPU. Use the ``device_gpu`` fixture to get only
-    GPU devices.
+@pytest.mark.gpu
+def test_gpu_only(device):
+    """ Some tests need a device but only operate correctly on the GPU.
+
+    Use the ``gpu`` mark to skip these tests on the GPU.
     """
 
-    assert device_gpu.mode == 'gpu'
+    assert device.mode == 'gpu'
 
 def test_python_only():
     """ Python only tests operate in pure python without a device or simulation context

--- a/hoomd/pytest/test_example.py
+++ b/hoomd/pytest/test_example.py
@@ -10,7 +10,6 @@ def test_typical(device):
     objects are re-used across all tests for efficiency, do not modify them.
     """
 
-    print(device.mode)
     assert True
 
 @pytest.mark.serial

--- a/hoomd/pytest/test_example.py
+++ b/hoomd/pytest/test_example.py
@@ -26,7 +26,7 @@ def test_cpu_only(device):
     Use the ``cpu`` mark to skip these tests on the GPU.
     """
 
-    assert device.mode == 'cpu'
+    assert isinstance(device, hoomd.device.CPU)
 
 @pytest.mark.gpu
 def test_gpu_only(device):
@@ -35,20 +35,10 @@ def test_gpu_only(device):
     Use the ``gpu`` mark to skip these tests on the GPU.
     """
 
-    assert device.mode == 'gpu'
+    assert isinstance(device, hoomd.device.GPU)
 
 def test_python_only():
     """ Python only tests operate in pure python without a device or simulation context
     """
 
     assert 2*2 == 4
-
-def test_create_own_device(device_class):
-    """ Some tests require that they instantiate their own device (i.e. need to specify MPI nrank options). Use the
-    ``device_class`` fixture to run these on both the CPU and GPU. Use this fixture only when necessary due to the
-    overhead of device creation.
-    """
-
-    device = device_class(notice_level = 1)
-    assert device.mode == 'gpu' or device.mode == 'cpu'
-

--- a/hoomd/pytest/test_filter.py
+++ b/hoomd/pytest/test_filter.py
@@ -12,7 +12,7 @@ import numpy
 @pytest.fixture(scope="function")
 def make_filter_snapshot(device):
     def filter_snapshot(n=10, particle_types=['A']):
-        s = Snapshot(device.comm)
+        s = Snapshot(device.communicator)
         if s.exists:
             s.configuration.box = [20, 20, 20, 0, 0, 0]
             s.particles.N = n

--- a/hoomd/pytest/test_local_snapshot.py
+++ b/hoomd/pytest/test_local_snapshot.py
@@ -374,7 +374,7 @@ class _TestLocalSnapshots:
         sim = simulation_factory()
         for lcl_snapshot_attr in self._lcl_snapshot_attrs:
             with getattr(sim.state, lcl_snapshot_attr) as data:
-                self.check_box(data, sim.state.box, sim.device.num_ranks)
+                self.check_box(data, sim.state.box, sim.device.comm.num_ranks)
 
     @staticmethod
     def check_tag_shape(base_snapshot, local_snapshot, group, ranks):
@@ -411,7 +411,7 @@ class _TestLocalSnapshots:
         for lcl_snapshot_attr in self._lcl_snapshot_attrs:
             with getattr(sim.state, lcl_snapshot_attr) as data:
                 self.check_tag_shape(
-                    base_snapshot, data, snapshot_section, sim.device.num_ranks)
+                    base_snapshot, data, snapshot_section, sim.device.comm.num_ranks)
 
     @staticmethod
     def check_global_properties(prop, global_property_dict, N):

--- a/hoomd/pytest/test_local_snapshot.py
+++ b/hoomd/pytest/test_local_snapshot.py
@@ -192,7 +192,7 @@ def base_snapshot(device):
             except TypeError:
                 setattr(snap_section, k, data[k]['value'])
 
-    snapshot = hoomd.Snapshot(device.comm)
+    snapshot = hoomd.Snapshot(device.communicator)
 
     if snapshot.exists:
         snapshot.configuration.box = [2.1, 2.1, 2.1, 0, 0, 0]
@@ -374,7 +374,7 @@ class _TestLocalSnapshots:
         sim = simulation_factory()
         for lcl_snapshot_attr in self._lcl_snapshot_attrs:
             with getattr(sim.state, lcl_snapshot_attr) as data:
-                self.check_box(data, sim.state.box, sim.device.comm.num_ranks)
+                self.check_box(data, sim.state.box, sim.device.communicator.num_ranks)
 
     @staticmethod
     def check_tag_shape(base_snapshot, local_snapshot, group, ranks):
@@ -411,7 +411,7 @@ class _TestLocalSnapshots:
         for lcl_snapshot_attr in self._lcl_snapshot_attrs:
             with getattr(sim.state, lcl_snapshot_attr) as data:
                 self.check_tag_shape(
-                    base_snapshot, data, snapshot_section, sim.device.comm.num_ranks)
+                    base_snapshot, data, snapshot_section, sim.device.communicator.num_ranks)
 
     @staticmethod
     def check_global_properties(prop, global_property_dict, N):

--- a/hoomd/pytest/test_local_snapshot.py
+++ b/hoomd/pytest/test_local_snapshot.py
@@ -467,14 +467,15 @@ class _TestLocalSnapshots:
                 property_check(hoomd_buffer, property_dict, tags)
 
 
+@pytest.mark.cpu
 class TestLocalSnapshotCPUDevice(_TestLocalSnapshots):
     _lcl_snapshot_attrs = ['cpu_local_snapshot']
 
     @pytest.fixture
-    def simulation_factory(self, device_cpu, base_snapshot):
+    def simulation_factory(self, device, base_snapshot):
         """Creates the simulation from the base_snapshot."""
         def factory():
-            sim = hoomd.Simulation(device_cpu)
+            sim = hoomd.Simulation(device)
 
             # reduce sorter grid to avoid Hilbert curve overhead in unit tests
             for tuner in sim.operations.tuners:
@@ -485,15 +486,18 @@ class TestLocalSnapshotCPUDevice(_TestLocalSnapshots):
             return sim
         return factory
 
-
+@pytest.mark.gpu
 class TestLocalSnapshotGPUDevice(_TestLocalSnapshots):
     _lcl_snapshot_attrs = ['cpu_local_snapshot', 'gpu_local_snapshot']
 
+    #TODO: see if this could work with the global simulation_factory to avoid
+    # code duplication
+
     @pytest.fixture
-    def simulation_factory(self, device_gpu, base_snapshot):
+    def simulation_factory(self, device, base_snapshot):
         """Creates the simulation from the base_snapshot."""
         def factory():
-            sim = hoomd.Simulation(device_gpu)
+            sim = hoomd.Simulation(device)
 
             # reduce sorter grid to avoid Hilbert curve overhead in unit tests
             for tuner in sim.operations.tuners:

--- a/hoomd/pytest/test_simulation.py
+++ b/hoomd/pytest/test_simulation.py
@@ -15,7 +15,7 @@ skip_gsd = pytest.mark.skipif(
 @pytest.fixture(scope="function")
 def get_snapshot(device):
     def make_snapshot(n=10, particle_types=['A']):
-        s = hoomd.snapshot.Snapshot(device.comm)
+        s = hoomd.snapshot.Snapshot(device.communicator)
         if s.exists:
             s.configuration.box = [20, 20, 20, 0, 0, 0]
             s.particles.N = n

--- a/hoomd/pytest/test_state.py
+++ b/hoomd/pytest/test_state.py
@@ -6,7 +6,7 @@ import pytest
 
 @pytest.fixture(scope='function')
 def snap(device):
-    s = Snapshot(device.comm)
+    s = Snapshot(device.communicator)
     N = 1000
 
     if s.exists:

--- a/hoomd/simulation.py
+++ b/hoomd/simulation.py
@@ -53,7 +53,7 @@ class Simulation(metaclass=Loggable):
             decomposition = pdata.getDomainDecomposition()
             if decomposition is not None:
                 # create the c++ Communicator
-                if self.device.mode == 'cpu':
+                if isinstance(self.device, hoomd.device.CPU):
                     cpp_communicator = _hoomd.Communicator(
                         self.state._cpp_sys_def, decomposition)
                 else:

--- a/hoomd/simulation.py
+++ b/hoomd/simulation.py
@@ -79,7 +79,7 @@ class Simulation(metaclass=Loggable):
         reader = _hoomd.GSDReader(self.device.cpp_exec_conf,
                                   filename, abs(frame), frame < 0)
         snapshot = Snapshot._from_cpp_snapshot(reader.getSnapshot(),
-                                               self.device.comm)
+                                               self.device.communicator)
 
         step = reader.getTimeStep() if self.timestep is None else self.timestep
         self._state = State(self, snapshot)

--- a/hoomd/simulation.py
+++ b/hoomd/simulation.py
@@ -3,6 +3,7 @@ from hoomd.logging import log, Loggable
 from hoomd.state import State
 from hoomd.snapshot import Snapshot
 from hoomd.operations import Operations
+import hoomd
 
 
 class Simulation(metaclass=Loggable):
@@ -74,9 +75,9 @@ class Simulation(metaclass=Loggable):
         if self.state is not None:
             raise RuntimeError("Cannot initialize more than once\n")
         filename = _hoomd.mpi_bcast_str(filename,
-                                        self.device.cpp_exec_conf)
+                                        self.device._cpp_exec_conf)
         # Grab snapshot and timestep
-        reader = _hoomd.GSDReader(self.device.cpp_exec_conf,
+        reader = _hoomd.GSDReader(self.device._cpp_exec_conf,
                                   filename, abs(frame), frame < 0)
         snapshot = Snapshot._from_cpp_snapshot(reader.getSnapshot(),
                                                self.device.communicator)

--- a/hoomd/state.py
+++ b/hoomd/state.py
@@ -1,10 +1,10 @@
-from copy import copy
 from collections import defaultdict
 
 from . import _hoomd
 from hoomd.box import Box
 from hoomd.snapshot import Snapshot
 from hoomd.data import LocalSnapshot, LocalSnapshotGPU
+import hoomd
 
 
 def _create_domain_decomposition(device, box):
@@ -23,7 +23,7 @@ def _create_domain_decomposition(device, box):
         return None
 
     # create a default domain decomposition
-    result = _hoomd.DomainDecomposition(device.cpp_exec_conf,
+    result = _hoomd.DomainDecomposition(device._cpp_exec_conf,
                                         box.getL(),
                                         0,
                                         0,
@@ -293,7 +293,7 @@ class State:
         Note:
             This property is only available when running on a GPU(s).
         """
-        if self._simulation.device.mode != 'gpu':
+        if not isinstance(self._simulation.device, hoomd.device.GPU):
             raise RuntimeError(
                 "Cannot access gpu_snapshot with a non GPU device.")
         elif self._in_context_manager:

--- a/hoomd/state.py
+++ b/hoomd/state.py
@@ -178,7 +178,7 @@ class State:
                              'hoomd.Box.from_box'.format(value))
 
         if value.dimensions != self._cpp_sys_def.getNDimensions():
-            self._simulation.device.cpp_msg.warning(
+            self._simulation.device._cpp_msg.warning(
                 "Box changing dimensions from {} to {}."
                 "".format(self._cpp_sys_def.getNDimensions(),
                           value.dimensions))

--- a/hoomd/state.py
+++ b/hoomd/state.py
@@ -19,7 +19,7 @@ def _create_domain_decomposition(device, box):
 
     # if we are only running on one processor, we use optimized code paths
     # for single-GPU execution
-    if device.comm.num_ranks == 1:
+    if device.communicator.num_ranks == 1:
         return None
 
     # create a default domain decomposition
@@ -61,7 +61,7 @@ class State:
     def snapshot(self):
         cpp_snapshot = self._cpp_sys_def.takeSnapshot_double()
         return Snapshot._from_cpp_snapshot(cpp_snapshot,
-                                           self._simulation.device.comm)
+                                           self._simulation.device.communicator)
 
     @snapshot.setter
     def snapshot(self, snapshot):
@@ -101,7 +101,7 @@ class State:
 
         """
 
-        if self._simulation.device.comm.rank == 0:
+        if self._simulation.device.communicator.rank == 0:
             if len(snapshot.particles.types) != len(self.particle_types):
                 raise RuntimeError(
                     "Number of particle types must remain the same")

--- a/hoomd/state.py
+++ b/hoomd/state.py
@@ -50,11 +50,11 @@ class State:
 
         if domain_decomp is not None:
             self._cpp_sys_def = _hoomd.SystemDefinition(
-                snapshot._cpp_obj, simulation.device.cpp_exec_conf,
+                snapshot._cpp_obj, simulation.device._cpp_exec_conf,
                 domain_decomp)
         else:
             self._cpp_sys_def = _hoomd.SystemDefinition(
-                snapshot._cpp_obj, simulation.device.cpp_exec_conf)
+                snapshot._cpp_obj, simulation.device._cpp_exec_conf)
         self._groups = defaultdict(dict)
 
     @property

--- a/hoomd/tune/balance.py
+++ b/hoomd/tune/balance.py
@@ -91,7 +91,7 @@ class LoadBalancer(_Tuner):
         self._param_dict.update(defaults)
 
     def attach(self, simulation):
-        if simulation.device.mode == 'gpu':
+        if isinstance(self._simulation.device, hoomd.device.GPU):
             cpp_cls = getattr(_hoomd, 'LoadBalancerGPU')
         else:
             cpp_cls = getattr(_hoomd, 'LoadBalancer')

--- a/hoomd/tune/sorter.py
+++ b/hoomd/tune/sorter.py
@@ -3,6 +3,7 @@ from hoomd.parameterdicts import ParameterDict
 from hoomd.typeconverter import OnlyType
 from hoomd.trigger import Trigger
 from hoomd import _hoomd
+import hoomd
 from math import log2, ceil
 
 
@@ -33,7 +34,7 @@ class ParticleSorter(_Tuner):
         self.grid = grid
 
     def attach(self, simulation):
-        if simulation.device.mode == 'gpu':
+        if isinstance(simulation.device, hoomd.device.GPU):
             cpp_cls = getattr(_hoomd, 'SFCPackTunerGPU')
         else:
             cpp_cls = getattr(_hoomd, 'SFCPackTuner')

--- a/sphinx-doc/command-line-options.rst
+++ b/sphinx-doc/command-line-options.rst
@@ -285,5 +285,5 @@ the number of threads can be set. On the command line, this is done using::
     python script.py --mode=cpu --nthreads=20
 
 Alternatively, the same option can be passed to ``hoomd.context.initialize``, and the number of threads can be updated any time
-by using the property :py:attr:`hoomd.device.num_threads`. If no number of threads is specified, TBB by default uses
+by using the property ``hoomd.device.num_threads``. If no number of threads is specified, TBB by default uses
 all CPUs  in the system. For compatibility with OpenMP, HOOMD also honors a value set in the environment variable **OMP_NUM_THREADS**.

--- a/sphinx-doc/module-hoomd-device.rst
+++ b/sphinx-doc/module-hoomd-device.rst
@@ -1,17 +1,21 @@
 hoomd.device
 ------------
 
+.. py:currentmodule:: hoomd.device
+
 .. rubric:: Overview
 
 .. autosummary::
     :nosignatures:
 
-    hoomd.device.CPU
-    hoomd.device.GPU
-    hoomd.device.Auto
+    _Device
+    Auto
+    CPU
+    GPU
 
 .. rubric:: Details
 
 .. automodule:: hoomd.device
     :synopsis: Devices used for simulation runs
-    :members:
+    :members: _Device, Auto, CPU, GPU
+    :show-inheritance:


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should based on *maint*. -->
<!-- New features should based on *master*. -->

## Description

<!-- Describe your changes in detail. -->
* Refactor `ExecutionConfiguration` to allow the Python API to query the available devices before initializing a device.
* Messages previously printed are now queryable properties.
* Clean up the `device.*` docs.
* Along the way I removed a number of unused functionality.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
1. Reduce stdout/stderr chatter: #684 
2. Enable `auto` as a function: #747 
3. Fix numerous bugs
4. Provide better status information to the user and better error messages when something goes wrong.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
The pytest tests pass.

Additionally, I ran this test script on collins to test the new APIs by hand. These are not trivial to test in an automated environment.
```
import hoomd

print("Available devices:")
for dev in hoomd.device.GPU.get_available_devices():
    print(dev)

print()
print("Unavailable device reasons:")

for reason in hoomd.device.GPU.get_unavailable_device_reasons():
    print(reason)

print()

dev = hoomd.device.GPU([0])
print("[GPU(0)] Active devices:", dev.devices)
print()

dev = hoomd.device.GPU([0,1])
print("[GPU(0,1)] Active devices:", dev.devices)
print()

dev = hoomd.device.CPU()
print("[CPU] Active devices:", dev.devices)
print()
```

Here is the output from this script:
```$ python test.py
Available devices:
[0]               TITAN V  80 SM_7.0 @ 1.46 GHz, 12066 MiB DRAM
[1]               TITAN V  80 SM_7.0 @ 1.46 GHz, 12066 MiB DRAM
[2]      TITAN X (Pascal)  28 SM_6.1 @ 1.53 GHz, 12194 MiB DRAM

Unavailable device reasons:
The device Tesla K40c with computed capability 3.5 does not support HOOMD-blue.

HOOMD-blue v2.9.2-2379-g6933ee1eb GPU [CUDA] (11.0) DOUBLE HPMC_MIXED SSE SSE2
Compiled: 08/26/2020
Copyright (c) 2009-2019 The Regents of the University of Michigan.
[GPU(0)] Active devices: ['[0]               TITAN V  80 SM_7.0 @ 1.46 GHz, 12066 MiB DRAM']

HOOMD-blue v2.9.2-2379-g6933ee1eb GPU [CUDA] (11.0) DOUBLE HPMC_MIXED SSE SSE2
Compiled: 08/26/2020
Copyright (c) 2009-2019 The Regents of the University of Michigan.
[GPU(0,1)] Active devices: ['[1]               TITAN V  80 SM_7.0 @ 1.46 GHz, 12066 MiB DRAM', '[0]               TITAN V  80 SM_7.0 @ 1.46 GHz, 12066 MiB DRAM']

HOOMD-blue v2.9.2-2379-g6933ee1eb GPU [CUDA] (11.0) DOUBLE HPMC_MIXED SSE SSE2
Compiled: 08/26/2020
Copyright (c) 2009-2019 The Regents of the University of Michigan.
[CPU] Active devices: ['CPU']
```

Now, If I artificially limit the number of devices available, you can see the improved error messages:
```
Available devices:
[0]               TITAN V  80 SM_7.0 @ 1.46 GHz, 12066 MiB DRAM

Unavailable device reasons:
The device Tesla K40c with computed capability 3.5 does not support HOOMD-blue.

HOOMD-blue v2.9.2-2379-g6933ee1eb GPU [CUDA] (11.0) DOUBLE HPMC_MIXED SSE SSE2
Compiled: 08/26/2020
Copyright (c) 2009-2019 The Regents of the University of Michigan.
[GPU(0)] Active devices: ['[0]               TITAN V  80 SM_7.0 @ 1.46 GHz, 12066 MiB DRAM']

HOOMD-blue v2.9.2-2379-g6933ee1eb GPU [CUDA] (11.0) DOUBLE HPMC_MIXED SSE SSE2
Compiled: 08/26/2020
Copyright (c) 2009-2019 The Regents of the University of Michigan.
Traceback (most recent call last):
  File "test.py", line 19, in <module>
    dev = hoomd.device.GPU([0,1])
  File "/nfs/turbo/bi-vislab/joaander/build/hoomd/hoomd/device.py", line 257, in __init__
    self.cpp_exec_conf = _hoomd.ExecutionConfiguration(_hoomd.ExecutionConfiguration.executionMode.GPU,
RuntimeError: Invalid device ID 1 - select a valid device from:
[0]               TITAN V  80 SM_7.0 @ 1.46 GHz, 12066 MiB DRAM
The device Tesla K40c with computed capability 3.5 does not support HOOMD-blue.
```

Notice that the message "The device Tesla K40c with computed capability 3.5 does not support HOOMD-blue." is included in the exception reason. I don't expect users to actually query `GPU.get_unavailable_device_reasons()` - so I include it and a list of valid devices in any relevant exception reasons where they will be seen.

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->
The sphinx docs format correctly and include all details.

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/hoomd-blue/blob/master/sphinx-doc/credits.rst).
