### PR TITLE
Fix syntax warnings in python3.8

### DIFF
--- a/hoomd/md/constrain.py
+++ b/hoomd/md/constrain.py
@@ -151,7 +151,7 @@ class _constraint_force(hoomd.meta._metadata):
     def get_metadata(self):
         data = hoomd.meta._metadata.get_metadata(self)
         data['enabled'] = self.enabled
-        if self.name is not "":
+        if self.name != "":
             data['name'] = self.name
         return data
 

--- a/hoomd/md/force.py
+++ b/hoomd/md/force.py
@@ -212,7 +212,7 @@ class _force(hoomd.meta._metadata):
         data = hoomd.meta._metadata.get_metadata(self)
         data['enabled'] = self.enabled
         data['log'] = self.log
-        if self.name is not "":
+        if self.name != "":
             data['name'] = self.name
 
         return data
@@ -447,7 +447,7 @@ class active(_force):
 
         # assign constraints
         if (constraint is not None):
-            if (constraint.__class__.__name__ is "constraint_ellipsoid"):
+            if (constraint.__class__.__name__ == "constraint_ellipsoid"):
                 P = constraint.P
                 rx = constraint.rx
                 ry = constraint.ry


### PR DESCRIPTION
## Description

Fix warnings about comparisons with `is` instead of `==` for literal strings that I found in python 3.8. I know you are focused on 3.0, so I based on this off the `2.9` branch as a small patch (not sure if that's right).

## How has this been tested?

No test needed, followed the interpreter's suggestion.

## Change log

```
* Fix syntax warnings in ``md.force`` and ``md.constrain``.
```

## Checklist:

- [X] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [X] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [X] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
