### PR TITLE
Convert NPH to v3 API

### DIFF
--- a/hoomd/md/methods.py
+++ b/hoomd/md/methods.py
@@ -487,17 +487,13 @@ class NPH(_Method):
     explicitly reversible and measure-preserving integration scheme. It allows for fully deformable simulation
     cells and uses the same underlying integrator as :py:class:`NPT` (with *nph=True*).
 
-    The available options are identical to those of :py:class:`NPT`, except that *kT* cannot be specified.
-    For further information, refer to the documentation of :py:class:`NPT`.
-
     Note:
-         A time scale *tauP* for the relaxation of the barostat is required. This is defined as the
-         relaxation time the barostat would have at an average temperature *T_0 = 1*, and it
-         is related to the internally used (Andersen) Barostat mass :math:`W` via
-         :math:`W=d N T_0 \tau_P^2`, where :math:`d` is the dimensionality and :math:`N` the number
-         of particles.
-
-    :py:class:`NPH` is an integration method and must be used with ``mode_standard``.
+        Coupling constant for barostat `tauS` should be set within appropriate
+        range for pressure and volume to fluctuate in reasonable rate and
+        equilibrate. Too small `tauS` can cause abrupt fluctuation, whereas too
+        large `tauS` would take long time to equilibrate. In most of systems,
+        recommended value for `tauS` is ``1000 * dt``, where ``dt`` is the
+        length of the time step.
 
     Examples::
 

--- a/hoomd/md/methods.py
+++ b/hoomd/md/methods.py
@@ -615,7 +615,7 @@ class NPH(_Method):
             seed (int): Random number seed
 
         `thermalize_barostat_dof` sets a random value for the
-        momentum :math:`\xi` and the barostat :math:`\nu_{\mathrm{ij}}`. Call
+        barostat :math:`\nu_{\mathrm{ij}}`. Call
         `thermalize_barostat_dof` to set a new random state for
         the barostat.
 

--- a/hoomd/md/methods.py
+++ b/hoomd/md/methods.py
@@ -546,7 +546,7 @@ class NPH(_Method):
             filter=ParticleFilter,
             kT=Variant,
             S=OnlyIf(to_type_converter((Variant,) * 6),
-                     preprocess=self.__preprocess_stress),
+                     preprocess=self._preprocess_stress),
             tauS=float(tauS),
             couple=str(couple),
             box_dof=(bool,) * 6,
@@ -588,7 +588,8 @@ class NPH(_Method):
         # Attach param_dict and typeparam_dict
         super()._attach()
 
-    def __preprocess_stress(self, value):
+    @staticmethod
+    def _preprocess_stress(value):
         if isinstance(value, Sequence):
             if len(value) != 6:
                 raise ValueError(

--- a/hoomd/md/methods.py
+++ b/hoomd/md/methods.py
@@ -540,7 +540,7 @@ class NPH(_Method):
                  S,
                  tauS,
                  couple,
-                 box_dof=[True, True, True, False, False, False],
+                 box_dof=(True, True, True, False, False, False),
                  rescale_all=False,
                  gamma=0.0):
         # store metadata

--- a/hoomd/md/methods.py
+++ b/hoomd/md/methods.py
@@ -483,12 +483,6 @@ class NPH(_Method):
         gamma (`float`): Dimensionless damping factor for the box degrees of
             freedom, Default to 0.
 
-    :py:class:`NPH` performs constant pressure, constant enthalpy (NPH)
-    simulations using a Martyna-Tobias-Klein barostat, an explicitly reversible
-    and measure-preserving integration scheme. It allows for fully deformable
-    simulation cells and uses the same underlying integrator as :py:class:`NPT`
-    (with *nph=True*).
-
     Note:
         Coupling constant for barostat `tauS` should be set within appropriate
         range for pressure and volume to fluctuate in reasonable rate and

--- a/hoomd/md/methods.py
+++ b/hoomd/md/methods.py
@@ -531,14 +531,6 @@ class NPH(_Method):
         gamma (float): Dimensionless damping factor for the box degrees of
             freedom.
 
-        translational_thermostat_dof (tuple[float, float]): Additional degrees
-            of freedom for the translational thermostat (:math:`\xi`,
-            :math:`\eta`)
-
-        rotational_thermostat_dof (tuple[float, float]): Additional degrees
-            of freedom for the rotational thermostat (:math:`\xi_\mathrm{rot}`,
-            :math:`\eta_\mathrm{rot}`)
-
         barostat_dof (tuple[float, float, float, float, float, float]):
             Additional degrees of freedom for the barostat (:math:`\nu_{xx}`,
             :math:`\nu_{xy}`, :math:`\nu_{xz}`, :math:`\nu_{yy}`,

--- a/hoomd/md/methods.py
+++ b/hoomd/md/methods.py
@@ -455,7 +455,7 @@ class NPT(_Method):
 
 
 class NPH(NPT):
-    R""" NPH Integration via MTK barostat-thermostat..
+    r"""NPH Integration via MTK barostat-thermostat.
 
     Args:
         filter (`hoomd.filter.ParticleFilter`): Subset of particles on which to

--- a/hoomd/md/methods.py
+++ b/hoomd/md/methods.py
@@ -503,7 +503,7 @@ class NPH(NPT):
 
     Examples::
 
-        nph = hoomd.md.methods.NPH(filter=hoomd.filter.All(), tau=1.0, tauS = 1.2, S=2.0)
+        nph = hoomd.md.methods.NPH(filter=hoomd.filter.All(), tauS = 1.2, S=2.0)
         # orthorhombic symmetry
         nph = hoomd.md.methods.NPH(filter=hoomd.filter.All(), tau=1.0, tauS = 1.2, S=2.0, couple="none")
         # tetragonal symmetry

--- a/hoomd/md/methods.py
+++ b/hoomd/md/methods.py
@@ -584,7 +584,7 @@ class NPH(NPT):
             run(100)
 
         """
-        self.cpp_method.setRandomizeVelocitiesParams(kT, seed)
+        self._cpp_obj.setRandomizeVelocitiesParams(kT, seed)
 
 
 class NVE(_Method):

--- a/hoomd/md/methods.py
+++ b/hoomd/md/methods.py
@@ -616,41 +616,35 @@ class NPH(_Method):
         else:
             return (value, value, value, 0, 0, 0)
 
-    def randomize_velocities(self, kT, seed):
-        R""" Assign random velocities and angular momenta to particles in the
-        group, sampling from the Maxwell-Boltzmann distribution. This method
-        considers the dimensionality of the system and particle anisotropy, and
-        removes drift (the center of mass velocity).
-
-        .. versionadded:: 2.3
-
-        Starting in version 2.5, `randomize_velocities` also chooses random values
-        for the internal integrator variables.
+    def thermalize_barostat_dof(self, seed):
+        r"""Set the barostat momentum to random values.
 
         Args:
-            kT (float): Temperature (in energy units)
             seed (int): Random number seed
 
+        `thermalize_barostat_dof` sets a random value for the
+        momentum :math:`\xi` and the barostat :math:`\nu_{\mathrm{ij}}`. Call
+        `thermalize_barostat_dof` to set a new random state for
+        the barostat.
+
+        .. important::
+            You must call `Simulation.run` before
+            `thermalize_barostat_dof`. Call ``run(steps=0)`` to
+            prepare a newly created `Simulation`.
+
+        .. seealso:: `State.thermalize_particle_momenta`
+
         Note:
-            Randomization is applied at the start of the next call to ```hoomd.run```.
-
-        Example::
-
-        constant_s = [hoomd.variant.Constant(1.0),
-                      hoomd.variant.Constant(2.0),
-                      hoomd.variant.Constant(3.0),
-                      hoomd.variant.Constant(0.125),
-                      hoomd.variant.Constant(.25),
-                      hoomd.variant.Constant(.5)]
-        nph = hoomd.md.methods.NPH(filter=hoomd.filter.All(),
-                                   tau=2.0,
-                                   S=constant_s,
-                                   tauS=2.0,
-                                   couple='xyz')
-            run(100)
-
+            The seed for the pseudorandom number stream includes the
+            simulation timestep and the provided *seed*.
         """
-        self._cpp_obj.setRandomizeVelocitiesParams(kT, seed)
+        if not self._attached:
+            raise RuntimeError(
+                "Call Simulation.run(0) before"
+                "thermalize_thermostat_and_barostat_dof")
+
+        self._cpp_obj.thermalizeThermostatAndBarostatDOF(
+            seed, self._simulation.timestep)
 
 
 class NVE(_Method):

--- a/hoomd/md/methods.py
+++ b/hoomd/md/methods.py
@@ -461,8 +461,6 @@ class NPH(_Method):
         filter (`hoomd.filter.ParticleFilter`): Subset of particles on which to
             apply this method.
 
-        tau (`float`): Coupling constant for the thermostat (in time units).
-
         S (`list` [ `hoomd.variant.Variant` ] or `float`): Stress components set
             point for the barostat (in pressure units).  In Voigt notation:
             :math:`[S_{xx}, S_{yy}, S_{zz}, S_{yz}, S_{xz}, S_{xy}]`.  In case
@@ -505,18 +503,16 @@ class NPH(_Method):
 
         nph = hoomd.md.methods.NPH(filter=hoomd.filter.All(), tauS = 1.2, S=2.0)
         # orthorhombic symmetry
-        nph = hoomd.md.methods.NPH(filter=hoomd.filter.All(), tau=1.0, tauS = 1.2, S=2.0, couple="none")
+        nph = hoomd.md.methods.NPH(filter=hoomd.filter.All(), tauS = 1.2, S=2.0, couple="none")
         # tetragonal symmetry
-        nph = hoomd.md.methods.NPH(filter=hoomd.filter.All(), tau=1.0, tauS = 1.2, S=2.0, couple="xy")
+        nph = hoomd.md.methods.NPH(filter=hoomd.filter.All(), tauS = 1.2, S=2.0, couple="xy")
         # triclinic symmetry
-        nph = hoomd.md.methods.NPH(filter=hoomd.filter.All(), tau=1.0, tauS = 1.2, S=2.0, couple="none", rescale_all=True)
+        nph = hoomd.md.methods.NPH(filter=hoomd.filter.All(), tauS = 1.2, S=2.0, couple="none", rescale_all=True)
         integrator = hoomd.md.Integrator(dt=0.005, methods=[nph], forces=[lj])
 
     Attributes:
         filter (hoomd.filter.ParticleFilter): Subset of particles on which to
             apply this method.
-
-        tau (float): Coupling constant for the thermostat (in time units).
 
         S (List[hoomd.variant.Variant]): Stress components set
             point for the barostat (in pressure units).
@@ -552,12 +548,11 @@ class NPH(_Method):
             :math:`\nu_{xy}`, :math:`\nu_{xz}`, :math:`\nu_{yy}`,
             :math:`\nu_{yz}`, :math:`\nu_{zz}`)
     """
-    def __init__(self, filter, tau, S, tauS, couple, box_dof=[True,True,True,False,False,False], rescale_all=False, gamma=0.0):
+    def __init__(self, filter, S, tauS, couple, box_dof=[True,True,True,False,False,False], rescale_all=False, gamma=0.0):
         # store metadata
         param_dict = ParameterDict(
             filter=ParticleFilter,
             kT=Variant,
-            tau=float(tau),
             S=OnlyIf(to_type_converter((Variant,)*6), preprocess=self.__preprocess_stress),
             tauS=float(tauS),
             couple=str(couple),
@@ -605,7 +600,7 @@ class NPH(_Method):
                                 thermo_group,
                                 thermo_half_step,
                                 thermo_full_step,
-                                self.tau,
+                                1.0,
                                 self.tauS,
                                 self.kT,
                                 self.S,

--- a/hoomd/md/methods.py
+++ b/hoomd/md/methods.py
@@ -555,8 +555,6 @@ class NPH(_Method):
                  S=S,
                  couple=couple,
                  box_dof=box_dof,
-                 translational_thermostat_dof=(0, 0),
-                 rotational_thermostat_dof=(0, 0),
                  barostat_dof=(0, 0, 0, 0, 0, 0)))
 
         # set defaults

--- a/hoomd/md/methods.py
+++ b/hoomd/md/methods.py
@@ -508,9 +508,8 @@ class NPH(_Method):
         filter (hoomd.filter.ParticleFilter): Subset of particles on which to
             apply this method.
 
-        S (List[hoomd.variant.Variant]): Stress components set
-            point for the barostat (in pressure units). Converted to a tuple
-            during NPH instantiation.  In Voigt notation,
+        S (tuple[hoomd.variant.Variant, hoomd.variant.Variant, hoomd.variant.Variant, hoomd.variant.Variant, hoomd.variant.Variant, hoomd.variant.Variant]): Stress components set
+            point for the barostat (in pressure units). In Voigt notation,
             :math:`[S_{xx}, S_{yy}, S_{zz}, S_{yz}, S_{xz}, S_{xy}]`. Stress can
             be reset after method object is created. For example, An isoropic
             pressure can be set by ``nph.S = 4.``
@@ -520,8 +519,8 @@ class NPH(_Method):
         couple (str): Couplings of diagonal elements of the stress tensor,
             can be "none", "xy", "xz","yz", or "all".
 
-        box_dof(List[bool]): Box degrees of freedom with six boolean elements
-            corresponding to x, y, z, xy, xz, yz, each.
+        box_dof(tuple[bool, bool, bool, bool, bool, bool]): Box degrees of freedom
+            with six boolean elements corresponding to x, y, z, xy, xz, yz, each.
 
         rescale_all (bool): if True, rescale all particles, not only those in
             the group.

--- a/hoomd/md/methods.py
+++ b/hoomd/md/methods.py
@@ -483,9 +483,11 @@ class NPH(_Method):
         gamma (`float`): Dimensionless damping factor for the box degrees of
             freedom, Default to 0.
 
-    :py:class:`NPH` performs constant pressure, constant enthalpy (NPH) simulations using a Martyna-Tobias-Klein barostat, an
-    explicitly reversible and measure-preserving integration scheme. It allows for fully deformable simulation
-    cells and uses the same underlying integrator as :py:class:`NPT` (with *nph=True*).
+    :py:class:`NPH` performs constant pressure, constant enthalpy (NPH)
+    simulations using a Martyna-Tobias-Klein barostat, an explicitly reversible
+    and measure-preserving integration scheme. It allows for fully deformable
+    simulation cells and uses the same underlying integrator as :py:class:`NPT`
+    (with *nph=True*).
 
     Note:
         Coupling constant for barostat `tauS` should be set within appropriate
@@ -536,15 +538,24 @@ class NPH(_Method):
             :math:`\nu_{xy}`, :math:`\nu_{xz}`, :math:`\nu_{yy}`,
             :math:`\nu_{yz}`, :math:`\nu_{zz}`)
     """
-    def __init__(self, filter, S, tauS, couple, box_dof=[True,True,True,False,False,False], rescale_all=False, gamma=0.0):
+
+    def __init__(self,
+                 filter,
+                 S,
+                 tauS,
+                 couple,
+                 box_dof=[True, True, True, False, False, False],
+                 rescale_all=False,
+                 gamma=0.0):
         # store metadata
         param_dict = ParameterDict(
             filter=ParticleFilter,
             kT=Variant,
-            S=OnlyIf(to_type_converter((Variant,)*6), preprocess=self.__preprocess_stress),
+            S=OnlyIf(to_type_converter((Variant,) * 6),
+                     preprocess=self.__preprocess_stress),
             tauS=float(tauS),
             couple=str(couple),
-            box_dof=(bool,)*6,
+            box_dof=(bool,) * 6,
             rescale_all=bool(rescale_all),
             gamma=float(gamma),
             barostat_dof=(float, float, float, float, float, float))
@@ -572,25 +583,13 @@ class NPH(_Method):
         cpp_sys_def = self._simulation.state._cpp_sys_def
         thermo_group = self._simulation.state._get_group(self.filter)
 
-        thermo_half_step = thermo_cls(cpp_sys_def,
-                                      thermo_group,
-                                      "")
+        thermo_half_step = thermo_cls(cpp_sys_def, thermo_group, "")
 
-        thermo_full_step = thermo_cls(cpp_sys_def,
-                                      thermo_group,
-                                      "")
+        thermo_full_step = thermo_cls(cpp_sys_def, thermo_group, "")
 
-        self._cpp_obj = cpp_cls(cpp_sys_def,
-                                thermo_group,
-                                thermo_half_step,
-                                thermo_full_step,
-                                1.0,
-                                self.tauS,
-                                self.kT,
-                                self.S,
-                                self.couple,
-                                self.box_dof,
-                                True)
+        self._cpp_obj = cpp_cls(cpp_sys_def, thermo_group, thermo_half_step,
+                                thermo_full_step, 1.0, self.tauS, self.kT,
+                                self.S, self.couple, self.box_dof, True)
 
         # Attach param_dict and typeparam_dict
         super()._attach()
@@ -627,9 +626,8 @@ class NPH(_Method):
             simulation timestep and the provided *seed*.
         """
         if not self._attached:
-            raise RuntimeError(
-                "Call Simulation.run(0) before"
-                "thermalize_thermostat_and_barostat_dof")
+            raise RuntimeError("Call Simulation.run(0) before"
+                               "thermalize_thermostat_and_barostat_dof")
 
         self._cpp_obj.thermalizeThermostatAndBarostatDOF(
             seed, self._simulation.timestep)

--- a/hoomd/md/methods.py
+++ b/hoomd/md/methods.py
@@ -492,15 +492,16 @@ class NPH(_Method):
         length of the time step.
 
     Examples::
-
-        nph = hoomd.md.methods.NPH(filter=hoomd.filter.All(), tauS = 1.2, S=2.0)
+        dt = 0.005
+        tauS = 1000 * dt
+        nph = hoomd.md.methods.NPH(filter=hoomd.filter.All(), tauS=tauS, S=2.0)
         # orthorhombic symmetry
-        nph = hoomd.md.methods.NPH(filter=hoomd.filter.All(), tauS = 1.2, S=2.0, couple="none")
+        nph = hoomd.md.methods.NPH(filter=hoomd.filter.All(), tauS=tauS, S=2.0, couple="none")
         # tetragonal symmetry
-        nph = hoomd.md.methods.NPH(filter=hoomd.filter.All(), tauS = 1.2, S=2.0, couple="xy")
+        nph = hoomd.md.methods.NPH(filter=hoomd.filter.All(), tauS=tauS, S=2.0, couple="xy")
         # triclinic symmetry
-        nph = hoomd.md.methods.NPH(filter=hoomd.filter.All(), tauS = 1.2, S=2.0, couple="none", rescale_all=True)
-        integrator = hoomd.md.Integrator(dt=0.005, methods=[nph], forces=[lj])
+        nph = hoomd.md.methods.NPH(filter=hoomd.filter.All(), tauS=tauS, S=2.0, couple="none", rescale_all=True)
+        integrator = hoomd.md.Integrator(dt=dt, methods=[nph], forces=[lj])
 
     Attributes:
         filter (hoomd.filter.ParticleFilter): Subset of particles on which to

--- a/hoomd/md/methods.py
+++ b/hoomd/md/methods.py
@@ -485,7 +485,7 @@ class NPH(NPT):
         gamma (`float`): Dimensionless damping factor for the box degrees of
             freedom, Default to 0.
 
-    :py:class:`NPH` performs constant pressure (NPH) simulations using a Martyna-Tobias-Klein barostat, an
+    :py:class:`NPH` performs constant pressure, constant enthalpy (NPH) simulations using a Martyna-Tobias-Klein barostat, an
     explicitly reversible and measure-preserving integration scheme. It allows for fully deformable simulation
     cells and uses the same underlying integrator as :py:class:`NPT` (with *nph=True*).
 

--- a/hoomd/md/methods.py
+++ b/hoomd/md/methods.py
@@ -547,8 +547,6 @@ class NPH(_Method):
             box_dof=(bool,)*6,
             rescale_all=bool(rescale_all),
             gamma=float(gamma),
-            translational_thermostat_dof=(float, float),
-            rotational_thermostat_dof=(float, float),
             barostat_dof=(float, float, float, float, float, float))
 
         param_dict.update(

--- a/hoomd/md/methods.py
+++ b/hoomd/md/methods.py
@@ -549,20 +549,23 @@ class NPH(_Method):
             kT=Variant,
             S=OnlyIf(to_type_converter((Variant,) * 6),
                      preprocess=self._preprocess_stress),
-            tauS=float(tauS),
-            couple=str(couple),
+            tauS=float,
+            couple=str,
             box_dof=(bool,) * 6,
-            rescale_all=bool(rescale_all),
-            gamma=float(gamma),
-            barostat_dof=(float, float, float, float, float, float))
+            rescale_all=bool,
+            gamma=float,
+            barostat_dof=(float,) * 6)
 
         param_dict.update(
             dict(filter=filter,
                  kT=hoomd.variant.Constant(1.0),
                  S=S,
-                 couple=couple,
-                 box_dof=box_dof,
-                 barostat_dof=(0, 0, 0, 0, 0, 0)))
+                 tauS=float(tauS),
+                 couple=str(couple),
+                 box_dof=tuple(box_dof),
+                 rescale_all=bool(rescale_all),
+                 gamma=float(gamma),
+                 barostat_dof=(0.0, 0.0, 0.0, 0.0, 0.0, 0.0)))
 
         # set defaults
         self._param_dict.update(param_dict)

--- a/hoomd/md/methods.py
+++ b/hoomd/md/methods.py
@@ -461,7 +461,7 @@ class NPH(_Method):
         filter (`hoomd.filter.ParticleFilter`): Subset of particles on which to
             apply this method.
 
-        S (`list` [ `hoomd.variant.Variant` ] or `float`): Stress components set
+        S (`tuple` [ `hoomd.variant.Variant` ] or `float`): Stress components set
             point for the barostat (in pressure units). Converted to a tuple 
             during NPH instantiation.  In Voigt notation:
             :math:`[S_{xx}, S_{yy}, S_{zz}, S_{yz}, S_{xz}, S_{xy}]`.  In case
@@ -472,7 +472,7 @@ class NPH(_Method):
         couple (`str`): Couplings of diagonal elements of the stress tensor,
             can be "none", "xy", "xz","yz", or "all", default to "all".
 
-        box_dof(`list` [ `bool` ]): Box degrees of freedom with six boolean
+        box_dof(`tuple` [ `bool` ]): Box degrees of freedom with six boolean
             elements corresponding to x, y, z, xy, xz, yz, each. Default to
             [True,True,True,False,False,False]). If turned on to True,
             rescale corresponding lengths or tilt factors and components of

--- a/hoomd/md/methods.py
+++ b/hoomd/md/methods.py
@@ -462,7 +462,8 @@ class NPH(_Method):
             apply this method.
 
         S (`list` [ `hoomd.variant.Variant` ] or `float`): Stress components set
-            point for the barostat (in pressure units).  In Voigt notation:
+            point for the barostat (in pressure units). Converted to a tuple 
+            during NPH instantiation.  In Voigt notation:
             :math:`[S_{xx}, S_{yy}, S_{zz}, S_{yz}, S_{xz}, S_{xy}]`.  In case
             of isotropic pressure P (:math:`[p, p, p, 0, 0, 0]`), use ``S = p``.
 
@@ -508,11 +509,11 @@ class NPH(_Method):
             apply this method.
 
         S (List[hoomd.variant.Variant]): Stress components set
-            point for the barostat (in pressure units).
-            In Voigt notation,
+            point for the barostat (in pressure units). Converted to a tuple
+            during NPH instantiation.  In Voigt notation,
             :math:`[S_{xx}, S_{yy}, S_{zz}, S_{yz}, S_{xz}, S_{xy}]`. Stress can
             be reset after method object is created. For example, An isoropic
-            pressure can be set by ``npt.S = 4.``
+            pressure can be set by ``nph.S = 4.``
 
         tauS (float): Coupling constant for the barostat (in time units).
 

--- a/hoomd/md/methods.py
+++ b/hoomd/md/methods.py
@@ -454,7 +454,7 @@ class NPT(_Method):
             seed, self._simulation.timestep)
 
 
-class NPH(NPT):
+class NPH(_Method):
     r"""NPH Integration via MTK barostat-thermostat.
 
     Args:

--- a/hoomd/md/pytest/test_methods.py
+++ b/hoomd/md/pytest/test_methods.py
@@ -219,78 +219,72 @@ def test_npt_attributes():
 def test_nph_attributes():
     """Test attributes of the NPT integrator before attaching."""
     all_ = hoomd.filter.All()
-    constant_t = hoomd.variant.Constant(2.0)
     constant_s = [hoomd.variant.Constant(1.0),
                   hoomd.variant.Constant(2.0),
                   hoomd.variant.Constant(3.0),
                   hoomd.variant.Constant(0.125),
                   hoomd.variant.Constant(.25),
                   hoomd.variant.Constant(.5)]
-    npt = hoomd.md.methods.NPH(filter = all_, kT=constant_t, tau=2.0,
-                               S = constant_s,
-                               tauS = 2.0,
+    nph = hoomd.md.methods.NPH(filter=all_, tau=2.0,
+                               S=constant_s,
+                               tauS=2.0,
                                couple='xyz')
 
-    assert npt.filter is all_
-    assert npt.kT is constant_t
-    assert npt.tau == 2.0
-    assert len(npt.S) == 6
+    assert nph.filter is all_
+    assert nph.tau == 2.0
+    assert len(nph.S) == 6
     for i in range(6):
-        assert npt.S[i] is constant_s[i]
-    assert npt.tauS == 2.0
-    assert npt.box_dof == (True,True,True,False,False,False)
-    assert npt.couple == 'xyz'
-    assert not npt.rescale_all
-    assert npt.gamma == 0.0
+        assert nph.S[i] is constant_s[i]
+    assert nph.tauS == 2.0
+    assert nph.box_dof == (True,True,True,False,False,False)
+    assert nph.couple == 'xyz'
+    assert not nph.rescale_all
+    assert nph.gamma == 0.0
 
     type_A = hoomd.filter.Type(['A'])
-    npt.filter = type_A
-    assert npt.filter is type_A
+    nph.filter = type_A
+    assert nph.filter is type_A
 
-    ramp = hoomd.variant.Ramp(1, 2, 1000000, 2000000)
-    npt.kT = ramp
-    assert npt.kT is ramp
-
-    npt.tau = 10.0
-    assert npt.tau == 10.0
+    nph.tau = 10.0
+    assert nph.tau == 10.0
 
     ramp_s = [hoomd.variant.Ramp(1.0, 4.0, 1000, 10000),
-                  hoomd.variant.Ramp(2.0, 4.0, 1000, 10000),
-                  hoomd.variant.Ramp(3.0, 4.0, 1000, 10000),
-                  hoomd.variant.Ramp(0.125, 4.0, 1000, 10000),
-                  hoomd.variant.Ramp(.25, 4.0, 1000, 10000),
-                  hoomd.variant.Ramp(.5, 4.0, 1000, 10000)]
-    npt.S = ramp_s
-    assert len(npt.S) == 6
+              hoomd.variant.Ramp(2.0, 4.0, 1000, 10000),
+              hoomd.variant.Ramp(3.0, 4.0, 1000, 10000),
+              hoomd.variant.Ramp(0.125, 4.0, 1000, 10000),
+              hoomd.variant.Ramp(.25, 4.0, 1000, 10000),
+              hoomd.variant.Ramp(.5, 4.0, 1000, 10000)]
+    nph.S = ramp_s
+    assert len(nph.S) == 6
     for i in range(6):
-        assert npt.S[i] is ramp_s[i]
+        assert nph.S[i] is ramp_s[i]
 
-    npt.tauS = 10.0
-    assert npt.tauS == 10.0
+    nph.tauS = 10.0
+    assert nph.tauS == 10.0
 
-    npt.box_dof = (True,False,False,False,True,False)
-    assert npt.box_dof == (True,False,False,False,True,False)
+    nph.box_dof = (True,False,False,False,True,False)
+    assert nph.box_dof == (True,False,False,False,True,False)
 
-    npt.couple = 'none'
-    assert npt.couple == 'none'
+    nph.couple = 'none'
+    assert nph.couple == 'none'
 
-    npt.rescale_all = True
-    assert npt.rescale_all
+    nph.rescale_all = True
+    assert nph.rescale_all
 
-    npt.gamma = 2.0
-    assert npt.gamma == 2.0
+    nph.gamma = 2.0
+    assert nph.gamma == 2.0
 
-    assert npt.translational_thermostat_dof == (0.0, 0.0)
-    npt.translational_thermostat_dof = (0.125, 0.5)
-    assert npt.translational_thermostat_dof == (0.125, 0.5)
+    assert nph.translational_thermostat_dof == (0.0, 0.0)
+    nph.translational_thermostat_dof = (0.125, 0.5)
+    assert nph.translational_thermostat_dof == (0.125, 0.5)
 
-    assert npt.rotational_thermostat_dof == (0.0, 0.0)
-    npt.rotational_thermostat_dof = (0.5, 0.25)
-    assert npt.rotational_thermostat_dof == (0.5, 0.25)
+    assert nph.rotational_thermostat_dof == (0.0, 0.0)
+    nph.rotational_thermostat_dof = (0.5, 0.25)
+    assert nph.rotational_thermostat_dof == (0.5, 0.25)
 
-    assert npt.barostat_dof == (0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
-    npt.barostat_dof = (1.0, 2.0, 4.0, 6.0, 8.0, 10.0)
-    assert npt.barostat_dof == (1.0, 2.0, 4.0, 6.0, 8.0, 10.0)
+    assert nph.barostat_dof == (0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
+    nph.barostat_dof = (1.0, 2.0, 4.0, 6.0, 8.0, 10.0)
+    assert nph.barostat_dof == (1.0, 2.0, 4.0, 6.0, 8.0, 10.0)
 
 
 def test_npt_attributes_attached_3d(simulation_factory,
@@ -376,85 +370,79 @@ def test_npt_attributes_attached_3d(simulation_factory,
 
 
 def test_nph_attributes_attached_3d(simulation_factory,
-                                      two_particle_snapshot_factory):
+                                    two_particle_snapshot_factory):
     """Test attributes of the NPT integrator before attaching."""
     all_ = hoomd.filter.All()
-    constant_t = hoomd.variant.Constant(2.0)
     constant_s = [hoomd.variant.Constant(1.0),
                   hoomd.variant.Constant(2.0),
                   hoomd.variant.Constant(3.0),
                   hoomd.variant.Constant(0.125),
                   hoomd.variant.Constant(.25),
                   hoomd.variant.Constant(.5)]
-    npt = hoomd.md.methods.NPH(filter = all_, kT=constant_t, tau=2.0,
-                               S = constant_s,
-                               tauS = 2.0,
+    nph = hoomd.md.methods.NPH(filter=all_, tau=2.0,
+                               S=constant_s,
+                               tauS=2.0,
                                couple='xyz')
 
     sim = simulation_factory(two_particle_snapshot_factory())
-    sim.operations.integrator = hoomd.md.Integrator(0.005, methods=[npt])
+    sim.operations.integrator = hoomd.md.Integrator(0.005, methods=[nph])
     sim.operations._schedule()
 
-    assert npt.filter is all_
-    assert npt.kT is constant_t
-    assert npt.tau == 2.0
-    assert len(npt.S) == 6
+    assert nph.filter is all_
+    assert nph.tau == 2.0
+    assert len(nph.S) == 6
     for i in range(6):
-        assert npt.S[i] is constant_s[i]
-    assert npt.tauS == 2.0
-    assert npt.couple == 'xyz'
+        assert nph.S[i] is constant_s[i]
+    assert nph.tauS == 2.0
+    assert nph.couple == 'xyz'
 
     type_A = hoomd.filter.Type(['A'])
     with pytest.raises(AttributeError):
         # filter cannot be set after scheduling
-        npt.filter = type_A
+        nph.filter = type_A
 
-    assert npt.filter is all_
+    assert nph.filter is all_
 
-    ramp = hoomd.variant.Ramp(1, 2, 1000000, 2000000)
-    npt.kT = ramp
-    assert npt.kT is ramp
-
-    npt.tau = 10.0
-    assert npt.tau == 10.0
+    nph.tau = 10.0
+    assert nph.tau == 10.0
 
     ramp_s = [hoomd.variant.Ramp(1.0, 4.0, 1000, 10000),
-                  hoomd.variant.Ramp(2.0, 4.0, 1000, 10000),
-                  hoomd.variant.Ramp(3.0, 4.0, 1000, 10000),
-                  hoomd.variant.Ramp(0.125, 4.0, 1000, 10000),
-                  hoomd.variant.Ramp(.25, 4.0, 1000, 10000),
-                  hoomd.variant.Ramp(.5, 4.0, 1000, 10000)]
-    npt.S = ramp_s
-    assert len(npt.S) == 6
+              hoomd.variant.Ramp(2.0, 4.0, 1000, 10000),
+              hoomd.variant.Ramp(3.0, 4.0, 1000, 10000),
+              hoomd.variant.Ramp(0.125, 4.0, 1000, 10000),
+              hoomd.variant.Ramp(.25, 4.0, 1000, 10000),
+              hoomd.variant.Ramp(.5, 4.0, 1000, 10000)]
+    nph.S = ramp_s
+    assert len(nph.S) == 6
     for i in range(6):
-        assert npt.S[i] is ramp_s[i]
+        assert nph.S[i] is ramp_s[i]
 
-    npt.tauS = 10.0
-    assert npt.tauS == 10.0
+    nph.tauS = 10.0
+    assert nph.tauS == 10.0
 
-    npt.box_dof = (True,False,False,False,True,False)
-    assert tuple(npt.box_dof) == (True,False,False,False,True,False)
+    nph.box_dof = (True, False, False, False, True, False)
+    assert tuple(nph.box_dof) == (True, False, False, False, True, False)
 
-    npt.couple = 'none'
-    assert npt.couple == 'none'
+    nph.couple = 'none'
+    assert nph.couple == 'none'
 
-    npt.rescale_all = True
-    assert npt.rescale_all
+    nph.rescale_all = True
+    assert nph.rescale_all
 
-    npt.gamma = 2.0
-    assert npt.gamma == 2.0
+    nph.gamma = 2.0
+    assert nph.gamma == 2.0
 
-    assert npt.translational_thermostat_dof == (0.0, 0.0)
-    npt.translational_thermostat_dof = (0.125, 0.5)
-    assert npt.translational_thermostat_dof == (0.125, 0.5)
+    assert nph.translational_thermostat_dof == (0.0, 0.0)
+    nph.translational_thermostat_dof = (0.125, 0.5)
+    assert nph.translational_thermostat_dof == (0.125, 0.5)
 
-    assert npt.rotational_thermostat_dof == (0.0, 0.0)
-    npt.rotational_thermostat_dof = (0.5, 0.25)
-    assert npt.rotational_thermostat_dof == (0.5, 0.25)
+    assert nph.rotational_thermostat_dof == (0.0, 0.0)
+    nph.rotational_thermostat_dof = (0.5, 0.25)
+    assert nph.rotational_thermostat_dof == (0.5, 0.25)
 
-    assert npt.barostat_dof == (0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
-    npt.barostat_dof = (1.0, 2.0, 4.0, 6.0, 8.0, 10.0)
-    assert npt.barostat_dof == (1.0, 2.0, 4.0, 6.0, 8.0, 10.0)
+    assert nph.barostat_dof == (0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
+    nph.barostat_dof = (1.0, 2.0, 4.0, 6.0, 8.0, 10.0)
+    assert nph.barostat_dof == (1.0, 2.0, 4.0, 6.0, 8.0, 10.0)
 
 
 def test_npt_thermalize_thermostat_and_barostat_dof(
@@ -558,6 +546,41 @@ def test_npt_attributes_attached_2d(simulation_factory,
 
     npt.box_dof = (True, True, True, True, True, True)
     assert tuple(npt.box_dof) == (True, True, False, True, False, False)
+
+
+def test_nph_attributes_attached_2d(simulation_factory,
+                                    two_particle_snapshot_factory):
+    """Test attributes of the NPT integrator specific to 2D simulations."""
+    all_ = hoomd.filter.All()
+    nph = hoomd.md.methods.NPH(filter=all_, tau=2.0,
+                               S=2.0,
+                               tauS=2.0,
+                               couple='xy')
+
+    assert nph.box_dof == (True, True, True, False, False, False)
+    assert nph.couple == 'xy'
+
+    sim = simulation_factory(two_particle_snapshot_factory(dimensions=2))
+    sim.operations.integrator = hoomd.md.Integrator(0.005, methods=[nph])
+    sim.operations._schedule()
+
+    # after attaching in 2d, only some coupling modes and box dof are valid
+    assert tuple(nph.box_dof) == (True, True, False, False, False, False)
+    assert nph.couple == 'xy'
+
+    with pytest.raises(ValueError):
+        nph.couple = 'xyz'
+    with pytest.raises(ValueError):
+        nph.couple = 'xz'
+    with pytest.raises(ValueError):
+        nph.couple = 'yz'
+
+    nph.couple = 'none'
+    assert nph.couple == 'none'
+
+    nph.box_dof = (True, True, True, True, True, True)
+    assert tuple(nph.box_dof) == (True, True, False, True, False, False)
+
 
 def test_nve_attributes():
     """Test attributes of the NVE integrator before attaching."""

--- a/hoomd/md/pytest/test_methods.py
+++ b/hoomd/md/pytest/test_methods.py
@@ -232,10 +232,10 @@ def test_nph_attributes():
                                tauS=2.0,
                                couple='xyz')
 
-    assert nph.filter is all_
+    assert nph.filter == all_
     assert len(nph.S) == 6
     for i in range(6):
-        assert nph.S[i] is constant_s[i]
+        assert nph.S[i] == constant_s[i]
     assert nph.tauS == 2.0
     assert nph.box_dof == (True, True, True, False, False, False)
     assert nph.couple == 'xyz'
@@ -244,7 +244,7 @@ def test_nph_attributes():
 
     type_A = hoomd.filter.Type(['A'])
     nph.filter = type_A
-    assert nph.filter is type_A
+    assert nph.filter == type_A
 
     ramp_s = [
         hoomd.variant.Ramp(1.0, 4.0, 1000, 10000),
@@ -257,7 +257,7 @@ def test_nph_attributes():
     nph.S = ramp_s
     assert len(nph.S) == 6
     for i in range(6):
-        assert nph.S[i] is ramp_s[i]
+        assert nph.S[i] == ramp_s[i]
 
     nph.tauS = 10.0
     assert nph.tauS == 10.0
@@ -382,10 +382,10 @@ def test_nph_attributes_attached_3d(simulation_factory,
     sim.operations.integrator = hoomd.md.Integrator(0.005, methods=[nph])
     sim.operations._schedule()
 
-    assert nph.filter is all_
+    assert nph.filter == all_
     assert len(nph.S) == 6
     for i in range(6):
-        assert nph.S[i] is constant_s[i]
+        assert nph.S[i] == constant_s[i]
     assert nph.tauS == 2.0
     assert nph.couple == 'xyz'
 
@@ -394,20 +394,7 @@ def test_nph_attributes_attached_3d(simulation_factory,
         # filter cannot be set after scheduling
         nph.filter = type_A
 
-    assert nph.filter is all_
-
-    ramp_s = [
-        hoomd.variant.Ramp(1.0, 4.0, 1000, 10000),
-        hoomd.variant.Ramp(2.0, 4.0, 1000, 10000),
-        hoomd.variant.Ramp(3.0, 4.0, 1000, 10000),
-        hoomd.variant.Ramp(0.125, 4.0, 1000, 10000),
-        hoomd.variant.Ramp(.25, 4.0, 1000, 10000),
-        hoomd.variant.Ramp(.5, 4.0, 1000, 10000)
-    ]
-    nph.S = ramp_s
-    assert len(nph.S) == 6
-    for i in range(6):
-        assert nph.S[i] is ramp_s[i]
+    assert nph.filter == all_
 
     nph.tauS = 10.0
     assert nph.tauS == 10.0
@@ -427,6 +414,21 @@ def test_nph_attributes_attached_3d(simulation_factory,
     assert nph.barostat_dof == (0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
     nph.barostat_dof = (1.0, 2.0, 4.0, 6.0, 8.0, 10.0)
     assert nph.barostat_dof == (1.0, 2.0, 4.0, 6.0, 8.0, 10.0)
+
+    ramp_s = [
+        hoomd.variant.Ramp(1.0, 4.0, 1000, 10000),
+        hoomd.variant.Ramp(2.0, 4.0, 1000, 10000),
+        hoomd.variant.Ramp(3.0, 4.0, 1000, 10000),
+        hoomd.variant.Ramp(0.125, 4.0, 1000, 10000),
+        hoomd.variant.Ramp(.25, 4.0, 1000, 10000),
+        hoomd.variant.Ramp(.5, 4.0, 1000, 10000)
+    ]
+    nph.S = ramp_s
+    assert len(nph.S) == 6
+    for _ in range(5):
+        sim.run(1)
+        for i in range(6):
+            assert nph.S[i] == ramp_s[i]
 
 
 def test_npt_thermalize_thermostat_and_barostat_dof(

--- a/hoomd/md/pytest/test_methods.py
+++ b/hoomd/md/pytest/test_methods.py
@@ -225,13 +225,12 @@ def test_nph_attributes():
                   hoomd.variant.Constant(0.125),
                   hoomd.variant.Constant(.25),
                   hoomd.variant.Constant(.5)]
-    nph = hoomd.md.methods.NPH(filter=all_, tau=2.0,
+    nph = hoomd.md.methods.NPH(filter=all_,
                                S=constant_s,
                                tauS=2.0,
                                couple='xyz')
 
     assert nph.filter is all_
-    assert nph.tau == 2.0
     assert len(nph.S) == 6
     for i in range(6):
         assert nph.S[i] is constant_s[i]
@@ -244,9 +243,6 @@ def test_nph_attributes():
     type_A = hoomd.filter.Type(['A'])
     nph.filter = type_A
     assert nph.filter is type_A
-
-    nph.tau = 10.0
-    assert nph.tau == 10.0
 
     ramp_s = [hoomd.variant.Ramp(1.0, 4.0, 1000, 10000),
               hoomd.variant.Ramp(2.0, 4.0, 1000, 10000),
@@ -379,7 +375,7 @@ def test_nph_attributes_attached_3d(simulation_factory,
                   hoomd.variant.Constant(0.125),
                   hoomd.variant.Constant(.25),
                   hoomd.variant.Constant(.5)]
-    nph = hoomd.md.methods.NPH(filter=all_, tau=2.0,
+    nph = hoomd.md.methods.NPH(filter=all_,
                                S=constant_s,
                                tauS=2.0,
                                couple='xyz')
@@ -389,7 +385,6 @@ def test_nph_attributes_attached_3d(simulation_factory,
     sim.operations._schedule()
 
     assert nph.filter is all_
-    assert nph.tau == 2.0
     assert len(nph.S) == 6
     for i in range(6):
         assert nph.S[i] is constant_s[i]
@@ -402,9 +397,6 @@ def test_nph_attributes_attached_3d(simulation_factory,
         nph.filter = type_A
 
     assert nph.filter is all_
-
-    nph.tau = 10.0
-    assert nph.tau == 10.0
 
     ramp_s = [hoomd.variant.Ramp(1.0, 4.0, 1000, 10000),
               hoomd.variant.Ramp(2.0, 4.0, 1000, 10000),
@@ -552,7 +544,7 @@ def test_nph_attributes_attached_2d(simulation_factory,
                                     two_particle_snapshot_factory):
     """Test attributes of the NPH integrator specific to 2D simulations."""
     all_ = hoomd.filter.All()
-    nph = hoomd.md.methods.NPH(filter=all_, tau=2.0,
+    nph = hoomd.md.methods.NPH(filter=all_,
                                S=2.0,
                                tauS=2.0,
                                couple='xy')

--- a/hoomd/md/pytest/test_methods.py
+++ b/hoomd/md/pytest/test_methods.py
@@ -505,6 +505,26 @@ def test_npt_thermalize_thermostat_and_barostat_aniso_dof(
         assert v != 0.0
 
 
+def test_nph_thermalize_barostat_dof(
+    simulation_factory, two_particle_snapshot_factory):
+    """Tests that NPT.thermalize_thermostat_and_barostat_dof can be called."""
+    all_ = hoomd.filter.All()
+    constant_s = [1, 2, 3, 0.125, 0.25, 0.5]
+    nph = hoomd.md.methods.NPH(filter=all_,
+                               S=constant_s,
+                               tauS=2.0,
+                               box_dof=[True, True, True, True, True, True],
+                               couple='xyz')
+
+    sim = simulation_factory(two_particle_snapshot_factory())
+    sim.operations.integrator = hoomd.md.Integrator(0.005, methods=[nph])
+    sim.operations._schedule()
+
+    nph.thermalize_barostat_dof(100)
+    for v in nph.barostat_dof:
+        assert v != 0.0
+
+
 def test_npt_attributes_attached_2d(simulation_factory,
                                       two_particle_snapshot_factory):
     """Test attributes of the NPT integrator specific to 2D simulations."""

--- a/hoomd/md/pytest/test_methods.py
+++ b/hoomd/md/pytest/test_methods.py
@@ -270,14 +270,6 @@ def test_nph_attributes():
     nph.gamma = 2.0
     assert nph.gamma == 2.0
 
-    assert nph.translational_thermostat_dof == (0.0, 0.0)
-    nph.translational_thermostat_dof = (0.125, 0.5)
-    assert nph.translational_thermostat_dof == (0.125, 0.5)
-
-    assert nph.rotational_thermostat_dof == (0.0, 0.0)
-    nph.rotational_thermostat_dof = (0.5, 0.25)
-    assert nph.rotational_thermostat_dof == (0.5, 0.25)
-
     assert nph.barostat_dof == (0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
     nph.barostat_dof = (1.0, 2.0, 4.0, 6.0, 8.0, 10.0)
     assert nph.barostat_dof == (1.0, 2.0, 4.0, 6.0, 8.0, 10.0)
@@ -423,14 +415,6 @@ def test_nph_attributes_attached_3d(simulation_factory,
 
     nph.gamma = 2.0
     assert nph.gamma == 2.0
-
-    assert nph.translational_thermostat_dof == (0.0, 0.0)
-    nph.translational_thermostat_dof = (0.125, 0.5)
-    assert nph.translational_thermostat_dof == (0.125, 0.5)
-
-    assert nph.rotational_thermostat_dof == (0.0, 0.0)
-    nph.rotational_thermostat_dof = (0.5, 0.25)
-    assert nph.rotational_thermostat_dof == (0.5, 0.25)
 
     assert nph.barostat_dof == (0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
     nph.barostat_dof = (1.0, 2.0, 4.0, 6.0, 8.0, 10.0)

--- a/hoomd/md/pytest/test_methods.py
+++ b/hoomd/md/pytest/test_methods.py
@@ -219,12 +219,14 @@ def test_npt_attributes():
 def test_nph_attributes():
     """Test attributes of the NPH integrator before attaching."""
     all_ = hoomd.filter.All()
-    constant_s = [hoomd.variant.Constant(1.0),
-                  hoomd.variant.Constant(2.0),
-                  hoomd.variant.Constant(3.0),
-                  hoomd.variant.Constant(0.125),
-                  hoomd.variant.Constant(.25),
-                  hoomd.variant.Constant(.5)]
+    constant_s = [
+        hoomd.variant.Constant(1.0),
+        hoomd.variant.Constant(2.0),
+        hoomd.variant.Constant(3.0),
+        hoomd.variant.Constant(0.125),
+        hoomd.variant.Constant(.25),
+        hoomd.variant.Constant(.5)
+    ]
     nph = hoomd.md.methods.NPH(filter=all_,
                                S=constant_s,
                                tauS=2.0,
@@ -235,7 +237,7 @@ def test_nph_attributes():
     for i in range(6):
         assert nph.S[i] is constant_s[i]
     assert nph.tauS == 2.0
-    assert nph.box_dof == (True,True,True,False,False,False)
+    assert nph.box_dof == (True, True, True, False, False, False)
     assert nph.couple == 'xyz'
     assert not nph.rescale_all
     assert nph.gamma == 0.0
@@ -244,12 +246,14 @@ def test_nph_attributes():
     nph.filter = type_A
     assert nph.filter is type_A
 
-    ramp_s = [hoomd.variant.Ramp(1.0, 4.0, 1000, 10000),
-              hoomd.variant.Ramp(2.0, 4.0, 1000, 10000),
-              hoomd.variant.Ramp(3.0, 4.0, 1000, 10000),
-              hoomd.variant.Ramp(0.125, 4.0, 1000, 10000),
-              hoomd.variant.Ramp(.25, 4.0, 1000, 10000),
-              hoomd.variant.Ramp(.5, 4.0, 1000, 10000)]
+    ramp_s = [
+        hoomd.variant.Ramp(1.0, 4.0, 1000, 10000),
+        hoomd.variant.Ramp(2.0, 4.0, 1000, 10000),
+        hoomd.variant.Ramp(3.0, 4.0, 1000, 10000),
+        hoomd.variant.Ramp(0.125, 4.0, 1000, 10000),
+        hoomd.variant.Ramp(.25, 4.0, 1000, 10000),
+        hoomd.variant.Ramp(.5, 4.0, 1000, 10000)
+    ]
     nph.S = ramp_s
     assert len(nph.S) == 6
     for i in range(6):
@@ -258,8 +262,8 @@ def test_nph_attributes():
     nph.tauS = 10.0
     assert nph.tauS == 10.0
 
-    nph.box_dof = (True,False,False,False,True,False)
-    assert nph.box_dof == (True,False,False,False,True,False)
+    nph.box_dof = (True, False, False, False, True, False)
+    assert nph.box_dof == (True, False, False, False, True, False)
 
     nph.couple = 'none'
     assert nph.couple == 'none'
@@ -361,12 +365,14 @@ def test_nph_attributes_attached_3d(simulation_factory,
                                     two_particle_snapshot_factory):
     """Test attributes of the NPH integrator after attaching in 3D."""
     all_ = hoomd.filter.All()
-    constant_s = [hoomd.variant.Constant(1.0),
-                  hoomd.variant.Constant(2.0),
-                  hoomd.variant.Constant(3.0),
-                  hoomd.variant.Constant(0.125),
-                  hoomd.variant.Constant(.25),
-                  hoomd.variant.Constant(.5)]
+    constant_s = [
+        hoomd.variant.Constant(1.0),
+        hoomd.variant.Constant(2.0),
+        hoomd.variant.Constant(3.0),
+        hoomd.variant.Constant(0.125),
+        hoomd.variant.Constant(.25),
+        hoomd.variant.Constant(.5)
+    ]
     nph = hoomd.md.methods.NPH(filter=all_,
                                S=constant_s,
                                tauS=2.0,
@@ -390,12 +396,14 @@ def test_nph_attributes_attached_3d(simulation_factory,
 
     assert nph.filter is all_
 
-    ramp_s = [hoomd.variant.Ramp(1.0, 4.0, 1000, 10000),
-              hoomd.variant.Ramp(2.0, 4.0, 1000, 10000),
-              hoomd.variant.Ramp(3.0, 4.0, 1000, 10000),
-              hoomd.variant.Ramp(0.125, 4.0, 1000, 10000),
-              hoomd.variant.Ramp(.25, 4.0, 1000, 10000),
-              hoomd.variant.Ramp(.5, 4.0, 1000, 10000)]
+    ramp_s = [
+        hoomd.variant.Ramp(1.0, 4.0, 1000, 10000),
+        hoomd.variant.Ramp(2.0, 4.0, 1000, 10000),
+        hoomd.variant.Ramp(3.0, 4.0, 1000, 10000),
+        hoomd.variant.Ramp(0.125, 4.0, 1000, 10000),
+        hoomd.variant.Ramp(.25, 4.0, 1000, 10000),
+        hoomd.variant.Ramp(.5, 4.0, 1000, 10000)
+    ]
     nph.S = ramp_s
     assert len(nph.S) == 6
     for i in range(6):
@@ -489,8 +497,8 @@ def test_npt_thermalize_thermostat_and_barostat_aniso_dof(
         assert v != 0.0
 
 
-def test_nph_thermalize_barostat_dof(
-    simulation_factory, two_particle_snapshot_factory):
+def test_nph_thermalize_barostat_dof(simulation_factory,
+                                     two_particle_snapshot_factory):
     """Tests that NPT.thermalize_thermostat_and_barostat_dof can be called."""
     all_ = hoomd.filter.All()
     constant_s = [1, 2, 3, 0.125, 0.25, 0.5]
@@ -548,10 +556,7 @@ def test_nph_attributes_attached_2d(simulation_factory,
                                     two_particle_snapshot_factory):
     """Test attributes of the NPH integrator specific to 2D simulations."""
     all_ = hoomd.filter.All()
-    nph = hoomd.md.methods.NPH(filter=all_,
-                               S=2.0,
-                               tauS=2.0,
-                               couple='xy')
+    nph = hoomd.md.methods.NPH(filter=all_, S=2.0, tauS=2.0, couple='xy')
 
     assert nph.box_dof == (True, True, True, False, False, False)
     assert nph.couple == 'xy'

--- a/hoomd/md/pytest/test_methods.py
+++ b/hoomd/md/pytest/test_methods.py
@@ -235,7 +235,7 @@ def test_nph_attributes():
     assert nph.filter == all_
     assert len(nph.S) == 6
     for i in range(6):
-        assert nph.S[i] == constant_s[i]
+        assert nph.S[i] is constant_s[i]
     assert nph.tauS == 2.0
     assert nph.box_dof == (True, True, True, False, False, False)
     assert nph.couple == 'xyz'
@@ -257,7 +257,7 @@ def test_nph_attributes():
     nph.S = ramp_s
     assert len(nph.S) == 6
     for i in range(6):
-        assert nph.S[i] == ramp_s[i]
+        assert nph.S[i] is ramp_s[i]
 
     nph.tauS = 10.0
     assert nph.tauS == 10.0
@@ -385,7 +385,7 @@ def test_nph_attributes_attached_3d(simulation_factory,
     assert nph.filter == all_
     assert len(nph.S) == 6
     for i in range(6):
-        assert nph.S[i] == constant_s[i]
+        assert nph.S[i] is constant_s[i]
     assert nph.tauS == 2.0
     assert nph.couple == 'xyz'
 
@@ -428,7 +428,7 @@ def test_nph_attributes_attached_3d(simulation_factory,
     for _ in range(5):
         sim.run(1)
         for i in range(6):
-            assert nph.S[i] == ramp_s[i]
+            assert nph.S[i] is ramp_s[i]
 
 
 def test_npt_thermalize_thermostat_and_barostat_dof(

--- a/hoomd/md/pytest/test_methods.py
+++ b/hoomd/md/pytest/test_methods.py
@@ -380,7 +380,7 @@ def test_nph_attributes_attached_3d(simulation_factory,
 
     sim = simulation_factory(two_particle_snapshot_factory())
     sim.operations.integrator = hoomd.md.Integrator(0.005, methods=[nph])
-    sim.operations._schedule()
+    sim.run(0)
 
     assert nph.filter == all_
     assert len(nph.S) == 6
@@ -512,7 +512,7 @@ def test_nph_thermalize_barostat_dof(simulation_factory,
 
     sim = simulation_factory(two_particle_snapshot_factory())
     sim.operations.integrator = hoomd.md.Integrator(0.005, methods=[nph])
-    sim.operations._schedule()
+    sim.run(0)
 
     nph.thermalize_barostat_dof(100)
     for v in nph.barostat_dof:
@@ -565,7 +565,7 @@ def test_nph_attributes_attached_2d(simulation_factory,
 
     sim = simulation_factory(two_particle_snapshot_factory(dimensions=2))
     sim.operations.integrator = hoomd.md.Integrator(0.005, methods=[nph])
-    sim.operations._schedule()
+    sim.run(0)
 
     # after attaching in 2d, only some coupling modes and box dof are valid
     assert tuple(nph.box_dof) == (True, True, False, False, False, False)

--- a/hoomd/md/pytest/test_methods.py
+++ b/hoomd/md/pytest/test_methods.py
@@ -216,6 +216,83 @@ def test_npt_attributes():
     assert npt.barostat_dof == (1.0, 2.0, 4.0, 6.0, 8.0, 10.0)
 
 
+def test_nph_attributes():
+    """Test attributes of the NPT integrator before attaching."""
+    all_ = hoomd.filter.All()
+    constant_t = hoomd.variant.Constant(2.0)
+    constant_s = [hoomd.variant.Constant(1.0),
+                  hoomd.variant.Constant(2.0),
+                  hoomd.variant.Constant(3.0),
+                  hoomd.variant.Constant(0.125),
+                  hoomd.variant.Constant(.25),
+                  hoomd.variant.Constant(.5)]
+    npt = hoomd.md.methods.NPH(filter = all_, kT=constant_t, tau=2.0,
+                               S = constant_s,
+                               tauS = 2.0,
+                               couple='xyz')
+
+    assert npt.filter is all_
+    assert npt.kT is constant_t
+    assert npt.tau == 2.0
+    assert len(npt.S) == 6
+    for i in range(6):
+        assert npt.S[i] is constant_s[i]
+    assert npt.tauS == 2.0
+    assert npt.box_dof == (True,True,True,False,False,False)
+    assert npt.couple == 'xyz'
+    assert not npt.rescale_all
+    assert npt.gamma == 0.0
+
+    type_A = hoomd.filter.Type(['A'])
+    npt.filter = type_A
+    assert npt.filter is type_A
+
+    ramp = hoomd.variant.Ramp(1, 2, 1000000, 2000000)
+    npt.kT = ramp
+    assert npt.kT is ramp
+
+    npt.tau = 10.0
+    assert npt.tau == 10.0
+
+    ramp_s = [hoomd.variant.Ramp(1.0, 4.0, 1000, 10000),
+                  hoomd.variant.Ramp(2.0, 4.0, 1000, 10000),
+                  hoomd.variant.Ramp(3.0, 4.0, 1000, 10000),
+                  hoomd.variant.Ramp(0.125, 4.0, 1000, 10000),
+                  hoomd.variant.Ramp(.25, 4.0, 1000, 10000),
+                  hoomd.variant.Ramp(.5, 4.0, 1000, 10000)]
+    npt.S = ramp_s
+    assert len(npt.S) == 6
+    for i in range(6):
+        assert npt.S[i] is ramp_s[i]
+
+    npt.tauS = 10.0
+    assert npt.tauS == 10.0
+
+    npt.box_dof = (True,False,False,False,True,False)
+    assert npt.box_dof == (True,False,False,False,True,False)
+
+    npt.couple = 'none'
+    assert npt.couple == 'none'
+
+    npt.rescale_all = True
+    assert npt.rescale_all
+
+    npt.gamma = 2.0
+    assert npt.gamma == 2.0
+
+    assert npt.translational_thermostat_dof == (0.0, 0.0)
+    npt.translational_thermostat_dof = (0.125, 0.5)
+    assert npt.translational_thermostat_dof == (0.125, 0.5)
+
+    assert npt.rotational_thermostat_dof == (0.0, 0.0)
+    npt.rotational_thermostat_dof = (0.5, 0.25)
+    assert npt.rotational_thermostat_dof == (0.5, 0.25)
+
+    assert npt.barostat_dof == (0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
+    npt.barostat_dof = (1.0, 2.0, 4.0, 6.0, 8.0, 10.0)
+    assert npt.barostat_dof == (1.0, 2.0, 4.0, 6.0, 8.0, 10.0)
+
+
 def test_npt_attributes_attached_3d(simulation_factory,
                                       two_particle_snapshot_factory):
     """Test attributes of the NPT integrator before attaching."""
@@ -228,6 +305,88 @@ def test_npt_attributes_attached_3d(simulation_factory,
                   hoomd.variant.Constant(.25),
                   hoomd.variant.Constant(.5)]
     npt = hoomd.md.methods.NPT(filter = all_, kT=constant_t, tau=2.0,
+                               S = constant_s,
+                               tauS = 2.0,
+                               couple='xyz')
+
+    sim = simulation_factory(two_particle_snapshot_factory())
+    sim.operations.integrator = hoomd.md.Integrator(0.005, methods=[npt])
+    sim.operations._schedule()
+
+    assert npt.filter is all_
+    assert npt.kT is constant_t
+    assert npt.tau == 2.0
+    assert len(npt.S) == 6
+    for i in range(6):
+        assert npt.S[i] is constant_s[i]
+    assert npt.tauS == 2.0
+    assert npt.couple == 'xyz'
+
+    type_A = hoomd.filter.Type(['A'])
+    with pytest.raises(AttributeError):
+        # filter cannot be set after scheduling
+        npt.filter = type_A
+
+    assert npt.filter is all_
+
+    ramp = hoomd.variant.Ramp(1, 2, 1000000, 2000000)
+    npt.kT = ramp
+    assert npt.kT is ramp
+
+    npt.tau = 10.0
+    assert npt.tau == 10.0
+
+    ramp_s = [hoomd.variant.Ramp(1.0, 4.0, 1000, 10000),
+                  hoomd.variant.Ramp(2.0, 4.0, 1000, 10000),
+                  hoomd.variant.Ramp(3.0, 4.0, 1000, 10000),
+                  hoomd.variant.Ramp(0.125, 4.0, 1000, 10000),
+                  hoomd.variant.Ramp(.25, 4.0, 1000, 10000),
+                  hoomd.variant.Ramp(.5, 4.0, 1000, 10000)]
+    npt.S = ramp_s
+    assert len(npt.S) == 6
+    for i in range(6):
+        assert npt.S[i] is ramp_s[i]
+
+    npt.tauS = 10.0
+    assert npt.tauS == 10.0
+
+    npt.box_dof = (True,False,False,False,True,False)
+    assert tuple(npt.box_dof) == (True,False,False,False,True,False)
+
+    npt.couple = 'none'
+    assert npt.couple == 'none'
+
+    npt.rescale_all = True
+    assert npt.rescale_all
+
+    npt.gamma = 2.0
+    assert npt.gamma == 2.0
+
+    assert npt.translational_thermostat_dof == (0.0, 0.0)
+    npt.translational_thermostat_dof = (0.125, 0.5)
+    assert npt.translational_thermostat_dof == (0.125, 0.5)
+
+    assert npt.rotational_thermostat_dof == (0.0, 0.0)
+    npt.rotational_thermostat_dof = (0.5, 0.25)
+    assert npt.rotational_thermostat_dof == (0.5, 0.25)
+
+    assert npt.barostat_dof == (0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
+    npt.barostat_dof = (1.0, 2.0, 4.0, 6.0, 8.0, 10.0)
+    assert npt.barostat_dof == (1.0, 2.0, 4.0, 6.0, 8.0, 10.0)
+
+
+def test_nph_attributes_attached_3d(simulation_factory,
+                                      two_particle_snapshot_factory):
+    """Test attributes of the NPT integrator before attaching."""
+    all_ = hoomd.filter.All()
+    constant_t = hoomd.variant.Constant(2.0)
+    constant_s = [hoomd.variant.Constant(1.0),
+                  hoomd.variant.Constant(2.0),
+                  hoomd.variant.Constant(3.0),
+                  hoomd.variant.Constant(0.125),
+                  hoomd.variant.Constant(.25),
+                  hoomd.variant.Constant(.5)]
+    npt = hoomd.md.methods.NPH(filter = all_, kT=constant_t, tau=2.0,
                                S = constant_s,
                                tauS = 2.0,
                                couple='xyz')

--- a/hoomd/md/pytest/test_methods.py
+++ b/hoomd/md/pytest/test_methods.py
@@ -217,7 +217,7 @@ def test_npt_attributes():
 
 
 def test_nph_attributes():
-    """Test attributes of the NPT integrator before attaching."""
+    """Test attributes of the NPH integrator before attaching."""
     all_ = hoomd.filter.All()
     constant_s = [hoomd.variant.Constant(1.0),
                   hoomd.variant.Constant(2.0),
@@ -371,7 +371,7 @@ def test_npt_attributes_attached_3d(simulation_factory,
 
 def test_nph_attributes_attached_3d(simulation_factory,
                                     two_particle_snapshot_factory):
-    """Test attributes of the NPT integrator before attaching."""
+    """Test attributes of the NPH integrator after attaching in 3D."""
     all_ = hoomd.filter.All()
     constant_s = [hoomd.variant.Constant(1.0),
                   hoomd.variant.Constant(2.0),
@@ -550,7 +550,7 @@ def test_npt_attributes_attached_2d(simulation_factory,
 
 def test_nph_attributes_attached_2d(simulation_factory,
                                     two_particle_snapshot_factory):
-    """Test attributes of the NPT integrator specific to 2D simulations."""
+    """Test attributes of the NPH integrator specific to 2D simulations."""
     all_ = hoomd.filter.All()
     nph = hoomd.md.methods.NPH(filter=all_, tau=2.0,
                                S=2.0,


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should based on *maint*. -->
<!-- New features should based on *master*. -->

## Description

<!-- Describe your changes in detail. -->
This converts the NPH method to the v3 API. I copy and pasted the code for the `NPT` Python class into the `NPH` class, except I removed the `kT` argument. I then copied the tests for the `NPT` method, removing the tests that set `kT`.
## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
The NPH method has not yet been converted to the v3 API.
<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves #862 

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
I tested the parameters of the class before and after attaching, for both 2D and 3D systems. I did not test the `randomize_velocities` function because the `setRandomizeVelocitiesParams` function is not in _hoomd/md/TwoStepNPTMTK.cc_.
<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```

```

## Checklist:

- [X] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [X] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [X] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
