### PR TITLE
Refactor BoxMC move selection

### DIFF
--- a/hoomd/hpmc/UpdaterBoxMC.cc
+++ b/hoomd/hpmc/UpdaterBoxMC.cc
@@ -936,7 +936,7 @@ void export_UpdaterBoxMC(py::module& m)
 void UpdaterBoxMC::updateChangedWeights()
     {
     // This line will need to be rewritten or updated when move types are added to the updater.
-    auto weights = std::vector<Scalar>{m_volume_weight, m_ln_volume_weight, m_length_weight, m_shear_weight, m_aspect_weight};
+    auto const weights = std::vector<Scalar>{m_volume_weight, m_ln_volume_weight, m_length_weight, m_shear_weight, m_aspect_weight};
     m_weight_partial_sums = std::vector<Scalar>(weights.size());
     std::partial_sum(weights.cbegin(), weights.cend(), m_weight_partial_sums.begin());
     }

--- a/hoomd/hpmc/UpdaterBoxMC.cc
+++ b/hoomd/hpmc/UpdaterBoxMC.cc
@@ -423,7 +423,7 @@ void UpdaterBoxMC::update(unsigned int timestep)
         if (m_prof) m_prof->pop();
         return;
         }
-    auto const selected = hoomd::detail::generate_canonical<Scalar>(rng) * weight_total; // generate a number on (0, sum_of_weights];
+    auto const selected = hoomd::detail::generate_canonical<Scalar>(rng) * weight_total; // generate a number on (0, weight_total];
     auto const move_type_select = std::distance(
         m_weight_partial_sums.cbegin(),
         std::lower_bound(m_weight_partial_sums.cbegin(), m_weight_partial_sums.cend(), selected)

--- a/hoomd/hpmc/UpdaterBoxMC.cc
+++ b/hoomd/hpmc/UpdaterBoxMC.cc
@@ -423,7 +423,11 @@ void UpdaterBoxMC::update(unsigned int timestep)
         if (m_prof) m_prof->pop();
         return;
         }
-    auto const selected = hoomd::detail::generate_canonical<Scalar>(rng) * weight_total; // generate a number on (0, weight_total];
+
+    // Generate a number between (0, weight_total]
+    auto const selected = hoomd::detail::generate_canonical<Scalar>(rng) * weight_total;
+    // Select the first move type whose partial sum of weights is greater than
+    // or equal to the generated value.
     auto const move_type_select = std::distance(
         m_weight_partial_sums.cbegin(),
         std::lower_bound(m_weight_partial_sums.cbegin(), m_weight_partial_sums.cend(), selected)

--- a/hoomd/hpmc/UpdaterBoxMC.cc
+++ b/hoomd/hpmc/UpdaterBoxMC.cc
@@ -416,7 +416,8 @@ void UpdaterBoxMC::update(unsigned int timestep)
     // Choose a move type
     // This line will need to be rewritten or updated when move types are added to the updater.
     auto weights = std::vector<Scalar>{m_volume_weight, m_ln_volume_weight, m_length_weight, m_shear_weight, m_aspect_weight};
-    auto weight_partial_sums = std::partial_sum(weights.cbegin(), weights.cend(), weight_sums.begin());
+    auto weight_partial_sums = std::vector<Scalar>(weights.size());
+    std::partial_sum(weights.cbegin(), weights.cend(), weight_partial_sums.begin());
     auto weight_total = weight_partial_sums.back();
     if (weight_total == 0.0)
         {

--- a/hoomd/hpmc/UpdaterBoxMC.h
+++ b/hoomd/hpmc/UpdaterBoxMC.h
@@ -13,6 +13,7 @@
 #include <hoomd/Variant.h>
 #include "hoomd/RandomNumbers.h"
 #include <cmath>
+#include <vector>
 
 #include "IntegratorHPMC.h"
 
@@ -96,6 +97,7 @@ class UpdaterBoxMC : public Updater
                 }
             // Calculate aspect ratio
             computeAspectRatios();
+            updateChangedWeights();
             }
 
         //! Gets parameters for box length moves as a dictionary
@@ -127,6 +129,7 @@ class UpdaterBoxMC : public Updater
             m_length_delta[0] = t[0].cast<Scalar>();
             m_length_delta[1] = t[1].cast<Scalar>();
             m_length_delta[2] = t[2].cast<Scalar>();
+            updateChangedWeights();
             }
 
         //! Gets parameters for box shear moves as a dictionary
@@ -168,6 +171,7 @@ class UpdaterBoxMC : public Updater
             m_shear_delta[1] = t[1].cast<Scalar>();
             m_shear_delta[2] = t[2].cast<Scalar>();
             m_shear_reduce = d["reduce"].cast<Scalar>();
+            updateChangedWeights();
             }
 
         //! Get parameters for box aspect moves as a dictionary
@@ -192,6 +196,7 @@ class UpdaterBoxMC : public Updater
             {
             m_aspect_weight = d["weight"].cast<Scalar>();
             m_aspect_delta = d["delta"].cast<Scalar>();
+            updateChangedWeights();
             }
 
         //! Calculate aspect ratios for use in isotropic volume changes
@@ -310,6 +315,8 @@ class UpdaterBoxMC : public Updater
 
         unsigned int m_seed;                        //!< Seed for pseudo-random number generator
 
+        std::vector<Scalar> m_weight_partial_sums;  //!< Partial sums of all weights used to select moves
+
         inline bool is_oversheared();               //!< detect oversheared box
         inline bool remove_overshear();             //!< detect and remove overshear
         inline bool box_resize(Scalar Lx,
@@ -333,6 +340,9 @@ class UpdaterBoxMC : public Updater
                                      //!< attempt specified box change and undo if overlaps generated
         inline bool safe_box(const Scalar newL[3], const unsigned int& Ndim);
                                                     //!< Perform appropriate checks for box validity
+
+        //! Update the internal vector of partial sums of weights
+        void updateChangedWeights();
     };
 
 //! Export UpdaterBoxMC to Python


### PR DESCRIPTION
## Description

This is a C++ refactoring that I [suggested in a comment](https://github.com/glotzerlab/hoomd-blue/pull/758#pullrequestreview-511026224) in #758.

## Motivation and context

This PR also caches the partial sums of weights for each move type rather than recomputing that on every move.

## How has this been tested?

Relying on existing tests to catch regressions -- I (or a reviewer who is familiar with the code) should look at those tests to ensure that this behaves as expected.

## Change log

```
Refactored C++ BoxMC move selection.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
