### PR TITLE
Fix type information in hoomd.md.methods

### DIFF
--- a/hoomd/md/compute.py
+++ b/hoomd/md/compute.py
@@ -45,7 +45,7 @@ class ThermodynamicQuantities(_Thermo):
             thermo_cls = _md.ComputeThermo
         else:
             thermo_cls = _md.ComputeThermoGPU
-        group = self._simulation.state.get_group(self._filter)
+        group = self._simulation.state._get_group(self._filter)
         self._cpp_obj = thermo_cls(self._simulation.state._cpp_sys_def, group, "")
         super()._attach()
 

--- a/hoomd/md/methods.py
+++ b/hoomd/md/methods.py
@@ -6,7 +6,6 @@
 # Maintainer: joaander / All Developers are free to add commands for new features
 
 
-from hoomd import _hoomd
 from hoomd.md import _md
 import hoomd
 from hoomd.operation import _HOOMDBaseObject
@@ -15,8 +14,6 @@ from hoomd.filter import _ParticleFilter
 from hoomd.typeparam import TypeParameter
 from hoomd.typeconverter import OnlyType, OnlyIf, to_type_converter
 from hoomd.variant import Variant
-from hoomd.typeconverter import OnlyFrom
-import copy
 from collections.abc import Sequence
 
 

--- a/hoomd/md/methods.py
+++ b/hoomd/md/methods.py
@@ -124,18 +124,17 @@ class NPT(_Method):
 
         tau (`float`): Coupling constant for the thermostat (in time units).
 
-        S (`list`[`hoomd.variant.Variant`] or `float`): Stress components set
-            point for the barostat (in pressure units).
-            In Voigt notation:
-            :math:`[S_{xx}, S_{yy}, S_{zz}, S_{yz}, S_{xz}, S_{xy}]`.
-            In case of isotropic pressure P (:math:`[p, p, p, 0, 0, 0]`), use ``S = p``.
+        S (`list` [ `hoomd.variant.Variant` ] or `float`): Stress components set
+            point for the barostat (in pressure units).  In Voigt notation:
+            :math:`[S_{xx}, S_{yy}, S_{zz}, S_{yz}, S_{xz}, S_{xy}]`.  In case
+            of isotropic pressure P (:math:`[p, p, p, 0, 0, 0]`), use ``S = p``.
 
         tauS (`float`): Coupling constant for the barostat (in time units).
 
         couple (`str`): Couplings of diagonal elements of the stress tensor,
             can be "none", "xy", "xz","yz", or "all", default to "all".
 
-        box_dof(`list`[`bool`]): Box degrees of freedom with six boolean
+        box_dof(`list` [ `bool` ]): Box degrees of freedom with six boolean
             elements corresponding to x, y, z, xy, xz, yz, each. Default to
             [True,True,True,False,False,False]). If turned on to True,
             rescale corresponding lengths or tilt factors and components of
@@ -584,12 +583,12 @@ class Langevin(_Method):
             coefficient where :math:`d_i` is particle diameter.
             Defaults to None.
 
-        gamma (TypeParameter[``particle type``, `float`]): The drag coefficient
+        gamma (TypeParameter[ ``particle type``, `float` ]): The drag coefficient
             can be directly set instead of the ratio of particle diameter
             (:math:`\gamma = \alpha d_i`). The type of ``gamma`` parameter is
             either positive float or zero.
 
-        gamma_r (TypeParameter[``particle type``, [`float`, `float` , `float` ]]):
+        gamma_r (TypeParameter[ ``particle type``, [ `float`, `float` , `float` ]]):
             The rotational drag coefficient can be set. The type of ``gamma_r``
             parameter is a tuple of three float. The type of each element of
             tuple is either positive float or zero.
@@ -751,12 +750,12 @@ class Brownian(_Method):
             coefficient where :math:`d_i` is particle diameter.
             Defaults to None.
 
-        gamma (TypeParameter[``particle type``, `float`]): The drag coefficient
-            can be directly set instead of the ratio of particle diameter
-            (:math:`\gamma = \alpha d_i`). The type of ``gamma`` parameter is
-            either positive float or zero.
+        gamma (TypeParameter[ ``particle type``, `float` ]): The drag
+        coefficient can be directly set instead of the ratio of particle
+        diameter (:math:`\gamma = \alpha d_i`). The type of ``gamma`` parameter
+        is either positive float or zero.
 
-        gamma_r (TypeParameter[``particle type``, [`float`, `float`, `float`] ]):
+        gamma_r (TypeParameter[ ``particle type``, [ `float`, `float`, `float` ] ]):
             The rotational drag coefficient can be set. The type of ``gamma_r``
             parameter is a tuple of three float. The type of each element of
             tuple is either positive float or zero.

--- a/hoomd/md/methods.py
+++ b/hoomd/md/methods.py
@@ -19,6 +19,7 @@ from hoomd.typeconverter import OnlyFrom
 import copy
 from collections.abc import Sequence
 
+
 class _Method(_HOOMDBaseObject):
     pass
 
@@ -111,6 +112,7 @@ class NVT(_Method):
                                  self.kT,
                                  "")
         super()._attach()
+
 
 class NPT(_Method):
     R""" NPT Integration via MTK barostat-thermostat.
@@ -340,6 +342,7 @@ class NPT(_Method):
         else:
             return (value,value,value,0,0,0)
 
+
 class nph(NPT):
     R""" NPH Integration via MTK barostat-thermostat..
 
@@ -470,6 +473,7 @@ class NVE(_Method):
         # Attach param_dict and typeparam_dict
         super()._attach()
 
+
 class Langevin(_Method):
     R""" Langevin dynamics.
 
@@ -583,10 +587,10 @@ class Langevin(_Method):
             coefficient where :math:`d_i` is particle diameter.
             Defaults to None.
 
-        gamma (TypeParameter[ ``particle type``, `float` ]): The drag coefficient
-            can be directly set instead of the ratio of particle diameter
-            (:math:`\gamma = \alpha d_i`). The type of ``gamma`` parameter is
-            either positive float or zero.
+        gamma (TypeParameter[ ``particle type``, `float` ]): The drag
+            coefficient can be directly set instead of the ratio of particle
+            diameter (:math:`\gamma = \alpha d_i`). The type of ``gamma``
+            parameter is either positive float or zero.
 
         gamma_r (TypeParameter[ ``particle type``, [ `float`, `float` , `float` ]]):
             The rotational drag coefficient can be set. The type of ``gamma_r``
@@ -751,15 +755,14 @@ class Brownian(_Method):
             Defaults to None.
 
         gamma (TypeParameter[ ``particle type``, `float` ]): The drag
-        coefficient can be directly set instead of the ratio of particle
-        diameter (:math:`\gamma = \alpha d_i`). The type of ``gamma`` parameter
-        is either positive float or zero.
+            coefficient can be directly set instead of the ratio of particle
+            diameter (:math:`\gamma = \alpha d_i`). The type of ``gamma``
+            parameter is either positive float or zero.
 
         gamma_r (TypeParameter[ ``particle type``, [ `float`, `float`, `float` ] ]):
             The rotational drag coefficient can be set. The type of ``gamma_r``
             parameter is a tuple of three float. The type of each element of
             tuple is either positive float or zero.
-
     """
 
     def __init__(self, filter, kT, seed, alpha=None):


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should based on *maint*. -->
<!-- New features should based on *master*. -->

## Description

Necessary to fix doc builds that are hosted on readthedocs.

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
