### PR TITLE
Convert Berendsen to v3 API

### DIFF
--- a/hoomd/md/TwoStepBerendsen.cc
+++ b/hoomd/md/TwoStepBerendsen.cc
@@ -155,7 +155,7 @@ void export_Berendsen(py::module& m)
                          Scalar,
                          std::shared_ptr<Variant>
                          >())
-        .def("setT", &TwoStepBerendsen::setT)
-        .def("setTau", &TwoStepBerendsen::setTau)
+        .def_property("kT", &TwoStepBerendsen::getT, &TwoStepBerendsen::setT)
+        .def_property("tau", &TwoStepBerendsen::getTau, &TwoStepBerendsen::setTau)
         ;
     }

--- a/hoomd/md/TwoStepBerendsen.h
+++ b/hoomd/md/TwoStepBerendsen.h
@@ -42,11 +42,25 @@ class PYBIND11_EXPORT TwoStepBerendsen : public IntegrationMethodTwoStep
             m_T = T;
             }
 
+        //! Get the temperature
+        //! \param T New temperature to set
+        virtual std::shared_ptr<Variant> getT()
+            {
+            return m_T;
+            }
+
         //! Update the tau value
         //! \param tau New time constant to set
         virtual void setTau(Scalar tau)
             {
             m_tau = tau;
+            }
+
+        //! Get the tau value
+        //! \param T New temperature to set
+        virtual Scalar getTau()
+            {
+            return m_tau;
             }
 
         //! Performs the first step of the integration

--- a/hoomd/md/TwoStepBerendsen.h
+++ b/hoomd/md/TwoStepBerendsen.h
@@ -43,7 +43,6 @@ class PYBIND11_EXPORT TwoStepBerendsen : public IntegrationMethodTwoStep
             }
 
         //! Get the temperature
-        //! \param T New temperature to set
         virtual std::shared_ptr<Variant> getT()
             {
             return m_T;
@@ -57,7 +56,6 @@ class PYBIND11_EXPORT TwoStepBerendsen : public IntegrationMethodTwoStep
             }
 
         //! Get the tau value
-        //! \param T New temperature to set
         virtual Scalar getTau()
             {
             return m_tau;

--- a/hoomd/md/methods.py
+++ b/hoomd/md/methods.py
@@ -955,6 +955,7 @@ class Berendsen(_Method):
 
         tau (float): Time constant of thermostat. (in time units)
     """
+
     def __init__(self, filter, kT, tau):
         # store metadata
         param_dict = ParameterDict(
@@ -986,21 +987,3 @@ class Berendsen(_Method):
                                    self.tau,
                                    self.kT)
         super()._attach()
-
-    def randomize_velocities(self, seed):
-        R""" Assign random velocities and angular momenta to particles in the
-        group, sampling from the Maxwell-Boltzmann distribution. This method
-        considers the dimensionality of the system and particle anisotropy, and
-        removes drift (the center of mass velocity).
-        .. versionadded:: 2.3
-        Args:
-            seed (int): Random number seed
-        Note:
-            Randomization is applied at the start of the next call to ```sim.run```.
-        Example::
-            berendsen = hoomd.md.methods.Berendsen(filter=hoomd.filter.All(), kT=0.2,
-            tau=10.0)
-            integrator = hoomd.md.Integrator(dt=0.001, methods=[berendsen], forces=[lj])
-            berendsen.randomize_velocities(seed=42)
-        """
-        self.cpp_method.setRandomizeVelocitiesParams(self.kT(self._simulation.timestep), seed)

--- a/hoomd/md/methods.py
+++ b/hoomd/md/methods.py
@@ -917,11 +917,15 @@ class Berendsen(_Method):
     R""" Applies the Berendsen thermostat.
 
     Args:
-        group (``hoomd.group``): Group to which the Berendsen thermostat will be applied.
-        kT (:py:mod:`hoomd.variant` or :py:obj:`float`): Temperature of thermostat. (in energy units).
-        tau (float): Time constant of thermostat. (in time units)
+        filter (`hoomd.filter.ParticleFilter`): Subset of particles to
+            apply this method to.
 
-    :py:class:`berendsen` rescales the velocities of all particles on each time step. The rescaling is performed so that
+        kT (`hoomd.variant.Variant` or `float`): Temperature of the
+            simulation (in energy units).
+
+        tau (`float`): Time constant of thermostat. (in time units)
+
+    :py:class:`Berendsen` rescales the velocities of all particles on each time step. The rescaling is performed so that
     the difference in the current temperature from the set point decays exponentially:
     `Berendsen et. al. 1984 <http://dx.doi.org/10.1063/1.448118>`_.
 
@@ -930,10 +934,26 @@ class Berendsen(_Method):
         \frac{dT_\mathrm{cur}}{dt} = \frac{T - T_\mathrm{cur}}{\tau}
 
     .. attention::
-        :py:class:`berendsen` does not function with MPI parallel simulations.
+        :py:class:`Berendsen` does not function with MPI parallel simulations.
 
     .. attention::
-        :py:class:`berendsen` does not integrate rotational degrees of freedom.
+        :py:class:`Berendsen` does not integrate rotational degrees of freedom.
+
+        Examples::
+
+        berendsen = hoomd.md.methods.Berendsen(filter=hoomd.filter.All(), kT=0.2,
+        tau=10.0)
+        integrator = hoomd.md.Integrator(dt=0.001, methods=[berendsen], forces=[lj])
+
+
+    Attributes:
+        filter (hoomd.filter.ParticleFilter): Subset of particles to
+            apply this method to.
+
+        kT (hoomd.variant.Variant): Temperature of the
+            simulation (in energy units).
+
+        tau (float): Time constant of thermostat. (in time units)
     """
     def __init__(self, group, kT, tau):
         # store metadata

--- a/hoomd/md/methods.py
+++ b/hoomd/md/methods.py
@@ -914,7 +914,7 @@ class Brownian(_Method):
 
 
 class Berendsen(_Method):
-    R""" Applies the Berendsen thermostat.
+    r"""Applies the Berendsen thermostat.
 
     Args:
         filter (`hoomd.filter.ParticleFilter`): Subset of particles to

--- a/hoomd/md/pytest/test_methods.py
+++ b/hoomd/md/pytest/test_methods.py
@@ -68,6 +68,7 @@ def test_brownian_attributes_attached(simulation_factory,
     assert brownian.alpha == 0.125
 
 
+@pytest.mark.serial
 def test_berendsen_attributes():
     """Test attributes of the Berendsen integrator before attaching."""
     all_ = hoomd.filter.All()

--- a/hoomd/md/pytest/test_methods.py
+++ b/hoomd/md/pytest/test_methods.py
@@ -75,17 +75,17 @@ def test_berendsen_attributes(device):
     constant = hoomd.variant.Constant(2.0)
     berendsen = hoomd.md.methods.Berendsen(filter=all_, kT=constant, tau=10.0)
 
-    assert berendsen.filter is all_
-    assert berendsen.kT is constant
+    assert berendsen.filter == all_
+    assert berendsen.kT == constant
     assert berendsen.tau == 10.0
 
     type_A = hoomd.filter.Type(['A'])
     berendsen.filter = type_A
-    assert berendsen.filter is type_A
+    assert berendsen.filter == type_A
 
     ramp = hoomd.variant.Ramp(1, 2, 1000000, 2000000)
     berendsen.kT = ramp
-    assert berendsen.kT is ramp
+    assert berendsen.kT == ramp
 
     berendsen.tau = 1.2
     assert berendsen.tau == 1.2
@@ -102,8 +102,8 @@ def test_berendsen_attributes_attached(simulation_factory,
     sim.operations.integrator = hoomd.md.Integrator(0.005, methods=[berendsen])
     sim.operations._schedule()
 
-    assert berendsen.filter is all_
-    assert berendsen.kT is constant
+    assert berendsen.filter == all_
+    assert berendsen.kT == constant
     assert berendsen.tau == 10.0
 
     type_A = hoomd.filter.Type(['A'])
@@ -111,11 +111,11 @@ def test_berendsen_attributes_attached(simulation_factory,
         # filter cannot be set after scheduling
         berendsen.filter = type_A
 
-    assert berendsen.filter is all_
+    assert berendsen.filter == all_
 
     ramp = hoomd.variant.Ramp(1, 2, 1000000, 2000000)
     berendsen.kT = ramp
-    assert berendsen.kT is ramp
+    assert berendsen.kT == ramp
 
     berendsen.tau = 1.2
     assert berendsen.tau == 1.2

--- a/hoomd/md/pytest/test_methods.py
+++ b/hoomd/md/pytest/test_methods.py
@@ -69,7 +69,7 @@ def test_brownian_attributes_attached(simulation_factory,
 
 
 @pytest.mark.serial
-def test_berendsen_attributes():
+def test_berendsen_attributes(device):
     """Test attributes of the Berendsen integrator before attaching."""
     all_ = hoomd.filter.All()
     constant = hoomd.variant.Constant(2.0)

--- a/hoomd/md/pytest/test_methods.py
+++ b/hoomd/md/pytest/test_methods.py
@@ -96,13 +96,10 @@ def test_berendsen_attributes_attached(simulation_factory,
     all_ = hoomd.filter.All()
     constant = hoomd.variant.Constant(2.0)
     berendsen = hoomd.md.methods.Berendsen(filter=all_, kT=constant, tau=10.0)
-    print(type(berendsen))
-    print(berendsen.kT)
     sim = simulation_factory(two_particle_snapshot_factory())
     sim.operations.integrator = hoomd.md.Integrator(0.005, methods=[berendsen])
     sim.operations._schedule()
-    print(type(berendsen))
-    print(berendsen.kT)
+
     assert berendsen.filter is all_
     assert berendsen.kT is constant
     assert berendsen.tau == 10.0

--- a/hoomd/md/pytest/test_methods.py
+++ b/hoomd/md/pytest/test_methods.py
@@ -91,6 +91,7 @@ def test_berendsen_attributes():
     assert berendsen.tau == 1.2
 
 
+@pytest.mark.serial
 def test_berendsen_attributes_attached(simulation_factory,
                                        two_particle_snapshot_factory):
     """Test attributes of the Berendsen integrator after attaching."""


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should based on *maint*. -->
<!-- New features should based on *master*. -->

## Description

<!-- Describe your changes in detail. -->
This converts the `Berendsen` method to the v3 API. I added an `_attach `method and added the parameter dict properties to the pybind export of the C++ class. I removed the `randomize_velocities` method, as there is no function related to randomizing velocities in _hoomd/md/TwoStepBerendsen.cc_.
## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
The Berendsen method has not yet been converted to the v3 API
<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves #864 

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
I added the same tests as the other method classes for testing the parameters before and after attaching.
<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```

```

## Checklist:

- [X] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [X] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [X] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
