### PR TITLE
Fix variable name in dihedral.py

### DIFF
--- a/hoomd/md/dihedral.py
+++ b/hoomd/md/dihedral.py
@@ -53,7 +53,7 @@ class Dihedral(Force):
         else:
             cpp_class = getattr(_md, self._cpp_class_name + "GPU")
 
-        self._cpp_obj = cpp_class(self.sim.state._cpp_sys_def)
+        self._cpp_obj = cpp_class(self._simulation.state._cpp_sys_def)
         super()._attach()
 
 

--- a/hoomd/md/dihedral.py
+++ b/hoomd/md/dihedral.py
@@ -53,7 +53,7 @@ class Dihedral(Force):
         else:
             cpp_class = getattr(_md, self._cpp_class_name + "GPU")
 
-        self._cpp_obj = cpp_class(sim.state._cpp_sys_def)
+        self._cpp_obj = cpp_class(self.sim.state._cpp_sys_def)
         super()._attach()
 
 

--- a/sphinx-doc/credits.rst
+++ b/sphinx-doc/credits.rst
@@ -27,6 +27,7 @@ The following people have contributed to the to HOOMD-blue:
 * Carolyn Phillips, University of Michigan
 * Charlie Slominski, Caltech
 * Chengyu Dai, University of Michigan
+* Chris Jones, Boise State University
 * Christoph Junghans
 * Christoph Klein, Vanderbilt University
 * Chrisy Du, University of Michigan


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should based on *maint*. -->
<!-- New features should based on *master*. -->

## Description

<!-- Describe your changes in detail. -->

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

I'm getting a `NameError` when initializing a system with dihedrals

```
~/miniconda3/envs/mbuild-hoomd3/lib/python3.8/site-packages/hoomd/md/dihedral.py in _attach(self)
     54             cpp_class = getattr(_md, self._cpp_class_name + "GPU")
     55 
---> 56         self._cpp_obj = cpp_class(sim.state._cpp_sys_def)
     57         super()._attach()
     58 

NameError: name 'sim' is not defined
```
This should be `self._cpp_obj = cpp_class(self._simulation.state._cpp_sys_def)`

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->

I edited the source code, and re-ran without error.

## Checklist:

- [X] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [X] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [X ] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
