### PR TITLE
Fix sphinx documentation builds

### DIFF
--- a/hoomd/trigger.py
+++ b/hoomd/trigger.py
@@ -43,7 +43,7 @@ from hoomd import _hoomd
 # methods which should allow for pickling Python subclasses. pybind11's
 # facilities do not work as they prevent us from getting the attributes of the
 # class be pickled and unpickled. We manual pass and set the instance __dict__
-# instead and instantiate _hoomd.Trigger in __setstate__ (which as not already
+# instead and instantiate _hoomd.Trigger in __setstate__ (which has not already
 # been called as __init__ was not called).
 
 class Trigger(_hoomd.Trigger): # noqa D214

--- a/sphinx-doc/module-hoomd-filter.rst
+++ b/sphinx-doc/module-hoomd-filter.rst
@@ -21,6 +21,7 @@ hoomd.filter
 
 .. automodule:: hoomd.filter
     :synopsis: Particle selection filters.
+    :no-members:
 
     .. autoclass:: ParticleFilter()
         :special-members: __call__, __hash__, __eq__, __str__

--- a/sphinx-doc/module-hoomd-triggers.rst
+++ b/sphinx-doc/module-hoomd-triggers.rst
@@ -19,8 +19,7 @@ hoomd.trigger
 
 .. automodule:: hoomd.trigger
     :synopsis: Trigger events at specific time steps.
-    :members:
-    :undoc-members:
+    :no-members:
 
     .. autoclass:: After(timestep)
     .. autoclass:: And(triggers)

--- a/sphinx-doc/module-hoomd-variant.rst
+++ b/sphinx-doc/module-hoomd-variant.rst
@@ -16,7 +16,7 @@ hoomd.variant
 
 .. automodule:: hoomd.variant
     :synopsis: Values that vary as a function of time step.
-    :members:
+    :no-members:
 
     .. autoclass:: Constant(value)
     .. autoclass:: Cycle(A, B, t_start, t_A, t_AB, t_B, t_BA)


### PR DESCRIPTION

<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should based on *maint*. -->
<!-- New features should based on *master*. -->

## Description

Fixes documentation build errors associated with the release of sphinx v3.4.2. We now use the ``:no-members:`` directive in documenting triggers since we must show their signature manually as sphinx cannot autodetect it given its pybind11 class inheritance.
<!-- Describe your changes in detail. -->

## Motivation and context

Fixes documentation builds for version 3 of HOOMD-blue.
<!--- Why is this change required? What problem does it solve? -->

<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves #???

## How has this been tested?

Docs build locally with latest version of sphinx.
<!--- Please describe in detail how you tested your changes. -->

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```

```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
