### PR TITLE
Improve GSD API and documentation

### DIFF
--- a/.azp/test.yml
+++ b/.azp/test.yml
@@ -134,4 +134,5 @@ jobs:
       hoomd/filter/set_.py
       hoomd/filter/tags.py
       hoomd/filter/type_.py
+      hoomd/write/gsd.py
     displayName: Run pydocstyle

--- a/hoomd/CMakeLists.txt
+++ b/hoomd/CMakeLists.txt
@@ -112,6 +112,7 @@ set(_hoomd_headers
     GPUPolymorph.h
     GPUPolymorph.cuh
     GPUVector.h
+    GSD.h
     GSDDumpWriter.h
     GSDReader.h
     GSDShapeSpecWriter.h

--- a/hoomd/CachedAllocator.h
+++ b/hoomd/CachedAllocator.h
@@ -18,6 +18,7 @@
 
 #include <map>
 #include <cassert>
+#include <stdexcept>
 
 //! Need to define an error checking macro that can be used in .cu files
 #define CHECK_CUDA() \

--- a/hoomd/GSD.h
+++ b/hoomd/GSD.h
@@ -77,7 +77,7 @@ class GSDUtils
         else if (retval == GSD_ERROR_FILE_MUST_BE_WRITABLE)
             {
             std::ostringstream s;
-            s << "GSD: File must be writeable"
+            s << "GSD: File must be writable"
                  " - "
               << fname;
             throw std::runtime_error(s.str());

--- a/hoomd/GSD.h
+++ b/hoomd/GSD.h
@@ -1,0 +1,102 @@
+// Copyright (c) 2009-2019 The Regents of the University of Michigan
+// This file is part of the HOOMD-blue project, released under the BSD 3-Clause License.
+
+#pragma once
+
+#include "hoomd/extern/gsd.h"
+#include <string>
+#include <sstream>
+
+namespace hoomd
+    {
+namespace detail
+    {
+/// Utility class to collect common GSD file operations.
+class GSDUtils
+    {
+    public:
+    /// Check and raise an exception if an error occurs
+    static void checkError(int retval, const std::string& fname)
+        {
+        // checkError prints errors and then throws exceptions for common gsd error codes
+        if (retval == GSD_ERROR_IO)
+            {
+            std::ostringstream s;
+            s << "GSD: " << strerror(errno) << " - " << fname;
+            throw std::runtime_error(s.str());
+            }
+        else if (retval == GSD_ERROR_INVALID_ARGUMENT)
+            {
+            std::ostringstream s;
+            s << "GSD: Invalid argument"
+                 " - "
+              << fname;
+            throw std::invalid_argument(s.str());
+            }
+        else if (retval == GSD_ERROR_NOT_A_GSD_FILE)
+            {
+            std::ostringstream s;
+            s << "GSD: Not a GSD file"
+                 " - "
+              << fname;
+            throw std::runtime_error(s.str());
+            }
+        else if (retval == GSD_ERROR_INVALID_GSD_FILE_VERSION)
+            {
+            std::ostringstream s;
+            s << "GSD: Invalid GSD file version"
+                 " - "
+              << fname;
+            throw std::runtime_error(s.str());
+            }
+        else if (retval == GSD_ERROR_FILE_CORRUPT)
+            {
+            std::ostringstream s;
+            s << "GSD: File corrupt"
+                 " - "
+              << fname;
+            throw std::runtime_error(s.str());
+            }
+        else if (retval == GSD_ERROR_MEMORY_ALLOCATION_FAILED)
+            {
+            std::ostringstream s;
+            s << "GSD: Memory allocation failed"
+                 " - "
+              << fname;
+            throw std::runtime_error(s.str());
+            }
+        else if (retval == GSD_ERROR_NAMELIST_FULL)
+            {
+            std::ostringstream s;
+            s << "GSD: Namelist full"
+                 " - "
+              << fname;
+            throw std::runtime_error(s.str());
+            }
+        else if (retval == GSD_ERROR_FILE_MUST_BE_WRITABLE)
+            {
+            std::ostringstream s;
+            s << "GSD: File must be writeable"
+                 " - "
+              << fname;
+            throw std::runtime_error(s.str());
+            }
+        else if (retval == GSD_ERROR_FILE_MUST_BE_READABLE)
+            {
+            std::ostringstream s;
+            s << "GSD: File must be readable"
+                 " - "
+              << fname;
+            throw std::runtime_error(s.str());
+            }
+        else if (retval != GSD_SUCCESS)
+            {
+            std::ostringstream s;
+            s << "GSD: "
+              << "Unknown error " << retval << " writing: " << fname;
+            throw std::runtime_error(s.str());
+            }
+        }
+    };
+    } // namespace detail
+    } // namespace hoomd

--- a/hoomd/GSD.h
+++ b/hoomd/GSD.h
@@ -6,6 +6,7 @@
 #include "hoomd/extern/gsd.h"
 #include <string>
 #include <sstream>
+#include <stdexcept>
 
 namespace hoomd
     {

--- a/hoomd/GSDDumpWriter.h
+++ b/hoomd/GSDDumpWriter.h
@@ -26,8 +26,7 @@
     every time analyze() is called. When a group is specified, only write out the
     particles in the group.
 
-    On the first call to analyze() \a fname is created with a dcd header. If it already
-    exists, append to the file (unless the user specifies overwrite=True).
+    The file is not openend until the first call to
 
     \ingroup analyzers
 */
@@ -38,7 +37,7 @@ class PYBIND11_EXPORT GSDDumpWriter : public Analyzer
         GSDDumpWriter(std::shared_ptr<SystemDefinition> sysdef,
                       const std::string &fname,
                       std::shared_ptr<ParticleGroup> group,
-                      bool overwrite=false,
+                      std::string mode="ab",
                       bool truncate=false);
 
         //! Control attribute writes
@@ -70,9 +69,9 @@ class PYBIND11_EXPORT GSDDumpWriter : public Analyzer
             return m_fname;
             }
 
-        bool getOverwrite()
+        std::string getMode()
             {
-            return m_overwrite;
+            return m_mode;
             }
 
         bool getTruncate()
@@ -139,7 +138,7 @@ class PYBIND11_EXPORT GSDDumpWriter : public Analyzer
 
     private:
         std::string m_fname;                //!< The file name we are writing to
-        bool m_overwrite;                   //!< True if file should be overwritten
+        std::string m_mode;                 //!< The file open mode
         bool m_truncate;                    //!< True if we should truncate the file on every analyze()
         bool m_is_initialized;              //!< True if the file is open
         bool m_write_attribute;             //!< True if attributes should be written
@@ -147,6 +146,8 @@ class PYBIND11_EXPORT GSDDumpWriter : public Analyzer
         bool m_write_momentum;              //!< True if momenta should be written
         bool m_write_topology;              //!< True if topology should be written
         gsd_handle m_handle;                //!< Handle to the file
+
+        static std::list<std::string> particle_chunks;
 
         /// Callback to write log quantities to file
         pybind11::object m_log_writer;

--- a/hoomd/GSDDumpWriter.h
+++ b/hoomd/GSDDumpWriter.h
@@ -26,7 +26,7 @@
     every time analyze() is called. When a group is specified, only write out the
     particles in the group.
 
-    The file is not openend until the first call to
+    The file is not opened until the first call to analyze().
 
     \ingroup analyzers
 */

--- a/hoomd/GSDReader.cc
+++ b/hoomd/GSDReader.cc
@@ -1,13 +1,7 @@
 // Copyright (c) 2009-2019 The Regents of the University of Michigan
 // This file is part of the HOOMD-blue project, released under the BSD 3-Clause License.
 
-
-// Maintainer: joaander
-
-/*! \file GSDReader.cc
-    \brief Defines the GSDReader class
-*/
-
+#include "GSD.h"
 #include "GSDReader.h"
 #include "SnapshotSystemData.h"
 #include "ExecutionConfiguration.h"
@@ -17,6 +11,7 @@
 
 #include <stdexcept>
 using namespace std;
+using namespace hoomd::detail;
 
 namespace py = pybind11;
 
@@ -47,7 +42,7 @@ GSDReader::GSDReader(std::shared_ptr<const ExecutionConfiguration> exec_conf,
     // open the GSD file in read mode
     m_exec_conf->msg->notice(3) << "data.gsd_snapshot: open gsd file " << name << endl;
     int retval = gsd_open(&m_handle, name.c_str(), GSD_OPEN_READONLY);
-    checkError(retval);
+    GSDUtils::checkError(retval, m_name);
 
     // validate schema
     if (string(m_handle.header.schema) != string("hoomd"))
@@ -126,7 +121,7 @@ bool GSDReader::readChunk(void *data, uint64_t frame, const char *name, size_t e
             throw runtime_error("Error reading GSD file");
             }
         int retval = gsd_read_chunk(&m_handle, data, entry);
-        checkError(retval);
+        GSDUtils::checkError(retval, m_name);
 
         return true;
         }
@@ -161,7 +156,7 @@ std::vector<std::string> GSDReader::readTypes(uint64_t frame, const char *name)
         size_t actual_size = entry->N * entry->M * gsd_sizeof_type((enum gsd_type)entry->type);
         std::vector<char> data(actual_size);
         int retval = gsd_read_chunk(&m_handle, &data[0], entry);
-        checkError(retval);
+        GSDUtils::checkError(retval, m_name);
 
         type_mapping.clear();
         for (unsigned int i = 0; i < entry->N; i++)
@@ -301,67 +296,11 @@ pybind11::list GSDReader::readTypeShapesPy(uint64_t frame)
     return type_shapes;
     }
 
-void GSDReader::checkError(int retval)
-    {
-    // checkError prints errors and then throws exceptions for common gsd error codes
-    if (retval == GSD_ERROR_IO)
-        {
-        m_exec_conf->msg->error() << "dump.gsd: " << strerror(errno) << " - " << m_name << endl;
-        throw runtime_error("Error reading GSD file");
-        }
-    else if (retval == GSD_ERROR_INVALID_ARGUMENT)
-        {
-        m_exec_conf->msg->error() << "dump.gsd: Invalid argument" " - " << m_name << endl;
-        throw runtime_error("Error reading GSD file");
-        }
-    else if (retval == GSD_ERROR_NOT_A_GSD_FILE)
-        {
-        m_exec_conf->msg->error() << "dump.gsd: Not a GSD file" " - " << m_name << endl;
-        throw runtime_error("Error reading GSD file");
-        }
-    else if (retval == GSD_ERROR_INVALID_GSD_FILE_VERSION)
-        {
-        m_exec_conf->msg->error() << "dump.gsd: Invalid GSD file version" " - " << m_name << endl;
-        throw runtime_error("Error reading GSD file");
-        }
-    else if (retval == GSD_ERROR_FILE_CORRUPT)
-        {
-        m_exec_conf->msg->error() << "dump.gsd: File corrupt" " - " << m_name << endl;
-        throw runtime_error("Error reading GSD file");
-        }
-    else if (retval == GSD_ERROR_MEMORY_ALLOCATION_FAILED)
-        {
-        m_exec_conf->msg->error() << "dump.gsd: Memory allocation failed" " - " << m_name << endl;
-        throw runtime_error("Error reading GSD file");
-        }
-    else if (retval == GSD_ERROR_NAMELIST_FULL)
-        {
-        m_exec_conf->msg->error() << "dump.gsd: Namelist full" " - " << m_name << endl;
-        throw runtime_error("Error reading GSD file");
-        }
-    else if (retval == GSD_ERROR_FILE_MUST_BE_WRITABLE)
-        {
-        m_exec_conf->msg->error() << "dump.gsd: File must be writeable" " - " << m_name << endl;
-        throw runtime_error("Error reading GSD file");
-        }
-    else if (retval == GSD_ERROR_FILE_MUST_BE_READABLE)
-        {
-        m_exec_conf->msg->error() << "dump.gsd: File must be readable" " - " << m_name << endl;
-        throw runtime_error("Error reading GSD file");
-        }
-    else if (retval != GSD_SUCCESS)
-        {
-        m_exec_conf->msg->error() << "dump.gsd: " << "Unknown error " << retval << " reading: "
-                                  << m_name << endl;
-        throw runtime_error("Error reading GSD file");
-        }
-    }
-
 GSDStateReader::GSDStateReader(const std::string &name, const int64_t frame)
     : m_name(name)
     {
     int retval = gsd_open(&m_handle, name.c_str(), GSD_OPEN_READONLY);
-    checkError(retval);
+    GSDUtils::checkError(retval, m_name);
 
     // validate schema
     if (string(m_handle.header.schema) != string("hoomd"))
@@ -496,74 +435,9 @@ pybind11::array GSDStateReader::readChunk(const std::string& name)
         }
 
     int retval = gsd_read_chunk(&m_handle, result.mutable_data(), entry);
-    checkError(retval);
+    GSDUtils::checkError(retval, m_name);
 
     return result;
-    }
-
-void GSDStateReader::checkError(int retval)
-    {
-    // checkError prints errors and then throws exceptions for common gsd error codes
-    if (retval == GSD_ERROR_IO)
-        {
-        ostringstream s;
-        s << "Error reading GSD file:" << m_name <<  " - " << strerror(errno);
-        throw runtime_error(s.str());
-        }
-    else if (retval == GSD_ERROR_INVALID_ARGUMENT)
-        {
-        ostringstream s;
-        s << "Error reading GSD file:" << m_name <<  " - Invalid argument.";
-        throw runtime_error(s.str());
-        }
-    else if (retval == GSD_ERROR_NOT_A_GSD_FILE)
-        {
-        ostringstream s;
-        s << "Error reading GSD file:" << m_name <<  " - Not a GSD file.";
-        throw runtime_error(s.str());
-        }
-    else if (retval == GSD_ERROR_INVALID_GSD_FILE_VERSION)
-        {
-        ostringstream s;
-        s << "Error reading GSD file:" << m_name <<  " - Invalid GSD file version.";
-        throw runtime_error(s.str());
-        }
-    else if (retval == GSD_ERROR_FILE_CORRUPT)
-        {
-        ostringstream s;
-        s << "Error reading GSD file:" << m_name <<  " - File corrupt.";
-        throw runtime_error(s.str());
-        }
-    else if (retval == GSD_ERROR_MEMORY_ALLOCATION_FAILED)
-        {
-        ostringstream s;
-        s << "Error reading GSD file:" << m_name <<  " - Memory allocation failed.";
-        throw runtime_error(s.str());
-        }
-    else if (retval == GSD_ERROR_NAMELIST_FULL)
-        {
-        ostringstream s;
-        s << "Error reading GSD file:" << m_name <<  " - Namelist full.";
-        throw runtime_error(s.str());
-        }
-    else if (retval == GSD_ERROR_FILE_MUST_BE_WRITABLE)
-        {
-        ostringstream s;
-        s << "Error reading GSD file:" << m_name <<  " - File must be writeable.";
-        throw runtime_error(s.str());
-        }
-    else if (retval == GSD_ERROR_FILE_MUST_BE_READABLE)
-        {
-        ostringstream s;
-        s << "Error reading GSD file:" << m_name <<  " - File must be readable.";
-        throw runtime_error(s.str());
-        }
-    else if (retval != GSD_SUCCESS)
-        {
-        ostringstream s;
-        s << "Error reading GSD file:" << m_name <<  " - Unknown error.";
-        throw runtime_error(s.str());
-        }
     }
 
 void export_GSDReader(py::module& m)

--- a/hoomd/GSDReader.h
+++ b/hoomd/GSDReader.h
@@ -1,13 +1,6 @@
 // Copyright (c) 2009-2019 The Regents of the University of Michigan
 // This file is part of the HOOMD-blue project, released under the BSD 3-Clause License.
 
-
-// Maintainer: joaander
-
-/*! \file HOOMDInitializer.h
-    \brief Declares the HOOMDInitializer class
-*/
-
 #ifdef __HIPCC__
 #error This header cannot be compiled by nvcc
 #endif
@@ -101,9 +94,6 @@ class PYBIND11_EXPORT GSDReader
         void readHeader();
         void readParticles();
         void readTopology();
-
-        /// Check and raise an exception if an error occurs
-        void checkError(int retval);
     };
 
 /** Read state information from a GSD file
@@ -139,9 +129,6 @@ class PYBIND11_EXPORT GSDStateReader
 
         /// Handle to the file
         gsd_handle m_handle;
-
-        /// Check and raise an exception if an error occurs
-        void checkError(int retval);
     };
 
 

--- a/hoomd/GSDShapeSpecWriter.h
+++ b/hoomd/GSDShapeSpecWriter.h
@@ -4,10 +4,13 @@
 #ifndef __GSDSHAPESPECWRITER_H__
 #define __GSDSHAPESPECWRITER_H__
 
+#include "GSD.h"
 #include "extern/gsd.h"
 #include "GSDDumpWriter.h"
 #include <sstream>
 #include <iostream>
+
+using namespace hoomd::detail;
 
 class GSDShapeSpecWriter
     {
@@ -22,12 +25,12 @@ class GSDShapeSpecWriter
             if(!m_exec_conf->isRoot())
                 return 0;
             int max_len = getMaxLen(type_shape_mapping);
-            m_exec_conf->msg->notice(10) << "dump.gsd: writing " << m_field_name << std::endl;
+            m_exec_conf->msg->notice(10) << "GSD: writing " << m_field_name << std::endl;
             std::vector<char> types(max_len * type_shape_mapping.size());
             for (unsigned int i = 0; i < type_shape_mapping.size(); i++)
                 strncpy(&types[max_len*i], type_shape_mapping[i].c_str(), max_len);
             int retval = gsd_write_chunk(&handle, m_field_name.c_str(), GSD_TYPE_UINT8, type_shape_mapping.size(), max_len, 0, (void *)&types[0]);
-            checkError(retval);
+            GSDUtils::checkError(retval, "");
             return retval;
             }
 
@@ -43,12 +46,12 @@ class GSDShapeSpecWriter
             {
             if (number == -1)
                 {
-                this->m_exec_conf->msg->error() << "dump.gsd: " << strerror(errno) << std::endl;
+                this->m_exec_conf->msg->error() << "GSD: " << strerror(errno) << std::endl;
                 throw std::runtime_error("Error writing GSD file");
                 }
             else if (number != 0)
                 {
-                this->m_exec_conf->msg->error() << "dump.gsd: " << "Unknown error " << number << std::endl;
+                this->m_exec_conf->msg->error() << "GSD: " << "Unknown error " << number << std::endl;
                 throw std::runtime_error("Error writing GSD file");
                 }
             }

--- a/hoomd/filter/all_.py
+++ b/hoomd/filter/all_.py
@@ -11,6 +11,7 @@ class All(ParticleFilter, ParticleFilterAll):
     """
 
     def __init__(self):
+        ParticleFilter.__init__(self)
         ParticleFilterAll.__init__(self)
 
     def __hash__(self):

--- a/hoomd/filter/set_.py
+++ b/hoomd/filter/set_.py
@@ -27,6 +27,8 @@ class _ParticleFilterSetOperations(ParticleFilter):
         raise NotImplementedError
 
     def __init__(self, f, g):
+        ParticleFilter.__init__(self)
+
         if f == g:
             raise ValueError("Cannot use same filter for {}"
                              "".format(self.__class__.__name__))

--- a/hoomd/filter/tags.py
+++ b/hoomd/filter/tags.py
@@ -19,6 +19,7 @@ class Tags(ParticleFilter, ParticleFilterTags):
     """
 
     def __init__(self, tags):
+        ParticleFilter.__init__(self)
         self._tags = np.ascontiguousarray(np.unique(tags), dtype=np.uint32)
         ParticleFilterTags.__init__(self, tags)
 

--- a/hoomd/filter/type_.py
+++ b/hoomd/filter/type_.py
@@ -14,6 +14,7 @@ class Type(ParticleFilter, ParticleFilterType):
     """
 
     def __init__(self, types):
+        ParticleFilter.__init__(self)
         types = set(types)
         self._types = frozenset(types)
         ParticleFilterType.__init__(self, types)

--- a/hoomd/hpmc/IntegratorHPMCMono.h
+++ b/hoomd/hpmc/IntegratorHPMCMono.h
@@ -2168,10 +2168,9 @@ pybind11::list IntegratorHPMCMono<Shape>::PyMapEnergies()
     {
     std::vector<float> v = IntegratorHPMCMono<Shape>::mapEnergies();
     pybind11::list energy_map;
-    // for( unsigned int i = 0; i < sizeof(v)/sizeof(v[0]); i++ )
     for (auto i: v)
         {
-        energy_map.append(pybind11::cast<float>(i));
+        energy_map.append(i);
         }
     return energy_map;
     }

--- a/hoomd/hpmc/integrate.py
+++ b/hoomd/hpmc/integrate.py
@@ -66,6 +66,16 @@ class HPMCIntegrator(BaseIntegrator):
     TODO: Describe implicit depletants algorithm. No need to write this now,
     as Jens is rewriting the implementation.
 
+    .. rubric:: Writing type_shapes to GSD files.
+
+    Use a Logger in combination with a HPMC integrator and a GSD writer to write
+    ``type_shapes`` to the GSD file for use with OVITO::
+
+        mc = hoomd.hpmc.integrate.<Shape>(...)
+        log = hoomd.logging.Logger()
+        log.add(mc, quantities=['type_shapes'])
+        gsd = hoomd.write.GSD(..., log=log)
+
     .. rubric:: Parameters
 
     Attributes:

--- a/hoomd/hpmc/integrate.py
+++ b/hoomd/hpmc/integrate.py
@@ -69,12 +69,13 @@ class HPMCIntegrator(BaseIntegrator):
     .. rubric:: Writing type_shapes to GSD files.
 
     Use a Logger in combination with a HPMC integrator and a GSD writer to write
-    ``type_shapes`` to the GSD file for use with OVITO::
+    ``type_shapes`` to the GSD file for use with OVITO. For example::
 
-        mc = hoomd.hpmc.integrate.<Shape>(...)
+        mc = hoomd.hpmc.integrate.Sphere(seed=123)
         log = hoomd.logging.Logger()
         log.add(mc, quantities=['type_shapes'])
-        gsd = hoomd.write.GSD(..., log=log)
+        gsd = hoomd.write.GSD(
+            'trajectory.gsd', hoomd.trigger.Periodic(1000), log=log)
 
     .. rubric:: Parameters
 

--- a/hoomd/trigger.py
+++ b/hoomd/trigger.py
@@ -87,6 +87,7 @@ class Periodic(_hoomd.PeriodicTrigger, Trigger):
     """
 
     def __init__(self, period, phase=0):
+        Trigger.__init__(self)
         _hoomd.PeriodicTrigger.__init__(self, period, phase)
 
     def __str__(self):
@@ -117,6 +118,7 @@ class Before(_hoomd.BeforeTrigger, Trigger):
         timestep (int): The step after the trigger ends.
     """
     def __init__(self, timestep):
+        Trigger.__init__(self)
         if timestep < 0:
             raise ValueError("timestep must be greater than or equal to 0.")
         else:
@@ -147,6 +149,7 @@ class On(_hoomd.OnTrigger, Trigger):
     """
 
     def __init__(self, timestep):
+        Trigger.__init__(self)
         if timestep < 0:
             raise ValueError("timestep must be positive.")
         else:
@@ -179,6 +182,7 @@ class After(_hoomd.AfterTrigger, Trigger):
         timestep (int): The step before the trigger will start.
     """
     def __init__(self, timestep):
+        Trigger.__init__(self)
         if timestep < 0:
             raise ValueError("timestep must be positive.")
         else:
@@ -207,6 +211,7 @@ class Not(_hoomd.NotTrigger, Trigger):
         trigger (hoomd.trigger.Trigger): The trigger object to negate.
     """
     def __init__(self, trigger):
+        Trigger.__init__(self)
         _hoomd.NotTrigger.__init__(self, trigger)
 
     def __str__(self):
@@ -237,6 +242,7 @@ class And(_hoomd.AndTrigger, Trigger):
     """
 
     def __init__(self, triggers):
+        Trigger.__init__(self)
         triggers = list(triggers)
         if not all(isinstance(t, Trigger) for t in triggers):
             raise ValueError("triggers must an iterable of Triggers.")
@@ -277,6 +283,7 @@ class Or(_hoomd.OrTrigger, Trigger):
         triggers (`list` [`hoomd.trigger.Trigger`]): List of triggers.
     """
     def __init__(self, triggers):
+        Trigger.__init__(self)
         triggers = list(triggers)
         if not all(isinstance(t, Trigger) for t in triggers):
             raise ValueError("triggers must an iterable of Triggers.")

--- a/hoomd/variant.py
+++ b/hoomd/variant.py
@@ -61,6 +61,7 @@ class Constant(_hoomd.VariantConstant, Variant):
     """
 
     def __init__(self, value):
+        Variant.__init__(self)
         _hoomd.VariantConstant.__init__(self, value)
 
 
@@ -86,6 +87,7 @@ class Ramp(_hoomd.VariantRamp, Variant):
     """
 
     def __init__(self, A, B, t_start, t_ramp):
+        Variant.__init__(self)
         _hoomd.VariantRamp.__init__(self, A, B, t_start, t_ramp)
 
 
@@ -120,6 +122,7 @@ class Cycle(_hoomd.VariantCycle, Variant):
     """
 
     def __init__(self, A, B, t_start, t_A, t_AB, t_B, t_BA):
+        Variant.__init__(self)
         _hoomd.VariantCycle.__init__(self, A, B, t_start, t_A, t_AB, t_B, t_BA)
 
 
@@ -152,4 +155,5 @@ class Power(_hoomd.VariantPower, Variant):
     """
 
     def __init__(self, A, B, power, t_start, t_ramp):
+        Variant.__init__(self)
         _hoomd.VariantPower.__init__(self, A, B, power, t_start, t_ramp)

--- a/hoomd/write/gsd.py
+++ b/hoomd/write/gsd.py
@@ -184,7 +184,7 @@ class GSD(Writer):
             state (State): Simulation state.
             filename (str): File name to write.
             filter (`hoomd.ParticleFilter`): Select the particles to write.
-            mode (str): The file open mode. Defaults to `wb`.
+            mode (str): The file open mode. Defaults to ``'wb'``.
             log (`hoomd.logger.Logger`): Provide log quantities to write.
 
         The valid file modes for `write` are ``'wb'`` and ``'xb'``.

--- a/hoomd/write/gsd.py
+++ b/hoomd/write/gsd.py
@@ -43,15 +43,14 @@ class GSD(Writer):
     +------------------+---------------------------------------------+
     | mode             | description                                 |
     +==================+=============================================+
-    | ``'wb'``         | Open the file for writing. Creates the file |
-    |                  | if needed, or overwrites an existing file.  |
+    | ``'wb'``         | Open the file for writing. Create the file  |
+    |                  | if needed, or overwrite an existing file.   |
     +------------------+---------------------------------------------+
-    | ``'xb'``         | Create a GSD file exclusively and opens it  |
-    |                  | for writing.                                |
-    |                  | Raise an exception when it already exists.  |
+    | ``'xb'``         | Create a GSD file exclusively.              |
+    |                  | Raise an exception when the file exists.    |
     +------------------+---------------------------------------------+
-    | ``'ab'``         | Appends to the file when it already exists. |
-    |                  | Creates the file when it does not exist.    |
+    | ``'ab'``         | Create the file if needed, or append to an  |
+    |                  | existing file.                              |
     +------------------+---------------------------------------------+
 
     To reduce file size, `GSD` does not write properties that are set to
@@ -112,8 +111,13 @@ class GSD(Writer):
 
     Tip:
         All logged data chunks must be present in the first frame in the gsd
-        file to provide the default value. Some (or all) chunks may be omitted
-        on later frames.
+        file to provide the default value. To achieve this, set the `log`
+        attribute before the operation is triggered to write the first frame
+        in the file.
+
+        Some (or all) chunks may be omitted on later frames. You can set `log`
+        to `None` or remove specific quantities from the logger, but do not
+        add additional quantities after the first frame.
 
     Attributes:
         filename (str): File name to write.

--- a/hoomd/write/gsd.py
+++ b/hoomd/write/gsd.py
@@ -101,8 +101,8 @@ class GSD(Writer):
         * pairs/
 
     See Also:
-        See the `GSD documentation <http://gsd.readthedocs.io/>`_ and `GitHub
-        project <https://github.com/glotzerlab/gsd>`_ for more information on
+        See the `GSD documentation <http://gsd.readthedocs.io/>`__ and `GitHub
+        project <https://github.com/glotzerlab/gsd>`__ for more information on
         GSD files.
 
     Note:

--- a/hoomd/write/gsd.py
+++ b/hoomd/write/gsd.py
@@ -144,7 +144,7 @@ class GSD(Writer):
         self._param_dict.update(
             ParameterDict(filename=str(filename),
                           filter=ParticleFilter,
-                          overwrite=str(mode), truncate=bool(truncate),
+                          mode=str(mode), truncate=bool(truncate),
                           dynamic=[dynamic_validation],
                           _defaults=dict(filter=filter, dynamic=dynamic)
                           )

--- a/hoomd/write/gsd.py
+++ b/hoomd/write/gsd.py
@@ -144,11 +144,10 @@ class GSD(Writer):
         self._param_dict.update(
             ParameterDict(filename=str(filename),
                           filter=ParticleFilter,
-                          mode=str(mode), truncate=bool(truncate),
+                          mode=str(mode),
+                          truncate=bool(truncate),
                           dynamic=[dynamic_validation],
-                          _defaults=dict(filter=filter, dynamic=dynamic)
-                          )
-            )
+                          _defaults=dict(filter=filter, dynamic=dynamic)))
 
         self._log = None if log is None else _GSDLogWriter(log)
 
@@ -160,16 +159,14 @@ class GSD(Writer):
         if self.dynamic is not None:
             for v in self.dynamic:
                 if v not in categories:
-                    raise RuntimeError("GSD: dynamic quantity " + v +
-                                       " is not valid")
+                    raise RuntimeError("GSD: dynamic quantity " + v
+                                       + " is not valid")
 
             dynamic_quantities = ['property'] + self.dynamic
 
         self._cpp_obj = _hoomd.GSDDumpWriter(
-            self._simulation.state._cpp_sys_def,
-            self.filename,
-            self._simulation.state._get_group(self.filter),
-            self.mode,
+            self._simulation.state._cpp_sys_def, self.filename,
+            self._simulation.state._get_group(self.filter), self.mode,
             self.truncate)
 
         self._cpp_obj.setWriteAttribute('attribute' in dynamic_quantities)
@@ -195,11 +192,8 @@ class GSD(Writer):
         if mode != 'wb' and mode != 'xb':
             raise ValueError(f"Invalid GSD.write file mode: {mode}")
 
-        writer = _hoomd.GSDDumpWriter(state._cpp_sys_def,
-                                      filename,
-                                      state._get_group(filter),
-                                      mode,
-                                      False)
+        writer = _hoomd.GSDDumpWriter(state._cpp_sys_def, filename,
+                                      state._get_group(filter), mode, False)
 
         if log is not None:
             writer.log_writer = _GSDLogWriter(log)
@@ -240,8 +234,10 @@ class _GSDLogWriter:
         _global_prepend (`str`): a str that gets prepending into the namespace
             of each logged quantity.
     """
-    _per_flags = TypeFlags.any(['angle', 'bond', 'constraint', 'dihedral',
-                                'improper', 'pair', 'particle'])
+    _per_flags = TypeFlags.any([
+        'angle', 'bond', 'constraint', 'dihedral', 'improper', 'pair',
+        'particle'
+    ])
     _convert_flags = TypeFlags.any(['string', 'strings'])
     _skip_flags = TypeFlags['object']
     _special_keys = ['type_shapes']
@@ -294,8 +290,10 @@ class _GSDLogWriter:
         special cases like this should be avoided if possible.
         """
         if key == 'type_shapes':
-            shape_list = [bytes(json.dumps(type_shape) + '\0', 'UTF-8')
-                          for type_shape in value]
+            shape_list = [
+                bytes(json.dumps(type_shape) + '\0', 'UTF-8')
+                for type_shape in value
+            ]
             max_len = np.max([len(shape) for shape in shape_list])
             num_shapes = len(shape_list)
             str_array = np.array(shape_list)

--- a/hoomd/write/gsd.py
+++ b/hoomd/write/gsd.py
@@ -163,8 +163,8 @@ class GSD(Writer):
         if self.dynamic is not None:
             for v in self.dynamic:
                 if v not in categories:
-                    raise RuntimeError("GSD: dynamic quantity " + v
-                                       + " is not valid")
+                    raise RuntimeError(
+                        f"GSD: dynamic quantity {v} is not valid")
 
             dynamic_quantities = ['property'] + self.dynamic
 

--- a/hoomd/write/gsd.py
+++ b/hoomd/write/gsd.py
@@ -187,9 +187,9 @@ class GSD(Writer):
         Args:
             state (State): Simulation state.
             filename (str): File name to write.
-            filter (`hoomd.ParticleFilter`): Select the particles to write.
+            filter (`hoomd.filter.ParticleFilter`): Select the particles to write.
             mode (str): The file open mode. Defaults to ``'wb'``.
-            log (`hoomd.logger.Logger`): Provide log quantities to write.
+            log (`hoomd.logging.Logger`): Provide log quantities to write.
 
         The valid file modes for `write` are ``'wb'`` and ``'xb'``.
         """
@@ -213,7 +213,7 @@ class GSD(Writer):
 
     @log.setter
     def log(self, log):
-        if (log is not None) and isinstance(log, Logger):
+        if log is not None and isinstance(log, Logger):
             log = _GSDLogWriter(log)
         else:
             raise ValueError("GSD.log can only be set with a Logger.")

--- a/hoomd/write/gsd.py
+++ b/hoomd/write/gsd.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2009-2020 The Regents of the University of Michigan This file is
 # part of the HOOMD-blue project, released under the BSD 3-Clause License.
 
-""" Write GSD files storing simulation trajectories and logging data."""
+"""Write GSD files storing simulation trajectories and logging data."""
 
 from hoomd import _hoomd
 from hoomd.util import dict_flatten, array_to_strings
@@ -15,28 +15,22 @@ import json
 
 
 class GSD(Writer):
-    R""" Write simulation trajectories in the GSD format.
+    """Write simulation trajectories in the GSD format.
 
     Args:
         filename (str): File name to write.
         trigger (hoomd.trigger.Trigger): Select the timesteps to write.
-        filter_ (hoomd.filter.ParticleFilter): Select the particles
-            to write, defaults to `hoomd.filter.All`.
-        overwrite (bool): When ``True``, overwite the file. When
-            ``False`` append frames to ``filename`` if it exists and create the
-            file if it does not, defaults to ``False``.
-        truncate (bool): When ``True``, truncate the file and write a
-            new frame 0 each time this operation triggers, defaults to
-            ``False``.
-        dynamic (list[str]): Quantity categories to save in every
-            frame, defaults to property.
-        log (hoomd.logging.Logger): A ``Logger`` object for GSD
-            logging, defaults to ``None``.
-
-    .. note::
-
-        All parameters are also available as instance attributes. Only
-        *trigger* and *log* may be modified after construction.
+        filter (hoomd.filter.ParticleFilter): Select the particles to write.
+            Defaults to `hoomd.filter.All`.
+        overwrite (bool): When `True`, overwite the file. When `False` append
+            frames to ``filename`` if it exists and create the file if it does
+            not. Defaults to `False`.
+        truncate (bool): When `True`, truncate the file and write a new frame 0
+            each time this operation triggers. Defaults to `False`.
+        dynamic (list[str]): Quantity categories to save in every frame.
+            Defaults to ``['property']``.
+        log (hoomd.logging.Logger): Provide log quantities to write. Defaults to
+            `None`.
 
     `GSD` writes a simulation snapshot to the specified file each time it
     triggers. `GSD` can store all particle, bond, angle, dihedral, improper,
@@ -53,8 +47,10 @@ class GSD(Writer):
     writes non-dynamic quantities only the first frame. When reading a GSD file,
     the data in frame 0 is read when a quantity is missing in frame *i*,
     supplying data that is static over the entire trajectory.  Set the *dynamic*
-    parameter to specify dynamic attributes by category.  **property** is always
-    dynamic:
+    parameter to specify dynamic attributes by category.
+
+    Specify the one or more of the following strings in **dynamic** to make the
+    corresponding quantities dynamic (**property** is always dynamic):
 
     * **property**
 
@@ -90,36 +86,34 @@ class GSD(Writer):
         * constraints/
         * pairs/
 
+    .. rubric:: type_shapes
 
-    .. seealso::
+    TODO
 
+    See Also:
         See the `GSD documentation <http://gsd.readthedocs.io/>`_ and `GitHub
         project <https://github.com/glotzerlab/gsd>`_ for more information on
         GSD files.
 
-    .. note::
+    Note:
+        When you use ``filter`` to select a subset of the whole system, `GSD`
+        will write out all of the selected particles in ascending tag order and
+        will **not** write out **topology**.
 
-        When you use *filter_* to select a subset of the whole system,
-        :py:class:`GSD` will write out all of the selected particles in
-        ascending tag order and will **not** write out **topology**.
-
-    .. note::
-
+    Tip:
         All logged data chunks must be present in the first frame in the gsd
         file to provide the default value. Some (or all) chunks may be omitted
         on later frames.
 
-    .. note::
-
-        In MPI parallel simulations, the callback will be called on all ranks.
-        :py:class:`GSD` will write the data returned by the root rank. Return
-        values from all other ranks are ignored (and may be None).
-
-    .. rubric:: Examples:
-
-    .. todo::
-
-        link to example notebooks
+    Attributes:
+        filename (str): File name to write.
+        trigger (hoomd.trigger.Trigger): Select the timesteps to write.
+        filter (hoomd.filter.ParticleFilter): Select the particles to write.
+        overwrite (bool): When `True`, overwite the file. When `False` append
+            frames.
+        truncate (bool): When `True`, truncate the file and write a new frame 0
+            each time this operation triggers.
+        dynamic (list[str]): Quantity categories to save in every frame.
     """
 
     def __init__(self,
@@ -183,8 +177,8 @@ class GSD(Writer):
         Args:
             state (State): Simulation state.
             filename (str): File name to write.
-            filter_ (``hoomd.ParticleFilter``): Select the particles to write.
-            log (``hoomd.logger.Logger``): A ``Logger`` object for GSD logging.
+            filter (`hoomd.ParticleFilter`): Select the particles to write.
+            log (`hoomd.logger.Logger`): Provide log quantities to write.
 
         Note:
             The file is always overwritten.
@@ -196,11 +190,15 @@ class GSD(Writer):
                                       False)
 
         if log is not None:
-            writer.log_writer = GSDLogWriter(log)
+            writer.log_writer = _GSDLogWriter(log)
         writer.analyze(state._simulation.timestep)
 
     @property
     def log(self):
+        """hoomd.logging.Logger: Provide log quantities to write.
+
+        May be `None`.
+        """
         return self._log
 
     @log.setter

--- a/hoomd/write/gsd.py
+++ b/hoomd/write/gsd.py
@@ -209,7 +209,7 @@ class GSD(Writer):
 
     @log.setter
     def log(self, log):
-        if isinstance(log, Logger):
+        if (log is not None) and isinstance(log, Logger):
             log = _GSDLogWriter(log)
         else:
             raise ValueError("GSD.log can only be set with a Logger.")

--- a/hoomd/write/gsd.py
+++ b/hoomd/write/gsd.py
@@ -22,7 +22,7 @@ class GSD(Writer):
         trigger (hoomd.trigger.Trigger): Select the timesteps to write.
         filter (hoomd.filter.ParticleFilter): Select the particles to write.
             Defaults to `hoomd.filter.All`.
-        mode (str): The file open mode. Defaults to `ab`.
+        mode (str): The file open mode. Defaults to ``'ab'``.
         truncate (bool): When `True`, truncate the file and write a new frame 0
             each time this operation triggers. Defaults to `False`.
         dynamic (list[str]): Quantity categories to save in every frame.


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should based on *maint*. -->
<!-- New features should based on *master*. -->

## Description

<!-- Describe your changes in detail. -->
* Use a string file `mode` instead of `overwrite` (breaking change).
* Clean up and make the documentation consistent with the rest of HOOMD.
* Include the exception reason in the exception and don't write to the messenger error() stream.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
String file modes are more Pythonic and enable a new mode: exclusive create. The documentation had errors and was not consistent with the rest of HOOMD. Users expect to find the exception reason in the exception output that Python writes.

<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves #674, resolves #814 and resolves #815.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
Unfortunately, there are no unit tests for GSD yet (#732). I tested this with the tutorial notebooks.

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
Added:

- Support pybind11 2.6.0
- Exclusive creation file mode for ``write.GSD``.

Changed:

- [breaking] Replace ``write.GSD`` argument ``overwrite`` with ``mode``.
```
(doc improvement change is already in the log).

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
