### PR TITLE
Fix documentation of hoomd.logging.log

### DIFF
--- a/hoomd/logging.py
+++ b/hoomd/logging.py
@@ -292,18 +292,18 @@ def log(func=None, *, is_property=True, flag='scalar', default=True):
         func (`method`): class method to make loggable. If using non-default
             arguments, func should not be set.
         is_property (:obj:`bool`, optional): Whether to make the method a
-            property, defaults to True. Argument position only
+            property, defaults to True. Argument keyword only
         flag (:obj:`str`, optional): The string represention of the type of
             loggable quantity, defaults to 'scalar'. See
             `hoomd.logging.TypeFlags` for available types. Argument
-            position only
+            keyword only
         default (:obj:`bool`, optional): Whether the quantity should be logged
             by default, defaults to True. This is orthogonal to the loggable
             quantity's type. An example would be performance orientated
             loggable quantities.  Many users may not want to log such
             quantities even when logging other quantities of that type. The
             default flag allows for these to be pass over by
-            `hoomd.logging.Logger` objects by default.
+            `hoomd.logging.Logger` objects by default. Argument keyword only.
 
     Note:
         The namespace (where the loggable object is stored in the


### PR DESCRIPTION
## Description

Fixes documentation of `hoomd.logging.log` to correctly label arguments as keyword only.
<!-- Describe your changes in detail. -->

## Motivation and context

Fixes incorrect documentation.
<!--- Why is this change required? What problem does it solve? -->

<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves #???

## How has this been tested?

Documentation fix.
<!--- Please describe in detail how you tested your changes. -->

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

NA
<!-- Propose a change log entry. -->
```

```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
