### PR TITLE
Fix/dump sphero shapes without vertices

### DIFF
--- a/hoomd/hpmc/ShapeConvexPolygon.h
+++ b/hoomd/hpmc/ShapeConvexPolygon.h
@@ -600,14 +600,15 @@ template<>
 inline std::string getShapeSpec(const ShapeConvexPolygon& poly)
     {
     std::ostringstream shapedef;
-    shapedef << "{\"type\": \"Polygon\", \"rounding_radius\": " << poly.verts.sweep_radius << ", \"vertices\": [";
+    const auto& verts = poly.verts;
+    shapedef << "{\"type\": \"Polygon\", \"rounding_radius\": " << verts.sweep_radius << ", \"vertices\": [";
     if (verts.N != 0)
         {
-        for (unsigned int i = 0; i < poly.verts.N-1; i++)
+        for (unsigned int i = 0; i < verts.N-1; i++)
             {
-            shapedef << "[" << poly.verts.x[i] << ", " << poly.verts.y[i] << "], ";
+            shapedef << "[" << verts.x[i] << ", " << verts.y[i] << "], ";
             }
-        shapedef << "[" << poly.verts.x[poly.verts.N-1] << ", " << poly.verts.y[poly.verts.N-1] << "]]}";
+        shapedef << "[" << verts.x[verts.N-1] << ", " << verts.y[verts.N-1] << "]]}";
         }
     else
         {

--- a/hoomd/hpmc/ShapeConvexPolygon.h
+++ b/hoomd/hpmc/ShapeConvexPolygon.h
@@ -601,11 +601,18 @@ inline std::string getShapeSpec(const ShapeConvexPolygon& poly)
     {
     std::ostringstream shapedef;
     shapedef << "{\"type\": \"Polygon\", \"rounding_radius\": " << poly.verts.sweep_radius << ", \"vertices\": [";
-    for (unsigned int i = 0; i < poly.verts.N-1; i++)
+    if (verts.N != 0)
         {
-        shapedef << "[" << poly.verts.x[i] << ", " << poly.verts.y[i] << "], ";
+        for (unsigned int i = 0; i < poly.verts.N-1; i++)
+            {
+            shapedef << "[" << poly.verts.x[i] << ", " << poly.verts.y[i] << "], ";
+            }
+        shapedef << "[" << poly.verts.x[poly.verts.N-1] << ", " << poly.verts.y[poly.verts.N-1] << "]]}";
         }
-    shapedef << "[" << poly.verts.x[poly.verts.N-1] << ", " << poly.verts.y[poly.verts.N-1] << "]]}";
+    else
+        {
+        shapedef << "[0, 0]]}";
+        }
     return shapedef.str();
     }
 #endif

--- a/hoomd/hpmc/ShapeConvexPolyhedron.h
+++ b/hoomd/hpmc/ShapeConvexPolyhedron.h
@@ -856,7 +856,7 @@ template<>
 inline std::string getShapeSpec(const ShapeConvexPolyhedron& poly)
     {
     std::ostringstream shapedef;
-    auto& verts = poly.verts;
+    const auto& verts = poly.verts;
     shapedef << "{\"type\": \"ConvexPolyhedron\", \"rounding_radius\": " << verts.sweep_radius << ", \"vertices\": [";
     if (verts.N != 0)
         {

--- a/hoomd/hpmc/ShapeConvexPolyhedron.h
+++ b/hoomd/hpmc/ShapeConvexPolyhedron.h
@@ -858,11 +858,18 @@ inline std::string getShapeSpec(const ShapeConvexPolyhedron& poly)
     std::ostringstream shapedef;
     auto& verts = poly.verts;
     shapedef << "{\"type\": \"ConvexPolyhedron\", \"rounding_radius\": " << verts.sweep_radius << ", \"vertices\": [";
-    for (unsigned int i = 0; i < verts.N-1; i++)
+    if (verts.N != 0)
         {
-        shapedef << "[" << verts.x[i] << ", " << verts.y[i] << ", " << verts.z[i] << "], ";
+        for (unsigned int i = 0; i < verts.N-1; i++)
+            {
+            shapedef << "[" << verts.x[i] << ", " << verts.y[i] << ", " << verts.z[i] << "], ";
+            }
+        shapedef << "[" << verts.x[verts.N-1] << ", " << verts.y[verts.N-1] << ", " << verts.z[verts.N-1] << "]]}";
         }
-    shapedef << "[" << verts.x[verts.N-1] << ", " << verts.y[verts.N-1] << ", " << verts.z[verts.N-1] << "]]}";
+    else
+        {
+        shapedef << "[0, 0, 0]]}";
+        }
     return shapedef.str();
     }
 #endif


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should based on *maint*. -->
<!-- New features should based on *master*. -->

## Description

<!-- Describe your changes in detail. -->
Ensure that spheropolygons and spheropolyhedra have at least 1 vertex when dumped.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves #600 

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

This was verified manually on a HOOMD 2.x script, but hasn't been tested in v3. If a test is desired I'd appreciate if someone else could write it.

## Change log

<!-- Propose a change log entry. -->
```
Fix segmentation fault that occurred when dumping GSD shapes for spheropolygons and spheropolyhedra with no vertices (discs and spheres respectively).
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
