### PR TITLE
Fix bug in nlist r_cut determination

### DIFF
--- a/hoomd/md/NeighborList.cc
+++ b/hoomd/md/NeighborList.cc
@@ -518,7 +518,6 @@ void NeighborList::checkBoxSize()
         rmax += 0.5*max_d_comp;
         }
 
-    std::cout << "rmax: " << rmax << std::endl;
     if ((periodic.x && nearest_plane_distance.x <= rmax * 2.0) ||
         (periodic.y && nearest_plane_distance.y <= rmax * 2.0) ||
         (m_sysdef->getNDimensions() == 3 && periodic.z && nearest_plane_distance.z <= rmax * 2.0))

--- a/hoomd/md/NeighborList.cc
+++ b/hoomd/md/NeighborList.cc
@@ -443,7 +443,7 @@ void NeighborList::updateRList()
         // take the maximum
         for (unsigned int i=0; i < m_pdata->getNTypes(); ++i)
             {
-            for (unsigned int j=0; i < m_pdata->getNTypes(); ++i)
+            for (unsigned int j=0; j < m_pdata->getNTypes(); ++j)
                 {
                 h_r_cut.data[m_typpair_idx(i,j)] = std::max(
                     h_r_cut.data[m_typpair_idx(i,j)],

--- a/hoomd/md/NeighborListGPUStencil.cc
+++ b/hoomd/md/NeighborListGPUStencil.cc
@@ -241,8 +241,17 @@ void NeighborListGPUStencil::buildNlist(unsigned int timestep)
         (box.getPeriodic().y && nearest_plane_distance.y <= rmax * 2.0) ||
         (this->m_sysdef->getNDimensions() == 3 && box.getPeriodic().z && nearest_plane_distance.z <= rmax * 2.0))
         {
-        m_exec_conf->msg->error() << "nlist: Simulation box is too small! Particles would be interacting with themselves." << std::endl;
-        throw std::runtime_error("Error updating neighborlist bins");
+        std::ostringstream oss;
+        oss << "nlist: Simulation box is too small! Particles would be interacting with themselves."
+            << "rmax=" << rmax << std::endl;
+
+        if (box.getPeriodic().x)
+            oss << "nearest_plane_distance.x=" << nearest_plane_distance.x << std::endl;
+        if (box.getPeriodic().y)
+            oss << "nearest_plane_distance.y=" << nearest_plane_distance.y << std::endl;
+        if (this->m_sysdef->getNDimensions() == 3 && box.getPeriodic().z)
+            oss << "nearest_plane_distance.z=" << nearest_plane_distance.z << std::endl;
+        throw std::runtime_error(oss.str());
         }
 
     // we should not call the tuner with MPI sync enabled

--- a/hoomd/md/NeighborListStencil.cc
+++ b/hoomd/md/NeighborListStencil.cc
@@ -136,8 +136,17 @@ void NeighborListStencil::buildNlist(unsigned int timestep)
         (periodic.y && nearest_plane_distance.y <= rmax * 2.0) ||
         (this->m_sysdef->getNDimensions() == 3 && periodic.z && nearest_plane_distance.z <= rmax * 2.0))
         {
-        m_exec_conf->msg->error() << "nlist: Simulation box is too small! Particles would be interacting with themselves." << endl;
-        throw runtime_error("Error updating neighborlist bins");
+        std::ostringstream oss;
+        oss << "nlist: Simulation box is too small! Particles would be interacting with themselves."
+            << "rmax=" << rmax << std::endl;
+
+        if (box.getPeriodic().x)
+            oss << "nearest_plane_distance.x=" << nearest_plane_distance.x << std::endl;
+        if (box.getPeriodic().y)
+            oss << "nearest_plane_distance.y=" << nearest_plane_distance.y << std::endl;
+        if (this->m_sysdef->getNDimensions() == 3 && box.getPeriodic().z)
+            oss << "nearest_plane_distance.z=" << nearest_plane_distance.z << std::endl;
+        throw std::runtime_error(oss.str());
         }
 
     // access the rlist data


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should based on *maint*. -->
<!-- New features should based on *master*. -->

## Description

<!-- Describe your changes in detail. -->
Fix a bug where the neighbor list determines the maximum r_cut incorrectly.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
This fixes incorrect behavior.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
Tested offline.

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
* Correctly determine the maximum r_cut in simulations with more than one pair potential and more than one type.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
