### PR TITLE
Skip GPU tests when no GPU is present

### DIFF
--- a/hoomd/conftest.py
+++ b/hoomd/conftest.py
@@ -8,7 +8,7 @@ from hoomd import Simulation
 
 devices = [hoomd.device.CPU]
 if (hoomd.device.GPU.is_available()
-        and len(hoomd.device.gpu.get_available_devices()) > 0):
+        and len(hoomd.device.GPU.get_available_devices()) > 0):
     devices.append(hoomd.device.GPU)
 
 

--- a/hoomd/conftest.py
+++ b/hoomd/conftest.py
@@ -7,7 +7,8 @@ from hoomd.snapshot import Snapshot
 from hoomd import Simulation
 
 devices = [hoomd.device.CPU]
-if hoomd.device.GPU.is_available():
+if (hoomd.device.GPU.is_available()
+        and len(hoomd.device.gpu.get_available_devices()) > 0):
     devices.append(hoomd.device.GPU)
 
 


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should based on *maint*. -->
<!-- New features should based on *master*. -->

## Description

<!-- Describe your changes in detail. -->
Skip GPU tests when no GPU is present.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
This allows `pytest --pyargs hoomd` to succeed when HOOMD is compile with GPU support but their are no GPUs in the system (e.g. on a docker build in a CI platform)

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
Tested in the glotzerlab-software build.

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
*Changed*

- Skip GPU tests when no GPU is present.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
