### PR TITLE
Fix failing CI

### DIFF
--- a/.azp/environment.yml
+++ b/.azp/environment.yml
@@ -1,0 +1,16 @@
+name: hoomd-dev
+channels:
+  - conda-forge
+dependencies:
+  - cereal=1.3.0
+  - cmake=3.19.6
+  - eigen=3.3.9
+  - gsd=2.4.0
+  - ninja=1.10.2
+  - openmpi=4.1.0
+  - python=3.8.8
+  - pybind11=2.6.2
+  - tbb=2020.2
+  - tbb-devel=2020.2
+  - pytest=6.2.2
+  - numpy=1.20.1

--- a/.azp/release.yml
+++ b/.azp/release.yml
@@ -1,8 +1,10 @@
+# Trigger on new tags to build and upload release tarballs.
 trigger:
   tags:
     include:
     - 'v*'
 
+# Trigger on PRs to test that PRs do not break the tarball build. PR builds skip the upload step.
 pr:
   - maint
   - master

--- a/.azp/release.yml
+++ b/.azp/release.yml
@@ -10,7 +10,7 @@ pr:
   - master
 
 variables:
-  image_root: glotzerlab/ci:2021.01
+  image_root: glotzerlab/ci:2021.03
   name: hoomd
 
 jobs:

--- a/.azp/templates/build.yml
+++ b/.azp/templates/build.yml
@@ -17,10 +17,10 @@ steps:
       -DCMAKE_INSTALL_PREFIX=$(Pipeline.Workspace)/install
     workingDirectory: $(Build.BinariesDirectory)
 
-- script: make -j 4
+- script: make -j $(($(getconf _NPROCESSORS_ONLN) + 2))
   displayName: Compile
   workingDirectory: $(Build.BinariesDirectory)
 
-- script: make install -j 4
+- script: make install -j $(($(getconf _NPROCESSORS_ONLN) + 2))
   displayName: Install
   workingDirectory: $(Build.BinariesDirectory)

--- a/.azp/templates/build.yml
+++ b/.azp/templates/build.yml
@@ -1,3 +1,5 @@
+# Build HOOMD and install to $(Build.BinariesDirectory)
+
 steps:
 - task: CMake@1
   inputs:

--- a/.azp/templates/build.yml
+++ b/.azp/templates/build.yml
@@ -1,7 +1,4 @@
 steps:
-- checkout: self
-  submodules: true
-
 - task: CMake@1
   inputs:
     cmakeArgs: >-

--- a/.azp/templates/run_tests.yml
+++ b/.azp/templates/run_tests.yml
@@ -1,3 +1,5 @@
+# Run unit tests
+
 steps:
 - script: >-
     PATH=/usr/lib/llvm-$(llvm_version)/bin:$PATH

--- a/.azp/templates/run_validation_tests.yml
+++ b/.azp/templates/run_validation_tests.yml
@@ -1,3 +1,5 @@
+# Run validation tests.
+
 steps:
 - script: >-
     PATH=/usr/lib/llvm-$(llvm_version)/bin:$PATH

--- a/.azp/test.yml
+++ b/.azp/test.yml
@@ -28,7 +28,6 @@ variables:
   ctest_start: 1
   ctest_stride: 1
   mpiexec_timeout: 3000
-  suite_name: $(Agent.JobName)
   cxxflags: "-Werror"
 
 jobs:

--- a/.azp/test.yml
+++ b/.azp/test.yml
@@ -7,16 +7,16 @@ pr:
 # repository.
 trigger: none
 
-# Instead, trigger nightly builds on active branches.
+# Instead, trigger periodic builds on active branches.
 schedules:
-- cron: "0 2 * * *"
-  displayName: Nightly build
+- cron: "0 2-20/6 * * *"
+  displayName: Periodic build
   branches:
     include:
     - "*"
 
 variables:
-  image_root: glotzerlab/ci:2021.01
+  image_root: glotzerlab/ci:2021.03
 
   # Default build parameters, will override as needed with job matrix values. Variables are
   # automatically set as environment variables (with names converted to all caps). These variables
@@ -79,7 +79,6 @@ jobs:
 
   pool:
     name: 'GPU'
-    demands: short_jobs
 
   container:
       image: $(image_root)-$(container_image)

--- a/.azp/test.yml
+++ b/.azp/test.yml
@@ -55,6 +55,8 @@ jobs:
     options: -u 0
 
   steps:
+  - checkout: self
+    submodules: true
   - template: templates/build.yml
   - template: templates/run_tests.yml
 
@@ -84,6 +86,8 @@ jobs:
     clean: all
 
   steps:
+  - checkout: self
+    submodules: true
   - template: templates/build.yml
   - template: templates/run_tests.yml
 

--- a/.azp/test.yml
+++ b/.azp/test.yml
@@ -1,13 +1,16 @@
-trigger: none
-
+# Trigger on PRs into stable branches.
 pr:
   - maint
   - master
 
+# Do not trigger on every push. This runs every commit twice for PRs with branches on the main
+# repository.
+trigger: none
+
+# Instead, trigger nightly builds on active branches.
 schedules:
 - cron: "0 2 * * *"
-  displayName: Daily 10PM build
-  # 2am UTC is 10PM eastern time
+  displayName: Nightly build
   branches:
     include:
     - "*"
@@ -15,7 +18,10 @@ schedules:
 variables:
   image_root: glotzerlab/ci:2021.01
 
-  # default build parameters, will override as needed with job matrix values
+  # Default build parameters, will override as needed with job matrix values. Variables are
+  # automatically set as environment variables (with names converted to all caps). These variables
+  # are used throughout the azure pipelines configuration (such as in build.yml) and implicitly by
+  # applications that respond to environment variables.
   enable_gpu: off
   enable_mpi: off
   enable_tbb: off
@@ -25,8 +31,6 @@ variables:
   llvm_version: '6.0'
   build_testing: on
   always_use_managed_memory: off
-  ctest_start: 1
-  ctest_stride: 1
   mpiexec_timeout: 3000
   cxxflags: "-Werror"
 
@@ -79,7 +83,7 @@ jobs:
 
   container:
       image: $(image_root)-$(container_image)
-      options: -u 0 --gpus=all --cpus=4 --memory=16g -e CUDA_VISIBLE_DEVICES
+      options: -u 0 --gpus=all -e CUDA_VISIBLE_DEVICES
 
   workspace:
     clean: all

--- a/.azp/validate.yml
+++ b/.azp/validate.yml
@@ -28,7 +28,6 @@ variables:
   ctest_start: 1
   ctest_stride: 1
   mpiexec_timeout: 3000
-  suite_name: $(Agent.JobName)
 
 stages:
 - stage: build_test_cpu2
@@ -200,7 +199,6 @@ stages:
           enable_tbb: on
           build_jit: on
           llvm_version: '9.0'
-          suite_name: CPU tbb2
 
         clang11_py39_mpi_tbb1:
           container_image: clang11_py39
@@ -209,21 +207,18 @@ stages:
           build_jit: on
           llvm_version: '9.0'
           omp_num_threads: '1'
-          suite_name: CPU tbb1
 
         clang11_py39_mpi:
           container_image: clang11_py39
           enable_mpi: on
           build_jit: on
           llvm_version: '9.0'
-          suite_name: CPU no-tbb
 
         clang11_py39:
           container_image: clang11_py39
           enable_mpi: off
           build_jit: on
           llvm_version: '9.0'
-          suite_name: CPU no-mpi
 
     pool:
       vmImage: 'ubuntu-latest'
@@ -253,10 +248,9 @@ stages:
 
     strategy:
       matrix:
-        cuda10_py37_cuda10_mpi:
-          container_image: cuda10_gcc7_py37
+        cuda11_py38_mpi:
+          container_image: cuda11_gcc9_py38
           enable_mpi: on
-          suite_name: GPU cuda10
 
     pool:
       name: 'GPU'

--- a/.azp/validate.yml
+++ b/.azp/validate.yml
@@ -264,7 +264,7 @@ stages:
 
     container:
        image: $(image_root)-$(container_image)
-       options: -u 0 --gpus=all --cpus=4 --memory=16g -e CUDA_VISIBLE_DEVICES
+       options: -u 0 --gpus=all -e CUDA_VISIBLE_DEVICES
 
     workspace:
       clean: all

--- a/.azp/validate.yml
+++ b/.azp/validate.yml
@@ -9,16 +9,16 @@ pr:
 # repository.
 trigger: none
 
-# Instead, trigger nightly builds on active branches.
+# Instead, trigger periodic builds on active branches.
 schedules:
-- cron: "0 2 * * *"
-  displayName: Nightly build
+- cron: "0 2-20/6 * * *"
+  displayName: Periodic build
   branches:
     include:
     - "*"
 
 variables:
-  image_root: glotzerlab/ci:2021.01
+  image_root: glotzerlab/ci:2021.03
 
   # Default build parameters, will override as needed with job matrix values. Variables are
   # automatically set as environment variables (with names converted to all caps). These variables
@@ -46,7 +46,6 @@ stages:
     timeoutInMinutes: 75
 
     strategy:
-      maxParallel: 5
       matrix:
         clang10_py38_mpi_tbb:
           container_image: clang10_py38
@@ -164,13 +163,11 @@ stages:
           always_use_managed_memory: on
           enable_mpi: on
 
-        cuda10_py37_mpi:
+        cuda10_py37:
           container_image: cuda10_gcc7_py37
-          enable_mpi: on
 
     pool:
       name: 'GPU'
-      demands: short_jobs
 
     container:
         image: $(image_root)-$(container_image)

--- a/.azp/validate.yml
+++ b/.azp/validate.yml
@@ -1,13 +1,18 @@
-trigger: none
-
+# Trigger on PRs into stable branches. These builds take a significant amount of time. In the Azure
+# Pipelines web UI, this pipeline is set to require a team member's request before building. Add a
+# PR comment `/azp run validate` to run this pipeline.
 pr:
   - maint
   - master
 
+# Do not trigger on every push. This runs every commit twice for PRs with branches on the main
+# repository.
+trigger: none
+
+# Instead, trigger nightly builds on active branches.
 schedules:
 - cron: "0 2 * * *"
-  displayName: Daily 10PM build
-  # 2am UTC is 10PM eastern time
+  displayName: Nightly build
   branches:
     include:
     - "*"
@@ -15,7 +20,10 @@ schedules:
 variables:
   image_root: glotzerlab/ci:2021.01
 
-  # default build parameters, will override as needed with job matrix values
+  # Default build parameters, will override as needed with job matrix values. Variables are
+  # automatically set as environment variables (with names converted to all caps). These variables
+  # are used throughout the azure pipelines configuration (such as in build.yml) and implicitly by
+  # applications that respond to environment variables.
   enable_gpu: off
   enable_mpi: off
   enable_tbb: off
@@ -25,8 +33,6 @@ variables:
   llvm_version: '6.0'
   build_testing: on
   always_use_managed_memory: off
-  ctest_start: 1
-  ctest_stride: 1
   mpiexec_timeout: 3000
 
 stages:
@@ -168,7 +174,7 @@ stages:
 
     container:
         image: $(image_root)-$(container_image)
-        options: -u 0 --gpus=all --cpus=4 --memory=16g -e CUDA_VISIBLE_DEVICES
+        options: -u 0 --gpus=all -e CUDA_VISIBLE_DEVICES
 
     workspace:
       clean: all

--- a/.azp/validate.yml
+++ b/.azp/validate.yml
@@ -126,6 +126,8 @@ stages:
       options: -u 0
 
     steps:
+    - checkout: self
+      submodules: true
     - template: templates/build.yml
     - template: templates/run_tests.yml
 
@@ -146,10 +148,14 @@ stages:
       vmImage: '$(mac_image)'
 
     steps:
-    - bash: echo "##vso[task.prependpath]$CONDA/bin"
+    - checkout: self
+      submodules: true
+    - bash: sudo chown -R $USER $CONDA
+      displayName: Take ownership of conda installation
+    - script: $CONDA/bin/conda env create --quiet --prefix=$(Pipeline.Workspace)/conda --file .azp/environment.yml
+      displayName: Create conda environment
+    - bash: echo "##vso[task.prependpath]$(Pipeline.Workspace)/conda/bin"
       displayName: Add conda to PATH
-    - script: sudo conda install --yes --quiet -c conda-forge cereal cmake eigen ninja openmpi python pybind11 tbb tbb-devel pytest numpy gsd
-      displayName: Conda install prereqs
     - template: templates/build.yml
     - template: templates/run_tests.yml
 
@@ -194,6 +200,8 @@ stages:
       clean: all
 
     steps:
+    - checkout: self
+      submodules: true
     - template: templates/build.yml
     - template: templates/run_tests.yml
 
@@ -250,6 +258,8 @@ stages:
       options: -u 0
 
     steps:
+    - checkout: self
+      submodules: true
     - template: templates/build.yml
     - template: templates/run_validation_tests.yml
 
@@ -285,5 +295,7 @@ stages:
       clean: all
 
     steps:
+    - checkout: self
+      submodules: true
     - template: templates/build.yml
     - template: templates/run_validation_tests.yml

--- a/.azp/validate.yml
+++ b/.azp/validate.yml
@@ -90,30 +90,12 @@ stages:
           container_image: gcc7_py37
           enable_tbb: on
 
-        gcc6_py37_mpi:
-          container_image: gcc6_py37
-          enable_mpi: on
-
-        gcc5_py37:
-          container_image: gcc5_py37
-
-        gcc48_py37_mpi_tbb:
-          container_image: gcc48_py37
-          enable_mpi: on
-          enable_tbb: on
-
         clang6_py37_mpi_tbb:
           container_image: clang6_py37
           enable_mpi: on
           enable_tbb: on
           build_jit: on
           llvm_version: '6.0'
-
-        clang5_py37_tbb_llvm5:
-          container_image: clang5_py37
-          enable_tbb: on
-          build_jit: on
-          llvm_version: '5.0'
 
         gcc7_py36:
           container_image: gcc7_py36
@@ -180,13 +162,6 @@ stages:
         cuda10_py37_mpi:
           container_image: cuda10_gcc7_py37
           enable_mpi: on
-
-        cuda9_py37_mpi:
-          container_image: cuda9_gcc7_py37
-          enable_mpi: on
-
-        cuda9_py37:
-          container_image: cuda9_gcc7_py37
 
     pool:
       name: 'GPU'

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,21 @@
+# HOOMD-blue code architecture
+
+## Testing
+
+### Continuous integration
+
+[Azure Pipelines][azp_docs] performs continuous integration testing on
+HOOMD-blue. Azure Pipelines compiles HOOMD-blue, runs the unit, validation, and
+style tests and reports the status to GitHub pull requests. A number of parallel
+builds test a variety of compiler and build configurations, including:
+
+* The 2 most recent **CUDA** toolkit versions
+* **gcc** and **clang** versions including the most recent releases back to the
+  defaults provided by the oldest maintained Ubuntu LTS release.
+
+Visit the [glotzerlab/hoomd-blue][hoomd_builds] pipelines page to find recent
+builds. The pipeline configuration files are in [.azp/](.azp/) which reference
+templates in [.azp/templates/](.azp/templates/).
+
+[azp_docs]: https://docs.microsoft.com/en-us/azure/devops/pipelines
+[hoomd_builds]: https://dev.azure.com/glotzerlab/hoomd-blue/_build

--- a/INSTALLING.rst
+++ b/INSTALLING.rst
@@ -74,9 +74,8 @@ Install prerequisites
 
 **General requirements**
 
-- C++11 capable compiler (tested with ``gcc`` 4.8, 5.5, 6.4, 7,
-  8, 9, ``clang`` 5, 6, 7, 8)
-- Python >= 3.5
+- C++14 capable compiler (tested with ``gcc`` 7, 8, 9, 10 / ``clang`` 6, 7, 8, 9, 10, 11)
+- Python >= 3.6
 - NumPy >= 1.7
 - pybind11 >= 2.2
 - Eigen >= 3.2
@@ -116,7 +115,7 @@ Install prerequisites
 
 **For runtime code generation** (required when ``BUILD_JIT=on``)
 
-- LLVM >= 5.0
+- LLVM >= 6.0
 
 **To build documentation**
 


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should based on *maint*. -->
<!-- New features should based on *master*. -->

## Description

<!-- Describe your changes in detail. -->
* Added `chown` command recommended by the Azure Pipelines documentation to use conda on the Microsoft hosted images.
* Remove azure pipelines testing matrix entries for old compilers.
* Add documentation comments to Azure Pipelines configuration and overview in `ARCHITECTURE.md`.
* Detect the number of CPU cores for parallel make builds.
* Remove CPU limits on self-hosted images. These are no longer needed because we only run one agent per host.
* Run scheduled builds every 6 hours to avoid a large backlog when running everything at night.
* Use the latest CI images.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

Fix the failing mac 10.5 CI build failures.

Also, remove testing for some old compilers that are causing difficulties on other branches, attempt to decrease build times, and improve the CI framework documentation.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
The CI tests on this PR test these changes.

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
Removed:

* Testing for CUDA 9, GCC 4.8, GCC 5.x, GCC 6.x, clang 5
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
