### PR TITLE
Handle kernel interrupt signals in Jupyter

### DIFF
--- a/hoomd/SignalHandler.cc
+++ b/hoomd/SignalHandler.cc
@@ -40,7 +40,6 @@ ScopedSignalHandler::ScopedSignalHandler()
     if (retval != 0)
         {
         cerr << "Error setting signal handler: " << strerror(errno) << endl;
-        return;
         }
     }
 

--- a/hoomd/SignalHandler.cc
+++ b/hoomd/SignalHandler.cc
@@ -24,8 +24,6 @@ extern "C" void sigint_handler(int sig)
     if (sig != SIGINT)
         return;
 
-    std::cout << "HOOMD caught SIGINT" << std::endl;
-
     // set the global
     g_sigint_recvd = 1;
     }

--- a/hoomd/SignalHandler.cc
+++ b/hoomd/SignalHandler.cc
@@ -15,9 +15,6 @@ using namespace std;
     \brief Defines variables and functions related to handling signals
 */
 
-//! Tracks the previous signal handler
-static struct sigaction g_oldact;
-
 volatile sig_atomic_t g_sigint_recvd = 0;
 
 //! The actual signal handler
@@ -33,16 +30,14 @@ extern "C" void sigint_handler(int sig)
     g_sigint_recvd = 1;
     }
 
-/*! This method installs a signal handler for SIGINT that will set \c g_sigint_recvd to 1.
-*/
-void InstallSIGINTHandler()
+ScopedSignalHandler::ScopedSignalHandler()
     {
     struct sigaction newact;
     newact.sa_handler = sigint_handler;
     sigemptyset(&newact.sa_mask);
     newact.sa_flags = 0;
 
-    int retval = sigaction(SIGINT, &newact, &g_oldact);
+    int retval = sigaction(SIGINT, &newact, &m_old_action);
 
     if (retval != 0)
         {
@@ -51,10 +46,10 @@ void InstallSIGINTHandler()
         }
     }
 
-void RemoveSIGINTHandler()
+ScopedSignalHandler::~ScopedSignalHandler()
     {
     struct sigaction dummy_action;
-    int retval = sigaction(SIGINT, &g_oldact, &dummy_action);
+    int retval = sigaction(SIGINT, &m_old_action, &dummy_action);
 
     if (retval != 0)
         {

--- a/hoomd/SignalHandler.cc
+++ b/hoomd/SignalHandler.cc
@@ -52,6 +52,5 @@ ScopedSignalHandler::~ScopedSignalHandler()
     if (retval != 0)
         {
         cerr << "Error setting signal handler: " << strerror(errno) << endl;
-        return;
         }
     }

--- a/hoomd/SignalHandler.cc
+++ b/hoomd/SignalHandler.cc
@@ -7,7 +7,7 @@
 #include <signal.h>
 #include "SignalHandler.h"
 #include <iostream>
-#include "string.h"
+#include <cstring>
 
 using namespace std;
 

--- a/hoomd/SignalHandler.h
+++ b/hoomd/SignalHandler.h
@@ -22,10 +22,22 @@
 */
 extern volatile sig_atomic_t g_sigint_recvd;
 
-//! Installs the signal handler
-void InstallSIGINTHandler();
+/** Manage the signal handler within a scope
 
-/// Removes the signal handler
-void RemoveSIGINTHandler();
+    This allows System::run to install the signal handler and have in removed when it returns
+    or an excpetion is thrown.
+*/
+class ScopedSignalHandler
+    {
+    public:
+        /// Install the signal handler
+        ScopedSignalHandler();
+
+        /// Remove the signal handler and restore the previous
+        ~ScopedSignalHandler();
+    private:
+        /// Save the old action
+        struct sigaction m_old_action;
+    };
 
 #endif

--- a/hoomd/SignalHandler.h
+++ b/hoomd/SignalHandler.h
@@ -24,8 +24,8 @@ extern volatile sig_atomic_t g_sigint_recvd;
 
 /** Manage the signal handler within a scope
 
-    This allows System::run to install the signal handler and have in removed when it returns
-    or an excpetion is thrown.
+    This allows System::run to install the signal handler and have it removed when it returns
+    or an exception is thrown.
 */
 class ScopedSignalHandler
     {

--- a/hoomd/SignalHandler.h
+++ b/hoomd/SignalHandler.h
@@ -25,4 +25,7 @@ extern volatile sig_atomic_t g_sigint_recvd;
 //! Installs the signal handler
 void InstallSIGINTHandler();
 
+/// Removes the signal handler
+void RemoveSIGINTHandler();
+
 #endif

--- a/hoomd/System.cc
+++ b/hoomd/System.cc
@@ -87,6 +87,7 @@ void System::setCommunicator(std::shared_ptr<Communicator> comm)
 
 void System::run(unsigned int nsteps, bool write_at_start)
     {
+    ScopedSignalHandler signal_handler;
     m_start_tstep = m_cur_tstep;
     m_end_tstep = m_cur_tstep + nsteps;
 
@@ -164,6 +165,8 @@ void System::run(unsigned int nsteps, bool write_at_start)
         if (g_sigint_recvd)
             {
             g_sigint_recvd = 0;
+            PyErr_SetString(PyExc_KeyboardInterrupt, "");
+            throw pybind11::error_already_set();
             return;
             }
         }

--- a/hoomd/module.cc
+++ b/hoomd/module.cc
@@ -66,8 +66,6 @@
 #endif // ENABLE_HIP
 #endif // ENABLE_MPI
 
-#include "SignalHandler.h"
-
 #include "HOOMDVersion.h"
 
 #include <pybind11/pybind11.h>
@@ -203,8 +201,6 @@ PYBIND11_MODULE(_hoomd, m)
     pybind11::bind_vector< std::vector<int> >(m,"std_vector_int");
     pybind11::bind_vector< std::vector<Scalar3> >(m,"std_vector_scalar3");
     pybind11::bind_vector< std::vector<Scalar4> >(m,"std_vector_scalar4");
-
-    InstallSIGINTHandler();
 
     // utils
     export_hoomd_math_functions(m);


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should based on *maint*. -->
<!-- New features should based on *master*. -->

## Description

<!-- Describe your changes in detail. -->
Install the `SIGINT` signal handler at the start of every call to `run`.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
See the discussion in #813 

<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves #813

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
I tested this manually with a jupyter notebook.

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
Fixed:
- ``Simulation.run`` now ends with a ``KeyboardInterrupt`` exception when Jupyter interrupts the kernel.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
