### PR TITLE
Reorder operations in run

### DIFF
--- a/.azp/test.yml
+++ b/.azp/test.yml
@@ -302,4 +302,5 @@ stages:
         pydocstyle -v
         hoomd/variant.py
         hoomd/device.py
+        hoomd/simulation.py
       displayName: Run pydocstyle

--- a/hoomd/System.cc
+++ b/hoomd/System.cc
@@ -85,7 +85,7 @@ void System::setCommunicator(std::shared_ptr<Communicator> comm)
 
 // -------------- Methods for running the simulation
 
-void System::run(unsigned int nsteps, bool check_writer_triggers_on_initial_step)
+void System::run(unsigned int nsteps, bool write_at_start)
     {
     m_start_tstep = m_cur_tstep;
     m_end_tstep = m_cur_tstep + nsteps;
@@ -118,7 +118,7 @@ void System::run(unsigned int nsteps, bool check_writer_triggers_on_initial_step
         }
 
     // execute analyzers on initial step if requested
-    if (check_writer_triggers_on_initial_step)
+    if (write_at_start)
         {
         for (auto &analyzer_trigger_pair: m_analyzers)
             {

--- a/hoomd/System.h
+++ b/hoomd/System.h
@@ -96,10 +96,10 @@ class PYBIND11_EXPORT System
             and Analyzers who's triggers evaluate true.
 
             @param nsteps Number of steps to advance the simulation
-            @param check_writer_triggers_on_initial_step Set to true to evaluate writers before the
+            @param write_at_start Set to true to evaluate writers before the
                 loop
         */
-        void run(unsigned int nsteps, bool check_writer_triggers_on_initial_step=false);
+        void run(unsigned int nsteps, bool write_at_start=false);
 
         //! Configures profiling of runs
         void enableProfiler(bool enable);

--- a/hoomd/System.h
+++ b/hoomd/System.h
@@ -90,8 +90,16 @@ class PYBIND11_EXPORT System
 
         // -------------- Methods for running the simulation
 
-        //! Runs the simulation for a number of time steps
-        void run(unsigned int nsteps);
+        /** Run the simulation for a number of time steps.
+
+            During the run, Simulation applies all of the Tuners, Updaters, the integrator,
+            and Analyzers who's triggers evaluate true.
+
+            @param nsteps Number of steps to advance the simulation
+            @param check_writer_triggers_on_initial_step Set to true to evaluate writers before the
+                loop
+        */
+        void run(unsigned int nsteps, bool check_writer_triggers_on_initial_step=false);
 
         //! Configures profiling of runs
         void enableProfiler(bool enable);
@@ -193,7 +201,15 @@ class PYBIND11_EXPORT System
         //! Get the flags needed for a particular step
         PDataFlags determineFlags(unsigned int tstep);
 
-        Scalar m_last_TPS;  //!< Stores the average TPS from the last run
+        /// Record the initial time of the last run
+        int64_t m_initial_time=0;
+
+        /// Store the last recorded tPS
+        Scalar m_last_TPS=0;
+
+        /// Update the TPS average
+        void updateTPS();
+
         std::shared_ptr<const ExecutionConfiguration> m_exec_conf; //!< Stored shared ptr to the execution configuration
     };
 

--- a/hoomd/pytest/test_simulation.py
+++ b/hoomd/pytest/test_simulation.py
@@ -241,9 +241,9 @@ def test_writer_order_initial(simulation_factory,
     sim = simulation_factory(two_particle_snapshot_factory())
     sim.operations.analyzers.append(analyzer)
 
-    sim.run(500, check_writer_triggers_on_initial_step=True)
+    sim.run(500, write_at_start=True)
     assert record.steps == [0, 100, 200, 300, 400, 500]
-    sim.run(500, check_writer_triggers_on_initial_step=True)
+    sim.run(500, write_at_start=True)
     assert record.steps == [
         0,
         100,

--- a/hoomd/simulation.py
+++ b/hoomd/simulation.py
@@ -202,13 +202,13 @@ class Simulation(metaclass=Loggable):
             if value:
                 self._state._cpp_sys_def.getParticleData().setPressureFlag()
 
-    def run(self, steps, check_writer_triggers_on_initial_step=False):
+    def run(self, steps, write_at_start=False):
         """Advance the simulation a number of steps.
 
         Args:
             steps (int): Number of steps to advance the simulation.
 
-            check_writer_triggers_on_initial_step (bool): When True, writers
+            write_at_start (bool): When True, writers
                with triggers that evaluate True for the initial step will be
                exected before the time step loop.
 
@@ -219,7 +219,7 @@ class Simulation(metaclass=Loggable):
         state in the order: Tuners, Updaters, Integrator, then Writers following
         the logic in this pseudocode::
 
-            if check_writer_triggers_on_initial_step:
+            if write_at_start:
                 for writer in operations.writers:
                     if writer.trigger(timestep):
                         writer.write(timestep)
@@ -247,11 +247,11 @@ class Simulation(metaclass=Loggable):
         capture the final output of the last step of the run loop. For example,
         a writer with a trigger ``hoomd.trigger.Periodic(period=100, phase=0)``
         active during a ``run(500)`` would write on steps 100, 200, 300, 400,
-        and 500. Set ``check_writer_triggers_on_initial_step=True`` on the first
+        and 500. Set ``write_at_start=True`` on the first
         call to `run` to also obtain output at step 0.
 
         Warning:
-            Using ``check_writer_triggers_on_initial_step=True`` in subsequent
+            Using ``write_at_start=True`` in subsequent
             calls to `run` will result in duplicate output frames.
         """
         # check if initialization has occurred
@@ -260,7 +260,7 @@ class Simulation(metaclass=Loggable):
         if not self.operations.scheduled:
             self.operations.schedule()
 
-        self._cpp_sys.run(int(steps), check_writer_triggers_on_initial_step)
+        self._cpp_sys.run(int(steps), write_at_start)
 
     def write_debug_data(self, filename):
         """Write debug data to a JSON file.

--- a/hoomd/simulation.py
+++ b/hoomd/simulation.py
@@ -14,7 +14,7 @@ import json
 
 
 class Simulation(metaclass=Loggable):
-    """Simulation description.
+    """Define a simulation.
 
     Args:
         device (`hoomd.device.Device`): Device to execute the simulation.
@@ -48,7 +48,7 @@ class Simulation(metaclass=Loggable):
         Note:
             Functions like `create_state_from_gsd` will set the initial timestep
             from the input. Set `timestep` before creating the simulation state
-            to set the initial timestep of the simulation::
+            to override values from ``create_`` methods::
 
                 sim.timestep = 5000
                 sim.create_state_from_gsd('gsd_at_step_10000000.gsd')
@@ -125,13 +125,13 @@ class Simulation(metaclass=Loggable):
         Args:
             snapshot (Snapshot): Snapshot to initialize the state from.
 
-        When no timestep is provided, `create_state_from_snapshot` sets
-        `timestep` to 0.
+        When `timestep` is `None` before calling, `create_state_from_snapshot`
+        sets `timestep` to 0.
 
         Warning:
-            *snapshot* must be a `hoomd.Snapshot`. `create_state_from_snapshot`
-            does not support `gsd.hoomd.Snapshot` objects from the ``gsd``
-            Python package - use `create_state_from_gsd` to read GSD files.
+            *snapshot* must be a `hoomd.Snapshot`. Use `create_state_from_gsd`
+            to read GSD files. `create_state_from_snapshot` does not support
+            ``gsd.hoomd.Snapshot`` objects from the ``gsd`` Python package.
         """
         if self.state is not None:
             raise RuntimeError("Cannot initialize more than once\n")
@@ -160,9 +160,13 @@ class Simulation(metaclass=Loggable):
     def tps(self):
         """float: The average number of time steps per second.
 
-        `tps` resets at the start of each call to `run`. During and after the
-        call `tps` is the number of steps executed divided by the elapsed
-        walltime in seconds.
+        `tps` is the number of steps executed divided by the elapsed
+        walltime in seconds. It is updated during the `run` loop and remains
+        fixed after `run` completes.
+
+        Note:
+            The start time and step are reset at the beginning of each call to
+            `run`.
         """
         if self.state is None:
             return None
@@ -208,8 +212,8 @@ class Simulation(metaclass=Loggable):
         Args:
             steps (int): Number of steps to advance the simulation.
 
-            write_at_start (bool): When True, writers
-               with triggers that evaluate True for the initial step will be
+            write_at_start (bool): When `True`, writers
+               with triggers that evaluate `True` for the initial step will be
                exected before the time step loop.
 
         Note:

--- a/hoomd/simulation.py
+++ b/hoomd/simulation.py
@@ -324,7 +324,6 @@ class Simulation(metaclass=Loggable):
         logger = hoomd.logging.Logger(only_default=False)
         logger += self
 
-        # children may appear several times, identify them uniquely
         for op in self.operations:
             logger.add(op)
 

--- a/hoomd/simulation.py
+++ b/hoomd/simulation.py
@@ -148,12 +148,12 @@ class Simulation(metaclass=Loggable):
 
     @property
     def state(self):
-        """State: The current simulation state."""
+        """hoomd.State: The current simulation state."""
         return self._state
 
     @property
     def operations(self):
-        """Operations: The operations that apply to the state."""
+        """hoomd.Operations: The operations that apply to the state."""
         return self._operations
 
     @property


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should based on *maint*. -->
<!-- New features should based on *master*. -->

## Description

<!-- Describe your changes in detail. -->
* Place the call to analyzers at the end of the run() loop body. Resolves #574
* Also, document the Simulation object. Resolves #710

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Many users expect that a periodic trigger and a run() for an integer number of periods (e.g. period=100, run(500)) will trigger the analyzers on final step computed by the run. This PR includes an optional flag to additional call analyzers before the start of the loop body for cases where users want output on step 0 or the first step in a new stage of the simulation.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
This PR adds unit tests to verify the change.

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->
All updated sphinx documentation renders properly in a local build.

## Note

This PR is based on #767 to avoid merge conflicts. I will take it out of draft state once that PR is merged.

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
