### PR TITLE
Fix Box Documentation and Motify Equality Checks

### DIFF
--- a/hoomd/box.py
+++ b/hoomd/box.py
@@ -87,7 +87,8 @@ class Box:
     .. rubric:: Factory Methods
 
     `Box` has factory methods to enable easier creation of boxes: `cube`,
-    `square`, and `from_matrix`. See the method documentation for usage.
+    `square`, `from_matrix`, and `from_box`. See the method documentation for
+    usage.
 
     Examples:
 
@@ -174,9 +175,9 @@ class Box:
         .. note:: Objects that can be converted to HOOMD-blue boxes include
                   lists like :code:`[Lx, Ly, Lz, xy, xz, yz]`,
                   dictionaries with keys
-                  :code:`'Lx', 'Ly', 'Lz', 'xy', 'xz', 'yz', 'dimensions'`,
+                  :code:`'Lx', 'Ly', 'Lz', 'xy', 'xz', 'yz',
                   objects with attributes
-                  :code:`Lx, Ly, Lz, xy, xz, yz, dimensions`,
+                  :code:`Lx, Ly, Lz, xy, xz, yz,
                   3x3 matrices (see `from_matrix`),
                   or existing :class:`hoomd.Box` objects.
 

--- a/hoomd/box.py
+++ b/hoomd/box.py
@@ -425,9 +425,13 @@ class Box:
             self.Lx, self.Ly, self.Lz, self.xy, self.xz, self.yz)
 
     def __eq__(self, other):
+        if not isinstance(other, Box):
+            return NotImplemented
         return self._cpp_obj == other._cpp_obj
 
     def __neq__(self, other):
+        if not isinstance(other, Box):
+            return NotImplemented
         return self._cpp_obj != other._cpp_obj
 
 #     def wrap(self, v, image=(0, 0, 0)):


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should based on *maint*. -->
<!-- New features should based on *master*. -->

## Description

Addresses #787 and uses ``NotImplemented`` as suggested in the Python data model for `__eq__` and `__neq__`.
<!-- Describe your changes in detail. -->

## Motivation and context
Corrects documentation.

Resolves #787

## How has this been tested?
Existing tests pass and are sufficient.
<!--- Please describe in detail how you tested your changes. -->

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
Changed: Box equality checking now returns `NotImplemented` for non-`hoomd.Box` objects.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
