### PR TITLE
Make Local Snapshots more Safe

### DIFF
--- a/hoomd/pytest/test_local_snapshot.py
+++ b/hoomd/pytest/test_local_snapshot.py
@@ -466,12 +466,19 @@ class _TestLocalSnapshots:
                 tags = getattr(snapshot_section, tag_name)
                 property_check(hoomd_buffer, property_dict, tags)
 
-    def test_run_failure(self, simulation_factory, base_snapshot):
+    def test_run_failure(self, simulation_factory):
         sim = simulation_factory()
         for lcl_snapshot_attr in self._lcl_snapshot_attrs:
             with getattr(sim.state, lcl_snapshot_attr) as data:
                 with pytest.raises(RuntimeError):
                     sim.run(1)
+
+    def test_setting_snapshot_failure(self, simulation_factory, base_snapshot):
+        sim = simulation_factory()
+        for lcl_snapshot_attr in self._lcl_snapshot_attrs:
+            with getattr(sim.state, lcl_snapshot_attr) as data:
+                with pytest.raises(RuntimeError):
+                    sim.state.snapshot = base_snapshot
 
 
 @pytest.mark.cpu

--- a/hoomd/pytest/test_local_snapshot.py
+++ b/hoomd/pytest/test_local_snapshot.py
@@ -445,7 +445,7 @@ class _TestLocalSnapshots:
                 getattr(getattr(data, section_name), prop_name), prop_dict, N)
 
     @pytest.mark.cupy_optional
-    def test_arrays_properties(self, simulation_factory, base_snapshot,
+    def test_arrays_properties(self, simulation_factory,
                                section_name_dict, affix, property_check):
         """This test makes extensive use of parameterizing in pytest.
 
@@ -465,6 +465,13 @@ class _TestLocalSnapshots:
                 hoomd_buffer = getattr(snapshot_section, property_name)
                 tags = getattr(snapshot_section, tag_name)
                 property_check(hoomd_buffer, property_dict, tags)
+
+    def test_run_failure(self, simulation_factory, base_snapshot):
+        sim = simulation_factory()
+        for lcl_snapshot_attr in self._lcl_snapshot_attrs:
+            with getattr(sim.state, lcl_snapshot_attr) as data:
+                with pytest.raises(RuntimeError):
+                    sim.run(1)
 
 
 @pytest.mark.cpu

--- a/hoomd/simulation.py
+++ b/hoomd/simulation.py
@@ -308,6 +308,9 @@ class Simulation(metaclass=Loggable):
             calls to `run` will result in duplicate output frames.
         """
         # check if initialization has occurred
+        if self._state._in_context_manager:
+            raise RuntimeError(
+                "Cannot call run inside of a local snapshot context manager.")
         if not hasattr(self, '_cpp_sys'):
             raise RuntimeError('Cannot run before state is set.')
         if not self.operations._scheduled:

--- a/hoomd/simulation.py
+++ b/hoomd/simulation.py
@@ -308,11 +308,11 @@ class Simulation(metaclass=Loggable):
             calls to `run` will result in duplicate output frames.
         """
         # check if initialization has occurred
+        if not hasattr(self, '_cpp_sys'):
+            raise RuntimeError('Cannot run before state is set.')
         if self._state._in_context_manager:
             raise RuntimeError(
                 "Cannot call run inside of a local snapshot context manager.")
-        if not hasattr(self, '_cpp_sys'):
-            raise RuntimeError('Cannot run before state is set.')
         if not self.operations._scheduled:
             self.operations._schedule()
 

--- a/hoomd/state.py
+++ b/hoomd/state.py
@@ -117,6 +117,9 @@ class State:
 
     @snapshot.setter
     def snapshot(self, snapshot):
+        if self._in_context_manager:
+            raise RuntimeError(
+                "Cannot set state to new snapshot inside local snapshot.")
         if self._simulation.device.communicator.rank == 0:
             if len(snapshot.particles.types) != len(self.particle_types):
                 raise RuntimeError(


### PR DESCRIPTION

<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should based on *maint*. -->
<!-- New features should based on *master*. -->

## Description

Prevent `hoomd.Simulation.run` from being called in a local snapshot context manager. This prevents the likely to be most common error in using local snapshots as the device that the data is on may switch multiple times during a run. This does not prevent operations that can operate on a simulation outside of a run from invalidating buffers (for instance if ``BoxResize`` could run on the GPU and a user was accessing the data on a CPU this could overwrite any changes they made). More crucial is this prevents a user from accessing data that has been freed as the result of setting the simulation's state to another snapshot, changing particle number, etc.
<!-- Describe your changes in detail. -->

## Motivation and context

Helps improve safety when using local snapshots.

## How has this been tested?

A test was added to ensure the proper errors were raised when attempting to run in a local snapshot context manager. A similar test for setting snapshots will soon be added.
<!--- Please describe in detail how you tested your changes. -->

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
Changed: attempting to run in a local snapshot context manager will now raise a RuntimeError.
Changed: attempting to set the state to a new snapshot in a local snapshot context manager will now raise a RuntimeError.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
