### PR TITLE
Snapshot dimension behavior change

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,7 +15,7 @@ v3.0.0-beta.2 (not yet released)
 *Changed*
 
 - ``hoomd.snapshot.ConfigurationData.dimensions`` is unsettable
-  and depends on the snapshot box. If :math:`box.Lz = 0` then
+  and depends on the snapshot box. If ``box.Lz = 0`` then
   the dimensions are 2 otherwise 3.
 - Building from source requires a C++14 compatible compiler.
 - Improved documentation.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,9 @@ v3.0.0-beta.2 (not yet released)
 
 *Changed*
 
+- ``hoomd.snapshot.ConfigurationData.dimensions`` is unsettable
+  and depends on the snapshot box. If :math:`box.Lz = 0` then
+  the dimensions are 2 otherwise 3.
 - Building from source requires a C++14 compatible compiler.
 - Improved documentation.
 - [breaking] Replace ``write.GSD`` argument ``overwrite`` with ``mode``.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,9 +14,9 @@ v3.0.0-beta.2 (not yet released)
 
 *Changed*
 
-- ``hoomd.snapshot.ConfigurationData.dimensions`` is unsettable
-  and depends on the snapshot box. If ``box.Lz = 0`` then
-  the dimensions are 2 otherwise 3.
+- ``hoomd.snapshot.ConfigurationData.dimensions`` is not settable and is
+  determined by the snapshot box. If ``box.Lz == 0``, the dimensions are 2
+  otherwise 3.
 - Building from source requires a C++14 compatible compiler.
 - Improved documentation.
 - [breaking] Replace ``write.GSD`` argument ``overwrite`` with ``mode``.

--- a/hoomd/conftest.py
+++ b/hoomd/conftest.py
@@ -71,9 +71,8 @@ def two_particle_snapshot_factory(device):
         if s.exists:
             box = [L, L, L, 0, 0, 0]
             if dimensions == 2:
-                box[2] = 1
+                box[2] = 0
             s.configuration.box = box
-            s.configuration.dimensions = dimensions
             s.particles.N = N
             # shift particle positions slightly in z so MPI tests pass
             s.particles.position[:] = [[-d / 2, 0, .1], [d / 2, 0, .1]]
@@ -109,9 +108,8 @@ def lattice_snapshot_factory(device):
         if s.exists:
             box = [n * a, n * a, n * a, 0, 0, 0]
             if dimensions == 2:
-                box[2] = 1
+                box[2] = 0
             s.configuration.box = box
-            s.configuration.dimensions = dimensions
 
             s.particles.N = n**dimensions
             s.particles.types = particle_types

--- a/hoomd/hpmc/pytest/test_small_box_2d.py
+++ b/hoomd/hpmc/pytest/test_small_box_2d.py
@@ -21,7 +21,6 @@ def one_square_simulation(simulation_factory):
     snap.particles.types = ['A']
     snap.particles.position[:] = [[0, 0, 0]]
     snap.configuration.box = [1.2, 1.2, 0, 0, 0, 0]
-    snap.configuration.dimensions = 2
 
     sim = simulation_factory(snap)
     mc = hoomd.hpmc.integrate.ConvexPolygon(seed=1)

--- a/hoomd/hpmc/pytest/test_small_box_3d.py
+++ b/hoomd/hpmc/pytest/test_small_box_3d.py
@@ -21,7 +21,6 @@ def one_cube_simulation(simulation_factory):
     snap.particles.types = ['A']
     snap.particles.position[:] = [[0, 0, 0]]
     snap.configuration.box = [1.2, 1.2, 1.2, 0, 0, 0]
-    snap.configuration.dimensions = 3
 
     sim = simulation_factory(snap)
     mc = hoomd.hpmc.integrate.ConvexPolyhedron(seed=1)

--- a/hoomd/md/pytest/test_thermo.py
+++ b/hoomd/md/pytest/test_thermo.py
@@ -115,9 +115,8 @@ def test_system_rotational_dof(simulation_factory, device):
 
     snap = hoomd.Snapshot(device.communicator)
     if snap.exists:
-        box= [10, 10, 10, 0, 0, 0]
+        box = [10, 10, 10, 0, 0, 0]
         snap.configuration.box = box
-        snap.configuration.dimensions = 3
         snap.particles.N = 3
         snap.particles.position[:] = [[0, 1, 0], [-1, 1, 0], [1, 1, 0]]
         snap.particles.velocity[:] = [[0, 0, 0], [0, -1, 0], [0, 1, 0]]

--- a/hoomd/pytest/test_snapshot.py
+++ b/hoomd/pytest/test_snapshot.py
@@ -63,8 +63,9 @@ def test_configuration(s):
         s.configuration.box = [10, 12, 7, 0.1, 0.4, 0.2]
         numpy.testing.assert_allclose(s.configuration.box, [10, 12, 7, 0.1, 0.4, 0.2])
 
-        s.configuration.dimensions = 2
-        assert s.configuration.dimensions == 2
+        with pytest.raises(AttributeError):
+            s.configuration.dimensions = 2
+        assert s.configuration.dimensions == 3
 
 
 def test_particles(s):

--- a/hoomd/snapshot.py
+++ b/hoomd/snapshot.py
@@ -25,8 +25,8 @@ class _ConfigurationData:
             new_box = hoomd.Box.from_box(box)
         except Exception:
             raise ValueError(
-                f"{box} is not convertible to a hoomd.Box object. "
-                f"using hoomd.Box.from_box")
+                f"{box} is not convertible to a hoomd.Box object using "
+                "hoomd.Box.from_box.")
         self._cpp_obj._dimensions = new_box.dimensions
         self._cpp_obj._global_box = new_box._cpp_obj
 

--- a/hoomd/snapshot.py
+++ b/hoomd/snapshot.py
@@ -25,8 +25,8 @@ class _ConfigurationData:
             new_box = hoomd.Box.from_box(box)
         except Exception:
             raise ValueError(
-                "{} is not convertible to a hoomd.Box object. "
-                "using hoomd.Box.from_box".format(box))
+                f"{box} is not convertible to a hoomd.Box object. "
+                f"using hoomd.Box.from_box")
         self._cpp_obj._dimensions = new_box.dimensions
         self._cpp_obj._global_box = new_box._cpp_obj
 

--- a/hoomd/snapshot.py
+++ b/hoomd/snapshot.py
@@ -10,10 +10,6 @@ class _ConfigurationData:
     def dimensions(self):
         return self._cpp_obj._dimensions
 
-    @dimensions.setter
-    def dimensions(self, d):
-        self._cpp_obj._dimensions = d
-
     @property
     def box(self):
         b = self._cpp_obj._global_box
@@ -31,6 +27,7 @@ class _ConfigurationData:
             raise ValueError(
                 "{} is not convertible to a hoomd.Box object. "
                 "using hoomd.Box.from_box".format(box))
+        self._cpp_obj._dimensions = new_box.dimensions
         self._cpp_obj._global_box = new_box._cpp_obj
 
 


### PR DESCRIPTION
`dimensions` can no longer be set, and is dependent on box.Lz. If `box.Lz
== 0` then `dimensions == 2` otherwise it equals 3.

<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should based on *maint*. -->
<!-- New features should based on *master*. -->

## Description

Changes `ConfigurationData.dimensions` to be unsettable and depend on the snapshot box. If `box.Lz == 0` then `dimensions == 2` otherwise 3.
<!-- Describe your changes in detail. -->

## Motivation and context

This helps keep behavior consistent with `hoomd.Box` and `hoomd.State.box`.
<!--- Why is this change required? What problem does it solve? -->

## How has this been tested?

Has not been tested directly.
<!--- Please describe in detail how you tested your changes. -->

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
hoomd.ConfigurationData.dimensions cannot be set and depends on box's z dimension.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
