### PR TITLE
Test fene bond v3

### DIFF
--- a/hoomd/md/EvaluatorBondFENE.h
+++ b/hoomd/md/EvaluatorBondFENE.h
@@ -42,17 +42,20 @@ struct fene_params
         {
         k = v["k"].cast<Scalar>();
         r_0 = v["r0"].cast<Scalar>();
-        lj1 = v["lj1"].cast<Scalar>();
-        lj2 = v["lj2"].cast<Scalar>();
+        Scalar epsilon = v["epsilon"].cast<Scalar>();
+        Scalar sigma = v["sigma"].cast<Scalar>();
+        lj1 = 4.0 * epsilon * std::pow(sigma, 12.0);
+        lj2 = 4.0 * epsilon * std::pow(sigma, 6.0);
         }
 
     pybind11::dict asDict()
         {
         pybind11::dict v;
-        v["r0"] = r_0;
-        v["lj1"] = lj1;
-        v["lj2"] = lj2;
         v["k"] = k;
+        v["r0"] = r_0;
+        Scalar sigma = std::pow(lj1 / lj2, 1.0 / 6.0);
+        v["sigma"] = sigma;
+        v["epsilon"] = lj1 / 4.0 / std::pow(sigma, 12.0);
         return v;
         }
     #endif

--- a/hoomd/md/pytest/CMakeLists.txt
+++ b/hoomd/md/pytest/CMakeLists.txt
@@ -3,6 +3,7 @@ set(files __init__.py
     aniso_forces_and_energies.json
     test_active.py
     test_aniso_pair.py
+    test_bond_FENE.py
     test_flags.py
     test_potential.py
     test_methods.py

--- a/hoomd/md/pytest/test_bond_FENE.py
+++ b/hoomd/md/pytest/test_bond_FENE.py
@@ -11,6 +11,16 @@ def get_bond_params():
     return zip(k, r0, epsilon, sigma)
 
 
+def get_bond_params_and_forces_and_energies():
+    k = [30.0, 25.0, 20.0]
+    r0 = [1.6, 1.7, 1.8]
+    epsilon = [0.9, 1.0, 1.1]
+    sigma = [1.1, 1.0, 0.9]
+    forces = [282.296, 146.288, 88.8238]
+    energies = [70.5638, 49.2476, 35.3135]
+    return zip(k, r0, epsilon, sigma, forces, energies)
+
+
 @pytest.mark.parametrize("bond_params_tuple", get_bond_params())
 def test_before_attaching(bond_params_tuple):
     k, r0, epsilon, sigma = bond_params_tuple
@@ -54,3 +64,49 @@ def test_after_attaching(two_particle_snapshot_factory,
         np.testing.assert_allclose(bond_potential.params['bond'][key],
                                    bond_params[key],
                                    rtol=1e-6)
+
+
+@pytest.mark.parametrize("bond_params_and_force_and_energy",
+                         get_bond_params_and_forces_and_energies())
+def test_forces_and_energies(two_particle_snapshot_factory,
+                             simulation_factory,
+                             bond_params_and_force_and_energy):
+    snap = two_particle_snapshot_factory(d=0.969, L=5)
+    if snap.exists:
+        snap.bonds.N = 1
+        snap.bonds.types = ['bond']
+        snap.bonds.typeid[0] = 0
+        snap.bonds.group[0] = (0, 1)
+        snap.particles.diameter[0] = 0.5
+        snap.particles.diameter[1] = 0.5
+    sim = simulation_factory(snap)
+
+    k, r0, epsilon, sigma, force, energy = bond_params_and_force_and_energy
+    bond_params = dict(k=k, r0=r0, epsilon=epsilon, sigma=sigma)
+    bond_potential = hoomd.md.bond.FENE()
+    bond_potential.params['bond'] = bond_params
+
+    integrator = hoomd.md.Integrator(dt=0.005)
+
+    integrator.forces.append(bond_potential)
+
+    nvt = hoomd.md.methods.Langevin(kT=1, filter=hoomd.filter.All(), alpha=0.1)
+    integrator.methods.append(nvt)
+    sim.operations.integrator = integrator
+
+    sim.run(0)
+
+    sim_energies = sim.operations.integrator.forces[0].energies
+    sim_forces = sim.operations.integrator.forces[0].forces
+    np.testing.assert_allclose(sum(sim_energies),
+                               energy,
+                               rtol=1e-2,
+                               atol=1e-5)
+    np.testing.assert_allclose(sim_forces[0],
+                               [force, 0.0, 0.0],
+                               rtol=1e-2,
+                               atol=1e-5)
+    np.testing.assert_allclose(sim_forces[1],
+                               [-1 * force, 0.0, 0.0],
+                               rtol=1e-2,
+                               atol=1e-5)

--- a/hoomd/md/pytest/test_bond_FENE.py
+++ b/hoomd/md/pytest/test_bond_FENE.py
@@ -1,0 +1,24 @@
+import hoomd
+import pytest
+import numpy as np
+
+
+def get_bond_params():
+    k = [30.0, 25.0, 20.0]
+    r0 = [1.6, 1.7, 1.8]
+    epsilon = [0.9, 1.0, 1.1]
+    sigma = [1.1, 1.0, 0.9]
+    return zip(k, r0, epsilon, sigma)
+
+
+@pytest.mark.parametrize("bond_params_tuple", get_bond_params())
+def test_before_attaching(bond_params_tuple):
+    k, r0, epsilon, sigma = bond_params_tuple
+    bond_params = dict(k=k, r0=r0, epsilon=epsilon, sigma=sigma)
+    bond_potential = hoomd.md.bond.FENE()
+    bond_potential.params['bond'] = bond_params
+
+    for key in bond_params.keys():
+        np.testing.assert_allclose(bond_potential.params['bond'][key],
+                                   bond_params[key],
+                                   rtol=1e-6)

--- a/hoomd/md/pytest/test_bond_FENE.py
+++ b/hoomd/md/pytest/test_bond_FENE.py
@@ -22,3 +22,35 @@ def test_before_attaching(bond_params_tuple):
         np.testing.assert_allclose(bond_potential.params['bond'][key],
                                    bond_params[key],
                                    rtol=1e-6)
+
+
+@pytest.mark.parametrize("bond_params_tuple", get_bond_params())
+def test_after_attaching(two_particle_snapshot_factory,
+                         simulation_factory,
+                         bond_params_tuple):
+    snap = two_particle_snapshot_factory(d=0.969, L=5)
+    if snap.exists:
+        snap.bonds.N = 1
+        snap.bonds.types = ['bond']
+        snap.bonds.typeid[0] = 0
+        snap.bonds.group[0] = (0, 1)
+    sim = simulation_factory(snap)
+
+    k, r0, epsilon, sigma = bond_params_tuple
+    bond_params = dict(k=k, r0=r0, epsilon=epsilon, sigma=sigma)
+    bond_potential = hoomd.md.bond.FENE()
+    bond_potential.params['bond'] = bond_params
+
+    integrator = hoomd.md.Integrator(dt=0.005)
+
+    integrator.forces.append(bond_potential)
+
+    nvt = hoomd.md.methods.Langevin(kT=1, filter=hoomd.filter.All(), alpha=0.1)
+    integrator.methods.append(nvt)
+    sim.operations.integrator = integrator
+
+    sim.run(0)
+    for key in bond_params.keys():
+        np.testing.assert_allclose(bond_potential.params['bond'][key],
+                                   bond_params[key],
+                                   rtol=1e-6)

--- a/hoomd/md/pytest/test_bond_FENE.py
+++ b/hoomd/md/pytest/test_bond_FENE.py
@@ -2,23 +2,20 @@ import hoomd
 import pytest
 import numpy as np
 
+_k = [30.0, 25.0, 20.0]
+_r0 = [1.6, 1.7, 1.8]
+_epsilon = [0.9, 1.0, 1.1]
+_sigma = [1.1, 1.0, 0.9]
+
 
 def get_bond_params():
-    k = [30.0, 25.0, 20.0]
-    r0 = [1.6, 1.7, 1.8]
-    epsilon = [0.9, 1.0, 1.1]
-    sigma = [1.1, 1.0, 0.9]
-    return zip(k, r0, epsilon, sigma)
+    return zip(_k, _r0, _epsilon, _sigma)
 
 
 def get_bond_params_and_forces_and_energies():
-    k = [30.0, 25.0, 20.0]
-    r0 = [1.6, 1.7, 1.8]
-    epsilon = [0.9, 1.0, 1.1]
-    sigma = [1.1, 1.0, 0.9]
     forces = [282.296, 146.288, 88.8238]
     energies = [70.5638, 49.2476, 35.3135]
-    return zip(k, r0, epsilon, sigma, forces, energies)
+    return zip(_k, _r0, _epsilon, _sigma, forces, energies)
 
 
 @pytest.mark.parametrize("bond_params_tuple", get_bond_params())


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should based on *maint*. -->
<!-- New features should based on *master*. -->

## Description
This fixes a bug attaching `hoomd.md.bond.FENE`. The python class takes `sigma` and `epsilon` for parameters but the C++ class was expecting an `lj1` term and an `lj2` term. I put the calculation to convert back and forth in the `fene_params` and `asDict` methods.
<!-- Describe your changes in detail. -->
## Motivation and context
<!--- Why is this change required? What problem does it solve? -->

<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves #941 

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
I tested setting the parameters before and after attaching and also validated the force and energy calculation.
<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```

```

## Checklist:

- [X] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [X] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [X] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
