### PR TITLE
Detect when m_comm is not set.

### DIFF
--- a/example_plugin/example_plugin/ExampleUpdater.cc
+++ b/example_plugin/example_plugin/ExampleUpdater.cc
@@ -26,6 +26,7 @@ ExampleUpdater::ExampleUpdater(std::shared_ptr<SystemDefinition> sysdef)
 */
 void ExampleUpdater::update(uint64_t timestep)
     {
+    Updater::update(timestep);
     if (m_prof) m_prof->push("ExampleUpdater");
 
     // access the particle data for writing on the CPU
@@ -70,6 +71,7 @@ ExampleUpdaterGPU::ExampleUpdaterGPU(std::shared_ptr<SystemDefinition> sysdef)
 */
 void ExampleUpdaterGPU::update(uint64_t timestep)
     {
+    Updater::update(timestep);
     if (m_prof) m_prof->push("ExampleUpdater");
 
     // access the particle data arrays for writing on the GPU

--- a/hoomd/Analyzer.h
+++ b/hoomd/Analyzer.h
@@ -23,6 +23,7 @@
 #include "Communicator.h"
 
 #include <memory>
+#include <typeinfo>
 
 /*! \ingroup hoomd_lib
     @{
@@ -72,7 +73,8 @@ class PYBIND11_EXPORT Analyzer
             if (m_pdata->getDomainDecomposition() && !m_comm)
                 {
                 throw std::runtime_error(
-                    "Bug: m_comm not set for a system with a domain decomposition.");
+                    "Bug: m_comm not set for a system with a domain decomposition in " +
+                    std::string(typeid(*this).name()));
                 }
             #endif
             }

--- a/hoomd/Analyzer.h
+++ b/hoomd/Analyzer.h
@@ -66,7 +66,16 @@ class PYBIND11_EXPORT Analyzer
         /*! Derived classes will implement this method to calculate their results
             \param timestep Current time step of the simulation
             */
-        virtual void analyze(uint64_t timestep){}
+        virtual void analyze(uint64_t timestep)
+            {
+            #ifdef ENABLE_MPI
+            if (m_pdata->getDomainDecomposition() && !m_comm)
+                {
+                throw std::runtime_error(
+                    "Bug: m_comm not set for a system with a domain decomposition.");
+                }
+            #endif
+            }
 
         //! Sets the profiler for the analyzer to use
         void setProfiler(std::shared_ptr<Profiler> prof);

--- a/hoomd/BoxResizeUpdater.cc
+++ b/hoomd/BoxResizeUpdater.cc
@@ -95,6 +95,7 @@ return new_box;
 */
 void BoxResizeUpdater::update(uint64_t timestep)
     {
+    Updater::update(timestep);
     m_exec_conf->msg->notice(10) << "Box resize update" << endl;
     if (m_prof) m_prof->push("BoxResize");
 

--- a/hoomd/CallbackAnalyzer.cc
+++ b/hoomd/CallbackAnalyzer.cc
@@ -40,6 +40,7 @@ CallbackAnalyzer::~CallbackAnalyzer()
 */
 void CallbackAnalyzer::analyze(uint64_t timestep)
     {
+    Analyzer::analyze(timestep);
       callback(timestep);
     }
 

--- a/hoomd/CellList.cc
+++ b/hoomd/CellList.cc
@@ -118,6 +118,7 @@ uint3 CellList::computeDimensions()
 
 void CellList::compute(uint64_t timestep)
     {
+    Compute::compute(timestep);
     bool force = false;
 
     if (m_prof)

--- a/hoomd/CellListStencil.cc
+++ b/hoomd/CellListStencil.cc
@@ -51,6 +51,7 @@ CellListStencil::~CellListStencil()
 
 void CellListStencil::compute(uint64_t timestep)
     {
+    Compute::compute(timestep);
     // guard against unnecessary calls
     if (!shouldCompute(timestep)) return;
 

--- a/hoomd/Compute.h
+++ b/hoomd/Compute.h
@@ -75,7 +75,8 @@ class PYBIND11_EXPORT Compute
             if (m_pdata->getDomainDecomposition() && !m_comm)
                 {
                 throw std::runtime_error(
-                    "Bug: m_comm not set for a system with a domain decomposition.");
+                    "Bug: m_comm not set for a system with a domain decomposition in " +
+                    std::string(typeid(*this).name()));
                 }
             #endif
             }

--- a/hoomd/Compute.h
+++ b/hoomd/Compute.h
@@ -63,13 +63,22 @@ class PYBIND11_EXPORT Compute
     public:
         //! Constructs the compute and associates it with the ParticleData
         Compute(std::shared_ptr<SystemDefinition> sysdef);
-        virtual ~Compute() {};
+        virtual ~Compute() {}
 
         //! Abstract method that performs the computation
         /*! \param timestep Current time step
             Derived classes will implement this method to calculate their results
         */
-        virtual void compute(uint64_t timestep){}
+        virtual void compute(uint64_t timestep)
+            {
+            #ifdef ENABLE_MPI
+            if (m_pdata->getDomainDecomposition() && !m_comm)
+                {
+                throw std::runtime_error(
+                    "Bug: m_comm not set for a system with a domain decomposition.");
+                }
+            #endif
+            }
 
         //! Abstract method that performs a benchmark
         virtual double benchmark(unsigned int num_iters);

--- a/hoomd/DCDDumpWriter.cc
+++ b/hoomd/DCDDumpWriter.cc
@@ -142,6 +142,7 @@ DCDDumpWriter::~DCDDumpWriter()
 */
 void DCDDumpWriter::analyze(uint64_t timestep)
     {
+    Analyzer::analyze(timestep);
     if (m_prof)
         m_prof->push("Dump DCD");
 

--- a/hoomd/ForceCompute.cc
+++ b/hoomd/ForceCompute.cc
@@ -459,6 +459,7 @@ pybind11::object ForceCompute::getVirialsPython()
 
 void ForceCompute::compute(uint64_t timestep)
     {
+    Compute::compute(timestep);
     // recompute forces if the particles were sorted, this is a new timestep, or the particle data
     // flags do not match
     if (m_particles_sorted ||

--- a/hoomd/GSDDumpWriter.cc
+++ b/hoomd/GSDDumpWriter.cc
@@ -141,6 +141,7 @@ GSDDumpWriter::~GSDDumpWriter()
 */
 void GSDDumpWriter::analyze(uint64_t timestep)
     {
+    Analyzer::analyze(timestep);
     int retval;
     bool root=true;
 

--- a/hoomd/GetarDumpWriter.cc
+++ b/hoomd/GetarDumpWriter.cc
@@ -339,6 +339,7 @@ namespace getardump{
 
     void GetarDumpWriter::analyze(uint64_t timestep)
         {
+        Analyzer::analyze(timestep);
         const uint64_t shiftedTimestep(timestep - m_offset);
         bool neededSnapshots[9] = {false, false, false, false, false,
                                    false, false, false, false};

--- a/hoomd/IMDInterface.cc
+++ b/hoomd/IMDInterface.cc
@@ -133,6 +133,7 @@ IMDInterface::~IMDInterface()
 */
 void IMDInterface::analyze(uint64_t timestep)
     {
+    Analyzer::analyze(timestep);
     if (m_prof)
         m_prof->push("IMD");
 

--- a/hoomd/Integrator.cc
+++ b/hoomd/Integrator.cc
@@ -851,6 +851,7 @@ void Integrator::computeNetForceGPU(uint64_t timestep)
 */
 void Integrator::update(uint64_t timestep)
     {
+    Updater::update(timestep);
     }
 
 /** prepRun() is to be called at the very beginning of each run, before any analyzers are called, but after the full

--- a/hoomd/LoadBalancer.cc
+++ b/hoomd/LoadBalancer.cc
@@ -61,6 +61,7 @@ LoadBalancer::~LoadBalancer()
  */
 void LoadBalancer::update(uint64_t timestep)
     {
+    Updater::update(timestep);
     // we need a communicator, but don't want to check for it in release builds
     assert(m_comm);
 

--- a/hoomd/LogHDF5.cc
+++ b/hoomd/LogHDF5.cc
@@ -37,6 +37,7 @@ LogHDF5::~LogHDF5(void)
  */
 void LogHDF5::analyze(uint64_t timestep)
     {
+    Analyzer::analyze(timestep);
     //Call the base class to cache all values.
     LogMatrix::analyze(timestep);
 

--- a/hoomd/LogPlainTXT.cc
+++ b/hoomd/LogPlainTXT.cc
@@ -92,6 +92,8 @@ void LogPlainTXT::setDelimiter(const std::string& delimiter)
 */
 void LogPlainTXT::analyze(uint64_t timestep)
     {
+    Analyzer::analyze(timestep);
+
     // do nothing if we do not output to a file
     if (!m_file_output)
         return;

--- a/hoomd/Logger.cc
+++ b/hoomd/Logger.cc
@@ -140,6 +140,7 @@ void Logger::setLoggedQuantities(const std::vector< std::string >& quantities)
 */
 void Logger::analyze(uint64_t timestep)
     {
+    Analyzer::analyze(timestep);
     if (m_prof) m_prof->push("Log");
 
     // update info in cache for later use and for immediate output.

--- a/hoomd/PythonAnalyzer.cc
+++ b/hoomd/PythonAnalyzer.cc
@@ -11,6 +11,7 @@ PythonAnalyzer::PythonAnalyzer(std::shared_ptr<SystemDefinition> sysdef,
 
 void PythonAnalyzer::analyze(uint64_t timestep)
     {
+    Analyzer::analyze(timestep);
     m_analyzer.attr("act")(timestep);
     }
 

--- a/hoomd/PythonTuner.cc
+++ b/hoomd/PythonTuner.cc
@@ -12,6 +12,7 @@ PythonTuner::PythonTuner(std::shared_ptr<SystemDefinition> sysdef,
 
 void PythonTuner::update(uint64_t timestep)
     {
+    Updater::update(timestep);
     m_tuner.attr("act")(timestep);
     }
 

--- a/hoomd/PythonUpdater.cc
+++ b/hoomd/PythonUpdater.cc
@@ -11,6 +11,7 @@ PythonUpdater::PythonUpdater(std::shared_ptr<SystemDefinition> sysdef,
 
 void PythonUpdater::update(uint64_t timestep)
     {
+    Updater::update(timestep);
     m_updater.attr("act")(timestep);
     }
 

--- a/hoomd/SFCPackTuner.cc
+++ b/hoomd/SFCPackTuner.cc
@@ -70,6 +70,7 @@ SFCPackTuner::~SFCPackTuner()
  */
 void SFCPackTuner::update(uint64_t timestep)
     {
+    Updater::update(timestep);
     m_exec_conf->msg->notice(6) << "SFCPackTuner: particle sort" << std::endl;
 
     #ifdef ENABLE_MPI

--- a/hoomd/Updater.h
+++ b/hoomd/Updater.h
@@ -66,7 +66,17 @@ class PYBIND11_EXPORT Updater
         /*! Derived classes will implement this method to perform their specific update
             \param timestep Current time step of the simulation
         */
-        virtual void update(uint64_t timestep)  {};
+        virtual void update(uint64_t timestep)
+            {
+            #ifdef ENABLE_MPI
+            if (m_pdata->getDomainDecomposition() && !m_comm)
+                {
+                throw std::runtime_error(
+                    "Bug: m_comm not set for a system with a domain decomposition in " +
+                    std::string(typeid(*this).name()));
+                }
+            #endif
+            };
 
         //! Sets the profiler for the compute to use
         virtual void setProfiler(std::shared_ptr<Profiler> prof);

--- a/hoomd/hpmc/AnalyzerSDF.h
+++ b/hoomd/hpmc/AnalyzerSDF.h
@@ -204,6 +204,7 @@ AnalyzerSDF<Shape>::AnalyzerSDF(std::shared_ptr<SystemDefinition> sysdef,
 template < class Shape >
 void AnalyzerSDF<Shape>::analyze(uint64_t timestep)
     {
+    Analyzer::analyze(timestep);
     m_exec_conf->msg->notice(8) << "Analyzing sdf at step " << timestep << std::endl;
 
     // kludge to update the max diameter dynamically if it changes

--- a/hoomd/hpmc/ComputeFreeVolume.h
+++ b/hoomd/hpmc/ComputeFreeVolume.h
@@ -111,6 +111,7 @@ ComputeFreeVolume< Shape >::ComputeFreeVolume(std::shared_ptr<SystemDefinition> 
 template<class Shape>
 void ComputeFreeVolume<Shape>::compute(uint64_t timestep)
     {
+    Compute::compute(timestep);
     if (!shouldCompute(timestep))
         return;
 

--- a/hoomd/hpmc/IntegratorHPMCMono.h
+++ b/hoomd/hpmc/IntegratorHPMCMono.h
@@ -884,6 +884,7 @@ void IntegratorHPMCMono<Shape>::slotNumTypesChange()
 template <class Shape>
 void IntegratorHPMCMono<Shape>::update(uint64_t timestep)
     {
+    Integrator::update(timestep);
     m_exec_conf->msg->notice(10) << "HPMCMono update: " << timestep << std::endl;
     IntegratorHPMC::update(timestep);
 

--- a/hoomd/hpmc/UpdaterBoxMC.cc
+++ b/hoomd/hpmc/UpdaterBoxMC.cc
@@ -399,6 +399,7 @@ inline bool UpdaterBoxMC::safe_box(const Scalar newL[3], const unsigned int& Ndi
 */
 void UpdaterBoxMC::update(uint64_t timestep)
     {
+    Updater::update(timestep);
     if (m_prof) m_prof->push("UpdaterBoxMC");
     m_count_step_start = m_count_total;
     m_exec_conf->msg->notice(10) << "UpdaterBoxMC: " << timestep << std::endl;

--- a/hoomd/hpmc/UpdaterClusters.h
+++ b/hoomd/hpmc/UpdaterClusters.h
@@ -1547,6 +1547,7 @@ void UpdaterClusters<Shape>::connectedComponents()
 template< class Shape >
 void UpdaterClusters<Shape>::update(uint64_t timestep)
     {
+    Updater::update(timestep);
     #ifdef ENABLE_MPI
     if (this->m_pdata->getDomainDecomposition())
         throw std::runtime_error("UpdaterClusters does not work with spatial domain decomposition.");

--- a/hoomd/hpmc/UpdaterClustersGPU.h
+++ b/hoomd/hpmc/UpdaterClustersGPU.h
@@ -308,6 +308,7 @@ UpdaterClustersGPU<Shape>::~UpdaterClustersGPU()
 template< class Shape >
 void UpdaterClustersGPU<Shape>::update(uint64_t timestep)
     {
+    Updater::update(timestep);
     // compute nominal cell width
     auto& params = this->m_mc->getParams();
     Scalar nominal_width = this->m_mc->getMaxCoreDiameter();

--- a/hoomd/hpmc/UpdaterMuVT.h
+++ b/hoomd/hpmc/UpdaterMuVT.h
@@ -806,6 +806,7 @@ bool UpdaterMuVT<Shape>::boxResizeAndScale(uint64_t timestep, const BoxDim old_b
 template<class Shape>
 void UpdaterMuVT<Shape>::update(uint64_t timestep)
     {
+    Updater::update(timestep);
     m_count_step_start = m_count_total;
     unsigned int ndim = this->m_sysdef->getNDimensions();
 

--- a/hoomd/hpmc/UpdaterQuickCompress.cc
+++ b/hoomd/hpmc/UpdaterQuickCompress.cc
@@ -37,6 +37,7 @@ UpdaterQuickCompress::~UpdaterQuickCompress()
 
 void UpdaterQuickCompress::update(uint64_t timestep)
     {
+    Updater::update(timestep);
     if (m_prof)
         m_prof->push("UpdaterQuickCompress");
     m_exec_conf->msg->notice(10) << "UpdaterQuickCompress: " << timestep << std::endl;

--- a/hoomd/md/ComputeThermo.cc
+++ b/hoomd/md/ComputeThermo.cc
@@ -82,6 +82,7 @@ ComputeThermo::~ComputeThermo()
 */
 void ComputeThermo::compute(uint64_t timestep)
     {
+    Compute::compute(timestep);
     if (shouldCompute(timestep))
         {
         computeProperties();

--- a/hoomd/md/ComputeThermoHMA.cc
+++ b/hoomd/md/ComputeThermoHMA.cc
@@ -81,6 +81,7 @@ ComputeThermoHMA::~ComputeThermoHMA()
 */
 void ComputeThermoHMA::compute(uint64_t timestep)
     {
+    Compute::compute(timestep);
     if (!shouldCompute(timestep))
         return;
 

--- a/hoomd/md/ConstraintEllipsoid.cc
+++ b/hoomd/md/ConstraintEllipsoid.cc
@@ -47,6 +47,7 @@ ConstraintEllipsoid::~ConstraintEllipsoid()
 */
 void ConstraintEllipsoid::update(uint64_t timestep)
     {
+    Updater::update(timestep);
     unsigned int group_size = m_group->getNumMembers();
     if (group_size == 0)
         return;

--- a/hoomd/md/ConstraintEllipsoidGPU.cc
+++ b/hoomd/md/ConstraintEllipsoidGPU.cc
@@ -44,6 +44,7 @@ ConstraintEllipsoidGPU::ConstraintEllipsoidGPU(std::shared_ptr<SystemDefinition>
 */
 void ConstraintEllipsoidGPU::update(uint64_t timestep)
     {
+    Updater::update(timestep);
     unsigned int group_size = m_group->getNumMembers();
     if (group_size == 0)
         return;

--- a/hoomd/md/Enforce2DUpdater.cc
+++ b/hoomd/md/Enforce2DUpdater.cc
@@ -43,6 +43,7 @@ Enforce2DUpdater::~Enforce2DUpdater()
 */
 void Enforce2DUpdater::update(uint64_t timestep)
     {
+    Updater::update(timestep);
     if (m_prof) m_prof->push("Enforce2D");
 
     assert(m_pdata);

--- a/hoomd/md/Enforce2DUpdaterGPU.cc
+++ b/hoomd/md/Enforce2DUpdaterGPU.cc
@@ -34,6 +34,7 @@ Enforce2DUpdaterGPU::Enforce2DUpdaterGPU(std::shared_ptr<SystemDefinition> sysde
 */
 void Enforce2DUpdaterGPU::update(uint64_t timestep)
     {
+    Updater::update(timestep);
     assert(m_pdata);
 
     if (m_prof)

--- a/hoomd/md/FIREEnergyMinimizer.cc
+++ b/hoomd/md/FIREEnergyMinimizer.cc
@@ -135,6 +135,7 @@ void FIREEnergyMinimizer::reset()
 */
 void FIREEnergyMinimizer::update(uint64_t timestep)
     {
+    Integrator::update(timestep);
     if (m_converged)
         return;
 

--- a/hoomd/md/FIREEnergyMinimizerGPU.cc
+++ b/hoomd/md/FIREEnergyMinimizerGPU.cc
@@ -64,7 +64,7 @@ FIREEnergyMinimizerGPU::FIREEnergyMinimizerGPU(std::shared_ptr<SystemDefinition>
 */
 void FIREEnergyMinimizerGPU::update(uint64_t timestep)
     {
-
+    Integrator::update(timestep);
     if (m_converged)
         return;
 

--- a/hoomd/md/IntegrationMethodTwoStep.h
+++ b/hoomd/md/IntegrationMethodTwoStep.h
@@ -189,7 +189,7 @@ class PYBIND11_EXPORT IntegrationMethodTwoStep
         //! Set the communicator to use
         /*! \param comm MPI communication class
          */
-        void setCommunicator(std::shared_ptr<Communicator> comm)
+        virtual void setCommunicator(std::shared_ptr<Communicator> comm)
             {
             assert(comm);
             m_comm = comm;

--- a/hoomd/md/IntegratorTwoStep.cc
+++ b/hoomd/md/IntegratorTwoStep.cc
@@ -87,6 +87,7 @@ Scalar IntegratorTwoStep::getLogValue(const std::string& quantity, uint64_t time
 */
 void IntegratorTwoStep::update(uint64_t timestep)
     {
+    Integrator::update(timestep);
     // issue a warning if no integration methods are set
     if (!m_gave_warning && m_methods.size() == 0)
         {

--- a/hoomd/md/MuellerPlatheFlow.cc
+++ b/hoomd/md/MuellerPlatheFlow.cc
@@ -63,6 +63,7 @@ MuellerPlatheFlow::~MuellerPlatheFlow(void)
 
 void MuellerPlatheFlow::update(uint64_t timestep)
     {
+    Updater::update(timestep);
     if( m_needs_orthorhombic_check)
         this->verify_orthorhombic_box();
 

--- a/hoomd/md/NeighborList.cc
+++ b/hoomd/md/NeighborList.cc
@@ -314,6 +314,7 @@ NeighborList::~NeighborList()
 */
 void NeighborList::compute(uint64_t timestep)
     {
+    Compute::compute(timestep);
     // check if the rcut array has changed and update it
     if (m_rcut_changed)
         {

--- a/hoomd/md/TempRescaleUpdater.cc
+++ b/hoomd/md/TempRescaleUpdater.cc
@@ -45,6 +45,7 @@ TempRescaleUpdater::~TempRescaleUpdater()
 */
 void TempRescaleUpdater::update(uint64_t timestep)
     {
+    Updater::update(timestep);
     // find the current temperature
 
     assert(m_thermo);

--- a/hoomd/md/TwoStepBerendsen.h
+++ b/hoomd/md/TwoStepBerendsen.h
@@ -67,6 +67,19 @@ class PYBIND11_EXPORT TwoStepBerendsen : public IntegrationMethodTwoStep
         //! Performs the second step of the integration
         virtual void integrateStepTwo(uint64_t timestep);
 
+        #ifdef ENABLE_MPI
+
+        virtual void setCommunicator(std::shared_ptr<Communicator> comm)
+            {
+            // call base class method
+            IntegrationMethodTwoStep::setCommunicator(comm);
+
+            // set the communicator on the internal thermo
+            m_thermo->setCommunicator(comm);
+            }
+
+        #endif
+
     protected:
         const std::shared_ptr<ComputeThermo> m_thermo; //!< compute for thermodynamic quantities
         Scalar m_tau;                    //!< time constant for Berendsen thermostat

--- a/hoomd/md/TwoStepNPTMTK.h
+++ b/hoomd/md/TwoStepNPTMTK.h
@@ -232,6 +232,20 @@ class PYBIND11_EXPORT TwoStepNPTMTK : public IntegrationMethodTwoStep
         /// Set the barostat degrees of freedom
         void setBarostatDOF(pybind11::tuple v);
 
+        #ifdef ENABLE_MPI
+
+        virtual void setCommunicator(std::shared_ptr<Communicator> comm)
+            {
+            // call base class method
+            IntegrationMethodTwoStep::setCommunicator(comm);
+
+            // set the communicator on the internal thermo
+            m_thermo_half_step->setCommunicator(comm);
+            m_thermo_full_step->setCommunicator(comm);
+            }
+
+        #endif
+
     protected:
         std::shared_ptr<ComputeThermo> m_thermo_half_step;   //!< ComputeThermo operating on the integrated group at t+dt/2
         std::shared_ptr<ComputeThermo> m_thermo_full_step; //!< ComputeThermo operating on the integrated group at t

--- a/hoomd/md/TwoStepNVTMTK.h
+++ b/hoomd/md/TwoStepNVTMTK.h
@@ -136,6 +136,19 @@ class PYBIND11_EXPORT TwoStepNVTMTK : public IntegrationMethodTwoStep
         /// Set the rotational thermostat degrees of freedom
         void setRotationalThermostatDOF(pybind11::tuple v);
 
+        #ifdef ENABLE_MPI
+
+        virtual void setCommunicator(std::shared_ptr<Communicator> comm)
+            {
+            // call base class method
+            IntegrationMethodTwoStep::setCommunicator(comm);
+
+            // set the communicator on the internal thermo
+            m_thermo->setCommunicator(comm);
+            }
+
+        #endif
+
     protected:
         std::shared_ptr<ComputeThermo> m_thermo;    //!< compute for thermodynamic quantities
 

--- a/hoomd/md/ZeroMomentumUpdater.cc
+++ b/hoomd/md/ZeroMomentumUpdater.cc
@@ -36,6 +36,7 @@ ZeroMomentumUpdater::~ZeroMomentumUpdater()
 */
 void ZeroMomentumUpdater::update(uint64_t timestep)
     {
+    Updater::update(timestep);
     if (m_prof) m_prof->push("ZeroMomentum");
 
     // calculate the average momentum

--- a/hoomd/mpcd/CellList.cc
+++ b/hoomd/mpcd/CellList.cc
@@ -58,6 +58,7 @@ mpcd::CellList::~CellList()
 
 void mpcd::CellList::compute(uint64_t timestep)
     {
+    Compute::compute(timestep);
     if (m_prof) m_prof->push(m_exec_conf, "MPCD cell list");
 
     if (m_virtual_change)

--- a/hoomd/mpcd/CellThermoCompute.cc
+++ b/hoomd/mpcd/CellThermoCompute.cc
@@ -55,6 +55,7 @@ mpcd::CellThermoCompute::~CellThermoCompute()
 
 void mpcd::CellThermoCompute::compute(uint64_t timestep)
     {
+    Compute::compute(timestep);
     // check if computation should proceed, and always mark the calculation as occurring at this timestep, even if forced
     if (!shouldCompute(timestep)) return;
     m_last_computed = timestep;

--- a/hoomd/mpcd/Integrator.cc
+++ b/hoomd/mpcd/Integrator.cc
@@ -62,6 +62,7 @@ void mpcd::Integrator::setProfiler(std::shared_ptr<Profiler> prof)
  */
 void mpcd::Integrator::update(uint64_t timestep)
     {
+    Integrator::update(timestep);
     // issue a warning if no integration methods are set
     if (!m_gave_warning && m_methods.size() == 0 && !m_stream)
         {

--- a/hoomd/mpcd/Integrator.cc
+++ b/hoomd/mpcd/Integrator.cc
@@ -62,7 +62,7 @@ void mpcd::Integrator::setProfiler(std::shared_ptr<Profiler> prof)
  */
 void mpcd::Integrator::update(uint64_t timestep)
     {
-    Integrator::update(timestep);
+    IntegratorTwoStep::update(timestep);
     // issue a warning if no integration methods are set
     if (!m_gave_warning && m_methods.size() == 0 && !m_stream)
         {

--- a/hoomd/mpcd/test/cell_communicator_mpi_test.cc
+++ b/hoomd/mpcd/test/cell_communicator_mpi_test.cc
@@ -9,6 +9,7 @@
 #include "hoomd/mpcd/CommunicatorUtilities.h"
 #include "hoomd/mpcd/ReductionOperators.h"
 #include "hoomd/mpcd/SystemData.h"
+#include "hoomd/Communicator.h"
 
 #include "hoomd/SnapshotSystemData.h"
 #include "hoomd/test/upp11_config.h"
@@ -135,6 +136,8 @@ void cell_communicator_overdecompose_test(std::shared_ptr<ExecutionConfiguration
     auto mpcd_sys_snap = std::make_shared<mpcd::SystemDataSnapshot>(sysdef);
     auto mpcd_sys = std::make_shared<mpcd::SystemData>(mpcd_sys_snap);
     std::shared_ptr<mpcd::CellList> cl = mpcd_sys->getCellList();
+    std::shared_ptr<Communicator> pdata_comm(new Communicator(sysdef, decomposition));
+    cl->setCommunicator(pdata_comm);
     cl->computeDimensions();
 
     // Don't really care what's in this array, just want to make sure errors get thrown appropriately

--- a/hoomd/mpcd/test/cell_list_mpi_test.cc
+++ b/hoomd/mpcd/test/cell_list_mpi_test.cc
@@ -9,7 +9,7 @@
 #endif // ENABLE_HIP
 
 #include "hoomd/mpcd/Communicator.h"
-
+#include "hoomd/Communicator.h"
 #include "hoomd/SnapshotSystemData.h"
 #include "hoomd/test/upp11_config.h"
 
@@ -753,6 +753,8 @@ void celllist_basic_test(std::shared_ptr<ExecutionConfiguration> exec_conf)
         }
 
     std::shared_ptr<mpcd::CellList> cl(new CL(sysdef, pdata));
+    std::shared_ptr<Communicator> pdata_comm(new Communicator(sysdef, decomposition));
+    cl->setCommunicator(pdata_comm);
     cl->compute(0);
     const unsigned int my_rank = exec_conf->getRank();
         {
@@ -962,6 +964,8 @@ void celllist_edge_test(std::shared_ptr<ExecutionConfiguration> exec_conf)
 
 
     std::shared_ptr<mpcd::CellList> cl(new CL(sysdef, pdata));
+    std::shared_ptr<Communicator> pdata_comm(new Communicator(sysdef, decomposition));
+    cl->setCommunicator(pdata_comm);
 
     // move particles to edges of domains for testing
     const unsigned int my_rank = exec_conf->getRank();

--- a/hoomd/mpcd/test/cell_thermo_compute_mpi_test.cc
+++ b/hoomd/mpcd/test/cell_thermo_compute_mpi_test.cc
@@ -12,6 +12,7 @@
 
 #include "hoomd/SnapshotSystemData.h"
 #include "hoomd/test/upp11_config.h"
+#include "hoomd/Communicator.h"
 
 HOOMD_UP_MAIN()
 
@@ -60,7 +61,10 @@ void cell_thermo_basic_test(std::shared_ptr<ExecutionConfiguration> exec_conf)
     std::shared_ptr<mpcd::ParticleData> pdata = mpcd_sys->getParticleData();
 
     std::shared_ptr<mpcd::CellList> cl = mpcd_sys->getCellList();
+    std::shared_ptr<Communicator> pdata_comm(new Communicator(sysdef, decomposition));
+    cl->setCommunicator(pdata_comm);
     std::shared_ptr<CT> thermo = std::make_shared<CT>(mpcd_sys);
+    thermo->setCommunicator(pdata_comm);
     AllThermoRequest thermo_req(thermo);
     thermo->compute(0);
         {

--- a/hoomd/update/box_resize.py
+++ b/hoomd/update/box_resize.py
@@ -108,5 +108,6 @@ class BoxResize(Updater):
                                           box,
                                           Constant(1),
                                           group)
-        updater.setCommunicator(state._simulation._system_communicator)
+        if state._simulation._system_communicator is not None:
+            updater.setCommunicator(state._simulation._system_communicator)
         updater.update(state._simulation.timestep)

--- a/hoomd/update/box_resize.py
+++ b/hoomd/update/box_resize.py
@@ -108,4 +108,5 @@ class BoxResize(Updater):
                                           box,
                                           Constant(1),
                                           group)
+        updater.setCommunicator(state._simulation._system_communicator)
         updater.update(state._simulation.timestep)


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should based on *maint*. -->
<!-- New features should based on *master*. -->

## Description

<!-- Describe your changes in detail. -->
Check on every call to `compute`, `update` and `analyze` that `m_comm` is set when needed.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
In the current API for HOOMD, it is possible to instantiate and use many objects in MPI mode without calling `setCommunicator()`. When doing so, this can lead to seg faults (#929) or silent but incorrect results (#923). I don't have a good general solution to this issue. This PR is an effort to detect when `setCommunicator` calls are missing and notify the developer, but it is not foolproof as it relies on calling the base class methods. in `compute`, `update` and `analyze`.

We can discuss later if there is a better way to handle this. This PR is a stopgap fix.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
This PR should fail tests on submission as it finds a missing `setCommunicator` call in the neighbor list. It will start passing once #929 is merged.

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
Internal changes only.

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
