### PR TITLE
Document particle filters

### DIFF
--- a/.azp/test.yml
+++ b/.azp/test.yml
@@ -302,4 +302,9 @@ stages:
         pydocstyle -v
         hoomd/variant.py
         hoomd/device.py
+        hoomd/filter/filter_.py
+        hoomd/filter/all_.py
+        hoomd/filter/set_.py
+        hoomd/filter/tags.py
+        hoomd/filter/type_.py
       displayName: Run pydocstyle

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -364,11 +364,7 @@ v2.4.2 (2018-12-20)
    returned from ``ParticleData`` and other classes (replace by
    ``GlobalArray``)
 
-<<<<<<< HEAD
-v2.4.1 (2018/11/27)
-=======
 v2.4.1 (2018-11-27)
->>>>>>> master
 ^^^^^^^^^^^^^^^^^^^
 
 *Bug fixes*

--- a/hoomd/dump.py
+++ b/hoomd/dump.py
@@ -12,7 +12,7 @@ from collections import namedtuple
 from hoomd import _hoomd
 from hoomd.util import dict_flatten, array_to_strings
 from hoomd.typeconverter import OnlyFrom
-from hoomd.filter import _ParticleFilter, All
+from hoomd.filter import ParticleFilter, All
 from hoomd.parameterdicts import ParameterDict
 from hoomd.logging import Logger, TypeFlags
 from hoomd.operation import _Analyzer
@@ -491,7 +491,7 @@ class GSD(_Analyzer):
     Args:
         filename (str): File name to write.
         trigger (hoomd.trigger.Trigger): Select the timesteps to write.
-        filter_ (hoomd.filter._ParticleFilter): Select the particles
+        filter_ (hoomd.filter.ParticleFilter): Select the particles
             to write, defaults to `hoomd.filter.All`.
         overwrite (bool): When ``True``, overwite the file. When
             ``False`` append frames to ``filename`` if it exists and create the
@@ -609,7 +609,7 @@ class GSD(_Analyzer):
         dynamic = ['property'] if dynamic is None else dynamic
         self._param_dict.update(
             ParameterDict(filename=str(filename),
-                          filter=_ParticleFilter,
+                          filter=ParticleFilter,
                           overwrite=bool(overwrite), truncate=bool(truncate),
                           dynamic=[dynamic_validation],
                           _defaults=dict(filter=filter, dynamic=dynamic)
@@ -652,7 +652,7 @@ class GSD(_Analyzer):
         Args:
             state (State): Simulation state.
             filename (str): File name to write.
-            filter_ (``hoomd._ParticleFilter``): Select the particles to write.
+            filter_ (`hoomd.filter.ParticleFilter`): Select the particles to write.
             log (``hoomd.logger.Logger``): A ``Logger`` object for GSD logging.
 
         Note:

--- a/hoomd/filter/__init__.py
+++ b/hoomd/filter/__init__.py
@@ -1,5 +1,7 @@
-from hoomd.filter.filter_ import _ParticleFilter
-from hoomd.filter.all_ import All
-from hoomd.filter.set_ import Intersection, SetDifference, Union
-from hoomd.filter.tags import Tags
-from hoomd.filter.type_ import Type
+"""Particle filters."""
+
+from hoomd.filter.filter_ import ParticleFilter  # noqa
+from hoomd.filter.all_ import All  # noqa
+from hoomd.filter.set_ import Intersection, SetDifference, Union  # noqa
+from hoomd.filter.tags import Tags  # noqa
+from hoomd.filter.type_ import Type  # noqa

--- a/hoomd/filter/__init__.py
+++ b/hoomd/filter/__init__.py
@@ -5,8 +5,9 @@ system for use by various operations throughout HOOMD. To maintain high
 performance, filters are **not** re-evaluated on every use. Instead, each unique
 particular filter (defined by the class name and hash) is mapped to a **group**,
 an internally maintained list of the selected particles. Subsequent uses of the
-same particle filter specification will resolve to the same group *and the
-originally selected particles*, **even if the state of the system has changed.**
+same particle filter specification (in the same `Simulation`) will resolve to
+the same group *and the originally selected particles*, **even if the state of
+the system has changed.**
 
 Groups are not completely static. HOOMD-blue re-evaluates the filter
 specifications and updates the group membership whenever the number of particles

--- a/hoomd/filter/__init__.py
+++ b/hoomd/filter/__init__.py
@@ -1,4 +1,25 @@
-"""Particle filters."""
+"""Particle filters.
+
+Particle filters describe criteria to select subsets of the particle in the
+system for use by various operations throughout HOOMD. To maintain high
+performance, filters are **not** re-evaluated on every use. Instead, each unique
+particular filter (defined by the class name and hash) is mapped to a **group**,
+an internally maintained list of the selected particles. Subsequent uses of the
+same particle filter specification will resolve to the same group *and the
+originally selected particles*, **even if the state of the system has changed.**
+
+Groups are not completely static. HOOMD-blue re-evaluates the filter
+specifications and updates the group membership whenever the number of particles
+in the simulation changes. A future release will include an operation that you
+can schedule to periodically update groups on demand.
+
+For molecular dynamics simulations, each group maintains a count of the number
+of degrees of freedom given to the group by integration methods. This count is
+used by `hoomd.md.compute.ThermodynamicQuantities` and the integration methods
+themselves to compute the kinetic temperature. See
+`hoomd.State.update_group_dof` for details on when HOOMD-blue updates this
+count.
+"""
 
 from hoomd.filter.filter_ import ParticleFilter  # noqa
 from hoomd.filter.all_ import All  # noqa

--- a/hoomd/filter/all_.py
+++ b/hoomd/filter/all_.py
@@ -1,13 +1,22 @@
-from hoomd.filter.filter_ import _ParticleFilter
+"""Define the All filter."""
+
+from hoomd.filter.filter_ import ParticleFilter
 from hoomd._hoomd import ParticleFilterAll
 
 
-class All(_ParticleFilter, ParticleFilterAll):
+class All(ParticleFilter, ParticleFilterAll):
+    """Select all particles in the system.
+
+    Base: `ParticleFilter`
+    """
+
     def __init__(self):
         ParticleFilterAll.__init__(self)
 
     def __hash__(self):
+        """Return a hash of the filter parameters."""
         return 0
 
     def __eq__(self, other):
+        """Test for equality between two particle filters."""
         return type(self) == type(other)

--- a/hoomd/filter/filter_.py
+++ b/hoomd/filter/filter_.py
@@ -1,21 +1,32 @@
-from hoomd._hoomd import ParticleFilter
+"""Define ParticleFilter."""
+
+from hoomd import _hoomd
 
 
-class _ParticleFilter(ParticleFilter):
-    """Base class for all particle filters.
-
-    Should not be instantiated or subclassed by users.
-    """
+class ParticleFilter(_hoomd.ParticleFilter):
+    """Base class for all particle filters."""
     def __hash__(self):
+        """Return a hash of the filter parameters."""
         return NotImplementedError("Must implement hash for ParticleFilters.")
 
     def __eq__(self, other):
+        """Test for equality between two particle filters."""
         raise NotImplementedError(
             "Equality between {} is not defined.".format(self.__class__))
 
     def __str__(self):
+        """Format a human readable string describing the filter."""
         return "ParticleFilter.{}".format(self.__class__.__name__)
 
     def __call__(self, state):
-        """Needs to interact with state to get particles across MPI rank."""
+        """Evaluate the filter.
+
+        Returns:
+            list[int]: The particle tags selected by this filter.
+
+        Note:
+            This method may return tags that are only present on the local MPI
+            rank. The full set of particles selected is the combination of
+            these the lists across ranks with a set union operation.
+        """
         return self._get_selected_tags(state._cpp_sys_def)

--- a/hoomd/filter/filter_.py
+++ b/hoomd/filter/filter_.py
@@ -4,7 +4,14 @@ from hoomd import _hoomd
 
 
 class ParticleFilter(_hoomd.ParticleFilter):
-    """Base class for all particle filters."""
+    """Base class for all particle filters.
+
+    This class provides methods common to all particle filters.
+
+    Attention:
+        Users should instantiate one of the subclasses. Calling `ParticleFilter`
+        directly may result in an error.
+    """
     def __hash__(self):
         """Return a hash of the filter parameters."""
         return NotImplementedError("Must implement hash for ParticleFilters.")

--- a/hoomd/filter/set_.py
+++ b/hoomd/filter/set_.py
@@ -1,11 +1,14 @@
-from hoomd.filter.filter_ import _ParticleFilter
+"""Define particle filter set operations."""
+
+from hoomd.filter.filter_ import ParticleFilter
 from hoomd import _hoomd
 
 
-class _ParticleFilterSetOperations(_ParticleFilter):
-    """An abstract class for `ParticleFilters` with set operations.
+class _ParticleFilterSetOperations(ParticleFilter):
+    """An abstract class for particle filters with set operations.
 
-    Should not be instantiated directly."""
+    Should not be instantiated directly.
+    """
 
     @property
     def _cpp_cls_name(self):
@@ -49,16 +52,49 @@ class _ParticleFilterSetOperations(_ParticleFilter):
 
 class SetDifference(_ParticleFilterSetOperations,
                     _hoomd.ParticleFilterSetDifference):
+    r"""Set difference operation.
+
+    Args:
+        f (ParticleFilter): First set in the difference.
+        g (ParticleFilter): Second set in the difference.
+
+    `SetDifference` is a comosite filter. It selects particles in the set
+    difference :math:`f \setminus g`.
+
+    Base: `ParticleFilter`
+    """
     _cpp_cls_name = 'ParticleFilterSetDifference'
     _symmetric = False
 
 
 class Union(_ParticleFilterSetOperations, _hoomd.ParticleFilterUnion):
+    r"""Set union operation.
+
+    Args:
+        f (ParticleFilter): First set in the union.
+        g (ParticleFilter): Second set in the union.
+
+    `Union` is a comosite filter. It selects particles in the set
+    union :math:`f \cup g`.
+
+    Base: `ParticleFilter`
+    """
     _cpp_cls_name = 'ParticleFilterUnion'
     _symmetric = True
 
 
 class Intersection(_ParticleFilterSetOperations,
                    _hoomd.ParticleFilterIntersection):
+    r"""Set intersection operation.
+
+    Args:
+        f (ParticleFilter): First set in the intersection.
+        g (ParticleFilter): Second set in the intersection.
+
+    `Intersection` is a comosite filter. It selects particles in the set
+    intersection :math:`f \cap g`.
+
+    Base: `ParticleFilter`
+    """
     _cpp_cls_name = 'ParticleFilterIntersection'
     _symmetric = True

--- a/hoomd/filter/set_.py
+++ b/hoomd/filter/set_.py
@@ -74,7 +74,7 @@ class Union(_ParticleFilterSetOperations, _hoomd.ParticleFilterUnion):
         f (ParticleFilter): First set in the union.
         g (ParticleFilter): Second set in the union.
 
-    `Union` is a comosite filter. It selects particles in the set
+    `Union` is a composite filter. It selects particles in the set
     union :math:`f \cup g`.
 
     Base: `ParticleFilter`

--- a/hoomd/filter/set_.py
+++ b/hoomd/filter/set_.py
@@ -58,7 +58,7 @@ class SetDifference(_ParticleFilterSetOperations,
         f (ParticleFilter): First set in the difference.
         g (ParticleFilter): Second set in the difference.
 
-    `SetDifference` is a comosite filter. It selects particles in the set
+    `SetDifference` is a composite filter. It selects particles in the set
     difference :math:`f \setminus g`.
 
     Base: `ParticleFilter`

--- a/hoomd/filter/set_.py
+++ b/hoomd/filter/set_.py
@@ -91,7 +91,7 @@ class Intersection(_ParticleFilterSetOperations,
         f (ParticleFilter): First set in the intersection.
         g (ParticleFilter): Second set in the intersection.
 
-    `Intersection` is a comosite filter. It selects particles in the set
+    `Intersection` is a composite filter. It selects particles in the set
     intersection :math:`f \cap g`.
 
     Base: `ParticleFilter`

--- a/hoomd/filter/tags.py
+++ b/hoomd/filter/tags.py
@@ -1,21 +1,34 @@
-from hoomd.filter.filter_ import _ParticleFilter
+"""Define the Tags filter."""
+
+from hoomd.filter.filter_ import ParticleFilter
 from hoomd._hoomd import ParticleFilterTags
 import numpy as np
 
 
-class Tags(_ParticleFilter, ParticleFilterTags):
+class Tags(ParticleFilter, ParticleFilterTags):
+    """Select particles by tag.
+
+    Args:
+        tags (list[int]): List of particle tags to select.
+
+    Base: `ParticleFilter`
+    """
+
     def __init__(self, tags):
         self._tags = np.ascontiguousarray(np.unique(tags), dtype=np.uint32)
         ParticleFilterTags.__init__(self, tags)
 
     def __hash__(self):
+        """Return a hash of the filter parameters."""
         if not hasattr(self, '_id'):
             self._id = hash(self._tags.tobytes())
         return self._id
 
     def __eq__(self, other):
+        """Test for equality between two particle filters."""
         return type(self) == type(other) and all(self.tags == other.tags)
 
     @property
     def tags(self):
+        """list[int]: List of particle tags to select."""
         return self._tags

--- a/hoomd/filter/tags.py
+++ b/hoomd/filter/tags.py
@@ -11,6 +11,10 @@ class Tags(ParticleFilter, ParticleFilterTags):
     Args:
         tags (list[int]): List of particle tags to select.
 
+    A particle tag is a unique identifier assigned to each particle in the
+    simulation state. When the state is first initialized, it assigns tags
+    0 through `N_particles` to the particles in the order provided.
+
     Base: `ParticleFilter`
     """
 

--- a/hoomd/filter/type_.py
+++ b/hoomd/filter/type_.py
@@ -1,19 +1,32 @@
-from hoomd.filter.filter_ import _ParticleFilter
+"""Define the Type filter."""
+
+from hoomd.filter.filter_ import ParticleFilter
 from hoomd._hoomd import ParticleFilterType
 
 
-class Type(_ParticleFilter, ParticleFilterType):
+class Type(ParticleFilter, ParticleFilterType):
+    """Select particles by type.
+
+    Args:
+        types (list[str]): List of particle type names to select.
+
+    Base: `ParticleFilter`
+    """
+
     def __init__(self, types):
         types = set(types)
         self._types = frozenset(types)
         ParticleFilterType.__init__(self, types)
 
     def __hash__(self):
+        """Return a hash of the filter parameters."""
         return hash(self._types)
 
     def __eq__(self, other):
+        """Test for equality between two particle filters."""
         return type(self) == type(other) and self._types == other._types
 
     @property
     def types(self):
+        """list[str]: List of particle type names to select."""
         return self._types

--- a/hoomd/md/force.py
+++ b/hoomd/md/force.py
@@ -16,7 +16,7 @@ from hoomd.logging import log
 from hoomd.typeparam import TypeParameter
 from hoomd.typeconverter import OnlyType
 from hoomd.parameterdicts import ParameterDict, TypeParameterDict
-from hoomd.filter import _ParticleFilter
+from hoomd.filter import ParticleFilter
 from hoomd.md.constrain import _ConstraintForce
 
 
@@ -284,7 +284,7 @@ class Active(_Force):
     def __init__(self, filter, seed, constraint=None, rotation_diff=0.1):
         # store metadata
         param_dict = ParameterDict(
-            filter=_ParticleFilter,
+            filter=ParticleFilter,
             seed=int(seed),
             rotation_diff=float(rotation_diff),
             constraint=OnlyType(_ConstraintForce, allow_none=True,

--- a/hoomd/md/methods.py
+++ b/hoomd/md/methods.py
@@ -11,7 +11,7 @@ from hoomd.md import _md
 import hoomd
 from hoomd.operation import _HOOMDBaseObject
 from hoomd.parameterdicts import ParameterDict, TypeParameterDict
-from hoomd.filter import _ParticleFilter
+from hoomd.filter import ParticleFilter
 from hoomd.typeparam import TypeParameter
 from hoomd.typeconverter import OnlyType, OnlyIf, to_type_converter
 from hoomd.variant import Variant
@@ -71,7 +71,7 @@ class NVT(_Method):
 
         # store metadata
         param_dict = ParameterDict(
-            filter=_ParticleFilter,
+            filter=ParticleFilter,
             kT=Variant,
             tau=float(tau),
         )
@@ -104,7 +104,7 @@ class NPT(_Method):
     R""" NPT Integration via MTK barostat-thermostat.
 
     Args:
-        filter (:py:mod:`hoomd.filter._ParticleFilter`): Subset of particles on which to apply this method.
+        filter (`hoomd.filter.ParticleFilter`): Subset of particles on which to apply this method.
 
         kT (:py:mod:`hoomd.variant` or :py:obj:`float`): Temperature set point for the thermostat, not needed if *nph=True* (in energy units).
 
@@ -216,7 +216,7 @@ class NPT(_Method):
 
         # store metadata
         param_dict = ParameterDict(
-            filter=_ParticleFilter,
+            filter=ParticleFilter,
             kT=Variant,
             tau=float(tau),
             S=OnlyIf(to_type_converter((Variant,)*6), preprocess=self.__preprocess_stress),
@@ -384,7 +384,7 @@ class NVE(_Method):
 
         # store metadata
         param_dict = ParameterDict(
-            filter=_ParticleFilter,
+            filter=ParticleFilter,
             limit=OnlyType(float, allow_none=True),
             zero_force=OnlyType(bool, allow_none=False),
         )
@@ -410,7 +410,7 @@ class Langevin(_Method):
     R""" Langevin dynamics.
 
     Args:
-        filter (:py:mod:`hoomd.filter._ParticleFilter`): Group of particles to
+        filter (`hoomd.filter.ParticleFilter`): Group of particles to
             apply this method to.
         kT (:py:mod:`hoomd.variant` or :py:obj:`float`): Temperature of the
             simulation (in energy units).
@@ -499,7 +499,7 @@ class Langevin(_Method):
 
         # store metadata
         param_dict = ParameterDict(
-            filter=_ParticleFilter,
+            filter=ParticleFilter,
             kT=Variant,
             seed=int(seed),
             alpha=OnlyType(float, allow_none=True),
@@ -540,7 +540,7 @@ class Brownian(_Method):
     R""" Brownian dynamics.
 
     Args:
-        filter (:py:mod:`hoomd.filter._ParticleFilter`): Group of particles to
+        filter (`hoomd.filter.ParticleFilter`): Group of particles to
             apply this method to.
         kT (:py:mod:`hoomd.variant` or :py:obj:`float`): Temperature of the
             simulation (in energy units).
@@ -613,7 +613,7 @@ class Brownian(_Method):
 
         # store metadata
         param_dict = ParameterDict(
-            filter=_ParticleFilter,
+            filter=ParticleFilter,
             kT=Variant,
             seed=int(seed),
             alpha=OnlyType(float, allow_none=True),

--- a/hoomd/md/methods.py
+++ b/hoomd/md/methods.py
@@ -27,7 +27,7 @@ class NVT(_Method):
     R""" NVT Integration via the Nosé-Hoover thermostat.
 
     Args:
-        filter (`hoomd.filter._ParticleFilter`): Subset of particles on which to
+        filter (`hoomd.filter.ParticleFilter`): Subset of particles on which to
             apply this method.
 
         kT (`hoomd.variant.Variant` or `float`): Temperature set point
@@ -69,7 +69,7 @@ class NVT(_Method):
 
 
     Attributes:
-        filter (hoomd.filter._ParticleFilter): Subset of particles on which to
+        filter (hoomd.filter.ParticleFilter): Subset of particles on which to
             apply this method.
 
         kT (hoomd.variant.Variant): Temperature set point
@@ -245,7 +245,7 @@ class NPT(_Method):
         integrator = hoomd.md.Integrator(dt=0.005, methods=[npt], forces=[lj])
 
     Attributes:
-        filter (hoomd.filter._ParticleFilter): Subset of particles on which to
+        filter (hoomd.filter.ParticleFilter): Subset of particles on which to
             apply this method.
 
         kT (hoomd.variant.Variant): Temperature set point for the
@@ -410,7 +410,7 @@ class NVE(_Method):
     R""" NVE Integration via Velocity-Verlet
 
     Args:
-        filter (`hoomd.filter._ParticleFilter`): Subset of particles on which to
+        filter (`hoomd.filter.ParticleFilter`): Subset of particles on which to
          apply this method.
 
         limit (None or `float`): Enforce that no particle moves more than a
@@ -437,7 +437,7 @@ class NVE(_Method):
 
 
     Attributes:
-        filter (hoomd.filter._ParticleFilter): Subset of particles on which to
+        filter (hoomd.filter.ParticleFilter): Subset of particles on which to
             apply this method.
 
         limit (None or float): Enforce that no particle moves more than a
@@ -571,7 +571,7 @@ class Langevin(_Method):
         langevin.gamma_r.default = [1.0,2.0,3.0]
 
     Attributes:
-        filter (hoomd.filter._ParticleFilter): Subset of particles to
+        filter (hoomd.filter.ParticleFilter): Subset of particles to
             apply this method to.
 
         kT (hoomd.variant.Variant): Temperature of the
@@ -738,7 +738,7 @@ class Brownian(_Method):
 
 
     Attributes:
-        filter (hoomd.filter._ParticleFilter): Subset of particles to
+        filter (hoomd.filter.ParticleFilter): Subset of particles to
             apply this method to.
 
         kT (hoomd.variant.Variant): Temperature of the

--- a/hoomd/operation.py
+++ b/hoomd/operation.py
@@ -12,7 +12,7 @@ _TriggeredOperation is _Operation for objects that are triggered.
 from hoomd.util import is_iterable, dict_map, dict_filter, str_to_tuple_keys
 from hoomd.trigger import Trigger
 from hoomd.variant import Variant, Constant
-from hoomd.filter import _ParticleFilter
+from hoomd.filter import ParticleFilter
 from hoomd.logging import Loggable, log
 from hoomd.typeconverter import RequiredArg
 from hoomd.util import NamespaceDict
@@ -36,7 +36,7 @@ def _convert_values_to_log_form(value):
             return (value.value, 'scalar')
         else:
             return (value, 'object')
-    elif isinstance(value, Trigger) or isinstance(value, _ParticleFilter):
+    elif isinstance(value, Trigger) or isinstance(value, ParticleFilter):
         return (value, 'object')
     elif isinstance(value, _Operation):
         return (value, 'object')

--- a/hoomd/typeconverter.py
+++ b/hoomd/typeconverter.py
@@ -6,7 +6,7 @@ from inspect import isclass
 from hoomd.util import is_iterable
 from hoomd.variant import Variant, Constant
 from hoomd.trigger import Trigger, Periodic
-from hoomd.filter import _ParticleFilter
+from hoomd.filter import ParticleFilter
 import hoomd
 
 
@@ -269,7 +269,7 @@ class TypeConverterValue(TypeConverter):
         str: OnlyType(str, strict=True),
         Variant: OnlyType(Variant, preprocess=variant_preprocessing),
         Trigger: OnlyType(Trigger, preprocess=trigger_preprocessing),
-        _ParticleFilter: OnlyType(_ParticleFilter, strict=True)
+        ParticleFilter: OnlyType(ParticleFilter, strict=True)
     }
 
     def __init__(self, value):

--- a/sphinx-doc/module-hoomd-filter.rst
+++ b/sphinx-doc/module-hoomd-filter.rst
@@ -8,6 +8,7 @@ hoomd.filter
 .. autosummary::
     :nosignatures:
 
+    ParticleFilter
     All
     Intersection
     SetDifference
@@ -20,11 +21,13 @@ hoomd.filter
 .. automodule:: hoomd.filter
     :synopsis: Particle selection filters.
 
-    .. autoclass:: _ParticleFilter()
+    .. autoclass:: ParticleFilter()
+        :special-members: __call__, __hash__, __eq__, __str__
     .. autoclass:: All()
     .. autoclass:: Intersection(f, g)
     .. autoclass:: SetDifference(f, g)
     .. autoclass:: Tags(tags)
+        :members: tags
     .. autoclass:: Type(types)
+        :members: types
     .. autoclass:: Union(f, g)
-


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should based on *maint*. -->
<!-- New features should based on *master*. -->

## Description

<!-- Describe your changes in detail. -->
Document particle filters and make the base class `ParticleFilter` (from `_ParticleFilter`)

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
HOOMD-blue functionality should be documented.

<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves #719

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
I added filter/*.py to the pydocstyle tests.

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->
The sphinx documentation builds and renders correctly. Note that I explicitly name the base classes because the sphinx option `:show-inerheritance` does not work. 1) It includes the base class with a full name (e.g. `hoomd.filter.filter_.ParticleFilter` which fails to link because this is not where the class appears in the documentation. 2) It lists all base classes, including the multiply inherited C++ base class which the user does not need to be aware of.

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
