### PR TITLE
fixes on active force of less than one

### DIFF
--- a/hoomd/md/ActiveForceCompute.cc
+++ b/hoomd/md/ActiveForceCompute.cc
@@ -109,10 +109,20 @@ void ActiveForceCompute::setActiveForce(const std::string& type_name, pybind11::
 
     Scalar f_activeMag = slow::sqrt(f_activeVec.x*f_activeVec.x+f_activeVec.y*f_activeVec.y+f_activeVec.z*f_activeVec.z);
 
-    f_activeVec.x /= f_activeMag;
-    f_activeVec.y /= f_activeMag;
-    f_activeVec.z /= f_activeMag;
-    f_activeVec.w = f_activeMag;
+    if(f_activeMag >0)
+        {
+        f_activeVec.x /= f_activeMag;
+        f_activeVec.y /= f_activeMag;
+        f_activeVec.z /= f_activeMag;
+        f_activeVec.w = f_activeMag;
+        }
+    else
+        {
+        f_activeVec.x = 0;
+        f_activeVec.y = 0;
+        f_activeVec.z = 0;
+        f_activeVec.w = 0;
+        }
 
     ArrayHandle<Scalar4> h_f_activeVec(m_f_activeVec, access_location::host, access_mode::readwrite);
     h_f_activeVec.data[typ] = f_activeVec;

--- a/hoomd/md/force.py
+++ b/hoomd/md/force.py
@@ -382,12 +382,12 @@ class Active(Force):
         active_force = TypeParameter(
             "active_force",
             type_kind="particle_types",
-            param_dict=TypeParameterDict((1., 0., 0.), len_keys=1),
+            param_dict=TypeParameterDict((1.0, 0.0, 0.0), len_keys=1),
         )
         active_torque = TypeParameter(
             "active_torque",
             type_kind="particle_types",
-            param_dict=TypeParameterDict((0., 0., 0.), len_keys=1),
+            param_dict=TypeParameterDict((0.0, 0.0, 0.0), len_keys=1),
         )
 
         self._extend_typeparam([active_force, active_torque])

--- a/hoomd/md/force.py
+++ b/hoomd/md/force.py
@@ -382,12 +382,12 @@ class Active(Force):
         active_force = TypeParameter(
             "active_force",
             type_kind="particle_types",
-            param_dict=TypeParameterDict((1, 0, 0), len_keys=1),
+            param_dict=TypeParameterDict((1., 0., 0.), len_keys=1),
         )
         active_torque = TypeParameter(
             "active_torque",
             type_kind="particle_types",
-            param_dict=TypeParameterDict((0, 0, 0), len_keys=1),
+            param_dict=TypeParameterDict((0., 0., 0.), len_keys=1),
         )
 
         self._extend_typeparam([active_force, active_torque])


### PR DESCRIPTION
## Description
It changes the numerical type of active force from int to float for active force less than one 
and added consideration of zero active force.

## Motivation and context
Active force smaller than 1 is treated 0 due to variable type int.

## How has this been tested?
The change is tested with a simple running script.

## Change log
1. Active force indicator's numerical type is changed from int to float in md/force.py
2. if statement is added to treat the case with zero active force magnitude in md/ActiveForceCompute.cc

## Checklist:

- [o] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [o] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
