### PR TITLE
Replace docs reference to undocumented hoomd.md.integrate module with hoomd.md.Integrator.

### DIFF
--- a/hoomd/operations.py
+++ b/hoomd/operations.py
@@ -45,8 +45,8 @@ class Operations(Collection):
     only ever hold one integrator at a time. On the other hand, an `Operations`
     object can hold any number of tuners, updaters, writers, or computes. To
     see examples of these types of operations see `hoomd.tune` (tuners),
-    `hoomd.update` (updaters), `hoomd.hpmc.integrate` or `hoomd.md.integrate`
-    (integrators), , `hoomd.write` (writers), and `hoomd.md.thermo`
+    `hoomd.update` (updaters), `hoomd.hpmc.integrate` or `hoomd.md.Integrator`
+    (integrators), `hoomd.write` (writers), and `hoomd.md.thermo`
     (computes).
 
     A given instance of an operation class can only be added to a single


### PR DESCRIPTION
## Description

I noticed that [this part of the docs](https://hoomd-blue.readthedocs.io/en/latest/package-hoomd.html#hoomd.Operations) had a reference to `hoomd.md.integrate` that didn't link anywhere. I replaced it with `hoomd.md.Integrator`.

## Motivation and context
Seems like an improvement to docs.

## How has this been tested?
Need to check RTD builds.

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
