### PR TITLE
Fix filter header installation

### DIFF
--- a/hoomd/filter/CMakeLists.txt
+++ b/hoomd/filter/CMakeLists.txt
@@ -1,16 +1,16 @@
-set (_header_files filter/ParticleFilter.h
-                   filter/ParticleFilterAll.h
-                   filter/ParticleFilterNull.h
-                   filter/ParticleFilterIntersection.h
-                   filter/ParticleFilterSetDifference.h
-                   filter/ParticleFilterTags.h
-                   filter/ParticleFilterType.h
-                   filter/ParticleFilterUnion.h
-                   filter/ParticleFilterCustom.h
-                   filter/export_filters.h
+set (_header_files export_filters.h
+                   ParticleFilterAll.h
+                   ParticleFilterCustom.h
+                   ParticleFilter.h
+                   ParticleFilterIntersection.h
+                   ParticleFilterNull.h
+                   ParticleFilterSetDifference.h
+                   ParticleFilterTags.h
+                   ParticleFilterType.h
+                   ParticleFilterUnion.h
            )
 
-install(FILES ${_headers_files}
+install(FILES ${_header_files}
         DESTINATION ${PYTHON_SITE_INSTALL_DIR}/include/hoomd/filter
        )
 


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should based on *maint*. -->
<!-- New features should based on *master*. -->

## Description

<!-- Describe your changes in detail. -->
Install the headers in filter/ for use by external plugins.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
External plugins do not compile.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
I installed locally and checked that the files exist:
```
▶ ls ~/hoomd-test-install/python/include/hoomd/filter
export_filters.h     ParticleFilterCustom.h  ParticleFilterIntersection.h  ParticleFilterSetDifference.h  ParticleFilterType.h
ParticleFilterAll.h  ParticleFilter.h        ParticleFilterNull.h          ParticleFilterTags.h           ParticleFilterUnion.h
```

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
*Fixed*

* Install ParticleFilter header files for external plugins.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
