### PR TITLE
Fix error in removing operations

### DIFF
--- a/hoomd/operation.py
+++ b/hoomd/operation.py
@@ -534,6 +534,13 @@ class _TriggeredOperation(Operation):
     def _attach(self):
         super()._attach()
 
+    def _update_param_dict(self):
+        if self._attached:
+            for key in self._param_dict:
+                if key == 'trigger':
+                    continue
+                self._param_dict[key] = getattr(self._cpp_obj, key)
+
 
 class Updater(_TriggeredOperation):
     """Base class for all HOOMD updaters.


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should based on *maint*. -->
<!-- New features should based on *master*. -->

## Description

Fixes an error that would occur if trying to remove a triggered operation after attaching. This will likely be fixed when `Updater` and `Writer` are made to own their own triggers.
<!-- Describe your changes in detail. -->

## Motivation and context

Fix behavior of hoomd.
<!--- Why is this change required? What problem does it solve? -->

<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves #???

## How has this been tested?

Tested locally to see if it fixes the bug I had.
<!--- Please describe in detail how you tested your changes. -->

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
Fix bug that caused an error when removing specific operations from a simulation's operations attribute.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
