### PR TITLE
Fix setting operations in simulation when unscheduled

### DIFF
--- a/hoomd/operations.py
+++ b/hoomd/operations.py
@@ -64,14 +64,14 @@ class Operations(Collection):
     def __init__(self):
         self._compute = list()
         self._scheduled = False
+        self._simulation = None
         self._updaters = SyncedList(OnlyTypes(Updater),
                                     _triggered_op_conversion)
         self._writers = SyncedList(OnlyTypes(Writer),
-                                     _triggered_op_conversion)
+                                   _triggered_op_conversion)
         self._tuners = SyncedList(OnlyTypes(Tuner), lambda x: x._cpp_obj)
         self._computes = SyncedList(OnlyTypes(Compute), lambda x: x._cpp_obj)
         self._integrator = None
-
         self._tuners.append(ParticleSorter())
 
     def _get_proper_container(self, operation):

--- a/hoomd/operations.py
+++ b/hoomd/operations.py
@@ -206,7 +206,8 @@ class Operations(Collection):
 
     def _unschedule(self):
         """Undo the effects of `Operations._schedule`."""
-        self._integrator._detach()
+        if self.integrator is not None:
+            self._integrator._detach()
         self._writers._unsync()
         self._updaters._unsync()
         self._tuners._unsync()

--- a/hoomd/simulation.py
+++ b/hoomd/simulation.py
@@ -239,7 +239,7 @@ class Simulation(metaclass=Loggable):
             reschedule = False
             if self._operations._scheduled:
                 self._operations._unschedule()
-                reschedule = False
+                reschedule = True
 
             self._operations._simulation = None
             operations._simulation = self

--- a/hoomd/simulation.py
+++ b/hoomd/simulation.py
@@ -236,12 +236,13 @@ class Simulation(metaclass=Loggable):
                     "Cannot add `hoomd.Operations` object that belongs to "
                     "another `hoomd.Simulation` object.")
             # Switch out `hoomd.Operations` objects.
-            elif self._operations._scheduled:
-                self._operations._unschedule()
-                self._operations._simulation = None
-                operations._simulation = self
+            self._operations._simulation = None
+            operations._simulation = self
+            old_operations = self._operations
+            self._operations = operations
+            if old_operations._scheduled:
+                old_operations._unschedule()
                 operations._schedule()
-                self._operations = operations
 
     @log
     def tps(self):

--- a/hoomd/simulation.py
+++ b/hoomd/simulation.py
@@ -236,13 +236,17 @@ class Simulation(metaclass=Loggable):
                     "Cannot add `hoomd.Operations` object that belongs to "
                     "another `hoomd.Simulation` object.")
             # Switch out `hoomd.Operations` objects.
+            reschedule = False
+            if self._operations._scheduled:
+                self._operations._unschedule()
+                reschedule = False
+
             self._operations._simulation = None
             operations._simulation = self
-            old_operations = self._operations
             self._operations = operations
-            if old_operations._scheduled:
-                old_operations._unschedule()
-                operations._schedule()
+
+            if reschedule:
+                self._operations._schedule()
 
     @log
     def tps(self):


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should based on *maint*. -->
<!-- New features should based on *master*. -->

## Description

Fixes a bug where setting the `Simulation.operations` property when the `Operations` object was unscheduled did not do anything.
<!-- Describe your changes in detail. -->

## Motivation and context

Fixes a lapse in the expected behavior.

## How has this been tested?

Has not yet, tests incoming.
<!--- Please describe in detail how you tested your changes. -->

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
Fixed: Setting the operations attribute in ``Simulation`` objects in specific circumstances.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
