### PR TITLE
Fix Logging Namespace

### DIFF
--- a/hoomd/conftest.py
+++ b/hoomd/conftest.py
@@ -244,3 +244,35 @@ def pytest_sessionfinish(session, exitstatus):
 
     if exitstatus != 0 and hoomd.version.mpi_enabled:
         atexit.register(abort, exitstatus)
+
+
+def logging_check(cls, expected_namespace, expected_loggables):
+    """Function for testing object logging specification.
+
+    Args:
+        cls (object): The loggable class to test for the correct logging
+            specfication.
+        expected_namespace (tuple[str]): A tuple of strings that indicate the
+            expected namespace minus the class name.
+        expected_loggables (dict[str, dict[str, Any]]): A dict with string keys
+            representing the expected loggable quantities. If the value for a
+            key is ``None`` then, only check for the existence of the loggable
+            quantity. Otherwise, the inner `dict` should consist of some
+            combination of the keys ``default`` and ``category`` indicating the
+            expected value of each for the loggable.
+    """
+    # Check namespace
+    assert all(log_quantity.namespace == expected_namespace + (cls.__name__,)
+               for log_quantity in cls._export_dict.values())
+
+    # Check specific loggables
+    def check_loggable(cls, name, properties):
+        assert name in cls._export_dict
+        if properties is None:
+            return None
+        log_quantity = cls._export_dict[name]
+        for name, prop in properties.items():
+            assert getattr(log_quantity, name) == prop
+
+    for name, properties in expected_loggables.items():
+        check_loggable(cls, name, properties)

--- a/hoomd/md/pytest/test_potential.py
+++ b/hoomd/md/pytest/test_potential.py
@@ -6,6 +6,8 @@ import numpy as np
 
 import hoomd
 from hoomd import md
+from hoomd.logging import LoggerCategories
+from hoomd.conftest import logging_check
 import pytest
 import itertools
 from copy import deepcopy
@@ -940,3 +942,34 @@ def test_force_energy_accuracy(simulation_factory,
             assert isclose(sum(sim_energies), forces_and_energies.energies[i])
             assert isclose(sim_forces[0], forces_and_energies.forces[i] * r)
             assert isclose(sim_forces[0], -forces_and_energies.forces[i] * r)
+
+
+# Test logging
+@pytest.mark.parametrize(
+    'cls, expected_namespace, expected_loggables',
+    zip((md.pair.Pair, md.pair.aniso.AnisotropicPair, md.many_body.Triplet),
+        (('md', 'pair'), ('md', 'pair', 'aniso'), ('md', 'many_body')),
+        itertools.repeat({
+            'energy': {
+                'category': LoggerCategories.scalar,
+                'default': True
+            },
+            'energies': {
+                'category': LoggerCategories.particle,
+                'default': True
+            },
+            'forces': {
+                'category': LoggerCategories.particle,
+                'default': True
+            },
+            'torques': {
+                'category': LoggerCategories.particle,
+                'default': True
+            },
+            'virials': {
+                'category': LoggerCategories.particle,
+                'default': True
+            },
+        })))
+def test_logging(cls, expected_namespace, expected_loggables):
+    logging_check(cls, expected_namespace, expected_loggables)


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should based on *maint*. -->
<!-- New features should based on *master*. -->

## Description

Refactor the logging namespace generation as well as introduce a new mechanism for detecting consecutive duplicates in the namespace such as `('md', 'pair', 'pair', 'LJ')` and remove them. This also adds a check in `hoomd/conftest.py` that can be used to check that the logging for a particular class is set up correctly. This check is then used in `hoomd/md/pytest/test_potential.py` to show how to use it with `pytest`.
<!-- Describe your changes in detail. -->

## Motivation and context

Fixes a regression in the logging namespace and partially addresses #922 by providing an infrastructure for writing quick tests and showing an example.

## How has this been tested?

The refactor of namespace generation does not fail any extant tests, and a new test was added to specifically test the namespace and loggables of two body and three body potentials.
<!--- Please describe in detail how you tested your changes. -->

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

Internal changes only.
<!-- Propose a change log entry. -->
```

```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
