### PR TITLE
Fixed create_state_from_snapshot and added a test

### DIFF
--- a/hoomd/pytest/test_simulation.py
+++ b/hoomd/pytest/test_simulation.py
@@ -197,6 +197,38 @@ def test_state_from_gsd(simulation_factory, get_snapshot,
         assert box == sim.state.box
         assert_equivalent_snapshots(snap, sim.state.snapshot)
 
+@skip_gsd
+def test_state_from_snapshot(simulation_factory, get_snapshot,
+                        device, state_args, tmp_path):
+    snap_params, nsteps = state_args
+
+    d = tmp_path / "sub"
+    d.mkdir()
+    filename = d / "temporary_test_file.gsd"
+    with gsd.hoomd.open(name=filename, mode='wb+') as file:
+        sim = simulation_factory(get_snapshot(n=snap_params[0],
+                                              particle_types=snap_params[1]))
+        snap = sim.state.snapshot
+        snap = make_gsd_snapshot(snap)
+        snapshot_dict = {}
+        snapshot_dict[0] = snap
+        file.append(snap)
+        box = sim.state.box
+        for step in range(1, nsteps):
+            particle_type = np.random.choice(snap_params[1])
+            snap = update_positions(sim.state.snapshot)
+            set_types(snap, random_inds(snap_params[0]),
+                      snap_params[1], particle_type)
+            snap = make_gsd_snapshot(snap)
+            file.append(snap)
+            snapshot_dict[step] = snap
+
+    for step, snap in snapshot_dict.items():
+        sim = hoomd.Simulation(device)
+        sim.create_state_from_snapshot(snap)
+        assert box == sim.state.box
+        assert_equivalent_snapshots(snap, sim.state.snapshot)
+
 
 def test_writer_order(simulation_factory, two_particle_snapshot_factory):
     """Ensure that writers run at the end of the loop step."""

--- a/hoomd/simulation.py
+++ b/hoomd/simulation.py
@@ -141,7 +141,7 @@ class Simulation(metaclass=Loggable):
             self._state = State(self, snapshot)
         elif _match_class_path(snapshot, 'gsd.hoomd.Snapshot'):
             # snapshot is gsd.hoomd.Snapshot
-            snapshot = Snapshot._from_gsd_snapshot(
+            snapshot = Snapshot.from_gsd_snapshot(
                     snapshot, self._device.communicator
                     )
             self._state = State(self, snapshot)


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should based on *maint*. -->
<!-- New features should based on *master*. -->

## Description

I wasn't able to create a state using ```create_state_from_snapshot``` with a ```gsd.hoomd.Snapshot()```, and found that there's a bug in the ```simulation.py```

## How has this been tested?

Added a test in ```test_simulation.py```

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->


## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
