### PR TITLE
Typo fixes in docs

### DIFF
--- a/hoomd/logging.py
+++ b/hoomd/logging.py
@@ -13,7 +13,7 @@ class TypeFlags(Flag):
     from strings to the enum wherever necessary in the API. This class is
     documented to show users what types of quantities can be logged, and what
     flags to use for limiting what data is logged, user specified logged
-    quantites, and custom actions (`hoomd.custom.Action`).
+    quantities, and custom actions (`hoomd.custom.Action`).
 
     Flags:
         scalar: `float` or `int` objects (i.e. numbers)
@@ -182,7 +182,7 @@ class Loggable(type):
     _meta_export_dict = dict()
 
     def __init__(cls, name, bases, dct):
-        """Adds marked quantites for logging in new class.
+        """Adds marked quantities for logging in new class.
 
         Also adds a loggables property that returns a mapping of loggable
         quantity names with the string flag. We overwrite __init__ instead of
@@ -252,7 +252,7 @@ class Loggable(type):
 
 
 def log(func=None, *, is_property=True, flag='scalar', default=True):
-    """Creates loggable quantites for classes of type Loggable.
+    """Creates loggable quantities for classes of type Loggable.
 
     For users this should be used with `hoomd.custom.Action` for exposing
     loggable quantities from a custom action.
@@ -394,10 +394,10 @@ class Logger(SafeNamespaceDict):
 
             logger = hoomd.logging.Logger()
             lj = md.pair.lj(nlist)
-            # Log all default quantites of the lj object
+            # Log all default quantities of the lj object
             logger += lj
             logger = hoomd.logging.Logger(flags=['scalar'])
-            # Log all default scalar quantites of the lj object
+            # Log all default scalar quantities of the lj object
             logger += lj
 
     The `Logger` class also supports user specified quantities using namespaces
@@ -430,9 +430,9 @@ class Logger(SafeNamespaceDict):
         if they wish. In making a custom logger back end, understanding the
         intermediate representation is key. To get an introduction see
         `hoomd.logging.Logger.log`. To understand the various flags
-        available to specify logged quantities, see `hoomd.logging.TypeFlags`. To
-        integrate with `hoomd.Operations` the back end should be a subclass of
-        `hoomd.custom.Action` and used with `hoomd.writer.CustomWriter`.
+        available to specify logged quantities, see `hoomd.logging.TypeFlags`.
+        To integrate with `hoomd.Operations` the back end should be a subclass
+        of `hoomd.custom.Action` and used with `hoomd.writer.CustomWriter`.
 
     Args:
         flags (`list` of `str`, optional): A list of string flags (list of flags
@@ -467,7 +467,7 @@ class Logger(SafeNamespaceDict):
     @property
     def only_default(self):
         """`bool`: Whether the logger object should only grab default loggable
-        quantites.
+        quantities.
         """
         return self._only_default
 

--- a/hoomd/logging.py
+++ b/hoomd/logging.py
@@ -378,7 +378,7 @@ class _LoggerEntry:
 class Logger(SafeNamespaceDict):
     '''Logs HOOMD-blue operation data and custom quantities.
 
-    The `Logger` class provides an intermediatary between a back end such as the
+    The `Logger` class provides an intermediary between a back end such as the
     `hoomd.write.Table` and many of HOOMD-blue's object (as most objects are
     loggable). The `Logger` class makes use of *namespaces* which denote where a
     logged quantity fits in. For example internally all loggable quantities are

--- a/hoomd/logging.py
+++ b/hoomd/logging.py
@@ -414,7 +414,7 @@ class Logger(SafeNamespaceDict):
 
     `Logger` objects support two ways of discriminating what loggable quantities
     they will accept: ``flags`` and ``only_default`` (the constructor
-    arguements). Both of these are static meaning that once instantiated a
+    arguments). Both of these are static meaning that once instantiated a
     `Logger` object will not change the values of these two properties.
     ``flags`` determines what if any types of loggable quantities (see
     `hoomd.logging.TypeFlags`) are appropriate for a given `Logger` object. This

--- a/hoomd/write/table.py
+++ b/hoomd/write/table.py
@@ -125,10 +125,10 @@ class _Formatter:
 class _TableInternal(_InternalAction):
     """Implements the logic for a simple text based logger backend.
 
-    This currently has to check the logged quantites every time to ensure it has
-    not changed since the last run of `~.act`. Performance could be improved by
-    allowing for writing of data without checking for a change in logged
-    quantites, but would be more fragile.
+    This currently has to check the logged quantities every time to ensure it
+    has not changed since the last run of `~.act`. Performance could be
+    improved by allowing for writing of data without checking for a change in
+    logged quantities, but would be more fragile.
     """
 
     _invalid_logger_flags = TypeFlags.any(
@@ -232,7 +232,7 @@ class _TableInternal(_InternalAction):
     def act(self, timestep=None):
         """Write row to designated output.
 
-        Will also write header when logged quantites are determined to have
+        Will also write header when logged quantities are determined to have
         changed.
         """
         output_dict = self._get_log_dict()


### PR DESCRIPTION
## Description

Just a few typo fixes in the docs that I saw in my first read-through. Should be safe to merge immediately.

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
