### PR TITLE
Document Loggable properties and methods

### DIFF
--- a/hoomd/logging.py
+++ b/hoomd/logging.py
@@ -247,8 +247,30 @@ class Loggable(type):
     @classmethod
     def _get_current_cls_loggables(cls, new_cls):
         """Gets the current class's new loggables (not inherited)."""
-        return {name: _LoggerQuantity(name, new_cls, entry.flag, entry.default)
-                for name, entry in cls._meta_export_dict.items()}
+        current_loggables = {}
+        for name, entry in cls._meta_export_dict.items():
+            current_loggables[name] = _LoggerQuantity(
+                name, new_cls, entry.flag, entry.default)
+            cls._add_loggable_docstring_info(
+                new_cls, name, entry.flag, entry.default)
+        return current_loggables
+
+    @classmethod
+    def _add_loggable_docstring_info(cls, new_cls, attr, flag, default):
+        doc = getattr(new_cls, attr).__doc__
+        str_msg = '\n\n{}(**Loggable**: '
+        str_msg += f'type "{str(flag)[10:]}", default {default})'
+        if doc is None:
+            getattr(new_cls, attr).__doc__ = str_msg.format('')
+        else:
+            indent = 0
+            lines = doc.split('\n')
+            if len(lines) >= 3:
+                cnt = 2
+                while lines[cnt] == '':
+                    cnt += 1
+                indent = len(lines[cnt]) - len(lines[cnt].lstrip())
+            getattr(new_cls, attr).__doc__ += str_msg.format(' ' * indent)
 
 
 def log(func=None, *, is_property=True, flag='scalar', default=True):

--- a/hoomd/logging.py
+++ b/hoomd/logging.py
@@ -258,8 +258,12 @@ class Loggable(type):
     @classmethod
     def _add_loggable_docstring_info(cls, new_cls, attr, flag, default):
         doc = getattr(new_cls, attr).__doc__
-        str_msg = '\n\n{}(**Loggable**: '
-        str_msg += f'type "{str(flag)[10:]}", default {default})'
+        str_msg = '\n\n{}(`Loggable <hoomd.logging.Logger>`: '
+        str_msg += f'type="{str(flag)[10:]}"'
+        if default:
+            str_msg += ')'
+        else:
+            str_msg += ', default=False)'
         if doc is None:
             getattr(new_cls, attr).__doc__ = str_msg.format('')
         else:

--- a/hoomd/logging.py
+++ b/hoomd/logging.py
@@ -258,6 +258,11 @@ class Loggable(type):
     @classmethod
     def _add_loggable_docstring_info(cls, new_cls, attr, flag, default):
         doc = getattr(new_cls, attr).__doc__
+        # Don't add documentation to empty docstrings. This means that the
+        # quantity is not documented would needs to be fixed, but this prevents
+        # the rendering of invalid docs since we need a non-empty docstring.
+        if __doc__ == "":
+            return
         str_msg = '\n\n{}(`Loggable <hoomd.logging.Logger>`: '
         str_msg += f'type="{str(flag)[10:]}"'
         if default:

--- a/hoomd/operation.py
+++ b/hoomd/operation.py
@@ -446,6 +446,14 @@ class _HOOMDBaseObject(_StatefulAttrBase, _DependencyRelation):
 
     @log(flag='state')
     def state(self):
+        """The state of the object.
+
+        Provides a mapping of attributes to their values for use in storing
+        objects state for later object reinitialization. An object's state can
+        be used to create an identical object using the `from_state` method
+        (some object require other parameters to be passed in `from_state`
+        besides the state mapping).
+        """
         self._update_param_dict()
         return super()._get_state()
 

--- a/sphinx-doc/module-hoomd-operation.rst
+++ b/sphinx-doc/module-hoomd-operation.rst
@@ -18,4 +18,7 @@ hoomd.operation
 
 .. automodule:: hoomd.operation
     :synopsis: Classes define the interfaces and types for HOOMD-blue operations.
-    :members: Compute, Operation, Tuner, Updater, Writer
+    :members: Compute, Tuner, Updater, Writer
+
+    .. autoclass:: Operation
+        :inherited-members:

--- a/sphinx-doc/module-md-force.rst
+++ b/sphinx-doc/module-md-force.rst
@@ -17,6 +17,7 @@ md.force
     :synopsis: Apply forces to particles.
 
     .. autoclass:: Force
+        :members:
 
     .. autoclass:: Active
         :show-inheritance:


### PR DESCRIPTION
## Description

Adds a method to `hoomd.logging.Loggable` to add documentation to property and method docstrings that displays that a property is loggable along with its logging type and default status.
<!-- Describe your changes in detail. -->

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves #771

## How has this been tested?

Documentation was built locally and reviewed.
<!--- Please describe in detail how you tested your changes. -->

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
- document loggable quantities in docstring
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
