### PR TITLE
Make ParticleFilter objects picklable.

### DIFF
--- a/hoomd/filter/all_.py
+++ b/hoomd/filter/all_.py
@@ -21,3 +21,6 @@ class All(ParticleFilter, ParticleFilterAll):
     def __eq__(self, other):
         """Test for equality between two particle filters."""
         return type(self) == type(other)
+
+    def __reduce__(self):
+        return (type(self), tuple())

--- a/hoomd/filter/all_.py
+++ b/hoomd/filter/all_.py
@@ -23,4 +23,5 @@ class All(ParticleFilter, ParticleFilterAll):
         return type(self) == type(other)
 
     def __reduce__(self):
+        """Enable (deep)copying and pickling of `All` particle filters."""
         return (type(self), tuple())

--- a/hoomd/filter/set_.py
+++ b/hoomd/filter/set_.py
@@ -51,6 +51,9 @@ class _ParticleFilterSetOperations(ParticleFilter):
             return type(self) == type(other) and \
                 self._f == other._f and self._g == other._g
 
+    def __reduce__(self):
+        return (type(self), (self._f, self._g))
+
 
 class SetDifference(_ParticleFilterSetOperations,
                     _hoomd.ParticleFilterSetDifference):

--- a/hoomd/filter/set_.py
+++ b/hoomd/filter/set_.py
@@ -52,6 +52,7 @@ class _ParticleFilterSetOperations(ParticleFilter):
                 self._f == other._f and self._g == other._g
 
     def __reduce__(self):
+        """Enable (deep)copying and pickling of set based particle filters."""
         return (type(self), (self._f, self._g))
 
 

--- a/hoomd/filter/tags.py
+++ b/hoomd/filter/tags.py
@@ -37,3 +37,6 @@ class Tags(ParticleFilter, ParticleFilterTags):
     def tags(self):
         """list[int]: List of particle tags to select."""
         return self._tags
+
+    def __reduce__(self):
+        return (type(self), (self.tags,))

--- a/hoomd/filter/tags.py
+++ b/hoomd/filter/tags.py
@@ -39,4 +39,5 @@ class Tags(ParticleFilter, ParticleFilterTags):
         return self._tags
 
     def __reduce__(self):
+        """Enable (deep)copying and pickling of `Tags` particle filters."""
         return (type(self), (self.tags,))

--- a/hoomd/filter/type_.py
+++ b/hoomd/filter/type_.py
@@ -31,3 +31,6 @@ class Type(ParticleFilter, ParticleFilterType):
     def types(self):
         """list[str]: List of particle type names to select."""
         return self._types
+
+    def __reduce__(self):
+        return (type(self), (self.types,))

--- a/hoomd/filter/type_.py
+++ b/hoomd/filter/type_.py
@@ -33,4 +33,5 @@ class Type(ParticleFilter, ParticleFilterType):
         return self._types
 
     def __reduce__(self):
+        """Enable (deep)copying and pickling of `Type` particle filters."""
         return (type(self), (self.types,))

--- a/hoomd/pytest/test_filter.py
+++ b/hoomd/pytest/test_filter.py
@@ -6,6 +6,7 @@ from hoomd.filter.all_ import All
 from hoomd.snapshot import Snapshot
 from copy import deepcopy
 from itertools import combinations
+import pickle
 import numpy
 
 
@@ -186,3 +187,32 @@ def test_difference(make_filter_snapshot, simulation_factory, set_indices):
             assert difference_filter(sim.state) == type_filter1(sim.state)
         difference_filter = SetDifference(combo_filter, remaining_filter)
         assert difference_filter(sim.state) == combo_filter(sim.state)
+
+
+_filter_classes = [
+    All,
+    Tags,
+    Type,
+    SetDifference,
+    Union,
+    Intersection
+]
+
+_constructor_args = [
+    tuple(),
+    ([1, 2, 3],),
+    ({'a', 'b'},),
+    (Tags([1, 4, 5]), Type({'a'})),
+    (Tags([1, 4, 5]), Type({'a'})),
+    (Tags([1, 4, 5]), Type({'a'}))
+]
+
+
+@pytest.mark.parametrize(
+    'constructor, args', zip(_filter_classes, _constructor_args),
+    ids=lambda x: None if isinstance(x, tuple) else x.__name__)
+def test_pickling(constructor, args):
+    filter_ = constructor(*args)
+    pkled_filter = pickle.loads(pickle.dumps(filter_))
+    assert pkled_filter == filter_
+    assert hash(pkled_filter) == hash(filter_)


### PR DESCRIPTION
## Description

Makes `ParticleFilter` objects picklable using Python using __reduce__ to reconstruct the object. This prevents problems in the set filters and prevents needing to construct getter and setters in C++ to be able to pickle through pybind11's facilities.

## Motivation and context

Moving towards most HOOMD-blue object being picklable for restartability.

## How has this been tested?

Has been tested locally. Will be tested through unit tests before merging.

## Change log

<!-- Propose a change log entry. -->
```
Added: ParticleFilters are picklable.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
