### PR TITLE
Support TBB 2021

### DIFF
--- a/.azp/environment.yml
+++ b/.azp/environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
 dependencies:
   - cereal=1.3.0
-  - cmake=3.19.7
+  - cmake=3.19.6
   - eigen=3.3.9
   - gsd=2.4.1
   - ninja=1.10.2

--- a/.azp/environment.yml
+++ b/.azp/environment.yml
@@ -3,14 +3,14 @@ channels:
   - conda-forge
 dependencies:
   - cereal=1.3.0
-  - cmake=3.19.6
+  - cmake=3.19.7
   - eigen=3.3.9
-  - gsd=2.4.0
+  - gsd=2.4.1
   - ninja=1.10.2
   - openmpi=4.1.0
-  - python=3.8.8
+  - python=3.9.2
   - pybind11=2.6.2
-  - tbb=2020.2
-  - tbb-devel=2020.2
+  - tbb=2021.1.1
+  - tbb-devel=2021.1.1
   - pytest=6.2.2
   - numpy=1.20.1

--- a/hoomd/ExecutionConfiguration.cc
+++ b/hoomd/ExecutionConfiguration.cc
@@ -24,6 +24,7 @@ namespace py = pybind11;
 #include <sstream>
 #include <iomanip>
 #include <algorithm>
+#include <thread>
 
 using namespace std;
 
@@ -207,15 +208,16 @@ ExecutionConfiguration::ExecutionConfiguration(executionMode mode,
     #endif
 
     #ifdef ENABLE_TBB
-    m_num_threads = std::thread::hardware_concurrency();
+    unsigned int num_threads = std::thread::hardware_concurrency();
 
     char *env;
     if ((env = getenv("OMP_NUM_THREADS")) != NULL)
         {
-        unsigned int num_threads = atoi(env);
+        num_threads = atoi(env);
         msg->notice(2) << "Setting number of TBB threads to value of OMP_NUM_THREADS=" << num_threads << std::endl;
-        setNumThreads(num_threads);
         }
+
+    setNumThreads(num_threads);
     #endif
 
     #if defined(ENABLE_HIP)

--- a/hoomd/ExecutionConfiguration.cc
+++ b/hoomd/ExecutionConfiguration.cc
@@ -207,7 +207,7 @@ ExecutionConfiguration::ExecutionConfiguration(executionMode mode,
     #endif
 
     #ifdef ENABLE_TBB
-    m_num_threads = tbb::task_scheduler_init::default_num_threads();
+    m_num_threads = std::thread::hardware_concurrency();
 
     char *env;
     if ((env = getenv("OMP_NUM_THREADS")) != NULL)

--- a/hoomd/ExecutionConfiguration.h
+++ b/hoomd/ExecutionConfiguration.h
@@ -264,7 +264,7 @@ class PYBIND11_EXPORT ExecutionConfiguration
         m_num_threads = num_threads;
         }
 
-    std::shared_ptr<tbb::task_arena> getTaskArena()
+    std::shared_ptr<tbb::task_arena> getTaskArena() const
         {
         return m_task_arena;
         }

--- a/hoomd/ExecutionConfiguration.h
+++ b/hoomd/ExecutionConfiguration.h
@@ -29,7 +29,7 @@
 #endif
 
 #ifdef ENABLE_TBB
-#include <tbb/task_scheduler_init.h>
+#include <tbb/task_arena.h>
 #endif
 
 #include "Messenger.h"
@@ -260,8 +260,13 @@ class PYBIND11_EXPORT ExecutionConfiguration
     //! set number of TBB threads
     void setNumThreads(unsigned int num_threads)
         {
-        m_task_scheduler.reset(new tbb::task_scheduler_init(num_threads));
+        m_task_arena = std::make_shared<tbb::task_arena>(num_threads);
         m_num_threads = num_threads;
+        }
+
+    std::shared_ptr<tbb::task_arena> getTaskArena()
+        {
+        return m_task_arena;
         }
     #endif
 
@@ -406,7 +411,7 @@ private:
     #endif
 
     #ifdef ENABLE_TBB
-    std::unique_ptr<tbb::task_scheduler_init> m_task_scheduler; //!< The TBB task scheduler
+    std::shared_ptr<tbb::task_arena> m_task_arena; //!< The TBB task arena
     unsigned int m_num_threads;            //!<  The number of TBB threads used
     #endif
 

--- a/hoomd/ExecutionConfiguration.h
+++ b/hoomd/ExecutionConfiguration.h
@@ -266,6 +266,8 @@ class PYBIND11_EXPORT ExecutionConfiguration
 
     std::shared_ptr<tbb::task_arena> getTaskArena() const
         {
+        if (!m_task_arena)
+            throw std::runtime_error("TBB task arena not set.");
         return m_task_arena;
         }
     #endif

--- a/hoomd/hpmc/ComputeFreeVolume.h
+++ b/hoomd/hpmc/ComputeFreeVolume.h
@@ -70,7 +70,6 @@ class ComputeFreeVolume : public Compute
         void setTestParticleType(std::string type)
             {
             unsigned int type_int = m_sysdef->getParticleData()->getTypeByName(type);
-            assert(type < m_pdata->getNTypes());
             m_type = type_int;
             }
 

--- a/hoomd/hpmc/IntegratorHPMCMono.h
+++ b/hoomd/hpmc/IntegratorHPMCMono.h
@@ -1488,6 +1488,8 @@ float IntegratorHPMCMono<Shape>::computePatchEnergy(uint64_t timestep)
 
     // Loop over all particles
     #ifdef ENABLE_TBB
+    m_exec_conf->getTaskArena()->execute([&]{
+
     energy = tbb::parallel_reduce(tbb::blocked_range<unsigned int>(0, m_pdata->getN()),
         0.0f,
         [&](const tbb::blocked_range<unsigned int>& r, float energy)->float {
@@ -1578,6 +1580,7 @@ float IntegratorHPMCMono<Shape>::computePatchEnergy(uint64_t timestep)
     #ifdef ENABLE_TBB
     return energy;
     }, [](float x, float y)->float { return x+y; } );
+    }); // end task arena execute()
     #endif
 
     if (this->m_prof) this->m_prof->pop(this->m_exec_conf);
@@ -2205,6 +2208,8 @@ std::vector<float> IntegratorHPMCMono<Shape>::mapEnergies()
 
     // Loop over all particles
     #ifdef ENABLE_TBB
+    m_exec_conf->getTaskArena()->execute([&]{
+
     tbb::parallel_for(tbb::blocked_range<unsigned int>(0, N),
         [&](const tbb::blocked_range<unsigned int>& r) {
     for (unsigned int i = r.begin(); i != r.end(); ++i)
@@ -2288,6 +2293,7 @@ std::vector<float> IntegratorHPMCMono<Shape>::mapEnergies()
         } // end loop over particles
     #ifdef ENABLE_TBB
         });
+        }); // end task arena execute()
     #endif
     return energy_map;
     }
@@ -2489,6 +2495,7 @@ inline bool IntegratorHPMCMono<Shape>::checkDepletantOverlap(unsigned int i, vec
     Scalar ln_denominator_tot(0.0);
 
     #ifdef ENABLE_TBB
+    m_exec_conf->getTaskArena()->execute([&]{
     try {
     #endif
 
@@ -3412,6 +3419,7 @@ inline bool IntegratorHPMCMono<Shape>::checkDepletantOverlap(unsigned int i, vec
 
     #ifdef ENABLE_TBB
     } catch (bool b) { }
+    }); // end task arena execute()
     #endif
 
     Scalar u = hoomd::UniformDistribution<Scalar>()(rng_depletants);

--- a/hoomd/hpmc/UpdaterClusters.h
+++ b/hoomd/hpmc/UpdaterClusters.h
@@ -173,6 +173,7 @@ void Graph::connectedComponents(std::vector<std::vector<unsigned int> >& cc)
 #endif
     {
     #ifdef ENABLE_TBB_TASK
+    m_exec_conf->getTaskArena()->execute([&]{
     for (unsigned int v = 0; v < visited.size(); ++v)
         {
         if (! visited[v].test_and_set())
@@ -183,6 +184,7 @@ void Graph::connectedComponents(std::vector<std::vector<unsigned int> >& cc)
             cc.push_back(component);
             }
         }
+    }); // end task arena execute()
     #else
     std::fill(visited.begin(), visited.end(), 0);
 
@@ -488,6 +490,7 @@ inline void UpdaterClusters<Shape>::checkDepletantOverlap(unsigned int i, vec3<S
     img_i = box.getImage(pos_i_transf);
 
     #ifdef ENABLE_TBB_TASK
+    m_exec_conf->getTaskArena()->execute([&]{
     tbb::parallel_for(tbb::blocked_range<unsigned int>(0, this->m_pdata->getNTypes()),
         [=, &shape_i](const tbb::blocked_range<unsigned int>& x) {
     for (unsigned int type_a = x.begin(); type_a != x.end(); ++type_a)
@@ -1051,6 +1054,7 @@ inline void UpdaterClusters<Shape>::checkDepletantOverlap(unsigned int i, vec3<S
         } // end loop over type_a
     #ifdef ENABLE_TBB_TASK
         });
+    }); // end task arena execute()
     #endif
     }
 
@@ -1196,6 +1200,7 @@ void UpdaterClusters<Shape>::findInteractions(uint64_t timestep, const quat<Scal
         {
         // test old configuration against itself
         #ifdef ENABLE_TBB_TASK
+        m_exec_conf->getTaskArena()->execute([&]{
         tbb::parallel_for((unsigned int)0,this->m_pdata->getN(), [&](unsigned int i)
         #else
         for (unsigned int i = 0; i < this->m_pdata->getN(); ++i)
@@ -1289,11 +1294,13 @@ void UpdaterClusters<Shape>::findInteractions(uint64_t timestep, const quat<Scal
             } // end loop over old configuration
         #ifdef ENABLE_TBB_TASK
             );
+        }); // end task arena execute()
         #endif
         }
 
     // loop over new configuration
     #ifdef ENABLE_TBB_TASK
+    m_exec_conf->getTaskArena()->execute([&]{
     tbb::parallel_for((unsigned int)0,nptl, [&](unsigned int i)
     #else
     for (unsigned int i = 0; i < nptl; ++i)
@@ -1452,6 +1459,7 @@ void UpdaterClusters<Shape>::findInteractions(uint64_t timestep, const quat<Scal
         } // end loop over local particles
     #ifdef ENABLE_TBB_TASK
         );
+    }); // end task arena execute()
     #endif
 
     /*
@@ -1477,6 +1485,7 @@ void UpdaterClusters<Shape>::findInteractions(uint64_t timestep, const quat<Scal
 
     // test old configuration against itself
     #ifdef ENABLE_TBB_TASK
+    m_exec_conf->getTaskArena()->execute([&]{
     tbb::parallel_for((unsigned int)0,this->m_pdata->getN(), [&](unsigned int i) {
     #else
     for (unsigned int i = 0; i < this->m_pdata->getN(); ++i)
@@ -1495,6 +1504,7 @@ void UpdaterClusters<Shape>::findInteractions(uint64_t timestep, const quat<Scal
         }
     #ifdef ENABLE_TBB_TASK
         });
+    }); // end task arena execute()
     #endif
 
     if (this->m_prof)
@@ -1649,6 +1659,7 @@ void UpdaterClusters<Shape>::update(uint64_t timestep)
         m_prof->push("overlap");
 
     #ifdef ENABLE_TBB_TASK
+    m_exec_conf->getTaskArena()->execute([&]{
     tbb::parallel_for(m_overlap.range(), [&] (decltype(m_overlap.range()) r)
     #else
     auto &r = m_overlap;
@@ -1666,6 +1677,7 @@ void UpdaterClusters<Shape>::update(uint64_t timestep)
         }
     #ifdef ENABLE_TBB_TASK
         );
+    }); // end task arena execute()
     #endif
 
     if (m_prof)
@@ -1716,6 +1728,7 @@ void UpdaterClusters<Shape>::update(uint64_t timestep)
             }
 
         #ifdef ENABLE_TBB_TASK
+        m_exec_conf->getTaskArena()->execute([&]{
         tbb::parallel_for(delta_U.range(), [&] (decltype(delta_U.range()) r)
         #else
         auto &r = delta_U;
@@ -1741,6 +1754,7 @@ void UpdaterClusters<Shape>::update(uint64_t timestep)
             }
         #ifdef ENABLE_TBB_TASK
             );
+        }); // end task arena execute()
         #endif
         } // end if (patch)
 

--- a/hoomd/hpmc/UpdaterMuVT.h
+++ b/hoomd/hpmc/UpdaterMuVT.h
@@ -54,7 +54,6 @@ class UpdaterMuVT : public Updater
          */
         std::shared_ptr<Variant> getFugacity(const std::string& typ)
             {
-            assert(type < m_pdata->getNTypes());
             unsigned int id = this->m_pdata->getTypeByName(typ);
             return m_fugacity[id];
             }

--- a/hoomd/jit/PatchEnergyJITUnion.cc
+++ b/hoomd/jit/PatchEnergyJITUnion.cc
@@ -158,6 +158,10 @@ float PatchEnergyJITUnion::energy(const vec3<float>& r_ij,
 
     float energy = 0.0;
 
+    #ifdef ENABLE_TBB
+    m_exec_conf->getTaskArena()->execute([&]{
+    #endif
+
     // evaluate isotropic part if necessary
     if (m_r_cut >= 0.0)
         energy += m_eval(r_ij, type_i, q_i, d_i, charge_i, type_j, q_j, d_j, charge_j);
@@ -232,6 +236,10 @@ float PatchEnergyJITUnion::energy(const vec3<float>& r_ij,
         }, [](float x, float y)->float { return x+y; } );
         #endif
         }
+
+    #ifdef ENABLE_TBB
+    }); // end task arena execute()
+    #endif
 
     return energy;
     }

--- a/hoomd/module.cc
+++ b/hoomd/module.cc
@@ -78,7 +78,7 @@ using namespace std;
 using namespace hoomd;
 
 #ifdef ENABLE_TBB
-#include "tbb/task_scheduler_init.h"
+#include <tbb/task_arena.h>
 #endif
 
 /*! \file hoomd_module.cc


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should based on *maint*. -->
<!-- New features should based on *master*. -->

## Description

<!-- Describe your changes in detail. -->
Enable support for TBB 2021. Implement this with an object based solution. `ExecutionConfiguration` holds a `task_arena` which TBB enabled computations use to limit the number of threads they use to execute.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
TBB 2021 removes deprecated functionality. Also, prior the object based solution, only the most recent call to setNumThreads was effective. The object based solution allows multiple `Simulation` objects to coexist and use a different number of threads.

As long as other libraries that users import also use the object based solution, HOOMD will interoperate with them. Those that use `global_control` may still interfere with the number of threads that HOOMD uses.

<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves #640 

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
I build locally against TBB 2020 and TBB 2021. The Linux CI tests still use TBB 2020 as that is the package that ubuntu provides. I updated the Mac tests to use TBB 2021 for coverage.

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
* Support TBB 2021.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
