### PR TITLE
Pass communicator down to embedded cell lists

### DIFF
--- a/hoomd/md/NeighborListBinned.h
+++ b/hoomd/md/NeighborListBinned.h
@@ -56,6 +56,16 @@ class PYBIND11_EXPORT NeighborListBinned : public NeighborList
             return m_cl->getSortCellList();
             }
 
+        virtual void setCommunicator(std::shared_ptr<Communicator> comm)
+            {
+            // call base class method
+            NeighborList::setCommunicator(comm);
+
+            // set the communicator on the internal cell list
+            m_cl->setCommunicator(comm);
+            }
+
+
     protected:
         std::shared_ptr<CellList> m_cl;   //!< The cell list
 

--- a/hoomd/md/NeighborListBinned.h
+++ b/hoomd/md/NeighborListBinned.h
@@ -56,6 +56,8 @@ class PYBIND11_EXPORT NeighborListBinned : public NeighborList
             return m_cl->getSortCellList();
             }
 
+        #ifdef ENABLE_MPI
+
         virtual void setCommunicator(std::shared_ptr<Communicator> comm)
             {
             // call base class method
@@ -65,6 +67,7 @@ class PYBIND11_EXPORT NeighborListBinned : public NeighborList
             m_cl->setCommunicator(comm);
             }
 
+        #endif
 
     protected:
         std::shared_ptr<CellList> m_cl;   //!< The cell list

--- a/hoomd/md/NeighborListGPUBinned.h
+++ b/hoomd/md/NeighborListGPUBinned.h
@@ -76,6 +76,15 @@ class PYBIND11_EXPORT NeighborListGPUBinned : public NeighborListGPU
             return m_cl->getSortCellList();
             }
 
+        virtual void setCommunicator(std::shared_ptr<Communicator> comm)
+            {
+            // call base class method
+            NeighborList::setCommunicator(comm);
+
+            // set the communicator on the internal cell lists
+            m_cl->setCommunicator(comm);
+            }
+
     protected:
         std::shared_ptr<CellList> m_cl;   //!< The cell list
         unsigned int m_block_size;          //!< Block size to execute on the GPU

--- a/hoomd/md/NeighborListGPUBinned.h
+++ b/hoomd/md/NeighborListGPUBinned.h
@@ -76,6 +76,8 @@ class PYBIND11_EXPORT NeighborListGPUBinned : public NeighborListGPU
             return m_cl->getSortCellList();
             }
 
+        #ifdef ENABLE_MPI
+
         virtual void setCommunicator(std::shared_ptr<Communicator> comm)
             {
             // call base class method
@@ -84,6 +86,8 @@ class PYBIND11_EXPORT NeighborListGPUBinned : public NeighborListGPU
             // set the communicator on the internal cell lists
             m_cl->setCommunicator(comm);
             }
+
+        #endif
 
     protected:
         std::shared_ptr<CellList> m_cl;   //!< The cell list

--- a/hoomd/md/NeighborListGPUStencil.h
+++ b/hoomd/md/NeighborListGPUStencil.h
@@ -69,6 +69,16 @@ class PYBIND11_EXPORT NeighborListGPUStencil : public NeighborListGPU
             m_tuner->setEnabled(enable);
             }
 
+        virtual void setCommunicator(std::shared_ptr<Communicator> comm)
+            {
+            // call base class method
+            NeighborList::setCommunicator(comm);
+
+            // set the communicator on the internal cell lists
+            m_cl->setCommunicator(comm);
+            m_cls->setCommunicator(comm);
+            }
+
     protected:
         //! Builds the neighbor list
         virtual void buildNlist(uint64_t timestep);

--- a/hoomd/md/NeighborListGPUStencil.h
+++ b/hoomd/md/NeighborListGPUStencil.h
@@ -69,6 +69,8 @@ class PYBIND11_EXPORT NeighborListGPUStencil : public NeighborListGPU
             m_tuner->setEnabled(enable);
             }
 
+        #ifdef ENABLE_MPI
+
         virtual void setCommunicator(std::shared_ptr<Communicator> comm)
             {
             // call base class method
@@ -78,6 +80,8 @@ class PYBIND11_EXPORT NeighborListGPUStencil : public NeighborListGPU
             m_cl->setCommunicator(comm);
             m_cls->setCommunicator(comm);
             }
+
+        #endif
 
     protected:
         //! Builds the neighbor list

--- a/hoomd/md/NeighborListStencil.h
+++ b/hoomd/md/NeighborListStencil.h
@@ -56,6 +56,8 @@ class PYBIND11_EXPORT NeighborListStencil : public NeighborList
             m_cl->setNominalWidth(cell_width);
             }
 
+        #ifdef ENABLE_MPI
+
         virtual void setCommunicator(std::shared_ptr<Communicator> comm)
             {
             // call base class method
@@ -65,6 +67,8 @@ class PYBIND11_EXPORT NeighborListStencil : public NeighborList
             m_cl->setCommunicator(comm);
             m_cls->setCommunicator(comm);
             }
+
+        #endif
 
     protected:
         //! Builds the neighbor list

--- a/hoomd/md/NeighborListStencil.h
+++ b/hoomd/md/NeighborListStencil.h
@@ -56,6 +56,16 @@ class PYBIND11_EXPORT NeighborListStencil : public NeighborList
             m_cl->setNominalWidth(cell_width);
             }
 
+        virtual void setCommunicator(std::shared_ptr<Communicator> comm)
+            {
+            // call base class method
+            NeighborList::setCommunicator(comm);
+
+            // set the communicator on the internal cell lists
+            m_cl->setCommunicator(comm);
+            m_cls->setCommunicator(comm);
+            }
+
     protected:
         //! Builds the neighbor list
         virtual void buildNlist(uint64_t timestep);


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should based on *maint*. -->
<!-- New features should based on *master*. -->

## Description

<!-- Describe your changes in detail. -->
Pass the `Communicator` from the neighbor lists down to the embedded cell list objects.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
This fixes a bug where the neighbor list would compute incorrect neighbors or seg fault in MPI simulations.

This bug was found on #929 . I cherry picked the fix here so we can git it released in beta.5.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
The fix has been tested on #929.

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
*Fixed*

- Incorrect MD neighbor lists in MPI simulations with more than 1 rank.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
