### PR TITLE
Indicate topology properties with an asterisk.

### DIFF
--- a/hoomd/write/gsd.py
+++ b/hoomd/write/gsd.py
@@ -92,12 +92,12 @@ class GSD(Writer):
 
     * **topology**
 
-        * bonds/
-        * angles/
-        * dihedrals/
-        * impropers/
-        * constraints/
-        * pairs/
+        * bonds/\*
+        * angles/\*
+        * dihedrals/\*
+        * impropers/\*
+        * constraints/\*
+        * pairs/\*
 
     See Also:
         See the `GSD documentation <http://gsd.readthedocs.io/>`__ and `GitHub

--- a/hoomd/write/gsd.py
+++ b/hoomd/write/gsd.py
@@ -15,7 +15,7 @@ import json
 
 
 class GSD(Writer):
-    """Write simulation trajectories in the GSD format.
+    r"""Write simulation trajectories in the GSD format.
 
     Args:
         filename (str): File name to write.
@@ -92,12 +92,12 @@ class GSD(Writer):
 
     * **topology**
 
-        * bonds/\*
-        * angles/\*
-        * dihedrals/\*
-        * impropers/\*
-        * constraints/\*
-        * pairs/\*
+        * bonds/*
+        * angles/*
+        * dihedrals/*
+        * impropers/*
+        * constraints/*
+        * pairs/*
 
     See Also:
         See the `GSD documentation <https://gsd.readthedocs.io/>`__, `GSD HOOMD

--- a/hoomd/write/gsd.py
+++ b/hoomd/write/gsd.py
@@ -100,9 +100,10 @@ class GSD(Writer):
         * pairs/\*
 
     See Also:
-        See the `GSD documentation <http://gsd.readthedocs.io/>`__ and `GitHub
-        project <https://github.com/glotzerlab/gsd>`__ for more information on
-        GSD files.
+        See the `GSD documentation <https://gsd.readthedocs.io/>`__, `GSD HOOMD
+        Schema <https://gsd.readthedocs.io/en/stable/schema-hoomd.html>`__, and
+        `GSD GitHub project <https://github.com/glotzerlab/gsd>`__ for more
+        information on GSD files.
 
     Note:
         When you use ``filter`` to select a subset of the whole system, `GSD`


### PR DESCRIPTION
## Description

Adds an asterisk to the topology properties. Adds a link to the GSD HOOMD schema.

## Motivation and context

Indicates that topology properties are specifically named.

Resolves #832.

## Change log

Not required.

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
