### PR TITLE
Fix Table int Representation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,6 +24,7 @@ v3.0.0-beta.2 (not yet released)
 
 *Fixed*
 
+- `hoomd.write.Table` objects' formatting of `int` objects.
 - ``Simulation.run`` now ends with a ``KeyboardInterrupt`` exception when
   Jupyter interrupts the kernel.
 - Logging the state of specific objects with nested attributes.


### PR DESCRIPTION
## Description

Fixes the formatting of `int` objects in the `Table` writer. Prevents the use of scientific notation to represent `int` objects and always displays the full number now.
<!-- Describe your changes in detail. -->

## Motivation and context

Required for accurate storing and representing of large integers.

## How has this been tested?

Tested locally by examining `Table` output.
<!--- Please describe in detail how you tested your changes. -->

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
Fix `hoomd.write.Table` objects' formatting of `int` objects.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
