### PR TITLE
Fix FacetedEllipsoid and state logging

### DIFF
--- a/hoomd/hpmc/integrate.py
+++ b/hoomd/hpmc/integrate.py
@@ -1163,7 +1163,7 @@ class FacetedEllipsoid(HPMCIntegrator):
                                              to_type_converter(
                                                  [(float, float, float)]),
                                              allow_none=True),
-                                         origin=(float, float, float),
+                                         origin=(0.0, 0.0, 0.0),
                                          ignore_statistics=False,
                                          len_keys=1,
                                          _defaults={'vertices': None}))

--- a/hoomd/operation.py
+++ b/hoomd/operation.py
@@ -24,6 +24,16 @@ from copy import deepcopy
 
 
 def _convert_values_to_log_form(value):
+    """Function for making state loggable quantity conform to spec.
+
+    Since the state dictionary is composed of properties for a given class
+    instance that does not have flags associated with it, we need to add the
+    flags when querying for the state. This does makes state logger type flag
+    generation dynamic meaning that we must be careful that we won't wrongly
+    detect different flags for the same attribute. In general this shouldn't
+    be a concern, though.
+    """
+
     if value is RequiredArg:
         return RequiredArg
     elif isinstance(value, Variant):
@@ -37,12 +47,14 @@ def _convert_values_to_log_form(value):
         return (value, 'object')
     elif isinstance(value, str):
         return (value, 'string')
-    elif is_iterable(value) and all([isinstance(v, str) for v in value]):
+    elif (is_iterable(value)
+            and len(value) != 0
+            and all([isinstance(v, str) for v in value])):
         return (value, 'strings')
     elif not is_iterable(value):
         return (value, 'scalar')
     else:
-        return (value, 'multi')
+        return (value, 'sequence')
 
 
 def _handle_gsd_arrays(arr):

--- a/hoomd/operation.py
+++ b/hoomd/operation.py
@@ -33,7 +33,6 @@ def _convert_values_to_log_form(value):
     detect different flags for the same attribute. In general this shouldn't
     be a concern, though.
     """
-
     if value is RequiredArg:
         return RequiredArg
     elif isinstance(value, Variant):

--- a/hoomd/write/gsd.py
+++ b/hoomd/write/gsd.py
@@ -3,9 +3,10 @@
 
 """ Write GSD files storing simulation trajectories and logging data."""
 
+from collections.abc import Mapping, Collection
 from hoomd import _hoomd
 from hoomd.util import dict_flatten, array_to_strings
-from hoomd.data.typeconverter import OnlyFrom
+from hoomd.data.typeconverter import OnlyFrom, RequiredArg
 from hoomd.filter import ParticleFilter, All
 from hoomd.data.parameterdicts import ParameterDict
 from hoomd.logging import Logger, TypeFlags
@@ -214,6 +215,32 @@ class GSD(Writer):
         self._log = log
 
 
+def _iterable_is_incomplete(iterable):
+    """Checks that any nested attribute has no instances of RequiredArg.
+
+    Given the arbitrary nesting of container types in HOOMD-blue's data
+    model, we need to ensure that no RequiredArg values exist at any depth
+    in a state loggable key. Otherwise, the gsd backend will fail in its
+    conversion to NumPy arrays.
+    """
+    if (not isinstance(iterable, Collection)
+            or isinstance(iterable, str)
+            or len(iterable) == 0):
+        return False
+    incomplete = False
+
+    if isinstance(iterable, Mapping):
+        iter_ = iterable.keys()
+    else:
+        iter_ = iterable
+    for v in iter_:
+        if isinstance(v, Collection):
+            incomplete |= _iterable_is_incomplete(v)
+        else:
+            incomplete |= v is RequiredArg
+    return incomplete
+
+
 class _GSDLogWriter:
     """Helper class to store `hoomd.logging.Logger` log data to GSD file.
 
@@ -244,6 +271,8 @@ class _GSDLogWriter:
         """Get the flattened dictionary for consumption by GSD object."""
         log = dict()
         for key, value in dict_flatten(self.logger.log()).items():
+            if 'state' in key and _iterable_is_incomplete(value[0]):
+                pass
             log_value, type_flag = value
             type_flag = TypeFlags[type_flag]
             # This has to be checked first since type_shapes has a flag
@@ -298,7 +327,7 @@ class _GSDLogWriter:
             value = bytes(value, 'UTF-8')
             value = np.array([value], dtype=np.dtype((bytes, len(value) + 1)))
             value = value.view(dtype=np.int8)
-        if flag == TypeFlags.strings:
+        elif flag == TypeFlags.strings:
             value = [bytes(v + '\0', 'UTF-8') for v in value]
             max_len = np.max([len(string) for string in value])
             num_strings = len(value)


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should based on *maint*. -->
<!-- New features should based on *master*. -->

## Description

Fixes a discrepancy between the documentation and implementation of `hoomd.hpmc.FacetedEllipsoid`. Also fixes multiple bugs in the logging of `hoomd.operation._HOOMDBaseObject.state`. There is an outstanding issue of the `hoomd.write.GSD` writer being unable to log quantities that are nested in a certain way such as the list of dict objects in the union shape definitions for `hoomd.hpmc.integrate`.
<!-- Describe your changes in detail. -->

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves #824

## How has this been tested?

Existing tests pass.
<!--- Please describe in detail how you tested your changes. -->

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

I don't know if this merits a change log entry.
<!-- Propose a change log entry. -->
```
- FacetedEllipsoid's shape specification now has a default origin of (0, 0, 0)
- logging the state of specific objects with nested attributes
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
