### PR TITLE
Use latest tutorials from hoomd-examples

### DIFF
--- a/sphinx-doc/index.rst
+++ b/sphinx-doc/index.rst
@@ -70,6 +70,7 @@ workflows all with Python code in your job.
     tutorial/00-Introducing-HOOMD-blue/00-index
     tutorial/01-Introducing-Molecular-Dynamics/00-index
     tutorial/02-Logging/00-index
+    tutorial/03-Custom-Actions-In-Python/00-index
 
 .. toctree::
    :maxdepth: 3


### PR DESCRIPTION
Add custom actions to the tutorial index.

<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should based on *maint*. -->
<!-- New features should based on *master*. -->

## Description

<!-- Describe your changes in detail. -->
* Bump the tutorials submodule to the latest version. 
* Add the custom actions tutorial to the index.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
HOOMD-blue should be documented.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
I tested sphinx builds locally. Reviewers can click the readthedocs link below to view the rendered tutorials.

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
Added:

- Custom action tutorials.

Changed:

- Tutorials require fresnel 0.13.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
