### PR TITLE
Feature/anisolj

### DIFF
--- a/hoomd/VectorMath.h
+++ b/hoomd/VectorMath.h
@@ -95,11 +95,42 @@ struct vec3
         z = tz;
         }
 
+    DEVICE Real& operator[](const unsigned int i)
+        {
+        switch(i) {
+            case 0:
+                return x;
+            case 1:
+                return y;
+            case 2:
+                return z;
+            }
+        // This branch is unreachable, but must include something to avoid
+        // compiler warnings. The return value is chosen to match the non-const
+        // version of the operator.
+        return x;
+        }
+
+    DEVICE const Real operator[](const unsigned int i) const
+        {
+        switch(i) {
+            case 0:
+                return x;
+            case 1:
+                return y;
+            case 2:
+                return z;
+            }
+        // This branch is unreachable, but must include something to avoid
+        // compiler warnings. The return value is chosen to match the non-const
+        // version of the operator.
+        return x;
+        }
+
     Real x; //!< x-component of the vector
     Real y; //!< y-component of the vector
     Real z; //!< z-component of the vector
     };
-
 
 //! Addition of two vec3s
 /*! \param a First vector

--- a/hoomd/md/AllAnisoPairPotentials.h
+++ b/hoomd/md/AllAnisoPairPotentials.h
@@ -9,6 +9,7 @@
 
 #include "AnisoPotentialPair.h"
 
+#include "EvaluatorPairALJ.h"
 #include "EvaluatorPairGB.h"
 #include "EvaluatorPairDipole.h"
 
@@ -22,6 +23,12 @@
     \brief Handy list of typedefs for all of the templated pair potentials in hoomd
 */
 
+//! Pair potential force compute for ALJ forces and torques in 2D
+typedef AnisoPotentialPair<EvaluatorPairALJ<2>> AnisoPotentialPairALJ2D;
+
+//! Pair potential force compute for ALJ forces and torques in 3D
+typedef AnisoPotentialPair<EvaluatorPairALJ<3>> AnisoPotentialPairALJ3D;
+
 //! Pair potential force compute for Gay-Berne forces and torques
 typedef AnisoPotentialPair<EvaluatorPairGB> AnisoPotentialPairGB;
 //! Pair potential force compute for dipole forces and torques
@@ -29,11 +36,17 @@ typedef AnisoPotentialPair<EvaluatorPairDipole> AnisoPotentialPairDipole;
 
 #ifdef ENABLE_HIP
 //! Pair potential force compute for Gay-Berne forces and torques on the GPU
+typedef AnisoPotentialPairGPU<EvaluatorPairALJ<2>,
+                              gpu_compute_pair_aniso_forces_alj_2d> AnisoPotentialPairALJ2DGPU;
+
+//! Pair potential force compute for Gay-Berne forces and torques on the GPU
+typedef AnisoPotentialPairGPU<EvaluatorPairALJ<3>,
+                              gpu_compute_pair_aniso_forces_alj_3d> AnisoPotentialPairALJ3DGPU;
+
+//! Pair potential force compute for Gay-Berne forces and torques on the GPU
 typedef AnisoPotentialPairGPU<EvaluatorPairGB,gpu_compute_pair_aniso_forces_gb> AnisoPotentialPairGBGPU;
 //! Pair potential force compute for dipole forces and torques on the GPU
 typedef AnisoPotentialPairGPU<EvaluatorPairDipole,gpu_compute_pair_aniso_forces_dipole> AnisoPotentialPairDipoleGPU;
 #endif
-
-//
 
 #endif // __ALL_ANISO_PAIR_POTENTIALS_H__

--- a/hoomd/md/AllDriverAnisoPotentialPairGPU.cu
+++ b/hoomd/md/AllDriverAnisoPotentialPairGPU.cu
@@ -9,6 +9,19 @@
 /*! \file AllDriverAnisoPotentialPairGPU.cu
     \brief Defines the driver functions for computing all types of anisotropic pair forces on the GPU
 */
+hipError_t gpu_compute_pair_aniso_forces_alj_2d(const a_pair_args_t& pair_args,
+            const EvaluatorPairALJ<2>::param_type* d_param,
+            const EvaluatorPairALJ<2>::shape_type* d_shape_param)
+    {
+    return gpu_compute_pair_aniso_forces<EvaluatorPairALJ<2>>(pair_args, d_param, d_shape_param);
+    }
+
+hipError_t gpu_compute_pair_aniso_forces_alj_3d(const a_pair_args_t& pair_args,
+            const EvaluatorPairALJ<3>::param_type* d_param,
+            const EvaluatorPairALJ<3>::shape_type* d_shape_param)
+    {
+    return gpu_compute_pair_aniso_forces<EvaluatorPairALJ<3>>(pair_args, d_param, d_shape_param);
+    }
 
 hipError_t gpu_compute_pair_aniso_forces_gb(const a_pair_args_t& pair_args,
             const EvaluatorPairGB::param_type* d_param,

--- a/hoomd/md/AllDriverAnisoPotentialPairGPU.cuh
+++ b/hoomd/md/AllDriverAnisoPotentialPairGPU.cuh
@@ -12,10 +12,21 @@
 #define __ALL_DRIVER_ANISO_POTENTIAL_PAIR_GPU_CUH__
 
 #include "AnisoPotentialPairGPU.cuh"
+#include "EvaluatorPairALJ.h"
 #include "EvaluatorPairGB.h"
 #include "EvaluatorPairDipole.h"
 
 //! Compute dipole forces and torques on the GPU with EvaluatorPairDipole
+
+hipError_t __attribute__((visibility("default")))
+gpu_compute_pair_aniso_forces_alj_2d(const a_pair_args_t&,
+            const EvaluatorPairALJ<2>::param_type*,
+            const EvaluatorPairALJ<2>::shape_type*);
+
+hipError_t __attribute__((visibility("default")))
+gpu_compute_pair_aniso_forces_alj_3d(const a_pair_args_t&,
+            const EvaluatorPairALJ<3>::param_type*,
+            const EvaluatorPairALJ<3>::shape_type*);
 
 hipError_t __attribute__((visibility("default")))
 gpu_compute_pair_aniso_forces_gb(const a_pair_args_t&,

--- a/hoomd/md/CMakeLists.txt
+++ b/hoomd/md/CMakeLists.txt
@@ -83,6 +83,7 @@ set(_md_headers ActiveForceComputeGPU.h
                 EvaluatorConstraintSphere.h
                 EvaluatorExternalElectricField.h
                 EvaluatorExternalPeriodic.h
+                EvaluatorPairALJ.h
                 EvaluatorPairBuckingham.h
                 EvaluatorPairDipole.h
                 EvaluatorPairDPDLJThermo.h

--- a/hoomd/md/EvaluatorPairALJ.h
+++ b/hoomd/md/EvaluatorPairALJ.h
@@ -189,7 +189,7 @@ class EvaluatorPairALJ
                 {
                 // Unpack the list[list] of vertices into a ManagedArray.
                 auto vertices = shape["vertices"].cast<pybind11::list>();
-                unsigned int N = len(vertices);
+                unsigned int N = static_cast<unsigned int>(len(vertices));
                 // TODO: add support for managed memory on GPU
                 verts = ManagedArray<vec3<Scalar> >(N, false);
                 for (unsigned int i = 0; i < N; ++i)
@@ -207,17 +207,18 @@ class EvaluatorPairALJ
                 // Then, we allocate the faces array and loop a second time to store
                 // those indices linearly.
                 auto faces_ = shape["faces"].cast<pybind11::list>();
-                N = len(faces_);
+                N = static_cast<unsigned int>(static_cast<unsigned int>(len(faces_)));
                 // TODO: add support for managed memory on GPU
                 face_offsets = ManagedArray<unsigned int>(N, false);
                 face_offsets[0] = 0;
                 for (unsigned int i = 0; i < (N-1); ++i)
                     {
                     pybind11::list faces_tmp = pybind11::cast<pybind11::list>(faces_[i]);
-                    face_offsets[i+1] = face_offsets[i] + len(faces_tmp);
+                    face_offsets[i+1] = face_offsets[i] + static_cast<unsigned int>(len(faces_tmp));
                     }
                 pybind11::list faces_tmp = pybind11::cast<pybind11::list>(faces_[N-1]);
-                const unsigned int total_face_indices = face_offsets[N-1] + len(faces_tmp);
+                const unsigned int total_face_indices = face_offsets[N-1]
+                    + static_cast<unsigned int>(len(faces_tmp));
 
                 // TODO: add support for managed memory on GPU
                 faces = ManagedArray<unsigned int>(total_face_indices, false);
@@ -225,7 +226,7 @@ class EvaluatorPairALJ
                 for (unsigned int i = 0; i < N; ++i)
                 {
                     pybind11::list face_tmp = pybind11::cast<pybind11::list>(faces_[i]);
-                    for (unsigned int j = 0; j < len(face_tmp); ++j)
+                    for (unsigned int j = 0; j < static_cast<unsigned int>(len(face_tmp)); ++j)
                     {
                         faces[counter] = pybind11::cast<unsigned int>(face_tmp[j]);
                         ++counter;

--- a/hoomd/md/EvaluatorPairALJ.h
+++ b/hoomd/md/EvaluatorPairALJ.h
@@ -1,0 +1,1208 @@
+// Copyright (c) 2009-2019 The Regents of the University of Michigan
+// This file is part of the HOOMD-blue project, released under the BSD 3-Clause License.
+
+// Maintainer: vramasub
+
+#ifndef __EVALUATOR_PAIR_ALJ_H__
+#define __EVALUATOR_PAIR_ALJ_H__
+
+#ifndef NVCC
+#include <string>
+#include <sstream>
+#endif
+
+#include "hoomd/VectorMath.h"
+#include "hoomd/ManagedArray.h"
+#include "GJK_SV.h"
+
+#ifndef NVCC
+#include "hoomd/ExecutionConfiguration.h"
+#include <hoomd/extern/pybind/include/pybind11/pybind11.h>
+#endif
+
+/*! \file EvaluatorPairALJ.h
+    \brief Defines an evaluator class for the anisotropic LJ potential.
+*/
+
+// need to declare these class methods with __host__ __device__ qualifiers when building in nvcc
+//! HOSTDEVICE is __host__ __device__ when included in nvcc and blank when included into the host compiler
+#ifdef NVCC
+#define HOSTDEVICE __host__ __device__
+#else
+#define HOSTDEVICE
+
+#if defined (__SSE__)
+#include <immintrin.h>
+#endif
+#endif
+
+//! Shape parameters for the ALJ potential.
+/*! The ALJ potential in its current form can be used to handle a generalized
+ * class of shapes composed of the Minkowski sum of an ellipsoid and a convex
+ * polyhedron. The shape parameters here are sufficiently general as to handle
+ * all possible cases in both 2D and 3D. The shape is stored as a set of
+ * (optional) vertices that trace out the underlying polytope (polygon in 2D,
+ * polyhedron in 3D) and a set of 3 rounding radii stored as a vec3. For
+ * simulations of polytopes, the contact point formalism is inherently unstable
+ * due to the oscillations that may occur when facets are nearly parallel. To
+ * resolve this, the ALJ potential implements a form of face averaging that is
+ * essentially a local form of the discrete element method (DEM). To do this,
+ * it sums over all relevant point-edge interactions in 2D, and in 3D it sums
+ * both point-face interactions and edge-edge interactions. To support this
+ * calculation over an entire polytope, the shape params also encode the faces.
+ * The faces are stored in two separate arrays. The faces array is a linear
+ * container that indexes into the vertices to indicate which vertices compose
+ * each face. Since this array is linear, the face_offsets array is used to
+ * indicate the index in teh faces array corresponding to the start of each
+ * face of the polytope.
+ */
+struct alj_shape_params
+    {
+    HOSTDEVICE alj_shape_params()
+        {}
+
+    #ifndef NVCC
+
+    //! Shape constructor
+    /*! \param vertices Nested pybind list that translates to an Nx3 set of vertices
+        \param faces_ Nested pybind list that contains indices into vertices corresponding to each face.
+        \param rr The semimajor axes of the rounding ellipse.
+        \param use_device Whether or not the shape params are managed on the host, forwarded through to underlying arrays for migration to the GPU as needed.
+     */
+    alj_shape_params(pybind11::list vertices, pybind11::list faces_, pybind11::list rr, bool use_device) : has_rounding(false)
+        {
+        // Unpack the list[list] of vertices into a ManagedArray.
+        unsigned int N = len(vertices);
+        verts = ManagedArray<vec3<Scalar> >(N, use_device);
+        for (unsigned int i = 0; i < N; ++i)
+            {
+            pybind11::list vertices_tmp = pybind11::cast<pybind11::list>(vertices[i]);
+            verts[i] = vec3<Scalar>(pybind11::cast<Scalar>(vertices_tmp[0]), pybind11::cast<Scalar>(vertices_tmp[1]), pybind11::cast<Scalar>(vertices_tmp[2]));
+            }
+
+        // Since we don't know the total number of face indices a priori (we
+        // only have access to the top-level list), we first construct the face
+        // offsets array and simultaneously compute the total number of faces.
+        // Then, we allocate the faces array and loop a second time to store
+        // those indices linearly.
+        N = len(faces_);
+        face_offsets = ManagedArray<unsigned int>(N, use_device);
+        face_offsets[0] = 0;
+        for (unsigned int i = 0; i < (N-1); ++i)
+            {
+            pybind11::list faces_tmp = pybind11::cast<pybind11::list>(faces_[i]);
+            face_offsets[i+1] = face_offsets[i] + len(faces_tmp);
+            }
+        pybind11::list faces_tmp = pybind11::cast<pybind11::list>(faces_[N-1]);
+        const unsigned int total_face_indices = face_offsets[N-1] + len(faces_tmp);
+
+        faces = ManagedArray<unsigned int>(total_face_indices, use_device);
+        unsigned int counter = 0;
+        for (unsigned int i = 0; i < N; ++i)
+        {
+            pybind11::list face_tmp = pybind11::cast<pybind11::list>(faces_[i]);
+            for (unsigned int j = 0; j < len(face_tmp); ++j)
+            {
+                faces[counter] = pybind11::cast<unsigned int>(face_tmp[j]);
+                ++counter;
+            }
+        }
+
+        // Store the rounding radii.
+        rounding_radii.x = pybind11::cast<Scalar>(rr[0]);
+        rounding_radii.y = pybind11::cast<Scalar>(rr[1]);
+        rounding_radii.z = pybind11::cast<Scalar>(rr[2]);
+        if (rounding_radii.x > 0 || rounding_radii.y > 0 || rounding_radii.z > 0)
+            {
+            has_rounding = true;
+            }
+        }
+
+    #endif
+
+    //! Load dynamic data members into shared memory and increase pointer
+    /*! \param ptr Pointer to load data to (will be incremented)
+        \param available_bytes Size of remaining shared memory allocation
+     */
+    HOSTDEVICE void load_shared(char *& ptr, unsigned int &available_bytes) const
+        {
+        verts.load_shared(ptr, available_bytes);
+        faces.load_shared(ptr, available_bytes);
+        face_offsets.load_shared(ptr, available_bytes);
+        }
+
+    #ifdef ENABLE_CUDA
+    //! Attach managed memory to CUDA stream
+    void attach_to_stream(cudaStream_t stream) const
+        {
+        verts.attach_to_stream(stream);
+        faces.attach_to_stream(stream);
+        face_offsets.attach_to_stream(stream);
+        }
+    #endif
+
+    //! Shape parameters
+    ManagedArray<vec3<Scalar> > verts;       //! Shape vertices.
+    ManagedArray<unsigned int> faces;       //! Shape faces.
+    ManagedArray<unsigned int> face_offsets;       //! Index where each faces starts.
+    vec3<Scalar> rounding_radii;  //! The semimajor axes of the rounding ellipse.
+    bool has_rounding;    //! Whether or not the shape has rounding radii.
+    };
+
+//! Potential parameters for the ALJ potential.
+struct pair_alj_params
+    {
+    DEVICE pair_alj_params()
+        : epsilon(0.0), sigma_i(0.0), sigma_j(0.0), contact_sigma_i(0.0), contact_sigma_j(0.0), alpha(0), average_simplices(false)
+        {}
+
+    #ifndef NVCC
+    //! Shape constructor
+    pair_alj_params(Scalar _epsilon, Scalar _sigma_i, Scalar _sigma_j, Scalar _contact_sigma_i, Scalar _contact_sigma_j, unsigned int _alpha, bool _average_simplices, bool use_device)
+        : epsilon(_epsilon), sigma_i(_sigma_i), sigma_j(_sigma_j), contact_sigma_i(_contact_sigma_i), contact_sigma_j(_contact_sigma_j), alpha(_alpha), average_simplices(_average_simplices) {}
+
+    #endif
+
+    //! Load dynamic data members into shared memory and increase pointer
+    /*! \param ptr Pointer to load data to (will be incremented)
+     *  \param available_bytes Size of remaining shared memory allocation
+     */
+    HOSTDEVICE void load_shared(char *& ptr, unsigned int &available_bytes) const {}
+
+    #ifdef ENABLE_CUDA
+    //! Attach managed memory to CUDA stream
+    void attach_to_stream(cudaStream_t stream) const {}
+    #endif
+
+    //! Potential parameters
+    Scalar epsilon;                      //! Interaction energy scale.
+    Scalar sigma_i;                      //! Size of particle i.
+    Scalar sigma_j;                      //! Size of particle j.
+    Scalar contact_sigma_i;              //! Size of contact sphere on particle i.
+    Scalar contact_sigma_j;              //! Size of contact sphere on particle j.
+    unsigned int alpha;                  //! Toggle switch of attractive branch of potential (0 for all repulsive, 3 for all attractive, 1 for center-center attraction, 2 for contact-contact attraction).
+    bool average_simplices;              //! Whether or not to average interactions over simplices.
+    };
+
+
+/*! Clip a value between 0 and 1 */
+HOSTDEVICE inline Scalar clip(const Scalar &x)
+    {
+    return (x >= 0)*(x + (x > 1)*(1 - x));
+    }
+
+
+// Note: delta is from the edge to the point.
+//! Compute the distance from a point to a line segment in 2D.
+/*! All the points (point, e1, and e2) must be provided in the same coordinate
+ * system i.e. relative to the same origin. The delta and projection arguments
+ * are overwritten by reference. The projection is provided in the same
+ * coordinate system as the input points, and the delta vector points from the
+ * projection to the input point (i.e. from the segment to the point).
+ *
+ * \param point The point to which to calculate distance.
+ * \param e1 The first endpoint of the segment from which to calculate distance.
+ * \param e2 The first endpoint of the segment from which to calculate distance.
+ * \param delta The vector pointing from the closest point on the input segment to the input point (updated by reference).
+ * \param projection The closest point on the segment defined by e2-e1 to the input point (updated by reference).
+ */
+HOSTDEVICE inline void
+pointSegmentDistance(const vec3<Scalar> &point, const vec3<Scalar> &e1, const vec3<Scalar> &e2, vec3<Scalar> &delta, vec3<Scalar> &projection)
+    {
+    vec3<Scalar> edge = e1 - e2;
+    Scalar edge_length_sq = dot(edge, edge);
+    Scalar t = clip(dot(point - e1, e2 - e1)/edge_length_sq);
+    projection = e1 - t * edge;
+    delta = point - projection;
+    }
+
+
+//! Compute the distance between a point and the face of a polytope.
+/*! This function is adapted from DEMEvaluator::vertexFace. The energy
+ * evaluation has been removed from this function, so this function only
+ * computes the distance and leaves the energy evaluation to a separate
+ * routine. The internals of this method are adapted from DEM to use the data
+ * structures of the ALJ potential, namely the alj_shape_params instead of the
+ * various arrays stored in the DEM3DForceCompute class.
+ *
+ * Note that all calculations in this method are done in particle j's reference
+ * frame, so r0 is immediately shifted to r0j and used accordingly.
+ *
+ * \param rij The vector from the particle containing r0 to the particle whose face is being evaluated.
+ * \param shape_j The shape parameters of shape j.
+ * \param r0 The vertex on the first particle.
+ * \param matj The orientation of the second particle.
+ * \param face_j The index into shape_j->face_offsets of the current face on the second particle.
+ * \param delta The vector pointing from the closest point on the face of particle j to the input point r0 (updated by reference).
+ * \param projection The closest point on the face to r0, IN THE FRAME OF PARTICLE j (updated by reference).
+ */
+HOSTDEVICE inline void pointFaceDistance(
+    const vec3<Scalar> &rij, const alj_shape_params *shape_j, const vec3<Scalar> &r0, const Scalar (&matj)[3][3], unsigned int face_j, vec3<Scalar> &delta, vec3<Scalar> &projection)
+    {
+    // distsq will be used to hold the square distance from r0 to the
+    // face of interest; work relative to particle j's center of mass
+    Scalar distsq(0);
+    // r0 from particle j's frame of reference
+    const vec3<Scalar> r0j(r0 - rij);
+    // rPrime is the closest point to r0
+    vec3<Scalar> rPrime;
+
+    // vertex0 is the reference point in particle j to "fan out" from
+    unsigned int start_idx = shape_j->face_offsets[face_j];
+    unsigned int end_idx = (face_j == shape_j->face_offsets.size() - 1) ? shape_j->faces.size() : shape_j->face_offsets[face_j+1];
+    const vec3<Scalar> vertex0(rotate(matj, shape_j->verts[shape_j->faces[start_idx]]));
+
+    // r0r0: vector from vertex0 to r0 relative to particle j
+    const vec3<Scalar> r0r0(r0j - vertex0);
+
+    // check distance for first edge of polygon
+    const vec3<Scalar> secondVertex(rotate(matj, shape_j->verts[shape_j->faces[start_idx+1]]));
+    const vec3<Scalar> rsec(secondVertex - vertex0);
+    Scalar lambda(dot(r0r0, rsec)/dot(rsec, rsec));
+    lambda = clip(lambda);
+    vec3<Scalar> closest(vertex0 + lambda*rsec);
+    vec3<Scalar> closestr0(closest - r0j);
+    Scalar closestDistsq(dot(closestr0, closestr0));
+    distsq = closestDistsq;
+    rPrime = closest;
+
+    // indices of three points in triangle of interest: vertex0Index, i, facesj[i]
+    // p01 and p02: two edge vectors of the triangle of interest
+    vec3<Scalar> p1, p2(secondVertex), p01, p02(secondVertex - vertex0);
+
+    // iterate through all fan triangles
+    for(unsigned int next_idx = start_idx+2; next_idx < end_idx; ++next_idx)
+        {
+        Scalar alpha(0), beta(0);
+
+        p1 = p2;
+        p2 = rotate(matj, shape_j->verts[shape_j->faces[next_idx]]);
+        p01 = p02;
+        p02 = p2 - vertex0;
+
+        // pc: vector normal to the triangle of interest
+        const vec3<Scalar> pc(cross(p01, p02));
+
+        // distance matrix A is:
+        // [ p01.x p02.x pc.x ]
+        // [ p01.y p02.y pc.y ]
+        // [ p01.z p02.z pc.z ]
+        Scalar magA(p01.x*(p02.y*pc.z - pc.y*p02.z) - p02.x*(p01.y*pc.z - pc.y*p01.z) +
+            pc.x*(p01.y*p02.z - p02.y*p01.z));
+
+        alpha = ((p02.y*pc.z - pc.y*p02.z)*r0r0.x + (pc.x*p02.z - p02.x*pc.z)*r0r0.y +
+            (p02.x*pc.y - pc.x*p02.y)*r0r0.z)/magA;
+        beta = ((pc.y*p01.z - p01.y*pc.z)*r0r0.x + (p01.x*pc.z - pc.x*p01.z)*r0r0.y +
+            (pc.x*p01.y - p01.x*pc.y)*r0r0.z)/magA;
+
+        alpha = clip(alpha);
+        beta = clip(beta);
+        const Scalar k(alpha + beta);
+
+        if(k > 1)
+            {
+            alpha /= k;
+            beta /= k;
+            }
+
+        // check distance for exterior edge of polygon
+        const vec3<Scalar> p12(p2 - p1);
+        Scalar lambda(dot(r0j - p1, p12)/dot(p12, p12));
+        lambda = clip(lambda);
+        vec3<Scalar> closest(p1 + lambda*p12);
+        vec3<Scalar> closestr0(closest - r0j);
+        Scalar closestDistsq(dot(closestr0, closestr0));
+        if(closestDistsq < distsq)
+            {
+            distsq = closestDistsq;
+            rPrime = closest;
+            }
+
+        // closest: closest point in triangle (in particle j's reference frame)
+        closest = vertex0 + alpha*p01 + beta*p02;
+        // closestr0: vector between r0 and closest
+        closestr0 = closest - r0j;
+        closestDistsq = dot(closestr0, closestr0);
+        if(closestDistsq < distsq)
+            {
+            distsq = closestDistsq;
+            rPrime = closest;
+            }
+        }
+
+    // check distance for last edge of polygon
+    const vec3<Scalar> rlast(p2 - vertex0);
+    lambda = dot(r0r0, rlast)/dot(rlast, rlast);
+    lambda = clip(lambda);
+    closest = vertex0 + lambda*rlast;
+    closestr0 = closest - r0j;
+    closestDistsq = dot(closestr0, closestr0);
+    if(closestDistsq < distsq)
+        {
+        distsq = closestDistsq;
+        rPrime = closest;
+        }
+
+    projection = rPrime;
+    delta = r0j - projection;
+    }
+
+
+//! Compute the distance between two line segments in 3D.
+/*! This function is adapted from DEMEvaluator::edgeEdge. Like
+ * pointFaceDistance, the energy evaluation has been removed from this
+ * function. The only other change is that the first few lines of
+ * DEMEvaluator::edgeEdge do an unnecessary number of repeated computations
+ * through calling the detp function defined there, but most of these dot
+ * products are identical and can be reduced as in the first 10 lines of this
+ * function. All inputs must be provided in the same coordinate system.
+ *
+ * \param e00 The first vertex of the first line segment.
+ * \param e01 The second vertex of the first line segment.
+ * \param e10 The first vertex of the second line segment.
+ * \param e11 The second vertex of the second line segment.
+ * \param closestI The closest point to the second segment on the first segment (overwritten by reference).
+ * \param closestI The closest point to the first segment on the second segment (overwritten by reference).
+ */
+HOSTDEVICE inline void
+edgeEdgeDistance(const vec3<Scalar> &e00, const vec3<Scalar> &e01, const vec3<Scalar> &e10, const vec3<Scalar> &e11, vec3<Scalar> &closestI, vec3<Scalar> &closestJ)
+    {
+    // This math is identical to DEM's but is simplified to reduce the number
+    // of dot products and clarify the purpose of the calculations that are
+    // present.
+    // in the style of http://paulbourke.net/geometry/pointlineplane/
+    const vec3<Scalar> r0(e01 - e00);
+    const vec3<Scalar> r1(e11 - e10);
+    const Scalar r0sq(dot(r0, r0));
+    const Scalar r1sq(dot(r1, r1));
+    const Scalar r1r0(dot(r1, r0));
+
+    const vec3<Scalar> diff0010(e00 - e10);
+    const Scalar detp5(dot(diff0010, r1));
+    const Scalar detp7(dot(diff0010, r0));
+
+    Scalar r0sqr1sq = r0sq * r1sq;
+    Scalar r1r0r1r0 = r1r0 * r1r0;
+    const Scalar denominator(r0sqr1sq - r1r0r1r0);
+    Scalar lambda0((detp5*r1r0 - detp7*r1sq)/denominator);
+    Scalar lambda1((detp5 + lambda0*r1r0)/r1sq);
+
+    lambda0 = clip(lambda0);
+    lambda1 = clip(lambda1);
+
+    closestI = e00 + lambda0*r0;
+    closestJ = e10 + lambda1*r1;
+    vec3<Scalar> rContact(closestJ - closestI);
+    Scalar closestDistsq = dot(rContact, rContact);
+
+    Scalar lambda(clip(dot(e10 - e00, r0)/r0sq));
+    vec3<Scalar> candidateI(e00 + lambda*r0);
+    rContact = e10 - candidateI;
+    Scalar distsq(dot(rContact, rContact));
+    if(distsq < closestDistsq)
+        {
+        closestI = candidateI;
+        closestJ = e10;
+        closestDistsq = distsq;
+        }
+
+    lambda = clip(dot(e11 - e00, r0)/r0sq);
+    candidateI = e00 + lambda*r0;
+    rContact = e11 - candidateI;
+    distsq = dot(rContact, rContact);
+    if(distsq < closestDistsq)
+        {
+        closestI = candidateI;
+        closestJ = e11;
+        closestDistsq = distsq;
+        }
+
+    lambda = clip(dot(diff0010, r1)/r1sq);
+    vec3<Scalar> candidateJ = e10 + lambda*r1;
+    rContact = candidateJ - e00;
+    distsq = dot(rContact, rContact);
+    if(distsq < closestDistsq)
+        {
+        closestI = e00;
+        closestJ = candidateJ;
+        closestDistsq = distsq;
+        }
+
+    lambda = clip(dot(e01 - e10, r1)/r1sq);
+    candidateJ = e10 + lambda*r1;
+    rContact = candidateJ - e01;
+    distsq = dot(rContact, rContact);
+    if(distsq < closestDistsq)
+        {
+        closestI = e01;
+        closestJ = candidateJ;
+        closestDistsq = distsq;
+        }
+
+    if(fabs(1 - r1r0r1r0/r0sqr1sq) < 1e-6)
+        {
+        const Scalar lambda00(clip(dot(e10-e00, r0)/r0sq));
+        const Scalar lambda01(clip(dot(e11-e00, r0)/r0sq));
+        const Scalar lambda10(clip(dot(e00-e10, r1)/r1sq));
+        const Scalar lambda11(clip(dot(e01-e10, r1)/r1sq));
+
+        lambda0 = Scalar(.5)*(lambda00 + lambda01);
+        lambda1 = Scalar(.5)*(lambda10 + lambda11);
+
+        closestI = e00 + lambda0*r0;
+        closestJ = e10 + lambda1*r1;
+        }
+    }
+
+
+//! Convert a quaternion to a rotation matrix.
+/*! The ALJ potential requires performing a large number of repeated rotations
+ * to evaluate the support function in GJK. This problem is exacerbated for
+ * polyhedra due to the numerous distance calculations that must be performed
+ * to average over all relevant interactions. Since the orientation of the
+ * particles is constant throughout these calculations, we can reduce the cost
+ * by converting the orientation quaternions to rotation matrices up front and
+ * reusing them.
+ *
+ * This implementation uses 12 multiplications and 12 additions, which is
+ * the minimal number of operations according to Wikipedia
+ * (https://en.wikipedia.org/wiki/Quaternions_and_spatial_rotation#Comparison_with_other_representations_of_rotations).
+ * Effort is also made using extra braces to indicate potential local
+ * optimizations, but a more optimal sequence of operations may exist.
+ *
+ * \param q The orientation quaternion to convert.
+ * \param mat The output matrix (overwritten by reference).
+ */
+HOSTDEVICE inline void quat2mat(const quat<Scalar> &q, Scalar (&mat)[3][3])
+    {
+    Scalar two_x = Scalar(2.0) * q.v.x;
+    Scalar two_y = Scalar(2.0) * q.v.y;
+    Scalar two_z = Scalar(2.0) * q.v.z;
+    Scalar two_x_sq = q.v.x * two_x;
+    Scalar two_y_sq = q.v.y * two_y;
+    Scalar two_z_sq = q.v.z * two_z;
+
+    mat[0][0] = Scalar(1.0) - two_y_sq - two_z_sq;
+    mat[1][1] = Scalar(1.0) - two_x_sq - two_z_sq;
+    mat[2][2] = Scalar(1.0) - two_x_sq - two_y_sq;
+
+        {
+        Scalar y_two_z = q.v.y * two_z;
+        Scalar s_two_x = q.s * two_x;
+        mat[1][2] = y_two_z - s_two_x;
+        mat[2][1] = y_two_z + s_two_x;
+        }
+
+        {
+        Scalar x_two_y = q.v.x * two_y;
+        Scalar s_two_z = q.s * two_z;
+        mat[0][1] = x_two_y - s_two_z;
+        mat[1][0] = x_two_y + s_two_z;
+        }
+
+        {
+        Scalar x_two_z = q.v.x * two_z;
+        Scalar s_two_y = q.s * two_y;
+        mat[0][2] = x_two_z + s_two_y;
+        mat[2][0] = x_two_z - s_two_y;
+        }
+    }
+
+
+//! Find the simplex defined by verts that is closest to the provided vector.
+/*! The closest simplex in this case is defined as the set of ndim points that
+ * are a subset of a face of the polytope defined by verts that also form the
+ * minimal set of angles with the provided vector. These angles are computed
+ * using dot products of the rotated vertices with the vector.
+ *
+ * \param verts The vertices of the shape.
+ * \param vector The point outside the shape, given in the body frame of the verts.
+ * \param mat The orientation of the verts.
+ * \param unique_vectors Array of vec3 to which the rotated vectors on the simplex are written (overwritten by references).
+ */
+template <unsigned int ndim>
+HOSTDEVICE inline void findSimplex(const ManagedArray<vec3<Scalar> > &verts, const vec3<Scalar> &vector, const Scalar (&mat)[3][3], vec3<Scalar> (&unique_vectors)[ndim])
+    {
+    Scalar angles[ndim];
+    for (unsigned int i = 0; i < ndim; ++i)
+        angles[i] = Scalar(M_PI);
+
+    vec3<Scalar> norm_vector = vector / sqrt(dot(vector, vector));
+
+    vec3<Scalar> rot_shift_vec = rotate(mat, verts[0]);
+    vec3<Scalar> norm_rot_shift_vector = rot_shift_vec / sqrt(dot(rot_shift_vec, rot_shift_vec));
+    unique_vectors[0] = rot_shift_vec;
+    angles[0] = acos(dot(norm_rot_shift_vector, norm_vector));
+
+    for (unsigned int i = 1; i < verts.size(); ++i)
+        {
+        rot_shift_vec = rotate(mat, verts[i]);
+        norm_rot_shift_vector = rot_shift_vec / sqrt(dot(rot_shift_vec, rot_shift_vec));
+        Scalar angle = acos(dot(norm_rot_shift_vector, norm_vector));
+
+        unsigned int insertion_index = (angle < angles[0] ? 0 : (angle < angles[1] ? 1 : 2 ));
+        if (ndim == 3 && angle >= angles[2])
+            {
+            insertion_index = 3;
+            }
+
+        if (insertion_index < ndim)
+            {
+            for (unsigned int j = (ndim-1); j > insertion_index; --j)
+                {
+                unique_vectors[j] = unique_vectors[j-1];
+                angles[j] = angles[j-1];
+                }
+            unique_vectors[insertion_index] = rot_shift_vec;
+            angles[insertion_index] = angle;
+            }
+        }
+    }
+
+
+//! Find the face defined by verts that is closest to the provided vector.
+/*! This function is very similar to findSimplex (see the documentation to that function above),
+ * except that this function is designed to work in three dimensions where the
+ * closest simplex may not be enough because a single face may be composed of
+ * multiple simplices (where a simplex is defined in the sense of a convex
+ * hull, i.e. it always contains exactly ndim points). For instance, a face of
+ * a cube is composed of two triangular simplices. The first part of this
+ * function is identical to findSimplex, except that instead of storing the
+ * vectors found only the corresponding indices are stored. Then, a search
+ * through all the faces of the shape is performed to identify the face
+ * containing those three vertices; that face must be unique, and is the face
+ * that will be used.
+ *
+ * \param vector The point outside the shape, given in the body frame of the verts.
+ * \param mat The orientation of the verts.
+ * \param face The face on the shape closest to vector (overwritten by reference).
+ * \param shape The shape parameters of the particle being tested.
+ */
+template <unsigned int ndim>
+HOSTDEVICE inline void findFace(const vec3<Scalar> &vector, const Scalar (&mat)[3][3], unsigned int &face, const alj_shape_params *shape)
+    {
+    // First identify the closest points
+    unsigned int unique_vectors[ndim];
+    Scalar angles[ndim];
+    for (unsigned int i = 0; i < ndim; ++i)
+        angles[i] = Scalar(M_PI);
+
+    vec3<Scalar> norm_vector = vector / sqrt(dot(vector, vector));
+
+    vec3<Scalar> rot_shift_vec = rotate(mat, shape->verts[0]);
+    vec3<Scalar> norm_rot_shift_vector = rot_shift_vec / sqrt(dot(rot_shift_vec, rot_shift_vec));
+    unique_vectors[0] = 0;
+    angles[0] = acos(dot(norm_rot_shift_vector, norm_vector));
+
+    for (unsigned int i = 1; i < shape->verts.size(); ++i)
+        {
+        rot_shift_vec = rotate(mat, shape->verts[i]);
+        norm_rot_shift_vector = rot_shift_vec / sqrt(dot(rot_shift_vec, rot_shift_vec));
+        Scalar angle = acos(dot(norm_rot_shift_vector, norm_vector));
+
+        unsigned int insertion_index = (angle < angles[0] ? 0 : (angle < angles[1] ? 1 : 2 ));
+        if (ndim == 3 && angle >= angles[2])
+            {
+            insertion_index = 3;
+            }
+
+        if (insertion_index < ndim)
+            {
+            for (unsigned int j = (ndim-1); j > insertion_index; --j)
+                {
+                unique_vectors[j] = unique_vectors[j-1];
+                angles[j] = angles[j-1];
+                }
+            unique_vectors[insertion_index] = i;
+            angles[insertion_index] = angle;
+            }
+        }
+
+    // Now loop over all faces and find the one that has the three closest points.
+    unsigned int num_faces = shape->face_offsets.size();
+    for (face = 0; face < num_faces; ++face)
+        {
+        unsigned int last_idx = (face == num_faces-1) ? shape->faces.size() : shape->face_offsets[face+1];
+        bool found0 = false, found1 = false, found2 = false;
+        for (unsigned int j = shape->face_offsets[face]; j < last_idx; ++j)
+            {
+            if (shape->faces[j] == unique_vectors[0])
+                found0 = true;
+            if (shape->faces[j] == unique_vectors[1])
+                found1 = true;
+            if (shape->faces[j] == unique_vectors[2])
+                found2 = true;
+            }
+        if (found0 && found1 && found2)
+            break;
+        }
+    }
+
+
+//! Anisotropic LJ (ALJ) potential.
+/*! The ALJ potential is a generalization of Lennard-Jones potential for convex
+ * anisotropic shapes. The potential is defined by a mean-field approximation
+ * to the total interaction energy between a pair of anistropic shapes that
+ * reduces the total interaction to a simple sum between 1) a contact
+ * interaction at between the closest points on each shape to the other, and 2)
+ * a center-center interaction analogous to the standard isotropic LJ
+ * potential.
+ */
+template <unsigned int ndim>
+class EvaluatorPairALJ
+    {
+    public:
+        typedef pair_alj_params param_type;
+
+        typedef alj_shape_params shape_param_type;
+
+        //! Constructs the pair potential evaluator.
+        /*! \param _dr Displacement vector between particle centers of mass.
+            \param _rcutsq Squared distance at which the potential goes to 0.
+            \param _q_i Quaternion of i^th particle.
+            \param _q_j Quaternion of j^th particle.
+            \param _params Per type pair parameters of this potential.
+        */
+        HOSTDEVICE EvaluatorPairALJ(Scalar3& _dr,
+                                Scalar4& _qi,
+                                Scalar4& _qj,
+                                Scalar _rcutsq,
+                                const param_type& _params)
+            : dr(_dr),rcutsq(_rcutsq),qi(_qi),qj(_qj), _params(_params)
+            {
+            }
+
+        //! Whether the pair potential needs particle diameters.
+        HOSTDEVICE static bool needsDiameter()
+            {
+            return false;
+            }
+
+        //! Whether the pair potential uses shape.
+        HOSTDEVICE static bool needsShape()
+            {
+            return true;
+            }
+
+        //! Whether the pair potential needs particle tags.
+        HOSTDEVICE static bool needsTags()
+            {
+            return true;
+            }
+
+        //! Whether pair potential requires charges
+        HOSTDEVICE static bool needsCharge()
+            {
+            return false;
+            }
+
+        //! Accept the optional diameter values
+        /*! \param di Diameter of particle i
+            \param dj Diameter of particle j
+        */
+        HOSTDEVICE void setDiameter(Scalar di, Scalar dj) {}
+
+        //! Accept the optional shape values
+        /*! \param shape_i Shape of particle i
+            \param shape_j Shape of particle j
+        */
+        HOSTDEVICE void setShape(const shape_param_type *shapei, const shape_param_type *shapej)
+            {
+            shape_i = shapei;
+            shape_j = shapej;
+            }
+
+        //! Accept the optional tags
+        /*! \param tag_i Tag of particle i
+            \param tag_j Tag of particle j
+        */
+        HOSTDEVICE void setTags(unsigned int tagi, unsigned int tagj)
+        {
+            tag_i = tagi;
+            tag_j = tagj;
+        }
+
+        //! Accept the optional charge values
+        /*! \param qi Charge of particle i
+            \param qj Charge of particle j
+        */
+        HOSTDEVICE void setCharge(Scalar qi, Scalar qj){}
+
+        //! Evaluate the force and energy.
+        /*! \param force Output parameter to write the computed force.
+            \param pair_eng Output parameter to write the computed pair energy.
+            \param energy_shift If true, the potential must be shifted so that V(r) is continuous at the cutoff.
+            \param torque_i The torque exterted on the i^th particle.
+            \param torque_j The torque exterted on the j^th particle.
+            \return True if they are evaluated or false if they are not because we are beyond the cutoff.
+        */
+        HOSTDEVICE  bool
+        evaluate(Scalar3& force, Scalar& pair_eng, bool energy_shift, Scalar3& torque_i, Scalar3& torque_j)
+            {
+            Scalar rsq = dot(dr, dr);
+
+            if (rsq < rcutsq)
+                {
+                Scalar r = sqrt(rsq);
+
+                // Since we will be performing a rotation many times, it's worthwhile to
+                // convert the quaternions to rotation matrices and use those for repeated
+                // rotations. The conversions below use the fewest operations I could come
+                // up with (12 multiplications and 12 additions). Optimizing this
+                // conversion is only really important for low vertex shapes where the
+                // additional cost of the conversion could offset the added speed of the
+                // rotations. We create local scope for all the intermediate products to
+                // avoid namespace pollution with unnecessary variables..
+                Scalar mati[3][3], matj[3][3];
+                quat2mat(qi, mati);
+                quat2mat(qj, matj);
+
+                // Call GJK. In order to ensure that Newton's third law is
+                // obeyed, we must avoid any imbalance caused by numerical
+                // errors leading to GJK(i, j) returning different results from
+                // GJK(j, i). To prevent any such problems, we choose i and j
+                // such that tag_i < tag_j.
+                vec3<Scalar> v = vec3<Scalar>(), a = vec3<Scalar>(), b = vec3<Scalar>();
+                    {
+                    // Create local scope to avoid polluting the local scope
+                    // with many unnecessary variables after GJK is done.
+                    bool flip = (tag_i >= tag_j);
+                    const ManagedArray<vec3<Scalar> > &verts1(flip ? shape_j->verts : shape_i->verts);
+                    const ManagedArray<vec3<Scalar> > &verts2(flip ? shape_i->verts : shape_j->verts);
+                    const Scalar (&mat1)[3][3](flip ? matj : mati), (&mat2)[3][3](flip ? mati : matj);
+                    const quat<Scalar> &q1(flip ? qj : qi), &q2(flip ? qi : qj);
+                    vec3<Scalar> dr_use(flip ? -dr : dr);
+
+                    bool success, overlap;
+                    // Note the signs of each of the vectors:
+                    //    - v points from the contact point on verts2 to the contact points on verts1.
+                    //    - a points from the centroid of verts1 to the contact points on verts1.
+                    //    - b points from the centroid of verts1 to the contact points on verts2.
+                    gjk<ndim>(verts1, verts2, v, a, b, success, overlap, mat1, mat2, q1, q2, dr_use, shape_i->rounding_radii, shape_j->rounding_radii, shape_i->has_rounding, shape_j->has_rounding);
+                    assert(success && !overlap);
+
+                    if (flip)
+                        {
+                        vec3<Scalar> a_tmp = a;
+                        a = b - dr;
+                        b = a_tmp - dr;
+                        }
+                    else
+                        {
+                        // We want v to be from verts1->verts2, but the value
+                        // returned from GJK is from verts2->verts1.
+                        v *= Scalar(-1.0);
+                        }
+
+                    }
+                if (ndim == 2)
+                    {
+                    v.z = 0;
+                    a.z = 0;
+                    b.z = 0;
+                    }
+
+                Scalar sigma12 = Scalar(0.5) * (_params.sigma_i + _params.sigma_j);
+                Scalar sigma12_sq = sigma12*sigma12;
+
+                Scalar contact_sphere_diameter = Scalar(0.5)*(_params.contact_sigma_i + _params.contact_sigma_j);
+                Scalar contact_sphere_diameter_sq = contact_sphere_diameter*contact_sphere_diameter;
+
+                // The energy for the central potential must be rescaled by the
+                // orientations (encoded in the a and b vectors).
+                Scalar k1 = sqrt(dot(a, a));
+                Scalar k2 = sqrt(dot(dr+b, dr+b));
+                Scalar rho = sigma12 / (r - (k1 - Scalar(0.5)*_params.sigma_i) - (k2 - Scalar(0.5)*_params.sigma_j));
+                Scalar invr_rsq = rho*rho;
+                Scalar invr_6 = invr_rsq*invr_rsq*invr_rsq;
+                Scalar numer = (invr_6*invr_6 - invr_6) - (_params.alpha % 2 == 0 ? SHIFT_RHO_DIFF : 0);
+
+                invr_rsq = sigma12_sq/rsq;
+                invr_6 = invr_rsq*invr_rsq*invr_rsq;
+                Scalar invr_12 = invr_6*invr_6;
+                Scalar denom = invr_12 - invr_6 - (_params.alpha % 2 == 0 ? SHIFT_RHO_DIFF : 0);
+                Scalar scale_factor = denom != 0 ? (numer/denom) : 1;
+
+                Scalar four_epsilon = Scalar(4.0) * _params.epsilon;
+                Scalar four_scaled_epsilon = four_epsilon * scale_factor;
+
+                // We must compute the central LJ force if we are including the
+                // attractive component. For pure repulsive (WCA), we only need
+                // to compute it if we are within the limited cutoff.
+                Scalar f_scalar = 0;
+                pair_eng = 0;
+                if ((_params.alpha % 2 != 0) || (rsq < TWO_P_13*sigma12_sq))
+                    {
+                    // Compute force and energy from LJ formula.
+                    pair_eng += four_scaled_epsilon * (invr_12 - invr_6);
+                    f_scalar = four_scaled_epsilon * (Scalar(12.0)*invr_12 - Scalar(6.0)*invr_6) / r;
+
+                    // For the WCA case
+                    if (_params.alpha % 2 == 0)
+                        {
+                        pair_eng -= four_scaled_epsilon * SHIFT_RHO_DIFF;
+                        }
+                    }
+
+                vec3<Scalar> f = f_scalar * (dr / r);
+                // TODO: If we anticipate running heavily mixed systems of
+                // ellipsoids and (sphero)poly[gons|hedra], we could get
+                // significant performance benefits from templating here and
+                // having multiple evaluators to handle the specific pairs of
+                // interactions. However, that requires significant reworkings
+                // of HOOMD internals, so it's probably not worthwhile. We
+                // should consider if we ever want to enable this during the
+                // HOOMD3.0 rewrite, though.
+
+                // TODO: Can prefilter whether we need to call the function
+                // based on whether the minimum distance is within rcut,
+                // otherwise we know that none of the interactions will count.
+                if (_params.average_simplices && shape_i->verts.size() > ndim && shape_j->verts.size() > ndim)
+                    {
+                    computeSimplexInteractions(
+                            a, b, dr, mati, matj, contact_sphere_diameter_sq, four_epsilon, f, pair_eng, torque_i, torque_j);
+                    }
+                else
+                    {
+                    vec3<Scalar> torquei, torquej;
+                    computeContactLJ(contact_sphere_diameter_sq, v, four_epsilon, a, dr+b, f, pair_eng, torquei, torquej);
+                    torque_i = vec_to_scalar3(torquei);
+                    torque_j = vec_to_scalar3(torquej);
+                    }
+                force = vec_to_scalar3(f);
+
+                if (ndim == 2)
+                    {
+                    force.z = 0;
+                    torque_i.x = 0;
+                    torque_i.y = 0;
+                    torque_j.x = 0;
+                    torque_j.y = 0;
+                    }
+
+                return true;
+                }
+              else
+                {
+                return false;
+                }
+            }
+
+        #ifndef NVCC
+        //! Get the name of the potential
+        /*! \returns The potential name. Must be short and all lowercase, as this is the name energies will be logged as
+            via analyze.log.
+        */
+        static std::string getName()
+            {
+            return "alj";
+            }
+
+        std::string getShapeSpec() const
+            {
+            throw std::runtime_error("Shape definition not supported for this pair potential.");
+            }
+        #endif
+
+    protected:
+
+        //! Calculate contact interaction between two simplices.
+        /*! This method takes two faces of polytopes and computes all requisite
+         * pairwise interactions between them. It must be specialized for each
+         * necessary dimensionality because the minimal set of interactions
+         * that must be computed depend on the set of lower-dimensional
+         * simplices that make up an n-dimensional face. The function is given
+         * an empty definition by default.
+         *
+         *  \param support_vectors1 Set of vectors composing the simplex on particle i.
+         *  \param support_vectors2 Set of vectors composing the simplex on particle j.
+         *  \param contact_sphere_diameter_sq The length scale of the LJ interaction (i.e. sigma^2).
+         *  \param four_epsilon 4*epsilon, the energy scale for the LJ interaction.
+         *  \param contact_point_i The contact point on particle i in the frame of particle i.
+         *  \param contact_point_j The contact point on particle j in the frame of particle j (IMPORTANT NOTE, this is different from many places in this code where vectors relating to particle j are in the coordinate system centered on particle i).
+         *  \param force The current force vector to which the force computed in this method is added.
+         *  \param pair_eng The current pair interaction energy to which the energy computed in this method is added.
+         *  \param torque_i The current torque on particle i to which the torque computed in this method is added.
+         *  \param torque_j The current torque on particle j to which the torque computed in this method is added.
+         */
+        HOSTDEVICE inline void computeSimplexInteractions(
+                const vec3<Scalar> &a, const vec3<Scalar> &b, const vec3<Scalar> &dr,
+                const Scalar (&mati)[3][3], const Scalar (&matj)[3][3],
+                const Scalar contact_sphere_diameter_sq, const Scalar &four_epsilon,
+                vec3<Scalar> &force, Scalar &pair_eng, Scalar3 &torque_i, Scalar3 &torque_j) {}
+
+        //! Core routine for calculating contact interaction between two points.
+        /*! This method is defined separately because it must be called for
+         * both the base contact-point formalism and the extended simplex
+         * averaging method we use for polytopes with many parallel faces. In
+         * the latter case, we may have to compute a large number of
+         * interactions, and each interaction will call this method.
+         * The contact points must be with respect to each particle's center of
+         * mass (contact_point_i is relative to the origin, which is the center
+         * of verts1, whereas contact_point_j is relative to the center of
+         * verts2, which is -dr). The contact_vector must point from verts1 to verts2
+         *
+         *  \param contact_sphere_diameter_sq The length scale of the LJ interaction (i.e. sigma^2).
+         *  \param contact_vector The vector pointing from the contact point on particle i to the contact point on particle j.
+         *  \param contact_distance The length of the contact_vector provided separately since it's typically computed as part of determining the contact_vector.
+         *  \param four_epsilon 4*epsilon, the energy scale for the LJ interaction.
+         *  \param contact_point_i The contact point on particle i in the frame of particle i.
+         *  \param contact_point_j The contact point on particle j in the frame of particle j (IMPORTANT NOTE, this is different from many places in this code where vectors relating to particle j are in the coordinate system centered on particle i).
+         *  \param force The current force vector to which the force computed in this method is added.
+         *  \param pair_eng The current pair interaction energy to which the energy computed in this method is added.
+         *  \param torque_i The current torque on particle i to which the torque computed in this method is added.
+         *  \param torque_j The current torque on particle j to which the torque computed in this method is added.
+         */
+        HOSTDEVICE inline void computeContactLJ(const Scalar &contact_sphere_diameter_sq, const vec3<Scalar> &contact_vector, const Scalar &four_epsilon, const vec3<Scalar> &contact_point_i, const vec3<Scalar> &contact_point_j,
+                vec3<Scalar> &force, Scalar &pair_eng, vec3<Scalar> &torque_i, vec3<Scalar> &torque_j)
+            {
+            Scalar contact_distance_sq = dot(contact_vector, contact_vector);
+            if ((_params.alpha / 2 != 0) || (contact_distance_sq < TWO_P_13*contact_sphere_diameter_sq))
+                {
+                Scalar contact_distance = sqrt(contact_distance_sq);
+                Scalar invr_rsq = contact_sphere_diameter_sq / contact_distance_sq;
+                Scalar invr_6 = invr_rsq*invr_rsq*invr_rsq;
+                Scalar invr_12 = invr_6*invr_6;
+                Scalar energy_contact = four_epsilon * (invr_12 - invr_6);
+                Scalar scalar_force_contact = four_epsilon * (Scalar(12.0)*invr_12 - Scalar(6.0)*invr_6) / contact_distance;
+
+                // For the WCA case
+                if (_params.alpha / 2 == 0)
+                    {
+                    energy_contact -= four_epsilon * SHIFT_RHO_DIFF;
+                    }
+
+                pair_eng += energy_contact;
+                vec3<Scalar> force_contact = -scalar_force_contact * contact_vector / contact_distance;
+                force += force_contact;
+
+                torque_i += cross(contact_point_i, force_contact);
+                torque_j += cross(contact_point_j, Scalar(-1.0) * force_contact);
+                }
+            }
+
+        vec3<Scalar> dr;   //!< Stored dr from the constructor
+        Scalar rcutsq;     //!< Stored rcutsq from the constructor
+        quat<Scalar> qi;   //!< Orientation quaternion for particle i
+        quat<Scalar> qj;   //!< Orientation quaternion for particle j
+        unsigned int tag_i;      //!< Tag of particle i.
+        unsigned int tag_j;      //!< Tag of particle j.
+        const shape_param_type *shape_i;      //!< Shape parameters of particle i.
+        const shape_param_type *shape_j;      //!< Shape parameters of particle j.
+        const param_type& _params;      //!< Potential parameters for the pair of interest.
+
+        constexpr static Scalar TWO_P_13 = 1.2599210498948732;  // 2^(1/3)
+        constexpr static Scalar SHIFT_RHO_DIFF = -0.25; // (1/(2^(1/6)))**12 - (1/(2^(1/6)))**6
+    };
+
+
+template <>
+HOSTDEVICE inline void EvaluatorPairALJ<2>::computeSimplexInteractions(
+        const vec3<Scalar> &a, const vec3<Scalar> &b, const vec3<Scalar> &dr,
+        const Scalar (&mati)[3][3], const Scalar (&matj)[3][3],
+        const Scalar contact_sphere_diameter_sq, const Scalar &four_epsilon,
+        vec3<Scalar> &force, Scalar &pair_eng, Scalar3 &torque_i, Scalar3 &torque_j)
+    {
+    vec3<Scalar> support_vectors1[2], support_vectors2[2];
+    findSimplex(shape_i->verts, b, mati, support_vectors1);
+    findSimplex(shape_j->verts, dr+a, matj, support_vectors2);
+    // Since simplex finding is based on angles, we need to compute dot
+    // products in the local frame of the second particle and then shift
+    // the final result back into the global frame (the body frame of
+    // particle 1).
+    for (unsigned int i = 0; i < 2; ++i)
+        {
+        support_vectors2[i] += Scalar(-1.0)*dr;
+        }
+
+    vec3<Scalar> torquei, torquej;
+    vec3<Scalar> projection, vec;
+    // First compute the interaction of the verts on 1 to the edge on 2.
+    for (unsigned int i = 0; i < 2; ++i)
+        {
+        pointSegmentDistance(support_vectors1[i], support_vectors2[0], support_vectors2[1], vec, projection);
+        computeContactLJ(contact_sphere_diameter_sq, -vec, four_epsilon, support_vectors1[i], dr + support_vectors1[i] - vec, force, pair_eng, torquei, torquej);
+        }
+
+    // Now compute the interaction of the verts on 2 to the edge on 1.
+    for (unsigned int i = 0; i < 2; ++i)
+        {
+        pointSegmentDistance(support_vectors2[i], support_vectors1[0], support_vectors1[1], vec, projection);
+
+        computeContactLJ(contact_sphere_diameter_sq, vec, four_epsilon, projection, dr + support_vectors2[i], force, pair_eng, torquei, torquej);
+        }
+    torque_i = vec_to_scalar3(torquei);
+    torque_j = vec_to_scalar3(torquej);
+    }
+
+template <>
+HOSTDEVICE inline void EvaluatorPairALJ<3>::computeSimplexInteractions(
+        const vec3<Scalar> &a, const vec3<Scalar> &b, const vec3<Scalar> &dr,
+        const Scalar (&mati)[3][3], const Scalar (&matj)[3][3],
+        const Scalar contact_sphere_diameter_sq, const Scalar &four_epsilon,
+        vec3<Scalar> &force, Scalar &pair_eng, Scalar3 &torque_i, Scalar3 &torque_j)
+    {
+    unsigned int face_i, face_j;
+    findFace<3>(b, mati, face_i, shape_i);
+    findFace<3>(dr+a, matj, face_j, shape_j);
+
+    vec3<Scalar> torquei, torquej;
+    vec3<Scalar> projection, vec;
+
+    unsigned int start_idx_i = shape_i->face_offsets[face_i];
+    unsigned int end_idx_i = (face_i == shape_i->face_offsets.size() - 1) ? shape_i->faces.size() : shape_i->face_offsets[face_i+1];
+    const vec3<Scalar> rij(Scalar(-1.0)*dr);
+    // Compute the interaction of the verts on 1 to the face on 2.
+    for (unsigned int i = start_idx_i; i < end_idx_i; ++i)
+        {
+        const vec3<Scalar> vertex(rotate(mati, shape_i->verts[shape_i->faces[i]]));
+        pointFaceDistance(rij, shape_j, vertex, matj, face_j, vec, projection);
+
+        computeContactLJ(contact_sphere_diameter_sq, -vec, four_epsilon, vertex, dr + vertex - vec, force, pair_eng, torquei, torquej);
+        }
+
+    unsigned int start_idx_j = shape_j->face_offsets[face_j];
+    unsigned int end_idx_j = (face_j == shape_j->face_offsets.size() - 1) ? shape_j->faces.size() : shape_j->face_offsets[face_j+1];
+    // Compute the interaction of the verts on 2 to the edge on 1.
+    for (unsigned int i = start_idx_j; i < end_idx_j; ++i)
+        {
+        const vec3<Scalar> vertex(rotate(matj, shape_j->verts[shape_j->faces[i]]));
+        pointFaceDistance(dr, shape_i, vertex, mati, face_i, vec, projection);
+        computeContactLJ(contact_sphere_diameter_sq, vec, four_epsilon, projection, dr + vertex, force, pair_eng, torquei, torquej);
+        }
+
+    // Compute interaction between pairs of edges.
+    for (unsigned int i = start_idx_i; i < end_idx_i; ++i)
+        {
+        vec3<Scalar> e00(rotate(mati, shape_i->verts[shape_i->faces[i]]));
+        unsigned int idx_e01(i == end_idx_i-1 ? start_idx_i : i+1);
+        vec3<Scalar> e01(rotate(mati, shape_i->verts[shape_i->faces[idx_e01]]));
+
+        for (unsigned int j = start_idx_j; j < end_idx_j; ++j)
+            {
+            vec3<Scalar> e10(rotate(matj, shape_j->verts[shape_j->faces[j]]) + Scalar(-1.0)*dr);
+            unsigned int idx_e11(j == end_idx_j-1 ? start_idx_j : j+1);
+            vec3<Scalar> e11(rotate(matj, shape_j->verts[shape_j->faces[idx_e11]]) + Scalar(-1.0)*dr);
+
+            vec3<Scalar> closestI, closestJ;
+            edgeEdgeDistance(e00, e01, e10, e11, closestI, closestJ);
+            vec3<Scalar> vec = closestJ-closestI;
+            computeContactLJ(contact_sphere_diameter_sq, vec, four_epsilon, closestI, dr + closestJ, force, pair_eng, torquei, torquej);
+            }
+        }
+    torque_i = vec_to_scalar3(torquei);
+    torque_j = vec_to_scalar3(torquej);
+    }
+
+
+
+#ifndef NVCC
+
+// Note: This method assumes that shape_i == shape_j. This should be valid for
+// all cases, and this logic will be moved up to the AnisoPotentialPair in
+// HOOMD 3.0.
+template <>
+std::string EvaluatorPairALJ<2>::getShapeSpec() const
+    {
+    std::ostringstream shapedef;
+    const ManagedArray<vec3<Scalar> > &verts(shape_i->verts);       //! Shape vertices.
+    const unsigned int N = verts.size();
+    if (N == 1)
+        {
+        shapedef << "{\"type\": \"Ellipsoid\", \"a\": " << shape_i->rounding_radii.x + (_params.contact_sigma_i/2) <<
+                    ", \"b\": " << shape_i->rounding_radii.y + (_params.contact_sigma_i/2) <<
+                    // Render ellipsoid with a third dimension of 1.
+                    ", \"c\": " << 1 <<
+                    "}";
+        }
+    else
+        {
+        if (shape_i->rounding_radii.x != shape_i->rounding_radii.y ||
+                shape_i->rounding_radii.x != shape_i->rounding_radii.z)
+            {
+                throw std::runtime_error("Shape definition not supported for spheropolygons with distinct rounding radii.");
+            }
+
+        shapedef << "{\"type\": \"Polygon\", \"rounding_radius\": " << shape_i->rounding_radii.x + (_params.contact_sigma_i/2) << ", \"vertices\": [";
+        for (unsigned int i = 0; i < N-1; ++i)
+            {
+            shapedef << "[" << verts[i].x << ", " << verts[i].y << "], ";
+            }
+        shapedef << "[" << verts[N-1].x << ", " << verts[N-1].y << "]]}";
+        }
+    return shapedef.str();
+    }
+
+// Note: This method assumes that shape_i == shape_j. This should be valid for
+// all cases, and this logic will be moved up to the AnisoPotentialPair in
+// HOOMD 3.0.
+template <>
+std::string EvaluatorPairALJ<3>::getShapeSpec() const
+    {
+    std::ostringstream shapedef;
+    const ManagedArray<vec3<Scalar> > &verts(shape_i->verts);
+    const unsigned int N = verts.size();
+    if (N == 1)
+        {
+        shapedef << "{\"type\": \"Ellipsoid\", \"a\": " << shape_i->rounding_radii.x + (_params.contact_sigma_i/2) <<
+                    ", \"b\": " << shape_i->rounding_radii.y + (_params.contact_sigma_i/2) <<
+                    ", \"c\": " << shape_i->rounding_radii.z + (_params.contact_sigma_i/2) <<
+                    "}";
+        }
+    else
+        {
+        if (shape_i->rounding_radii.x != shape_i->rounding_radii.y ||
+                shape_i->rounding_radii.x != shape_i->rounding_radii.z)
+            {
+                throw std::runtime_error("Shape definition not supported for spheropolyhedra with distinct rounding radii.");
+            }
+        shapedef << "{\"type\": \"ConvexPolyhedron\", \"rounding_radius\": " << shape_i->rounding_radii.x + (_params.contact_sigma_i/2) << ", \"vertices\": [";
+        for (unsigned int i = 0; i < N-1; ++i)
+            {
+            shapedef << "[" << verts[i].x << ", " << verts[i].y << ", " << verts[i].z << "], ";
+            }
+        shapedef << "[" << verts[N-1].x << ", " << verts[N-1].y << ", " << verts[N-1].z << "]]}";
+        }
+
+    return shapedef.str();
+    }
+#endif
+
+
+
+#ifndef NVCC
+alj_shape_params make_alj_shape_params(pybind11::list vertices, pybind11::list faces, pybind11::list rounding_radii, std::shared_ptr<const ExecutionConfiguration> exec_conf)
+    {
+    alj_shape_params result(vertices, faces, rounding_radii, exec_conf->isCUDAEnabled());
+    return result;
+    }
+
+pair_alj_params make_pair_alj_params(Scalar epsilon, Scalar sigma_i, Scalar sigma_j, Scalar contact_sigma_i, Scalar contact_sigma_j, unsigned int alpha, bool average_simplices, std::shared_ptr<const ExecutionConfiguration> exec_conf)
+    {
+    pair_alj_params result(epsilon, sigma_i, sigma_j, contact_sigma_i, contact_sigma_j, alpha, average_simplices, exec_conf->isCUDAEnabled());
+    return result;
+    }
+
+//! Function to export the ALJ parameter type to python
+void export_alj_params(pybind11::module& m)
+{
+    pybind11::class_<pair_alj_params>(m, "pair_alj_params")
+        .def(pybind11::init<>())
+        .def_readwrite("alpha", &pair_alj_params::alpha)
+        .def_readwrite("epsilon", &pair_alj_params::epsilon)
+        .def_readwrite("sigma_i", &pair_alj_params::sigma_i)
+        .def_readwrite("sigma_j", &pair_alj_params::sigma_j);
+
+    m.def("make_pair_alj_params", &make_pair_alj_params);
+}
+
+void export_alj_shape_params(pybind11::module& m)
+    {
+    pybind11::class_<alj_shape_params>(m, "alj_shape_params")
+        .def(pybind11::init<>());
+
+    m.def("make_alj_shape_params", &make_alj_shape_params);
+    }
+#endif
+
+#endif // __EVALUATOR_PAIR_ALJ_H__

--- a/hoomd/md/GJK.h
+++ b/hoomd/md/GJK.h
@@ -1,0 +1,466 @@
+#ifndef __GJK_H__
+#define __GJK_H__
+
+#include "hoomd/VectorMath.h"
+
+#ifdef NVCC
+#define HOSTDEVICE __host__ __device__
+#else
+#define HOSTDEVICE
+#include <stdexcept>
+#endif
+
+HOSTDEVICE inline unsigned int support(const ManagedArray<vec3<Scalar> > &verts, const vec3<Scalar> &vector, const quat<Scalar> &q, const vec3<Scalar> shift)
+    {
+    unsigned int index = 0;
+
+    Scalar max_dist = dot((rotate(q, verts[index]) + shift), vector);
+    for (unsigned int i = 1; i < verts.size(); ++i)
+        {
+        Scalar dist = dot((rotate(q, verts[i]) + shift), vector);
+        if (dist > max_dist)
+            {
+            max_dist = dist;
+            index = i;
+            }
+        }
+    return index;
+    }
+
+
+// Note: All of the bitwise indexing schemes could fail if ndim is too large.
+// However, this shouldn't be a concern for any realistic number of dimensions.
+// All bit flags are representing either arrays of size max_num_points, which
+// is ndim+1, or of size max_power_set_size, which is 2^(max_num_points).
+// Therefore, the largest possible bit indexer (which is currently
+// comb_contains, must be of size 2^(2^(ndim+1)). As long as these indexes are
+// declared of type unsigned long long int, they are guaranteed at least 64
+// bits, which means they support up to 5 dimensions 2^(5+1) = 2^6 = 64). If
+// more dimensions were ever needed, we could replace these bit indexes with
+// simple boolean arrays, but this slows down code substantially on the GPU.
+
+//! Apply the GJK algorithm to find the vector between the closest points on two sets of shapes.
+/*! This function implements the GJK algorithm as described in
+ *  Gino Van den Bergen (1999) A Fast and Robust GJK Implementation for
+ *  Collision Detection of Convex Objects, Journal of Graphics Tools, 4:2, 7-25,
+ *  DOI: 10.1080/10867651.1999.10487502.
+ *
+ *  The standard GJK algorithm takes the Minkowski difference (more precisely,
+ *  the Minkowski sum A-B) of two convex shapes and performs a search to see if
+ *  the origin is contained in the difference (this difference is also known as
+ *  the translational configuration space obstacle, or TCSO, in this context).
+ *  If the origin is contained in the TCSO, the same point is encompassed by
+ *  both shapes, so they must be overlapping. In order to determine whether the
+ *  origin is contained in the TCSO, the algorithm iteratively constructs
+ *  simplices that are composed of points on the TCSO until one is found that
+ *  contains the origin. In the case of nonoverlapping shapes, the algorithm
+ *  ultimately constructs a simplex of the TCSO containing the closest point to
+ *  the origin. The termination condition in this case relies on maintaining a
+ *  lower bound of this distance that is based on the distance from the origin
+ *  to the closest hyperplane. For efficiency in overlap checks, it is notable
+ *  that this lower bound provides an immediate indication if two shapes are
+ *  nonoverlapping if at any point a separating axis is found (i.e. a
+ *  hyperplane with positive distance). To actually find the distance between
+ *  two shapes, the algorithm proceeds until the vector distance between the
+ *  two shapes is within some tolerance of the estimated lower bound.
+ *
+ *  There are two important components of the algorithm worthy of special note.
+ *  One critical component of this algorithm is the actual construction of the
+ *  simplex at each step in the iteration. This construction is performed using
+ *  the Johnson subalgorithm, which essentially uses Cramer's rule to solve a
+ *  system of linear equations. Although normally inadvisable, in this case
+ *  Cramer's rule is optimal because at each iteration only one new vertex is
+ *  added to the simplex, so most of the minors computed in Cramer's rule are
+ *  already known. The second crucial component is the use of support mappings,
+ *  which provide a way to find the furthest point from the center of a given
+ *  convex shape in a specified direction. These support mappings can be
+ *  implemented for any general convex shape, and their usage makes this
+ *  algorithm both general and efficient since it eschews any need for any
+ *  other explicit mathematical description of the shape.
+ *
+ *  The implementation discussed in the above paper offers multiple
+ *  optimizations on the original, including the separating hyperplane check
+ *  noted previously. The algorithm is accelerated by caching all support
+ *  function evaluations and the cofactors required for Cramer's rule. To
+ *  improve robustness, we apply the improved termination conditions suggested
+ *  by van den Bergen as well. Additionally, we omit the use of the classical
+ *  backup procedure provided in the original paper, which in practice provides
+ *  very minimal improvement on the solution at significant computational cost.
+ *
+ *  \param verts1 The vertices of the first body.
+ *  \param verts2 The vertices of the second body.
+ *  \param v Reference to vec3 that will be overwritten with the vector joining the closest intersecting points on the two bodies (CRITICAL NOTE: The direction of the vector is from verts2 to verts1).
+ *  \param a Reference to vec3 that will be overwritten with the vector from the origin (in the frame defined by verts1) to the point on the body represented by verts1 that is closest to verts2.
+ *  \param b Reference to vec3 that will be overwritten with the vector from the origin (in the frame defined by verts1) to the point on the body represented by verts2 that is closest to verts1.
+ *  \param success Reference to bool that will be overwritten with whether or not the algorithm terminated in the maximum number of allowed iterations (verts1.size + verts2.size + 1).
+ *  \param overlap Reference to bool that will be overwritten with whether or not an overlap was detected.
+ *  \param qi The orientation of the first shape (will be applied to verts1).
+ *  \param qj The orientation of the first shape (will be applied to verts2).
+ *  \param dr The vector pointing from the position of particle 2 to the position of particle 1 (note the sign; this is reversed throughout most of the calculations below).
+ */
+template <unsigned int ndim>
+HOSTDEVICE inline void gjk(const ManagedArray<vec3<Scalar> > &verts1, const ManagedArray<vec3<Scalar> > &verts2, vec3<Scalar> &v, vec3<Scalar> &a, vec3<Scalar> &b, bool& success, bool& overlap, const quat<Scalar> &qi, const quat<Scalar> &qj, const vec3<Scalar> &dr)
+    {
+    // At any point only a subset of W is in use (identified by W_used), but
+    // the total possible is capped at ndim+1 because that is the largest
+    // number of affinely independent points in R^n.
+    constexpr unsigned int max_num_points = ndim + 1;
+    success = true;
+    overlap = true;
+
+    // Start with guess as vector pointing from the centroid of verts1 to the
+    // centroid of verts2.
+    vec3<Scalar> mean1, mean2;
+    for(unsigned int i = 0; i < verts1.size(); ++i)
+        {
+        mean1 += rotate(qi, verts1[i]);
+        }
+    for(unsigned int i = 0; i < verts2.size(); ++i)
+        {
+        mean2 += (rotate(qj, verts2[i]) + Scalar(-1.0)*dr);
+        }
+    mean1 /= Scalar(verts1.size());
+    mean2 /= Scalar(verts2.size());
+    v = mean1 - mean2;
+
+    vec3<Scalar> W[max_num_points];
+    Scalar lambdas[max_num_points] = {0};
+    unsigned int W_used = 0;  // To be used as a set of bit flags
+    unsigned int indices1[max_num_points] = {0};
+    unsigned int indices2[max_num_points] = {0};
+
+    for (unsigned int i = 0; i < max_num_points; ++i)
+        {
+        // We initialize W to avoid accidentally terminating if the new w is
+        // somehow equal to something saved in one of the uninitialized W[i].
+        W[i] = vec3<Scalar>();
+        }
+
+    // The first dimension shape of the deltas array is the total
+    // number of possible subsets, which is the cardinality
+    // of the power set (technically minus the empty set, but
+    // for indexing simplicity we just leave the 0th row empty).
+    // The second is the maximum number of affinely
+    // independent points, which is the dimension + 1
+    constexpr unsigned int max_power_set_size = (1 << (max_num_points));
+    Scalar deltas[max_power_set_size][max_num_points];
+    for (unsigned int i = 0; i < max_power_set_size; ++i)
+        {
+        for (unsigned int j = 0; j < max_num_points; ++j)
+            {
+            deltas[i][j] = 0;
+            }
+        }
+
+    // Base case for recursive algorithm is a set of size 1. While the distance
+    // subalgorithm is recursive in computing sets of increasing size, the
+    // outer GJK algorithm is not. Therefore, there is no guarantee that all
+    // sets of size one will have been set by other calls to the Johnson
+    // algorithm before accessing them, so we need to establish the base case
+    // explicitly by setting these here.
+    for (unsigned int i = 0; i < max_num_points; ++i)
+        {
+        deltas[1 << i][i] = 1;
+        }
+
+    // The tolerances are compile-time constants.
+    constexpr Scalar eps(1e-8), omega(1e-4);
+
+    Scalar u(0);
+    bool close_enough(false);
+    unsigned int max_iterations = verts1.size() + verts2.size() + 1;
+    unsigned int iteration = 0;
+    while (!close_enough)
+        {
+        iteration += 1;
+        if (iteration > max_iterations)
+            {
+            success = false;
+            break;
+            }
+        // support_{A-B}(-v) = support(A, -v) - support(B, v)
+        unsigned int i1 = support(verts1, -v, qi, vec3<Scalar>(0, 0, 0));
+        unsigned int i2 = support(verts2, v, qj, Scalar(-1.0)*dr);
+        vec3<Scalar> w = rotate(qi, verts1[i1]) - (rotate(qj, verts2[i2]) + Scalar(-1.0)*dr);
+
+        // Check termination conditions for degenerate cases:
+        // 1) If we are repeatedly finding the same point but can't get closer
+        // and can't terminate within machine precision.
+        // 2) If we are cycling between two points.
+        // In either case, because of the tracking with W_used, we can
+        // guarantee that the new w will be found in one of the W (but possibly
+        // in one of the unused slots.
+        //
+        // We don't bother with this on the GPU, the resulting warp divergence
+        // is worse for performance than just going through the max number of
+        // iterations on all threads.
+#ifndef NVCC
+        bool degenerate(false);
+        for (unsigned int i = 0; i < max_num_points; ++i)
+            {
+            if (w == W[i])
+                {
+                degenerate = true;
+                break;
+                }
+            }
+#endif
+
+        Scalar vnorm = sqrt(dot(v, v));
+        Scalar dvw = dot(v, w);
+        Scalar d = dvw/vnorm;
+        u = u > d ? u : d;
+        if (d > 0)
+            {
+            overlap = false;
+            }
+
+#ifdef NVCC
+        close_enough = ( ((vnorm - u) <= eps*vnorm) || (vnorm < omega) );
+#else
+        close_enough = ( degenerate || ((vnorm - u) <= eps*vnorm) || (vnorm < omega) );
+#endif
+        if (!close_enough)
+            {
+            unsigned int added_element(0);
+            for (; added_element < max_num_points; ++added_element)
+                {
+                // At least one of these must be empty, otherwise we have an
+                // overlap.
+                if (!(W_used & (1 << added_element)))
+                    {
+                    W[added_element] = w;
+                    W_used |= (1 << added_element);
+                    indices1[added_element] = i1;
+                    indices2[added_element] = i2;
+                    break;
+                    }
+                }
+            bool use_last(false);
+
+            /////////////////////////////////////////////
+            ////////// BEGIN JOHNSON ALGORITHM //////////
+            /////////////////////////////////////////////
+            unsigned int added_index = 1 << added_element;
+
+            // If there is only one point in use, we can return immediately.
+            unsigned int num_used = 0;
+            for (unsigned int i = 0; i < max_num_points; ++i)
+                {
+                num_used += (W_used >> i) & (1);
+                }
+            if (num_used == 1)
+                {
+                for (unsigned int i = 0; i < max_num_points; ++i)
+                    {
+                    if (W_used & (1 << i))
+                        {
+                        lambdas[i] = 1.0;
+                        }
+                    }
+                }
+            else
+                {
+                // The check_indexes array is simply linearly indexed, and it contains the
+                // subsets of W that we need to test. The sets are inserted as they are
+                // created over the course of the recursive algorithm. The sets are stored
+                // as unsigned integer representations of (ndim+1)-bits. For example, if W
+                // has 4 points, the subset consisting of the first 3 points is stored as
+                // 0111. The current_subset is used to select the current index to check, and
+                // next_subset_slot indicates the next open spot when a new set is found. To
+                // efficiently determine whether a particular subset is new or has been
+                // seen before, we maintain a separate boolean array comb_contains that is
+                // updated as new subsets are found. Note that comb_contains[0] is never
+                // used since it corresponds to the empty set, but is left indexed this way
+                // to simplify the access pattern using the bit-based indexing
+                // scheme. For efficiency, comb_contains is not actually an
+                // array, but is instead an unsigned int whose digits are bit
+                // flags.
+                unsigned int current_subset = 0, next_subset_slot = 0;
+                unsigned int check_indexes[max_power_set_size - 1] = {0};
+                unsigned long long int comb_contains = 0;
+
+                for (unsigned int i = 0; i < max_num_points; ++i)
+                    {
+                    unsigned int index_i(1 << i);
+                    if (W_used & index_i)
+                        {
+                        check_indexes[next_subset_slot] = index_i;
+                        comb_contains |= (1 << index_i);
+                        next_subset_slot += 1;
+                        }
+                    }
+
+                unsigned int desired_index = max_power_set_size;
+                while (current_subset < next_subset_slot)
+                    {
+                    unsigned int current_index = check_indexes[current_subset];
+
+                    // Make a local copy of the deltas that will be used frequently
+                    // to hint to the GPU that these values should be cached.
+                    // To give the GPU a hint that we need to cache specific
+                    // delta values, we point to just the relevant subset for
+                    // the current index. Rather than making another local
+                    // array (which would require further memory allocation and
+                    // copying), we just access the relevant deltas by pointer,
+                    // which seems to be sufficient.
+                    Scalar *deltas_current = deltas[current_index];
+
+                    // The vector k must be fixed, but can be chosen
+                    // arbitrarily. A simple deterministic choice is the last
+                    // used index.
+                    unsigned int k = 0;
+                    for (unsigned int i = 0; i < max_num_points; ++i)
+                        {
+                        if ((1 << i) & current_index)
+                            {
+                            k = i;
+                            break;
+                            }
+                        }
+
+                    // Caching the W_k value for speed on the GPU.
+                    const vec3<Scalar> W_k = W[k];
+
+                    bool complete = true;
+                    for (unsigned int new_element = 0; new_element < max_num_points; ++new_element)
+                        {
+                        unsigned int shifted_new_element = 1 << new_element;
+                        // Add new elements that are in use and not contained in the current set.
+                        if ((W_used & shifted_new_element) && !(current_index & shifted_new_element))
+                            {
+                            // Generate the corresponding bit-based index for the new set.
+                            unsigned int new_index = current_index | shifted_new_element;
+
+                            Scalar delta_new = 0;
+
+                            // The only sets for which we will not have cached data are
+                            // sets that contain the element most recently added to W.
+                            if ((added_index & current_index) || (added_element == new_element))
+                                {
+                                // Caching the W_new value for speed on the GPU.
+                                const vec3<Scalar> W_diff = W_k - W[new_element];
+
+                                // Use bitwise checks of all possible elements to find set members
+                                for (unsigned int possible_element = 0; possible_element < max_num_points; ++possible_element)
+                                    {
+                                    if ((1 << possible_element) & current_index)
+                                        {
+                                        delta_new += *(deltas_current + possible_element)*dot(W[possible_element], W_diff);
+                                        }
+                                    }
+                                deltas[new_index][new_element] = delta_new;
+                                }
+                            else
+                                {
+                                // Minimize data reads by using delta_current
+                                // in the termination conditional below and
+                                // only reading from deltas when we are using a
+                                // cached value.
+                                delta_new = deltas[new_index][new_element];
+                                }
+                            unsigned int shifted_new_index = 1 << new_index;
+                            if (!(comb_contains & shifted_new_index))
+                                {
+                                comb_contains |= shifted_new_index;
+                                check_indexes[next_subset_slot] = new_index;
+                                next_subset_slot += 1;
+                                }
+
+                            // Part (ii) of termination condition: Delta_j(X U {y_j}) <= 0
+                            // for all j not in current_subset
+                            // Could add additional check beforehand using added_index
+                            if (delta_new > 0)
+                                {
+                                complete = false;
+                                }
+                            }
+                        }
+                    // Part (i) of termination condition: Delta_i(X) > 0 for all i in current_subset
+                    // Could add additional check beforehand using added_index
+                    if (complete)
+                        {
+                        for (unsigned int i = 0; i < max_num_points; ++i)
+                            {
+                            if (((1 << i) & current_index) && (*(deltas_current+i) <= 0))
+                                {
+                                complete = false;
+                                break;
+                                }
+                            }
+                        }
+                    if (complete)
+                        {
+                        desired_index = current_index;
+                        break;
+                        }
+                    current_subset += 1;
+                    }
+
+                // If we didn't find a solution that fits the termination
+                // criterion, we just use the previous solution, because it's
+                // typically close enough.
+                if (desired_index == max_power_set_size)
+                    {
+                    use_last = true;
+                    }
+                else
+                    {
+                    // The sum of relevant deltas is used to scale the lambdas.
+                    Scalar delta_total(0);
+                    for (unsigned int i = 0; i < max_num_points; ++i)
+                        {
+                        delta_total += deltas[desired_index][i];
+                        }
+
+                    for (unsigned int i = 0; i < max_num_points; ++i)
+                        {
+                        unsigned int shifted_i = 1 << i;
+                        if (shifted_i & desired_index)
+                            {
+                            W_used |= shifted_i;
+                            lambdas[i] = deltas[desired_index][i]/delta_total;
+                            }
+                        else
+                            {
+                            W_used &= ~shifted_i;
+                            }
+                        }
+                    }
+                }
+            /////////////////////////////////////////////
+            /////////// END JOHNSON ALGORITHM ///////////
+            /////////////////////////////////////////////
+
+            if (use_last)
+                {
+                break;
+                }
+
+            v = vec3<Scalar>();
+            for (unsigned int i = 0; i < max_num_points; ++i)
+                {
+                if (W_used & (1 << i))
+                    {
+                    v += lambdas[i]*W[i];
+                    }
+                }
+            }
+        }
+
+    // A compiler bug causes the for loop below to never terminate when
+    // using max_num_points as the upper bound. Defining a new (equivalent)
+    // variable seems to fix it.
+    constexpr unsigned int new_limit = max_num_points;
+    a = vec3<Scalar>();
+    b = vec3<Scalar>();
+    for (unsigned int i = 0; i < new_limit; ++i)
+        {
+        if (W_used & (1 << i))
+            {
+            a += lambdas[i]*rotate(qi, verts1[indices1[i]]);
+            b += lambdas[i]*(rotate(qj, verts2[indices2[i]]) + Scalar(-1.0)*dr);
+            }
+        }
+    }
+#endif // __GJK_H__

--- a/hoomd/md/GJK_SV.h
+++ b/hoomd/md/GJK_SV.h
@@ -1,0 +1,784 @@
+#ifndef __GJK_SV_H__
+#define __GJK_SV_H__
+
+#include "hoomd/VectorMath.h"
+#include "hoomd/ManagedArray.h"
+
+#ifdef NVCC
+#define HOSTDEVICE __host__ __device__
+#else
+#define HOSTDEVICE
+#include <stdexcept>
+#endif
+
+// Define matrix vector multiplication since it's faster than quat vector.
+template <typename Scalar>
+HOSTDEVICE inline vec3<Scalar> rotate(const Scalar (&mat)[3][3], const vec3<Scalar> &v)
+    {
+    return vec3<Scalar>(
+            mat[0][0]*v.x + mat[0][1]*v.y + mat[0][2]*v.z,
+            mat[1][0]*v.x + mat[1][1]*v.y + mat[1][2]*v.z,
+            mat[2][0]*v.x + mat[2][1]*v.y + mat[2][2]*v.z
+            );
+    }
+
+
+HOSTDEVICE inline void support_polyhedron(const ManagedArray<vec3<Scalar> > &verts, const vec3<Scalar> &vector, const Scalar (&mat)[3][3], const vec3<Scalar> shift, unsigned int &idx)
+    {
+    // Compute the support function of the polyhedron.
+    unsigned int index = 0;
+
+    Scalar max_dist_sq = dot((rotate(mat, verts[index]) + shift), vector);
+    for (unsigned int i = 1; i < verts.size(); ++i)
+        {
+        Scalar dist_sq = dot((rotate(mat, verts[i]) + shift), vector);
+
+        if (dist_sq > max_dist_sq)
+            {
+            max_dist_sq = dist_sq;
+            index = i;
+            }
+        }
+    idx = index;
+    }
+
+
+HOSTDEVICE inline void support_ellipsoid(const vec3<Scalar> &rounding_radii, const vec3<Scalar> &vector, const quat<Scalar> &q, vec3<Scalar> &ellipsoid_support_vector)
+    {
+    // Compute the support function of the rounding ellipsoid. Since we only
+    // have the principal axes, we have to rotate the vector into the principal
+    // frame, compute the support, and then rotate back out.
+    vec3<Scalar> rotated_vector = rotate(conj(q), vector);
+    vec3<Scalar> numerator(
+            rounding_radii.x*rounding_radii.x*rotated_vector.x,
+            rounding_radii.y*rounding_radii.y*rotated_vector.y,
+            rounding_radii.z*rounding_radii.z*rotated_vector.z);
+    vec3<Scalar> dvec(
+            rounding_radii.x*rotated_vector.x,
+            rounding_radii.y*rotated_vector.y,
+            rounding_radii.z*rotated_vector.z);
+    ellipsoid_support_vector = rotate(q, numerator / fast::sqrt(dot(dvec, dvec)));
+    }
+
+
+//! Returns 1 if a and b have the same sign, and zero otherwise.
+/*! The compareSigns function is used to implement the signed hyperplane checks
+ *  that are used by the Signed Volumes subalgorithm to discard various Voronoi
+ *  regions from consideration as containing the closest point to the origin.
+ */
+HOSTDEVICE inline unsigned int compareSigns(Scalar a, Scalar b)
+{
+    // Maybe there's a faster way to deal with this set of operations?
+    return static_cast<unsigned int>(!((a > 0) ^ (b > 0)));
+}
+
+
+//! Find the point of minimum norm in a 1-simplex (an edge).
+/*! \param W The set of (at most ndim+1) vectors making up the current simplex. The size of W is constant, but not all vectors are active at any given time.
+ *  \param W_used A set of bit flags used to indicate which elements of W are actually participating in defining the current simplex (updated in place by the subalgorithm).
+ *  \param lambdas The multipliers (that will be overwritten in place) that indicate what linear combination of W represents the point of minimum norm.
+ */
+template <unsigned int ndim>
+HOSTDEVICE inline void s1d(vec3<Scalar>* W, unsigned int &W_used, Scalar* lambdas)
+{
+    // Identify the appropriate indices
+    constexpr unsigned int max_num_points = ndim + 1;
+    bool s1_set = false;
+    unsigned int i1 = 0xffffffff, i2 = 0xffffffff;
+    for (unsigned int i = 0; i < max_num_points; ++i)
+    {
+        if (W_used & (1 << i))
+        {
+            if (s1_set)
+            {
+                i2 = i;
+                break;
+            }
+            else
+            {
+                i1 = i;
+                s1_set = true;
+            }
+        }
+    }
+
+    // Calculate the signed volume of the simplex.
+    vec3<Scalar> t = W[i2] - W[i1];
+    unsigned int I = 0;
+    Scalar neg_tI = -t[0];
+    
+    if (abs(t[1]) > abs(neg_tI))
+    {
+        I = 1;
+        neg_tI = -t[1];
+    }
+
+    if (abs(t[2]) > abs(neg_tI))
+    {
+        I = 2;
+        neg_tI = -t[2];
+    }
+
+    Scalar pI = (dot(W[i2], t)/dot(t, t)) * neg_tI + W[i2][I];
+    
+    // Identify the signed volume resulting from replacing each point by the origin.
+    Scalar C[2] = {-W[i2][I] + pI, W[i1][I] - pI};
+    unsigned int sign_comparisons[2] = {compareSigns(neg_tI, C[0]), compareSigns(neg_tI, C[1])};
+    
+    // If all signed volumes are identical, the origin lies inside the simplex.
+    if (sign_comparisons[0] + sign_comparisons[1] == 2)
+    {
+        lambdas[i1] = C[0] / neg_tI;
+        lambdas[i2] = C[1] / neg_tI;
+    }
+    else
+    {
+        // The point to retain is the one whose sign matches. In the
+        // first case, the origin lies past the first point.
+        if (sign_comparisons[0])
+        {
+            W_used &= ~(1 << i2);
+            lambdas[i1] = 1;
+        }
+        else
+        {
+            W_used &= ~(1 << i1);
+            lambdas[i2] = 1;
+        }
+    }
+}
+
+
+//! Find the point of minimum norm in a 2-simplex (a face).
+/*! \param W The set of (at most ndim+1) vectors making up the current simplex. The size of W is constant, but not all vectors are active at any given time.
+ *  \param W_used A set of bit flags used to indicate which elements of W are actually participating in defining the current simplex (updated in place by the subalgorithm).
+ *  \param lambdas The multipliers (that will be overwritten in place) that indicate what linear combination of W represents the point of minimum norm.
+ */
+template <unsigned int ndim>
+HOSTDEVICE inline void s2d(vec3<Scalar>* W, unsigned int &W_used, Scalar* lambdas)
+{
+    // This function is always called with two points. This constant is defined
+    // to avoid magical 3s everywhere in loops.
+    constexpr unsigned int max_num_points = ndim + 1;
+    constexpr unsigned int num_points = 3;
+    unsigned int counter = 0, point0_idx = 0, point1_idx = 0, point2_idx = 0;
+    for (unsigned int i = 0; i < max_num_points; ++i)
+    {
+        if (W_used & (1 << i))
+        {
+            if (counter == 0)
+            {
+                point0_idx = i;
+            }
+            else if (counter == 1)
+            {
+                point1_idx  = i;
+            }
+            else
+            {
+                point2_idx  = i;
+            }
+            counter += 1;
+        }
+    }
+
+    vec3<Scalar> n = cross(W[point1_idx] - W[point0_idx], W[point2_idx] - W[point0_idx]);
+    vec3<Scalar> p0 = (dot(W[point0_idx], n)/dot(n, n))*(n);
+    
+    // Choose maximum area plane to project onto.
+    // Make sure to store the *signed* area of the plane.
+    // This loop is unrolled to save a few extra ops (assigning
+    // an initial area of zero, an extra abs, etc)
+    unsigned int idx_x = 1;
+    unsigned int idx_y = 2;
+    Scalar mu_max = (
+            W[point1_idx][1] * W[point2_idx][2] +
+            W[point0_idx][1] * W[point1_idx][2] +
+            W[point2_idx][1] * W[point0_idx][2] -
+            W[point1_idx][1] * W[point0_idx][2] -
+            W[point2_idx][1] * W[point1_idx][2] -
+            W[point0_idx][1] * W[point2_idx][2]);
+    
+    // This term is multiplied by -1.
+    Scalar mu = (
+            W[point1_idx][2] * W[point0_idx][0] +
+            W[point2_idx][2] * W[point1_idx][0] +
+            W[point0_idx][2] * W[point2_idx][0] -
+            W[point1_idx][2] * W[point2_idx][0] -
+            W[point0_idx][2] * W[point1_idx][0] -
+            W[point2_idx][2] * W[point0_idx][0]);
+    if (abs(mu) > abs(mu_max))
+    {
+        mu_max = mu;
+        idx_x = 0;
+    }
+
+    mu = (
+            W[point1_idx][0] * W[point2_idx][1] +
+            W[point0_idx][0] * W[point1_idx][1] +
+            W[point2_idx][0] * W[point0_idx][1] -
+            W[point1_idx][0] * W[point0_idx][1] -
+            W[point2_idx][0] * W[point1_idx][1] -
+            W[point0_idx][0] * W[point2_idx][1]);
+    if (abs(mu) > abs(mu_max))
+    {
+        mu_max = mu;
+        idx_x = 0;
+        idx_y = 1;
+    }
+    
+    // Compute the signed areas of each of the simplices formed by replacing an
+    // index with a projection of the origin onto the area in this plane
+    Scalar C[num_points] = {0};
+    bool sign_comparisons[num_points] = {false};
+    
+    C[0] = (p0[idx_x] * W[point1_idx][idx_y] +
+            p0[idx_y] * W[point2_idx][idx_x] +
+            W[point1_idx][idx_x] * W[point2_idx][idx_y] -
+            p0[idx_x] * W[point2_idx][idx_y] -
+            p0[idx_y] * W[point1_idx][idx_x] -
+            W[point2_idx][idx_x] * W[point1_idx][idx_y]);
+    sign_comparisons[0] = compareSigns(mu_max, C[0]);
+    
+    C[1] = (p0[idx_x] * W[point2_idx][idx_y] +
+            p0[idx_y] * W[point0_idx][idx_x] +
+            W[point2_idx][idx_x] * W[point0_idx][idx_y] -
+            p0[idx_x] * W[point0_idx][idx_y] -
+            p0[idx_y] * W[point2_idx][idx_x] -
+            W[point0_idx][idx_x] * W[point2_idx][idx_y]);
+    sign_comparisons[1] = compareSigns(mu_max, C[1]);
+    
+    C[2] = (p0[idx_x] * W[point0_idx][idx_y] +
+            p0[idx_y] * W[point1_idx][idx_x] +
+            W[point0_idx][idx_x] * W[point1_idx][idx_y] -
+            p0[idx_x] * W[point1_idx][idx_y] -
+            p0[idx_y] * W[point0_idx][idx_x] -
+            W[point1_idx][idx_x] * W[point0_idx][idx_y]);
+    sign_comparisons[2] = compareSigns(mu_max, C[2]);
+
+    if (sign_comparisons[0] + sign_comparisons[1] + sign_comparisons[2] == 3)
+    {
+        lambdas[point0_idx] = C[0] / mu_max;
+        lambdas[point1_idx] = C[1] / mu_max;
+        lambdas[point2_idx] = C[2] / mu_max;
+    }
+    else
+    {
+        Scalar d = 1e9;
+        vec3<Scalar> new_point;
+        unsigned int new_W_used = 0;
+        for (unsigned int j = 0; j < num_points; ++j)
+        {
+            if (!sign_comparisons[j])
+            {
+                unsigned int new_used = W_used;
+                // Test removal of the current point.
+                if (j == 0)
+                {
+                    new_used &= ~(1 << point0_idx);
+                }
+                else if (j == 1)
+                {
+                    new_used &= ~(1 << point1_idx);
+                }
+                else
+                {
+                    new_used &= ~(1 << point2_idx);
+                }
+
+                Scalar new_lambdas[max_num_points] = {0};
+                
+                s1d<ndim>(W, new_used, new_lambdas);
+                // Consider resetting in place if possible.
+                new_point[0] = 0;
+                new_point[1] = 0;
+                new_point[2] = 0;
+                for (unsigned int i = 0; i < max_num_points; ++i)
+                {
+                    if (new_used & (1 << i))
+                    {
+                        new_point += new_lambdas[i] * W[i];
+                    }
+                }
+                Scalar d_star = dot(new_point, new_point);
+                if (d_star < d)
+                {
+                    new_W_used = new_used;
+                    d = d_star;
+                    for (unsigned int i = 0; i < max_num_points; ++i)
+                    {
+                        lambdas[i] = new_lambdas[i];
+                    }
+                }
+            }
+        }
+        W_used = new_W_used;
+    }
+}
+
+
+//! Find the point of minimum norm in a 3-simplex (a volume, i.e. a tetrahedron).
+/*! \param W The set of (at most ndim+1) vectors making up the current simplex. The size of W is constant, but not all vectors are active at any given time.
+ *  \param W_used A set of bit flags used to indicate which elements of W are actually participating in defining the current simplex (updated in place by the subalgorithm).
+ *  \param lambdas The multipliers (that will be overwritten in place) that indicate what linear combination of W represents the point of minimum norm.
+ */
+HOSTDEVICE inline void s3d(vec3<Scalar>* W, unsigned int &W_used, Scalar* lambdas)
+{
+    // This function is always called with 4 points, so a constant is defined
+    // for clarity.
+    constexpr unsigned int num_points = 4;
+    // Unlike s1d and s2d, this function can only be called in 3d so it does not use the template 
+    constexpr unsigned int ndim = 3;
+    constexpr unsigned int max_num_points = ndim + 1;
+    Scalar C[num_points] = {0};
+
+    // Compute all minors and the total determinant of the matrix M,
+    // which is the transpose of the W matrix with an extra row of
+    // ones at the bottom. Since the indexing is nontrivial and the
+    // array is small (and we can save on some negation), all the
+    // computations are done directly rather than with a loop.
+    // C[0] and C[2] are negated due to the (-1)^(i+j+1) prefactor,
+    // where i is always 4 because we're expanding about the 4th row.
+    C[0] = (W[3][0] * W[2][1] * W[1][2] +
+            W[2][0] * W[1][1] * W[3][2] +
+            W[1][0] * W[3][1] * W[2][2] -
+            W[1][0] * W[2][1] * W[3][2] -
+            W[2][0] * W[3][1] * W[1][2] -
+            W[3][0] * W[1][1] * W[2][2]);
+    C[1] = (W[0][0] * W[2][1] * W[3][2] +
+            W[2][0] * W[3][1] * W[0][2] +
+            W[3][0] * W[0][1] * W[2][2] -
+            W[3][0] * W[2][1] * W[0][2] -
+            W[2][0] * W[0][1] * W[3][2] -
+            W[0][0] * W[3][1] * W[2][2]);
+    C[2] = (W[3][0] * W[1][1] * W[0][2] +
+            W[1][0] * W[0][1] * W[3][2] +
+            W[0][0] * W[3][1] * W[1][2] -
+            W[0][0] * W[1][1] * W[3][2] -
+            W[1][0] * W[3][1] * W[0][2] -
+            W[3][0] * W[0][1] * W[1][2]);
+    C[3] = (W[0][0] * W[1][1] * W[2][2] +
+            W[1][0] * W[2][1] * W[0][2] +
+            W[2][0] * W[0][1] * W[1][2] -
+            W[2][0] * W[1][1] * W[0][2] -
+            W[1][0] * W[0][1] * W[2][2] -
+            W[0][0] * W[2][1] * W[1][2]);
+
+    Scalar dM = C[0] + C[1] + C[2] + C[3];
+
+    unsigned int sign_comparisons[4] = {0};
+    sign_comparisons[0] = compareSigns(dM, C[0]);
+    sign_comparisons[1] = compareSigns(dM, C[1]);
+    sign_comparisons[2] = compareSigns(dM, C[2]);
+    sign_comparisons[3] = compareSigns(dM, C[3]);
+
+    if ((sign_comparisons[0] + sign_comparisons[1] + sign_comparisons[2] +
+            sign_comparisons[3]) == num_points)
+    {
+        for (unsigned int i = 0; i < num_points; ++i)
+        {
+            lambdas[i] = C[i] / dM;
+        }
+    }
+    else
+    {
+        Scalar d = 1e9, d_star = 0;
+        vec3<Scalar> new_point;
+        unsigned int new_W_used = 0;
+        for (unsigned int j = 0; j < num_points; ++j)
+        {
+            if (!sign_comparisons[j])
+            {
+                // Test removal of the current point.
+                unsigned int new_used = W_used;
+                new_used &= ~(1 << j);
+                Scalar new_lambdas[max_num_points] = {0};
+
+                s2d<3>(W, new_used, new_lambdas);
+
+                new_point = vec3<Scalar>();
+                for (unsigned int i = 0; i < max_num_points; ++i)
+                {
+                    if (new_used & (1 << i))
+                    {
+                        new_point += new_lambdas[i] * W[i];
+                    }
+                }
+                d_star = dot(new_point, new_point);
+                if (d_star < d)
+                {
+                    new_W_used = new_used;
+                    d = d_star;
+                    for (unsigned int i = 0; i < max_num_points; ++i)
+                    {
+                        lambdas[i] = new_lambdas[i];
+                    }
+                }
+            }
+        }
+        W_used = new_W_used;
+    }
+}
+
+
+// TODO: Rewrite the subalgorithm function separately for 2d and 3d.
+// That will avoid the extra if check for 2d (probably premature optimization,
+// but may help clean the code's usage of a template parameter for s3d.
+//! The Signed Volumes subalgorithm for finding minimal spanning convex sets.
+/*! The Signed Volumes subalgorithm (described in Montanari, M., Petrinic, N.,
+ *  & Barbieri, E. (2017). Improving the GJK algorithm for faster and more
+ *  reliable distance queries between convex objects. ACM Transactions on
+ *  Graphics (TOG), 36(3), 1-17, DOI: 10.1145/3083724) is a robust procedure
+ *  for finding the point of minimum norm in a convex set as a linear
+ *  combination of the extremal points of that set. The algorithm takes a
+ *  convex simplex and solves a linear system of equations for the closest
+ *  point to the origin. Since the algorithm is specifically designed for 3
+ *  dimensional queries, this function dispatches to three separate subroutines
+ *  that handle the different dimensionalities explicitly.
+ *
+ *  \param W The set of (at most ndim+1) vectors making up the current simplex. The size of W is constant, but not all vectors are active at any given time.
+ *  \param W_used A set of bit flags used to indicate which elements of W are actually participating in defining the current simplex (updated in place by the subalgorithm).
+ *  \param lambdas The multipliers (that will be overwritten in place) that indicate what linear combination of W represents the point of minimum norm.
+ */
+template <unsigned int ndim>
+HOSTDEVICE inline void sv_subalgorithm(vec3<Scalar>* W, unsigned int &W_used, Scalar* lambdas)
+{
+    // The W array is never modified by this function.  The W_used may be
+    // modified if necessary, and the lambdas will be updated.  All the other
+    // functions (if they need to make deeper calls e.g. s3d->s2d) will have to
+    // make copies of W_used to avoid overwriting that data incorrectly.
+    unsigned int num_used = 0;
+    constexpr unsigned int max_num_points = ndim + 1;
+    for (unsigned int i = 0; i < max_num_points; ++i)
+    {
+        num_used += (W_used >> i) & 1;
+    }
+
+    // Start with the most common cases.
+    if (num_used == 1)
+    {
+        for (unsigned int i = 0; i < max_num_points; ++i)
+        {
+            if (W_used & (1 << i))
+            {
+                lambdas[i] = 1;
+            }
+        }
+    }
+    else if (num_used == 2)
+    {
+        s1d<ndim>(W, W_used, lambdas);
+    }
+    else if (num_used == 3)
+    {
+        s2d<ndim>(W, W_used, lambdas);
+    }
+    // TODO: This branch will never happen in 3D, but without using C++17 features (if constexpr) I'm not
+    // sure how to avoid compiling this for the 2D template, so I get a lot of warnings on compilation.
+    else
+    {
+        // This case only happens in 3D, so no dimensionality is specified.
+        s3d(W, W_used, lambdas);
+    }
+}
+
+
+//! Apply the GJK algorithm to find the vector between the closest points on two sets of shapes.
+/*! This function implements the Gilbert-Johnson-Keerthi distance algorithm for
+ *  finding the minimum distance between two convex sets. The purpose of this
+ *  function is to be used in concert with the EvaluatorPairALJI class for
+ *  computing the force and energy between two anisotropic bodies. This paper
+ *  uses information from two papers:
+ *      1. Gino Van den Bergen (1999) A Fast and Robust GJK Implementation for
+ *         Collision Detection of Convex Objects, Journal of Graphics Tools,
+ *         4:2, 7-25, DOI: 10.1080/10867651.1999.10487502.
+ *      2. Montanari, M., Petrinic, N., & Barbieri, E. (2017). Improving the
+ *         GJK algorithm for faster and more reliable distance queries between
+ *         convex objects. ACM Transactions on Graphics (TOG), 36(3), 1-17,
+ *         DOI: 10.1145/3083724.
+ *
+ *  The standard GJK algorithm is a descent algorithm for finding the minimum
+ *  distance between two convex sets. The core insight of the algorithm is that
+ *  this query can be performed in the configuration space of the Minkowski
+ *  difference body of the two sets. The algorithm takes the Minkowski
+ *  difference (more precisely, the Minkowski sum A-B) of two convex sets and
+ *  performs a search to see if the origin is contained in the difference (this
+ *  difference is also known as the translational configuration space obstacle,
+ *  or TCSO, in this context).  If the origin is contained in the TCSO, the
+ *  same point is encompassed by both shapes, so they must be overlapping. If
+ *  not, the point on the TCSO closest to the origin corresponds to the vector
+ *  of minimum norm connecting the two sets.
+ *
+ *  In order to determine whether the origin is contained in the TCSO, the
+ *  algorithm iteratively constructs simplices that are composed of points on
+ *  the TCSO until one is found that contains the origin. In the case of
+ *  nonoverlapping shapes, the algorithm ultimately constructs a simplex of the
+ *  TCSO containing the closest point to the origin. The termination condition
+ *  in this case relies on maintaining a lower bound of this distance that is
+ *  based on the distance from the origin to the closest hyperplane. For
+ *  efficiency in overlap checks, it is notable that this lower bound provides
+ *  an immediate indication if two shapes are nonoverlapping if at any point a
+ *  separating axis is found (i.e. a hyperplane with positive distance). To
+ *  actually find the distance between two shapes, the algorithm proceeds until
+ *  the vector distance between the two shapes is within some tolerance of the
+ *  estimated lower bound.
+ *
+ *  The GJK algorithm relies on support mappings, which provide a way to find
+ *  the furthest point from the center of a given convex set in a specified
+ *  direction. Crucially, the support function for the Minkowski sum of two
+ *  convex shapes is the sum of the support functions of each shape, so knowing
+ *  the support functions for the underlying shapes immediately allows
+ *  evaluation of the support function of the difference body. Since the
+ *  support function of the difference body is all that is needed to construct
+ *  simplices at each GJK iteration, at each iteration the GJK algorithm
+ *  requires only minimal geometric information. The use of support mappings
+ *  eschews the need for any explicit mathematical descriptions of the two sets
+ *  and obviates the need for constructing the full difference body between the
+ *  two convex sets. As a result, GJK is more generally applicable than other
+ *  related algorithms, which are typically designed specially for polytopes or
+ *  other classes of shapes.
+ *
+ *  A critical component of the algorithm is the determination of a minimal
+ *  simplex.  The support function is used to define a new candidate point for
+ *  inclusion in the minimal simplex at each iteration, and then the resulting
+ *  simplex is reduced to a minimal set such that the closest point to the
+ *  origin is contained in the span of that set. Constructing this minimal
+ *  simplex essentially involves solving a (possibly overdetermined) system of
+ *  linear equations to find the point closest to the origin. The classic
+ *  solution to this, the Johnson subalgorithm, uses Cramer's rule to solve
+ *  this system.  Although normally inefficient, in this case Cramer's rule is
+ *  optimal because at each iteration only one new vertex is added to the
+ *  simplex, so most of the minors computed in Cramer's rule are already known.
+ *  However, in certain nearly degenerate cases the Johnson subalgorithm can
+ *  fail to return the correct result. In this case, the original solution has
+ *  always been to follow a backup procedure that amounts to a brute force
+ *  search through all possible simplices. 
+ *
+ *  The backup procedure is quite expensive, so in principle we would like to
+ *  use the Johnson algorithm alone. Bergen et al assert that in practice the
+ *  difference between the best result of the Johnson algorithm and the output
+ *  of the backup procedure are nearly equivalent with the appropriate
+ *  termination conditions imposed to avoid instabilities. In practice, we have
+ *  found this to be true. However, for our purposes we require more
+ *  information than the original GJK algorithm provides. Since our use-case is
+ *  to compute forces and torques in EvaluatorPairALJ, we also need information
+ *  on the points in the original convex sets that correspond to the minimum
+ *  distance vector in the TCSO. Although the GJK algorithm can easily be
+ *  augmented to provide this information, we find that for this usage the
+ *  Johnson algorithm falls short. While the distances it provides remain close
+ *  to optimal, the exact points it finds can deviate substantially from the
+ *  correct ones in nearly degenerate cases, such as when faces are nearly
+ *  parallel. The result of this is that while forces can still be calculated
+ *  nearly correctly, torques can be completely incorrect, and in fact may even
+ *  point in the wrong direction.
+ *
+ *  To ameliorate this problem, we instead use the Signed Volumes subalgorithm
+ *  described by Montenari et al. This algorithm resolves the issues with the
+ *  Johnson algorithm in all tested cases. Moreover, the Johnson algorithm is
+ *  quite memory intensive because it requires caching all support function
+ *  evaluations and cofactors required for Cramer's rule. As a result, we find
+ *  that the Signed Volumes subalgorithm performs better than the Johnson
+ *  algorithm (even without the backup procedure) when run on modern GPUs. A
+ *  reference implementation of GJK using the Johnson algorithm can be found
+ *  in GJK.h.
+ *
+ *  Important notes on the outputs:
+ *      - The output vector v points from verts2 to verts1.
+ *      - The shape defined by verts1 is assumed to sit at the origin, and the vertices in verts2 are defined relative to -dr.
+ *      - The output vectors a and b are all relative to this origin, so the vector pointing from the origin in the body frame of verts2 out to the contact point is dr+b.
+ *
+ *  \param verts1 The vertices of the first body.
+ *  \param verts2 The vertices of the second body.
+ *  \param v Reference to vec3 that will be overwritten with the vector joining the closest intersecting points on the two bodies (CRITICAL NOTE: The direction of the vector is from verts2 to verts1).
+ *  \param a Reference to vec3 that will be overwritten with the vector from the origin (in the frame defined by verts1) to the point on the body represented by verts1 that is closest to verts2.
+ *  \param b Reference to vec3 that will be overwritten with the vector from the origin (in the frame defined by verts1) to the point on the body represented by verts2 that is closest to verts1.
+ *  \param success Reference to bool that will be overwritten with whether or not the algorithm terminated in the maximum number of allowed iterations (verts1.size + verts2.size + 1).
+ *  \param overlap Reference to bool that will be overwritten with whether or not an overlap was detected.
+ *  \param mati The orientation of the first shape to be applied to verts1.
+ *  \param matj The orientation of the second shape to be applied to verts2.
+ *  \param qi The orientation of the first shape to be applied to verts1 (used in place of mati when the inverse rotation is required).
+ *  \param qj The orientation of the second shape to be applied to verts2 (used in place of matj when the inverse rotation is required).
+ *  \param dr The vector pointing from the position of particle 2 to the position of particle 1 (note the sign; this is reversed throughout most of the calculations below).
+ *  \param rounding_radii1 The semimajor axes of the rounding ellipse for particle i.
+ *  \param rounding_radii2 The semimajor axes of the rounding ellipse for particle j.
+ *  \param has_rounding1 Whether or not to actually use roundingradii1 to add to the support function.
+ *  \param has_rounding2 Whether or not to actually use roundingradii2 to add to the support function.
+ */
+template <unsigned int ndim>
+HOSTDEVICE inline void gjk(const ManagedArray<vec3<Scalar> > &verts1, const ManagedArray<vec3<Scalar> > &verts2, vec3<Scalar> &v, vec3<Scalar> &a, vec3<Scalar> &b, bool& success, bool& overlap, const Scalar (&mati)[3][3], const Scalar (&matj)[3][3], const quat<Scalar> &qi, const quat<Scalar> &qj, const vec3<Scalar> &dr, const vec3<Scalar> &rounding_radii1, const vec3<Scalar> &rounding_radii2, bool has_rounding1, bool has_rounding2)
+    {
+    // At any point only a subset of W is in use (identified by W_used), but
+    // the total possible is capped at ndim+1 because that is the largest
+    // number of affinely independent points in R^n.
+    constexpr unsigned int max_num_points = ndim + 1;
+    success = true;
+
+    // Start with guess as vector pointing from the centroid of verts1 to the
+    // centroid of verts2.
+    v = dr;
+
+    // We don't bother to initialize most of these arrays since the W_used
+    // array controls which data is valid. 
+    vec3<Scalar> W[max_num_points];
+    Scalar lambdas[max_num_points];
+    unsigned int W_used = 0;
+    unsigned int indices1[max_num_points] = {0};
+    unsigned int indices2[max_num_points] = {0};
+    vec3<Scalar> ellipsoid_supports1[max_num_points];
+    vec3<Scalar> ellipsoid_supports2[max_num_points];
+
+    for (unsigned int i = 0; i < max_num_points; ++i)
+        {
+        // We initialize W to avoid accidentally terminating if the new w is
+        // somehow equal to something saved in one of the uninitialized W[i].
+        W[i] = vec3<Scalar>();
+        ellipsoid_supports1[i] = vec3<Scalar>();
+        ellipsoid_supports2[i] = vec3<Scalar>();
+        }
+
+    // The tolerances are compile-time constants.
+    constexpr Scalar eps(1e-8), omega(1e-4);
+
+    Scalar u(0); 
+    bool close_enough(false);
+    // Value of 50 chosen based on empirical observations.
+    const unsigned int max_iterations = ((has_rounding1 || has_rounding2) ? 50 : verts1.size() + verts2.size() + 1);
+    unsigned int iteration = 0;
+    while (!close_enough)
+        {
+        iteration += 1;
+        if (iteration > max_iterations)
+            {
+            success = false;
+            break;
+            }
+        // support_{A-B}(-v) = support(A, -v) - support(B, v)
+        vec3<Scalar> ellipsoid_support1, ellipsoid_support2;
+        unsigned int i1, i2;
+        support_polyhedron(verts1, -v, mati, vec3<Scalar>(0, 0, 0), i1);
+        support_polyhedron(verts2, v, matj, Scalar(-1.0)*dr, i2);
+        if (has_rounding1)
+            {
+            support_ellipsoid(rounding_radii1, -v, qi, ellipsoid_support1);
+            }
+        if (has_rounding2)
+            {
+            support_ellipsoid(rounding_radii2, v, qj, ellipsoid_support2);
+            }
+
+        // In this line we always add the ellipsoid supports, which are
+        // initialized to 0 anyway. Everywhere else, since we need to access
+        // the supports through the ellipsoid_supports[1|2] arrays, we branch
+        // based on has_rounding[1|2] to avoid memory accesses if they're
+        // unnecessary.
+        vec3<Scalar> w(rotate(mati, verts1[i1]) + ellipsoid_support1 - (rotate(matj, verts2[i2]) + Scalar(-1.0)*dr + ellipsoid_support2));
+
+        // Check termination conditions for degenerate cases:
+        // 1) If we are repeatedly finding the same point but can't get closer
+        // and can't terminate within machine precision.
+        // 2) If we are cycling between two points.
+        // In either case, because of the tracking with W_used, we can
+        // guarantee that the new w will be found in one of the W (but possibly
+        // in one of the unused slots. We skip this check on the GPU because
+        // it introduces branch divergence (at least one thread almost always
+        // needs the algorithm to run to completion, so the early termination
+        // due to degeneracy just adds extra work to check degeneracy without
+        // any corresponding performance gains).
+#ifndef NVCC
+        bool degenerate(false);
+        for (unsigned int i = 0; i < max_num_points; ++i)
+            {
+            if (w == W[i])
+                {
+                degenerate = true;
+                break;
+                }
+            }
+#endif
+
+        Scalar vnorm = sqrt(dot(v, v));
+        Scalar d = dot(v, w)/vnorm;
+        // If we ever have d > 0, we can immediately that the two shapes never
+        // intersect! Actually finding an intersection requires waiting until
+        // we actually have an affinely dependent set of points, though.
+        u = u > d ? u : d;
+#ifdef NVCC
+        close_enough = (((vnorm - u) <= eps*vnorm) || (vnorm < omega));
+#else
+        close_enough = (degenerate || ((vnorm - u) <= eps*vnorm) || (vnorm < omega));
+#endif
+        if (!close_enough)
+            {
+            unsigned int new_index(0);
+            for (; new_index < max_num_points; ++new_index)
+                {
+                // At least one of these must be empty, otherwise we have an
+                // overlap. 
+                if (!(W_used & (1 << new_index)))
+                    {
+                    W[new_index] = w;
+                    W_used |= (1 << new_index);
+                    indices1[new_index] = i1;
+                    indices2[new_index] = i2;
+                    // Microoptimization: Don't access ellipsoid_supports array unless
+                    // needed. The branching should be free since the shape is defined
+                    // identically on all threads.
+                    if (has_rounding1)
+                        {
+                        ellipsoid_supports1[new_index] = ellipsoid_support1;
+                        }
+                    if (has_rounding2)
+                        {
+                        ellipsoid_supports2[new_index] = ellipsoid_support2;
+                        }
+                    break;
+                    }
+                }
+            sv_subalgorithm<ndim>(W, W_used, lambdas);
+
+            v = vec3<Scalar>();
+            for (unsigned int i = 0; i < max_num_points; ++i)
+                {
+                if (W_used & (1 << i))
+                    {
+                    v += lambdas[i]*W[i];
+                    }
+                }
+            }
+        }
+
+    a = vec3<Scalar>();
+    b = vec3<Scalar>();
+    unsigned int counter = 0;
+    for (unsigned int i = 0; i < max_num_points; ++i)
+        {
+        if (W_used & (1 << i))
+            {
+            // Microoptimization: Don't access ellipsoid_supports array unless
+            // needed. The branching should be free since the shape is defined
+            // identically on all threads.
+            if (has_rounding1)
+                {
+                a += lambdas[i]*(rotate(mati, verts1[indices1[i]]) + ellipsoid_supports1[i]);
+                }
+            else
+                {
+                a += lambdas[i]*(rotate(mati, verts1[indices1[i]]));
+                }
+
+            if (has_rounding2)
+                {
+                b += lambdas[i]*(rotate(matj, verts2[indices2[i]]) + Scalar(-1.0)*dr + ellipsoid_supports2[i]);
+                }
+            else
+                {
+                b += lambdas[i]*(rotate(matj, verts2[indices2[i]]) + Scalar(-1.0)*dr);
+                }
+            counter += 1;
+            }
+        }
+    overlap = (counter == max_num_points);
+    }
+
+
+#endif // __GJK_SV_H__

--- a/hoomd/md/module-md.cc
+++ b/hoomd/md/module-md.cc
@@ -250,6 +250,8 @@ PYBIND11_MODULE(_md, m)
     export_PotentialPair<PotentialPairTWF>(m, "PotentialPairTWF");
     export_AnisoPotentialPair<AnisoPotentialPairGB>(m, "AnisoPotentialPairGB");
     export_AnisoPotentialPair<AnisoPotentialPairDipole>(m, "AnisoPotentialPairDipole");
+    export_AnisoPotentialPair<AnisoPotentialPairALJ2D>(m, "AnisoPotentialPairALJ2D");
+    export_AnisoPotentialPair<AnisoPotentialPairALJ3D>(m, "AnisoPotentialPairALJ3D");
     export_PotentialPair<PotentialPairForceShiftedLJ>(m, "PotentialPairForceShiftedLJ");
     export_PotentialPairDPDThermo<PotentialPairDPDThermoDPD, PotentialPairDPD>(m, "PotentialPairDPDThermoDPD");
     export_PotentialPair<PotentialPairDPDLJ>(m, "PotentialPairDPDLJ");
@@ -314,6 +316,10 @@ PYBIND11_MODULE(_md, m)
     export_PotentialPairDPDThermoGPU<PotentialPairDPDLJThermoDPDGPU, PotentialPairDPDLJThermoDPD >(m, "PotentialPairDPDLJThermoDPDGPU");
     export_AnisoPotentialPairGPU<AnisoPotentialPairGBGPU, AnisoPotentialPairGB>(m, "AnisoPotentialPairGBGPU");
     export_AnisoPotentialPairGPU<AnisoPotentialPairDipoleGPU, AnisoPotentialPairDipole>(m, "AnisoPotentialPairDipoleGPU");
+    export_AnisoPotentialPairGPU<AnisoPotentialPairALJ2DGPU,
+                                 AnisoPotentialPairALJ2D>(m, "AnisoPotentialPairALJ2DGPU");
+    export_AnisoPotentialPairGPU<AnisoPotentialPairALJ3DGPU,
+                                 AnisoPotentialPairALJ3D>(m, "AnisoPotentialPairALJ3DGPU");
     export_PotentialBondGPU<PotentialBondHarmonicGPU, PotentialBondHarmonic>(m, "PotentialBondHarmonicGPU");
     export_PotentialBondGPU<PotentialBondFENEGPU, PotentialBondFENE>(m, "PotentialBondFENEGPU");
     export_PotentialSpecialPairGPU<PotentialSpecialPairLJGPU, PotentialSpecialPairLJ>(m, "PotentialSpecialPairLJGPU");

--- a/hoomd/md/pair/aniso.py
+++ b/hoomd/md/pair/aniso.py
@@ -46,6 +46,145 @@ class AnisotropicPair(Pair):
         return ret
 
 
+class ALJ(AnisotropicPair):
+    R"""Anistropic LJ potential.
+
+    Args:
+        r_cut (float): Default cutoff radius (in distance units).
+        nlist (:py:mod:`hoomd.md.nlist`): Neighbor list
+        name (str): Name of the force instance.
+        average_simplices (bool): Whether or not to perform simplex averaging (see below for more details).
+
+    :py:class:`alj` computes the LJ potential between anisotropic particles.
+    The anisotropy is implemented as a composite of two interactions, a
+    center-center component and a component of interaction measured at the
+    closest point of contact between the two particles. The potential supports
+    both standard LJ interactions as well as repulsive-only WCA interactions.
+    This behavior is controlled using the :code:`alpha` parameter, which can
+    take on the following values:
+
+    * :code:`0`:
+      All interactions are WCA (no attraction).
+
+    * :code:`1`:
+      Center-center interactions include attraction,
+      contact-contact interactions are solely repulsive.
+
+    * :code:`2`:
+      Center-center interactions are solely repulsive,
+      contact-contact interactions include attraction.
+
+    * :code:`3`:
+      All interactions include attractive and repulsive components.
+
+    For polytopes, computing interactions using a single contact point leads to
+    significant instabilities in the torques because the contact point can jump
+    from one end of a face to another in an arbitrarily small time interval. To
+    ameliorate this, the alj potential performs a local averaging over all the
+    features associated with the closest simplices on two polytopes. This
+    averaging can be turned off by setting the ``average_simplices`` argument
+    to ``False``.
+
+    Use :py:meth:`pair_coeff.set <coeff.set>` to set potential coefficients.
+
+    The following coefficients must be set per unique pair of particle types:
+
+    - *epsilon* - :math:`\varepsilon` (in energy units)
+    - *sigma_i* - the insphere radius of the first particle type.
+    - *sigma_j* - the insphere radius of the second particle type.
+    - *alpha* - Integer 0-3 indicating whether or not to include the attractive
+                component of the interaction (see above for details).
+    - *contact_sigma_i* - the contact sphere radius of the first type.
+      - *optional*: defaults to 0.15*sigma_i
+    - *contact_sigma_j* - the contact sphere radius of the second type.
+      - *optional*: defaults to 0.15*sigma_j
+    - :math:`r_{\mathrm{cut}}` - *r_cut* (in distance units)
+      - *optional*: defaults to the global r_cut specified in the pair command
+
+    The following shape parameters may be set per particle type:
+
+    - *vertices* - The vertices of a convex polytope in 2 or 3 dimensions. The
+                   array may be :math:`N\times2` or :math:`N\times3` in 2D (in
+                   the latter case, the third dimension is ignored).
+    - *rounding radii* - The semimajor axes of a rounding ellipsoid. If a
+                         single number is specified, the rounding ellipsoid is
+                         a sphere.
+    - *faces* - The faces of the polyhedron specified as a (possible ragged) 2D
+                array of integers. The vertices must be ordered (see
+                :meth:`~.convexHull` for more information).
+
+    At least one of ``vertices`` or ``rounding_radii`` must be specified.
+    Specifying only ``rounding radii creates an ellipsoid, while specifying
+    only vertices creates a convex polytope. In general, the faces will be
+    inferred by computing the convex hull of the vertices and merging coplanar
+    faces. However, because merging of faces requires applying a numerical
+    threshold to find coplanar faces, in some cases the default value may
+    result in not all coplanar faces actually being merged. In such cases,
+    users can precompute the faces and provide them. The convenience class
+    method :meth:`~.convexHull` can be used for this purpose.
+
+    Example::
+
+        nl = nlist.Cell()
+        alj = pair.ALJ(nl, r_cut=2.5)
+        
+        cube_verts = [(-0.5, -0.5, -0.5),
+                      (-0.5, -0.5, 0.5),
+                      (-0.5, 0.5, -0.5),
+                      (-0.5, 0.5, 0.5),
+                      (0.5, -0.5, -0.5),
+                      (0.5, -0.5, 0.5),
+                      (0.5, 0.5, -0.5),
+                      (0.5, 0.5, 0.5)];
+        
+        cube_faces = [[0, 2, 6],
+                      [6, 4, 0],
+                      [5, 0, 4],
+                      [5,1,0],
+                      [5,4,6],
+                      [5,6,7],
+                      [3,2,0],
+                      [3,0,1],
+                      [3,6,2],
+                      [3,7,6],
+                      [3,1,5],
+                      [3,5,7]]
+ 
+        alj.params[('A')] = dict(epsilon=2.0,
+                                      sigma_i=1.0,
+                                      sigma_j=1.0,
+                                      alpha=1,
+                                      )
+
+        alj.shape["A"] = dict(vertices=cube_verts,
+                              faces=cube_faces,
+                              rounding_radii=[1])
+    """
+
+
+    _cpp_class_name = "AnisoPotentialALJ"
+
+    def __init__(self, nlist, r_cut=None, mode='none'):
+        super().__init__(nlist, r_cut, mode)
+        params = TypeParameter(
+            'params', 'particle_types',
+            TypeParameterDict(epsilon=float,
+                              sigma_i=float,
+                              sigma_j=float,
+                              alpha=int,
+                              contact_sigma_i=float,
+                              contact_sigma_j=float,
+                              len_keys=2)) # Allen -I do not what to set this to.
+        shape = TypeParameter(
+            'shape', 'particle_types',
+            TypeParameterDict(vertices=(float, float, float),
+                              faces=[[int]],
+                              rounding_radii=[float]
+                              len_keys=1))# Allen -I do not what to set this to.
+
+        self._extend_typeparam((params, shape))
+
+
 class Dipole(AnisotropicPair):
     R""" Screened dipole-dipole interactions.
 


### PR DESCRIPTION


## Description

I have started working on porting the anisotropic potential. I have ported over the GJK files and EvaluatorPairALJ. Within EvaluatorPairALJ, I moved the two structs inside the class EvaluatorPairALJ and renamed them type_param and shape_param. 

I also edited hoomd/md/par/aniso.py with the potential, including the documentation. I assumed that the pair potential behave similarly to those in HPMC for convex polyhedron.

## Motivation and context

People would like to use it in hoomd 3.0.

## How has this been tested?

It has not.
## Change log

<!-- Propose a change log entry. -->
```
Ported over the GJK files and EvaluatorPairALJ. 
Within EvaluatorPairALJ, moved the two structs inside the class EvaluatorPairALJ and renamed them type_param and shape_param. 
Edited hoomd/md/par/aniso.py with the potential, including the documentation.
```

## Checklist:

- [ x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [ x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [ x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
