### PR TITLE
Switch CMake to use C++14 standard. Resolves #784.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -31,7 +31,7 @@ functionality.
 
 *Changed*
 
-- The `run` method has minimal overhead
+- The ``run`` method has minimal overhead
 - All loggable quantities are directly accessible as object properties.
 - Operation parameters are always synchronized.
 - Operations can be instantiated without a device or MPI communicator.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,10 +56,10 @@ if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
     "MinSizeRel" "RelWithDebInfo")
 endif()
 
-# enable c++11
-set(CMAKE_CXX_STANDARD 11)
+# enable c++14
+set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CUDA_STANDARD 11)
+set(CMAKE_CUDA_STANDARD 14)
 
 # Enable compiler warnings on gcc and clang (common compilers used by developers)
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")

--- a/hoomd/jit/CMakeLists.txt
+++ b/hoomd/jit/CMakeLists.txt
@@ -42,10 +42,6 @@ pybind11_add_module(_${PACKAGE_NAME} SHARED ${_${PACKAGE_NAME}_sources} ${_${PAC
 add_library(HOOMD::_${PACKAGE_NAME} ALIAS _${PACKAGE_NAME})
 
 add_library (_${PACKAGE_NAME}_llvm SHARED ${_${PACKAGE_NAME}_llvm_sources})
-if (CMAKE_CXX_STANDARD LESS 14)
-    set_property(TARGET _${PACKAGE_NAME}_llvm PROPERTY CXX_STANDARD 14)
-    set_property(TARGET _${PACKAGE_NAME} PROPERTY CXX_STANDARD 14)
-endif()
 
 if (ENABLE_HIP AND HIP_PLATFORM STREQUAL "nvcc")
     # no device linking

--- a/hoomd/jit/CMakeLists.txt
+++ b/hoomd/jit/CMakeLists.txt
@@ -61,12 +61,6 @@ list(APPEND CMAKE_MODULE_PATH "${LLVM_CMAKE_DIR}")
 include(AddLLVM)
 llvm_update_compile_flags(_${PACKAGE_NAME}_llvm)
 
-# bug: llvm_update_compile_flags removes the c++11 compile flag that hoomd sets for old cmake versions
-# cmake 3.1 and newer are not affected becuase we use CMAKE_CXX_STANDARD
-if (CMAKE_VERSION VERSION_LESS 3.1.0)
-    message(FATAL_ERROR "CMake 3.1.0 or newer is required to buid the JIT module")
-endif()
-
 # work around missing LLVM link information
 if(LLVM_ENABLE_TERMINFO)
     find_library(TERMINFO NAMES tinfo ncurses)

--- a/hoomd/jit/patch.py
+++ b/hoomd/jit/patch.py
@@ -122,7 +122,7 @@ class user(object):
 
     ``vec3`` and ``quat`` are defined in HOOMDMath.h.
 
-    Compile the file with clang: ``clang -O3 --std=c++11 -DHOOMD_LLVMJIT_BUILD -I /path/to/hoomd/include -S -emit-llvm code.cc`` to produce
+    Compile the file with clang: ``clang -O3 --std=c++14 -DHOOMD_LLVMJIT_BUILD -I /path/to/hoomd/include -S -emit-llvm code.cc`` to produce
     the LLVM IR in ``code.ll``.
 
     .. versionadded:: 2.3
@@ -227,9 +227,9 @@ float eval(const vec3<float>& r_ij,
             clang = 'clang';
 
         if fn is not None:
-            cmd = [clang, '-O3', '--std=c++11', '-DHOOMD_LLVMJIT_BUILD', '-I', include_path, '-I', include_path_source, '-S', '-emit-llvm','-x','c++', '-o',fn,'-']
+            cmd = [clang, '-O3', '--std=c++14', '-DHOOMD_LLVMJIT_BUILD', '-I', include_path, '-I', include_path_source, '-S', '-emit-llvm','-x','c++', '-o',fn,'-']
         else:
-            cmd = [clang, '-O3', '--std=c++11', '-DHOOMD_LLVMJIT_BUILD', '-I', include_path, '-I', include_path_source, '-S', '-emit-llvm','-x','c++', '-o','-','-']
+            cmd = [clang, '-O3', '--std=c++14', '-DHOOMD_LLVMJIT_BUILD', '-I', include_path, '-I', include_path_source, '-S', '-emit-llvm','-x','c++', '-o','-','-']
         p = subprocess.Popen(cmd,stdin=subprocess.PIPE,stdout=subprocess.PIPE,stderr=subprocess.PIPE)
 
         # pass C++ function to stdin


### PR DESCRIPTION
## Description

This resolves #784 by using the C++14 standard.

## Motivation and context

Newer version of Thrust and TBB require C++14. Compiler support is available in gcc 5, clang 3.4, nvcc 9, xlc 13.1.2. https://en.cppreference.com/w/cpp/compiler_support
Resolves: #784

## How has this been tested?

I'm letting CI try this with GCC 4.8. It may support enough C++14 features for HOOMD to build correctly, but I will remove GCC 4.8 from CI in this PR if it fails.

## Change log

```
Changed:
- Building from source requires a C++14 compatible compiler.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
