### PR TITLE
Fix docstring formatting and one other small bug.

### DIFF
--- a/hoomd/md/force.py
+++ b/hoomd/md/force.py
@@ -60,8 +60,7 @@ class Force(_HOOMDBaseObject):
 
     @log(category="particle")
     def energies(self):
-        """(*N_particles*, ) `numpy.ndarray` of ``numpy.float64``: The energies
-        for all particles."""
+        """(*N_particles*, ) `numpy.ndarray` of ``numpy.float64``: The energies for all particles.""" # noqa: E501
         if self._attached:
             self._cpp_obj.compute(self._simulation.timestep)
             return self._cpp_obj.getEnergies()
@@ -70,8 +69,7 @@ class Force(_HOOMDBaseObject):
 
     @log(category="particle")
     def forces(self):
-        """(*N_particles*, 3) `numpy.ndarray` of ``numpy.float64``: The forces
-        for all particles."""
+        """(*N_particles*, 3) `numpy.ndarray` of ``numpy.float64``: The forces for all particles.""" # noqa: E501
         if self._attached:
             self._cpp_obj.compute(self._simulation.timestep)
             return self._cpp_obj.getForces()
@@ -80,8 +78,7 @@ class Force(_HOOMDBaseObject):
 
     @log(category="particle")
     def torques(self):
-        """(*N_particles*, 3) `numpy.ndarray` of ``numpy.float64``: The torque
-        for all particles."""
+        """(*N_particles*, 3) `numpy.ndarray` of ``numpy.float64``: The torque for all particles.""" # noqa: E501
         if self._attached:
             self._cpp_obj.compute(self._simulation.timestep)
             return self._cpp_obj.getTorques()
@@ -90,8 +87,7 @@ class Force(_HOOMDBaseObject):
 
     @log(category="particle")
     def virials(self):
-        """(*N_particles*, ) `numpy.ndarray` of ``numpy.float64``: The virial
-        for all particles."""
+        """(*N_particles*, ) `numpy.ndarray` of ``numpy.float64``: The virial for all particles.""" # noqa: E501
         if self._attached:
             self._cpp_obj.compute(self._simulation.timestep)
             return self._cpp_obj.getVirials()
@@ -457,7 +453,7 @@ class dipole(Force):
         self.field_y = field_y
         self.field_z = field_z
 
-    def set_params(field_x, field_y, field_z, p):
+    def set_params(self, field_x, field_y, field_z, p):
         R"""Change the constant field and dipole moment.
 
         Args:


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should based on *maint*. -->
<!-- New features should based on *master*. -->

## Description

<!-- Describe your changes in detail. -->
Fix docstring appearance and add missing `self` parameter in one method.

I should note that the `ellip_preprocessing` function used to preprocess the Active force looks wrong, it's returning a nonexistent variable `act_force`. I'm not sure what that method is supposed to do, though, so I didn't fix that here.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves #1001

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->
Built locally and it fixes the problem.

## Change log

<!-- Propose a change log entry. -->
None needed

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
