### PR TITLE
fix kernel launch parameters for excell kernel

### DIFF
--- a/hoomd/hpmc/IntegratorHPMCMonoGPU.cu
+++ b/hoomd/hpmc/IntegratorHPMCMonoGPU.cu
@@ -325,8 +325,9 @@ void hpmc_excell(unsigned int *d_excell_idx,
         }
 
     // setup the grid to run the kernel
-    dim3 threads(min(block_size, (unsigned int)max_block_size), 1, 1);
-    dim3 grid(ci.getNumElements() / block_size + 1, 1, 1);
+    unsigned int run_block_size = min(block_size, (unsigned int)max_block_size);
+    dim3 threads(run_block_size, 1, 1);
+    dim3 grid(ci.getNumElements() / run_block_size + 1, 1, 1);
 
     hipLaunchKernelGGL(kernel::hpmc_excell, dim3(grid), dim3(threads), 0, 0, d_excell_idx,
                                            d_excell_size,


### PR DESCRIPTION
## Description

FIx spurious overlaps in the HPMC GPU kernel, and segfaults on AMD.

## Motivation and Context

The grid for the excell kernel is sometimes too small, leaving excell lists uninitialized.

Resolves: N/A

## How Has This Been Tested?

Offline.

## Change log


```
- Fix spurious overlaps or illegal memory access in HPMC GPU kernel 
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/hoomd-blue/blob/master/sphinx-doc/credits.rst).
