### PR TITLE
Add __version__ as attribute of hoomd module.

### DIFF
--- a/hoomd/__init__.py
+++ b/hoomd/__init__.py
@@ -59,3 +59,5 @@ def _hoomd_sys_excepthook(type, value, traceback):
 
 
 sys.excepthook = _hoomd_sys_excepthook
+
+__version__ = version.version

--- a/hoomd/pytest/CMakeLists.txt
+++ b/hoomd/pytest/CMakeLists.txt
@@ -19,6 +19,7 @@ set(files __init__.py
           test_simulation.py
           test_table.py
           test_variant.py
+          test_version.py
           test_sorter.py
           pytest-openmpi.sh
     )

--- a/hoomd/pytest/test_version.py
+++ b/hoomd/pytest/test_version.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2009-2020 The Regents of the University of Michigan
+# This file is part of the HOOMD-blue project, released under the BSD 3-Clause
+# License.
+
+import hoomd
+
+def test_version():
+    """Test version information."""
+    assert hoomd.__version__


### PR DESCRIPTION
## Description

I added back `__version__` as an attribute of the hoomd module. This was originally added in v2.0 and was removed in #781.

**Edit:** I was pointed to a GitHub conversation where adding `__version__` [was explicitly rejected](https://github.com/glotzerlab/hoomd-blue/pull/781#discussion_r488637970). I was not aware of that conversation when making this PR (I didn't know why it had been removed in #781). I don't see any significant maintenance burden or user confusion from exposing `hoomd.__version__` and would encourage reconsideration if @joaander is open to it.

## Motivation and context

The `__version__` attribute is a standard way of exposing a package's version number. The [PEP 396](https://www.python.org/dev/peps/pep-0396/) has been deferred but this still seems like a de facto standard among scientific Python libraries (it's reliable enough that I use it for some of my own scripts to manage repositories I contribute to and haven't noticed issues before).

For a point of comparison with other complex libraries: h5py has additional version info (for HDF5, etc.) exposed in the `h5py.version` module but [exposes the actual version string](https://github.com/h5py/h5py/blob/27829cb3221dfe3e921eb745d69c47304327c0ae/h5py/__init__.py#L82) in `h5py.__version__`.

The Python Packaging Authority also recommends using `__version__`: https://packaging.python.org/guides/single-sourcing-package-version/

## How has this been tested?

I am creating a test module for version information.

## Change log

This is what the change log entry said for version 2.0 when `__version__` was added, so I copied it.
```
-  ``__version__`` is now available in the top level package
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
