### PR TITLE
Remove/Reduce Test Warnings

### DIFF
--- a/hoomd/box.py
+++ b/hoomd/box.py
@@ -348,7 +348,7 @@ class Box:
     def periodic(self):
         """(3) `numpy.ndarray` of `bool`: The periodicity of
         each dimension."""
-        return _vec3_to_array(self._cpp_obj.getPeriodic(), np.bool)
+        return _vec3_to_array(self._cpp_obj.getPeriodic(), bool)
 
     @property
     def lattice_vectors(self):
@@ -416,7 +416,7 @@ class Box:
                 single float is given then scale all dimensions by s; otherwise,
                 s must be a sequence of 3 values used to scale each dimension.
         """
-        s = np.asarray(s, dtype=np.float)
+        s = np.asarray(s, dtype=float)
         self.L *= s
 
     # Magic Methods

--- a/hoomd/md/pytest/test_potential.py
+++ b/hoomd/md/pytest/test_potential.py
@@ -907,6 +907,11 @@ def isclose(value, reference, rtol=5e-6):
             value, reference, rel_tol=rtol, abs_tol=atol)
 
 
+# We ignore this warning raise by NumPy so we can test the use of infinity in
+# some pair potentials currently TWF. This is used when the force from the JSON
+# file needs to be multipled by r to compare with the computed force of the
+# simulation.
+@pytest.mark.filterwarnings("ignore:invalid value encountered in multiply")
 @pytest.mark.parametrize(
     "forces_and_energies",
     _forces_and_energies(),

--- a/hoomd/pytest/test_dcd.py
+++ b/hoomd/pytest/test_dcd.py
@@ -11,6 +11,9 @@ def test_attach(simulation_factory, two_particle_snapshot_factory, tmp_path):
     sim.run(10)
 
 
+# pip installing garnett does not use Cythonized code, so this warning will
+# always be raised unless garnett is built locally.
+@pytest.mark.filterwarnings("ignore:Failed to import dcdreader library")
 def test_write(simulation_factory, two_particle_snapshot_factory, tmp_path):
     garnett = pytest.importorskip("garnett")
     dcd_reader = garnett.reader.DCDFileReader()

--- a/hoomd/pytest/test_local_snapshot.py
+++ b/hoomd/pytest/test_local_snapshot.py
@@ -66,8 +66,8 @@ _particle_data = dict(
                   new_value=[2, 1, 0.5, 1, 2], shape=(Np,)),
     image=dict(
         np_type=np.integer,
-        value=np.linspace(-10, 20, Np * 3, dtype=np.int).reshape(Np, 3),
-        new_value=np.linspace(-20, 10, Np * 3, dtype=np.int).reshape(Np, 3),
+        value=np.linspace(-10, 20, Np * 3, dtype=int).reshape(Np, 3),
+        new_value=np.linspace(-20, 10, Np * 3, dtype=int).reshape(Np, 3),
         shape=(Np, 3)),
     tag=dict(np_type=np.unsignedinteger, value=None, shape=(Np,)),
     _types=['p1', 'p2']


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should based on *maint*. -->
<!-- New features should based on *master*. -->

## Description

Removes the code that generates warnings or adds a `pytest.mark.filterwarnings` decorator to remove warning output from tests.
<!-- Describe your changes in detail. -->

## Motivation and context

Warnings that are not indicative or something to be changed in the testing code base are distracting.
<!--- Why is this change required? What problem does it solve? -->


## How has this been tested?

Tests still pass and I did not observe warnings generated from running tests.
<!--- Please describe in detail how you tested your changes. -->

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

Internal change.
<!-- Propose a change log entry. -->
```

```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
