### PR TITLE
Document mode in md.pair.Pair #974

### DIFF
--- a/hoomd/md/pair/pair.py
+++ b/hoomd/md/pair/pair.py
@@ -348,7 +348,7 @@ class SLJ(Pair):
     particle :math:`i`.
 
     See `Pair` for details on how forces are calculated and the
-    available energy shifting and smoothing modes. 
+    available energy shifting and smoothing modes.
 
     Attention:
         Due to the way that `SLJ` modifies the cutoff criteria, a shift_mode

--- a/hoomd/md/pair/pair.py
+++ b/hoomd/md/pair/pair.py
@@ -106,15 +106,15 @@ class Pair(force.Force):
     .. py:attribute:: r_on
 
         *r_on* (in distance units),  *optional*: defaults to the value ``r_on``
-        specified on construction
+        specified on construction.
 
         Type: `TypeParameter` [`tuple` [``particle_type``, ``particle_type``],
         `float`])
 
     .. py:attribute:: mode
 
-        *mode*, *optional*: defaults to ``none``.
-        Possible values: ``none``, ``shift``, ``xplor``
+        *mode*, *optional*: defaults to ``"none"``.
+        Possible values: ``"none"``, ``"shift"``, ``"xplor"``
 
         Type: `str`
     """
@@ -139,9 +139,9 @@ class Pair(force.Force):
 
         Args:
             tags1 (``ndarray<int32>``): a numpy array of particle tags in the
-                first group
+                first group.
             tags2 (``ndarray<int32>``): a numpy array of particle tags in the
-                second group
+                second group.
 
         .. math::
 
@@ -214,10 +214,10 @@ class LJ(Pair):
     r"""Lennard-Jones pair potential.
 
     Args:
-        nlist (`hoomd.md.nlist.NList`): Neighbor list
+        nlist (`hoomd.md.nlist.NList`): Neighbor list.
         r_cut (float): Default cutoff radius (in distance units).
         r_on (float): Default turn-on radius (in distance units).
-        mode (str): Energy shifting/smoothing mode
+        mode (str): Energy shifting/smoothing mode.
 
     `LJ` specifies that a Lennard-Jones pair potential should be
     applied between every non-excluded particle pair in the simulation.
@@ -232,8 +232,8 @@ class LJ(Pair):
         = & 0 & r \ge r_{\mathrm{cut}} \\
         \end{eqnarray*}
 
-    See `Pair` for details on how forces are calculated and the
-    available energy shifting and smoothing modes.
+    See `Pair` for details on how forces are calculated and the available
+    energy shifting and smoothing modes.
 
     .. py:attribute:: params
 
@@ -268,7 +268,7 @@ class Gauss(Pair):
     r"""Gaussian pair potential.
 
     Args:
-        nlist (`hoomd.md.nlist.NList`): Neighbor list
+        nlist (`hoomd.md.nlist.NList`): Neighbor list.
         r_cut (float): Default cutoff radius (in distance units).
         r_on (float): Default turn-on radius (in distance units).
         mode (str): Energy shifting/smoothing mode.
@@ -286,8 +286,8 @@ class Gauss(Pair):
                                  = & 0 & r \ge r_{\mathrm{cut}} \\
         \end{eqnarray*}
 
-    See `Pair` for details on how forces are calculated and the
-    available energy shifting and smoothing modes.
+    See `Pair` for details on how forces are calculated and the available
+    energy shifting and smoothing modes.
 
     .. py:attribute:: params
 
@@ -323,10 +323,10 @@ class SLJ(Pair):
     r"""Shifted Lennard-Jones pair potential.
 
     Args:
-        nlist (`hoomd.md.nlist.NList`): Neighbor list
+        nlist (`hoomd.md.nlist.NList`): Neighbor list.
         r_cut (float): Default cutoff radius (in distance units).
         r_on (float): Default turn-on radius (in distance units).
-        mode (str): Energy shifting mode
+        mode (str): Energy shifting mode.
 
     `SLJ` specifies that a shifted Lennard-Jones type pair potential
     should be applied between every non-excluded particle pair in the
@@ -351,7 +351,7 @@ class SLJ(Pair):
     available energy shifting and smoothing modes.
 
     Attention:
-        Due to the way that `SLJ` modifies the cutoff criteria, a shift_mode
+        Due to the way that `SLJ` modifies the cutoff criteria, a smoothing mode
         of *xplor* is not supported.
 
     Set the ``max_diameter`` property of the neighbor list object to the largest
@@ -411,7 +411,7 @@ class Yukawa(Pair):
     r"""Yukawa pair potential.
 
     Args:
-        nlist (`hoomd.md.nlist.NList`): Neighbor list
+        nlist (`hoomd.md.nlist.NList`): Neighbor list.
         r_cut (float): Default cutoff radius (in distance units).
         r_on (float): Default turn-on radius (in distance units).
         mode (str): Energy shifting/smoothing mode.
@@ -465,7 +465,7 @@ class Ewald(Pair):
     r"""Ewald pair potential.
 
     Args:
-        nlist (`hoomd.md.nlist.NList`): Neighbor list
+        nlist (`hoomd.md.nlist.NList`): Neighbor list.
         r_cut (float): Default cutoff radius (in distance units).
         r_on (float): Default turn-on radius (in distance units).
 
@@ -524,7 +524,7 @@ class Morse(Pair):
     r"""Morse pair potential.
 
     Args:
-        nlist (`hoomd.md.nlist.NList`): Neighbor list
+        nlist (`hoomd.md.nlist.NList`): Neighbor list.
         r_cut (float): Default cutoff radius (in distance units).
         r_on (float): Default turn-on radius (in distance units).
         mode (str): Energy shifting/smoothing mode.
@@ -628,7 +628,7 @@ class DPD(Pair):
     describes the DPD implementation details in HOOMD-blue. Cite it if you
     utilize the DPD functionality in your work.
 
-    `DPD` does not implement and energy shift / smoothing modes due to the
+    `DPD` does not implement any energy shift / smoothing modes due to the
     function of the force.
 
     To use the DPD thermostat, an `hoomd.md.methods.NVE` integrator
@@ -688,7 +688,7 @@ class DPDConservative(Pair):
     r"""DPD Conservative pair force.
 
     Args:
-        nlist (`hoomd.md.nlist.NList`): Neighbor list
+        nlist (`hoomd.md.nlist.NList`): Neighbor list.
         r_cut (float): Default cutoff radius (in distance units).
         r_on (float): Default turn-on radius (in distance units).
 
@@ -709,7 +709,7 @@ class DPDConservative(Pair):
         \end{eqnarray*}
 
 
-    `DPDConservative` does not implement and energy shift / smoothing modes due
+    `DPDConservative` does not implement any energy shift / smoothing modes due
     to the function of the force.
 
     .. py:attribute:: params
@@ -743,7 +743,7 @@ class DPDLJ(Pair):
     r"""Dissipative Particle Dynamics with a LJ conservative force.
 
     Args:
-        nlist (`hoomd.md.nlist.NList`): Neighbor list
+        nlist (`hoomd.md.nlist.NList`): Neighbor list.
         kT (`hoomd.variant` or `float`): Temperature of
             thermostat (in energy units).
         r_cut (float): Default cutoff radius (in distance units).
@@ -806,7 +806,7 @@ class DPDLJ(Pair):
     of the dpd thermostat pair force with other integrators will result in
     unphysical behavior.
 
-    DPDLJ does not support xplor smoothing mode. See `Pair` for details on
+    DPDLJ does not support smoothing with ``mode="xplor"``. See `Pair` for details on
     how forces are calculated and the available energy shifting
     and smoothing modes.
 
@@ -870,7 +870,7 @@ class ForceShiftedLJ(Pair):
     r"""Force-shifted Lennard-Jones pair potential.
 
     Args:
-        nlist (`hoomd.md.nlist.NList`): Neighbor list
+        nlist (`hoomd.md.nlist.NList`): Neighbor list.
         r_cut (float): Default cutoff radius (in distance units).
         r_on (float): Default turn-on radius (in distance units).
         mode (str): Energy shifting/smoothing mode.
@@ -901,8 +901,8 @@ class ForceShiftedLJ(Pair):
         \Delta V(r) = -(r - r_{\mathrm{cut}}) \frac{\partial
           V_{\mathrm{LJ}}}{\partial r}(r_{\mathrm{cut}})
 
-    See `Pair` for details on how forces are calculated and the
-    available energy shifting and smoothing modes.
+    See `Pair` for details on how forces are calculated and the available
+    energy shifting and smoothing modes.
 
     .. py:attribute:: params
 
@@ -938,7 +938,7 @@ class Moliere(Pair):
     r"""Moliere pair potential.
 
     Args:
-        nlist (`hoomd.md.nlist.NList`): Neighbor list
+        nlist (`hoomd.md.nlist.NList`): Neighbor list.
         r_cut (float): Default cutoff radius (in distance units).
         r_on (float): Default turn-on radius (in distance units).
         mode (str): Energy shifting/smoothing mode.
@@ -1014,7 +1014,7 @@ class ZBL(Pair):
     r"""ZBL pair potential.
 
     Args:
-        nlist (`hoomd.md.nlist.NList`): Neighbor list
+        nlist (`hoomd.md.nlist.NList`): Neighbor list.
         r_cut (float): Default cutoff radius (in distance units).
         r_on (float): Default turn-on radius (in distance units).
 
@@ -1109,8 +1109,8 @@ class Mie(Pair):
           = & 0 & r \ge r_{\mathrm{cut}} \\
         \end{eqnarray*}
 
-    `Pair` for details on how forces are calculated and the available energy
-    shifting and smoothing modes.
+    See `Pair` for details on how forces are calculated and the available
+    energy shifting and smoothing modes.
 
     .. py:attribute:: params
 
@@ -1155,10 +1155,10 @@ class ReactionField(Pair):
     r"""Onsager reaction field pair potential.
 
     Args:
-        nlist (`hoomd.md.nlist.NList`): Neighbor list
+        nlist (`hoomd.md.nlist.NList`): Neighbor list.
         r_cut (float): Default cutoff radius (in distance units).
         r_on (float): Default turn-on radius (in distance units).
-        mode (str): Energy shifting/smoothing mode
+        mode (str): Energy shifting/smoothing mode.
 
     `ReactionField` specifies that an Onsager reaction field pair potential
     should be applied between every non-excluded particle pair in the
@@ -1233,10 +1233,10 @@ class DLVO(Pair):
 
     Args:
         r_cut (float): Default cutoff radius (in distance units).
-        nlist (`hoomd.md.nlist.NList`): Neighbor list
+        nlist (`hoomd.md.nlist.NList`): Neighbor list.
         name (str): Name of the force instance.
         d_max (float): Maximum diameter particles in the simulation will have
-          (in distance units)
+          (in distance units).
         mode (str): Energy shifting mode.
 
     `DLVO` specifies that a DLVO dispersion and electrostatic interaction should
@@ -1323,10 +1323,10 @@ class Buckingham(Pair):
     r"""Buckingham pair potential.
 
     Args:
-        nlist (`hoomd.md.nlist.NList`): Neighbor list
+        nlist (`hoomd.md.nlist.NList`): Neighbor list.
         r_cut (float): Default cutoff radius (in distance units).
         r_on (float): Default turn-on radius (in distance units).
-        mode (str): Energy shifting/smoothing mode
+        mode (str): Energy shifting/smoothing mode.
 
     `Buckingham` specifies that a Buckingham pair potential should be applied
     between every non-excluded particle pair in the simulation.
@@ -1377,10 +1377,10 @@ class LJ1208(Pair):
     r"""Lennard-Jones 12-8 pair potential.
 
     Args:
-        nlist (`hoomd.md.nlist.NList`): Neighbor list
+        nlist (`hoomd.md.nlist.NList`): Neighbor list.
         r_cut (float): Default cutoff radius (in distance units).
         r_on (float): Default turn-on radius (in distance units).
-        mode (str): Energy shifting/smoothing mode
+        mode (str): Energy shifting/smoothing mode.
 
     `LJ1208` specifies that a Lennard-Jones 12-8 pair potential should be
     applied between every non-excluded particle pair in the simulation.
@@ -1432,10 +1432,10 @@ class LJ0804(Pair):
     r"""Lennard-Jones 8-4 pair potential.
 
     Args:
-        nlist (`hoomd.md.nlist.NList`): Neighbor list
+        nlist (`hoomd.md.nlist.NList`): Neighbor list.
         r_cut (float): Default cutoff radius (in distance units).
         r_on (float): Default turn-on radius (in distance units).
-        mode (str): Energy shifting/smoothing mode
+        mode (str): Energy shifting/smoothing mode.
 
     `LJ0804` specifies that a Lennard-Jones 8-4 pair potential should be
     applied between every non-excluded particle pair in the simulation.
@@ -1451,8 +1451,8 @@ class LJ0804(Pair):
           = & 0 & r \ge r_{\mathrm{cut}} \\
         \end{eqnarray*}
 
-    See `Pair` for details on how forces are calculated and the
-    available energy shifting and smoothing modes.
+    See `Pair` for details on how forces are calculated and the available
+    energy shifting and smoothing modes.
 
     .. py:attribute:: params
 
@@ -1488,7 +1488,7 @@ class Fourier(Pair):
     r"""Fourier pair potential.
 
     Args:
-        nlist (`hoomd.md.nlist.NList`): Neighbor list
+        nlist (`hoomd.md.nlist.NList`): Neighbor list.
         r_cut (float): Default cutoff radius (in distance units).
         r_on (float): Default turn-on radius (in distance units).
         mode (str): Energy shifting/smoothing mode.
@@ -1557,7 +1557,7 @@ class OPP(Pair):
     r"""Oscillating pair potential.
 
     Args:
-        nlist (:py:mod:`hoomd.md.nlist.NList`): Neighbor list
+        nlist (:py:mod:`hoomd.md.nlist.NList`): Neighbor list.
         r_cut (float): Default cutoff radius (in distance units).
         r_on (float): Default turn-on radius (in distance units).
 
@@ -1644,8 +1644,8 @@ class TWF(Pair):
         \alpha {\left(\frac{\sigma^2}{r^2} - 1 \right)}^3\right]}
         \end{equation}
 
-    See `hoomd.md.pair.Pair` for details on how forces are calculated and the
-    available energy shifting and smoothing modes.
+    See `Pair` for details on how forces are calculated and the available
+    energy shifting and smoothing modes.
 
     The potential comes from Pieter Rein ten Wolde and Daan Frenkel 1997
     `paper link`_.

--- a/hoomd/md/pair/pair.py
+++ b/hoomd/md/pair/pair.py
@@ -496,8 +496,8 @@ class Ewald(Pair):
 
     The Ewald potential is designed to be used in conjunction with PPPM.
 
-    See `Pair` for details on how forces are calculated. Note Ewald does not support
-    energy shifting or smoothing.
+    See `Pair` for details on how forces are calculated. Note Ewald does not
+    support energy shifting or smoothing.
     Use the `params` dictionary to set
     potential coefficients. The coefficients must be set per unique pair of
     particle types.
@@ -826,8 +826,9 @@ class DPDLJ(Pair):
     of the dpd thermostat pair force with other integrators will result in
     unphysical behavior.
    
-    DPDLJ does not support xplor smoothing mode. See Pair for details on how forces are
-    calculated and the available energy shifting and smoothing modes.
+    DPDLJ does not support xplor smoothing mode. See Pair for details on
+    how forces are calculated and the available energy shifting
+    and smoothing modes.
 
     .. py:attribute:: params
 
@@ -1067,8 +1068,8 @@ class ZBL(Pair):
     - :math:`a_F = \frac{0.8853 a_0}{ Z_i^{0.23} + Z_j^{0.23} }`, where
       :math:`a_0` is the Bohr radius (in distance units)
 
-    See `Pair` for details on how forces are calculated. Note ZBL does not support
-    energy shifting or smoothing. Use `params` dictionary to set
+    See `Pair` for details on how forces are calculated. Note ZBL does not
+    support energy shifting or smoothing. Use `params` dictionary to set
     potential coefficients.
 
     .. py:attribute:: params
@@ -1607,10 +1608,10 @@ class OPP(Pair):
             + C_2 r^{-\eta_2} \cos{\left(k r - \phi\right)}
         \end{equation*}
 
-    See `Pair` for details on how forces are calculate. Note OPP does not support
-    energy shifting or smoothing.  Use `params` dictionary to set potential
-    coefficients. The coefficients must be set per unique pair of particle
-    types.
+    See `Pair` for details on how forces are calculate. Note OPP does not
+    support energy shifting or smoothing.  Use `params` dictionary to set
+    potential coefficients. The coefficients must be set per unique pair
+    of particle types.
 
     The potential comes from Marek Mihalkovič and C. L. Henley 2012
     `paper link`_.

--- a/hoomd/md/pair/pair.py
+++ b/hoomd/md/pair/pair.py
@@ -113,8 +113,9 @@ class Pair(force.Force):
 
     .. py:attribute:: mode
         
-        *mode*, *optional*: defaults to ``none``
+        *mode*, *optional*: defaults to ``none``.
         Possible values: ``none``, ``shift``, ``xplor``
+
         Type: ``str``
     """
 
@@ -334,6 +335,7 @@ class SLJ(Pair):
     `SLJ` specifies that a shifted Lennard-Jones type pair potential
     should be applied between every non-excluded particle pair in the
     simulation.
+
     .. math::
         :nowrap:
 
@@ -494,8 +496,9 @@ class Ewald(Pair):
 
     The Ewald potential is designed to be used in conjunction with PPPM.
 
-    See `Pair` for details on how forces are calculated and the available
-    energy shifting and smoothing modes. Use the `params` dictionary to set
+    See `Pair` for details on how forces are calculated. Note Ewald does not support
+    energy shifting or smoothing.
+    Use the `params` dictionary to set
     potential coefficients. The coefficients must be set per unique pair of
     particle types.
 
@@ -1064,8 +1067,8 @@ class ZBL(Pair):
     - :math:`a_F = \frac{0.8853 a_0}{ Z_i^{0.23} + Z_j^{0.23} }`, where
       :math:`a_0` is the Bohr radius (in distance units)
 
-    See `Pair` for details on how forces are calculated and the available
-    energy shifting and smoothing modes. Use `params` dictionary to set
+    See `Pair` for details on how forces are calculated. Note ZBL does not support
+    energy shifting or smoothing. Use `params` dictionary to set
     potential coefficients.
 
     .. py:attribute:: params
@@ -1462,7 +1465,7 @@ class LJ0804(Pair):
         nlist (`hoomd.md.nlist.NList`): Neighbor list
         r_cut (float): Default cutoff radius (in distance units).
         r_on (float): Default turn-on radius (in distance units).
-        mode (str): energy shifting/smoothing mode
+        mode (str): Energy shifting/smoothing mode
 
     `LJ0804` specifies that a Lennard-Jones 8-4 pair potential should be
     applied between every non-excluded particle pair in the simulation.
@@ -1604,8 +1607,8 @@ class OPP(Pair):
             + C_2 r^{-\eta_2} \cos{\left(k r - \phi\right)}
         \end{equation*}
 
-    See `Pair` for details on how forces are calculated and the available energy
-    shifting and smoothing modes.  Use `params` dictionary to set potential
+    See `Pair` for details on how forces are calculate. Note OPP does not support
+    energy shifting or smoothing.  Use `params` dictionary to set potential
     coefficients. The coefficients must be set per unique pair of particle
     types.
 

--- a/hoomd/md/pair/pair.py
+++ b/hoomd/md/pair/pair.py
@@ -825,7 +825,7 @@ class DPDLJ(Pair):
     must be applied to the system and the user must specify a temperature. Use
     of the dpd thermostat pair force with other integrators will result in
     unphysical behavior.
-    
+
     DPDLJ does not support xplor smoothing mode. See Pair for details on
     how forces are calculated and the available energy shifting
     and smoothing modes.

--- a/hoomd/md/pair/pair.py
+++ b/hoomd/md/pair/pair.py
@@ -110,6 +110,12 @@ class Pair(force.Force):
 
         Type: `TypeParameter` [`tuple` [``particle_type``, ``particle_type``],
         `float`])
+
+    .. py:attribute:: mode
+        
+        *mode*, *optional*: defaults to ``none``
+        Possible values: ``none``, ``shift``, ``xplor``
+        Type: ``str``
     """
 
     def __init__(self, nlist, r_cut=None, r_on=0., mode='none'):
@@ -210,7 +216,7 @@ class LJ(Pair):
         nlist (`hoomd.md.nlist.NList`): Neighbor list
         r_cut (float): Default cutoff radius (in distance units).
         r_on (float): Default turn-on radius (in distance units).
-        mode (str): energy shifting/smoothing mode
+        mode (str): Energy shifting/smoothing mode
 
     `LJ` specifies that a Lennard-Jones pair potential should be
     applied between every non-excluded particle pair in the simulation.
@@ -266,7 +272,7 @@ class Gauss(Pair):
         nlist (`hoomd.md.nlist.NList`): Neighbor list
         r_cut (float): Default cutoff radius (in distance units).
         r_on (float): Default turn-on radius (in distance units).
-        mode (str): energy shifting/smoothing mode.
+        mode (str): Energy shifting/smoothing mode.
 
     `Gauss` specifies that a Gaussian pair potential should be applied
     between every non-excluded particle pair in the simulation.
@@ -323,12 +329,11 @@ class SLJ(Pair):
         nlist (`hoomd.md.nlist.NList`): Neighbor list
         r_cut (float): Default cutoff radius (in distance units).
         r_on (float): Default turn-on radius (in distance units).
-        mode (str): Energy shifting/smoothing mode
+        mode (str): Energy shifting mode
 
     `SLJ` specifies that a shifted Lennard-Jones type pair potential
     should be applied between every non-excluded particle pair in the
     simulation.
-
     .. math::
         :nowrap:
 
@@ -413,7 +418,7 @@ class Yukawa(Pair):
         nlist (`hoomd.md.nlist.NList`): Neighbor list
         r_cut (float): Default cutoff radius (in distance units).
         r_on (float): Default turn-on radius (in distance units).
-        mode (str): Energy shifting mode.
+        mode (str): Energy shifting/smoothing mode.
 
     `Yukawa` specifies that a Yukawa pair potential should be applied between
     every non-excluded particle pair in the simulation.
@@ -469,7 +474,6 @@ class Ewald(Pair):
         nlist (`hoomd.md.nlist.NList`): Neighbor list
         r_cut (float): Default cutoff radius (in distance units).
         r_on (float): Default turn-on radius (in distance units).
-        mode (str): Energy shifting mode.
 
     `Ewald` specifies that a Ewald pair potential should be applied between
     every non-excluded particle pair in the simulation.
@@ -531,7 +535,7 @@ class Morse(Pair):
         nlist (`hoomd.md.nlist.NList`): Neighbor list
         r_cut (float): Default cutoff radius (in distance units).
         r_on (float): Default turn-on radius (in distance units).
-        mode (str): energy shifting/smoothing mode.
+        mode (str): Energy shifting/smoothing mode.
 
     `Morse` specifies that a Morse pair potential should be applied between
     every non-excluded particle pair in the simulation.
@@ -758,6 +762,7 @@ class DPDLJ(Pair):
             thermostat (in energy units).
         r_cut (float): Default cutoff radius (in distance units).
         r_on (float): Default turn-on radius (in distance units).
+        mode (str): Energy shifting mode.
 
     `DPDLJ` specifies that a DPD thermostat and a Lennard-Jones pair potential
     should be applied between every non-excluded particle pair in the
@@ -817,6 +822,9 @@ class DPDLJ(Pair):
     must be applied to the system and the user must specify a temperature.  Use
     of the dpd thermostat pair force with other integrators will result in
     unphysical behavior.
+   
+    DPDLJ does not support xplor smoothing mode. See Pair for details on how forces are
+    calculated and the available energy shifting and smoothing modes.
 
     .. py:attribute:: params
 
@@ -881,7 +889,7 @@ class ForceShiftedLJ(Pair):
         nlist (`hoomd.md.nlist.NList`): Neighbor list
         r_cut (float): Default cutoff radius (in distance units).
         r_on (float): Default turn-on radius (in distance units).
-        mode (str): energy shifting/smoothing mode.
+        mode (str): Energy shifting/smoothing mode.
 
     `ForceShiftedLJ` specifies that a modified Lennard-Jones pair force should
     be applied between non-excluded particle pair in the simulation. The force
@@ -951,7 +959,7 @@ class Moliere(Pair):
         nlist (`hoomd.md.nlist.NList`): Neighbor list
         r_cut (float): Default cutoff radius (in distance units).
         r_on (float): Default turn-on radius (in distance units).
-        mode (str): energy shifting/smoothing mode.
+        mode (str): Energy shifting/smoothing mode.
 
     `Moliere` specifies that a Moliere type pair potential should be applied
     between every non-excluded particle pair in the simulation.
@@ -1029,7 +1037,6 @@ class ZBL(Pair):
         nlist (`hoomd.md.nlist.NList`): Neighbor list
         r_cut (float): Default cutoff radius (in distance units).
         r_on (float): Default turn-on radius (in distance units).
-        mode (str): energy shifting/smoothing mode.
 
     `ZBL` specifies that a Ziegler-Biersack-Littmark pair potential
     should be applied between every non-excluded particle pair in the
@@ -1106,7 +1113,7 @@ class Mie(Pair):
         nlist (`hoomd.md.nlist.NList`): Neighbor list
         r_cut (float): Default cutoff radius (in distance units).
         r_on (float): Default turn-on radius (in distance units).
-        mode (str): energy shifting/smoothing mode.
+        mode (str): Energy shifting/smoothing mode.
 
     `Mie` specifies that a Mie pair potential should be applied between every
     non-excluded particle pair in the simulation.
@@ -1174,7 +1181,7 @@ class ReactionField(Pair):
         nlist (`hoomd.md.nlist.NList`): Neighbor list
         r_cut (float): Default cutoff radius (in distance units).
         r_on (float): Default turn-on radius (in distance units).
-        mode (str): energy shifting/smoothing mode
+        mode (str): Energy shifting/smoothing mode
 
     `ReactionField` specifies that an Onsager reaction field pair potential
     should be applied between every non-excluded particle pair in the
@@ -1255,6 +1262,7 @@ class DLVO(Pair):
         name (str): Name of the force instance.
         d_max (float): Maximum diameter particles in the simulation will have
           (in distance units)
+        mode (str): Energy shifting mode.
 
     `DLVO` specifies that a DLVO dispersion and electrostatic interaction should
     be applied between every non-excluded particle pair in the simulation.
@@ -1343,7 +1351,7 @@ class Buckingham(Pair):
         nlist (`hoomd.md.nlist.NList`): Neighbor list
         r_cut (float): Default cutoff radius (in distance units).
         r_on (float): Default turn-on radius (in distance units).
-        mode (str): energy shifting/smoothing mode
+        mode (str): Energy shifting/smoothing mode
 
     `Buckingham` specifies that a Buckingham pair potential should be applied
     between every non-excluded particle pair in the simulation.
@@ -1398,7 +1406,7 @@ class LJ1208(Pair):
         nlist (`hoomd.md.nlist.NList`): Neighbor list
         r_cut (float): Default cutoff radius (in distance units).
         r_on (float): Default turn-on radius (in distance units).
-        mode (str): energy shifting/smoothing mode
+        mode (str): Energy shifting/smoothing mode
 
     `LJ1208` specifies that a Lennard-Jones 12-8 pair potential should be
     applied between every non-excluded particle pair in the simulation.
@@ -1512,7 +1520,7 @@ class Fourier(Pair):
         nlist (`hoomd.md.nlist.NList`): Neighbor list
         r_cut (float): Default cutoff radius (in distance units).
         r_on (float): Default turn-on radius (in distance units).
-        mode (str): Energy shifting mode.
+        mode (str): Energy shifting/smoothing mode.
 
     `Fourier` specifies that a Fourier pair potential should be applied between
     every non-excluded particle pair in the simulation.
@@ -1583,7 +1591,6 @@ class OPP(Pair):
         nlist (:py:mod:`hoomd.md.nlist.NList`): Neighbor list
         r_cut (float): Default cutoff radius (in distance units).
         r_on (float): Default turn-on radius (in distance units).
-        mode (str): energy shifting/smoothing mode
 
     `OPP` specifies that an oscillating pair potential should be applied between
     every non-excluded particle pair in the simulation. The OPP potential can

--- a/hoomd/md/pair/pair.py
+++ b/hoomd/md/pair/pair.py
@@ -233,9 +233,7 @@ class LJ(Pair):
         \end{eqnarray*}
 
     See `Pair` for details on how forces are calculated and the
-    available energy shifting and smoothing modes.  Use `params` dictionary
-    to set potential coefficients. The coefficients must be set per
-    unique pair of particle types.
+    available energy shifting and smoothing modes.
 
     .. py:attribute:: params
 
@@ -289,9 +287,7 @@ class Gauss(Pair):
         \end{eqnarray*}
 
     See `Pair` for details on how forces are calculated and the
-    available energy shifting and smoothing modes. Use `params` dictionary to
-    set potential coefficients. The coefficients must be set per unique pair of
-    particle types.
+    available energy shifting and smoothing modes.
 
     .. py:attribute:: params
 
@@ -352,9 +348,7 @@ class SLJ(Pair):
     particle :math:`i`.
 
     See `Pair` for details on how forces are calculated and the
-    available energy shifting and smoothing modes. Use `params` dictionary to
-    set potential coefficients. The coefficients must be set per unique pair of
-    particle types.
+    available energy shifting and smoothing modes. 
 
     Attention:
         Due to the way that `SLJ` modifies the cutoff criteria, a shift_mode
@@ -435,9 +429,7 @@ class Yukawa(Pair):
         \end{eqnarray*}
 
     See `Pair` for details on how forces are calculated and the available
-    energy shifting and smoothing modes. Use `params` dictionary to set
-    potential coefficients. The coefficients must be set per unique pair of
-    particle types.
+    energy shifting and smoothing modes.
 
     .. py:attribute:: params
 
@@ -498,9 +490,6 @@ class Ewald(Pair):
 
     See `Pair` for details on how forces are calculated. Note Ewald does not
     support energy shifting or smoothing.
-    Use the `params` dictionary to set
-    potential coefficients. The coefficients must be set per unique pair of
-    particle types.
 
     .. py:attribute:: params
 
@@ -554,9 +543,7 @@ class Morse(Pair):
         \end{eqnarray*}
 
     See `Pair` for details on how forces are calculated and the available
-    energy shifting and smoothing modes. Use `params` dictionary to set
-    potential coefficients. The coefficients must be set per unique pair of
-    particle types.
+    energy shifting and smoothing modes.
 
     .. py:attribute:: params
 
@@ -642,9 +629,7 @@ class DPD(Pair):
     utilize the DPD functionality in your work.
 
     `DPD` does not implement and energy shift / smoothing modes due to the
-    function of the force. Use `params` dictionary to set potential
-    coefficients. The coefficients must be set per unique pair of particle
-    types.
+    function of the force.
 
     To use the DPD thermostat, an `hoomd.md.methods.NVE` integrator
     must be applied to the system and the user must specify a temperature.  Use
@@ -725,9 +710,7 @@ class DPDConservative(Pair):
 
 
     `DPDConservative` does not implement and energy shift / smoothing modes due
-    to the function of the force. Use `params` dictionary to set potential
-    coefficients. The coefficients must be set per unique pair of particle
-    types.
+    to the function of the force.
 
     .. py:attribute:: params
 
@@ -817,9 +800,6 @@ class DPDLJ(Pair):
     where :math:`\hat r_{ij}` is a normalized vector from particle i to
     particle j, :math:`v_{ij} = v_i - v_j`, and :math:`\theta_{ij}` is a
     uniformly distributed random number in the range [-1, 1].
-
-    Use `params` dictionary to set potential coefficients. The coefficients must
-    be set per unique pair of particle types.
 
     To use the DPD thermostat, an `hoomd.md.methods.NVE` integrator
     must be applied to the system and the user must specify a temperature. Use
@@ -922,9 +902,7 @@ class ForceShiftedLJ(Pair):
           V_{\mathrm{LJ}}}{\partial r}(r_{\mathrm{cut}})
 
     See `Pair` for details on how forces are calculated and the
-    available energy shifting and smoothing modes. Use `params` dictionary to
-    set potential coefficients. The coefficients must be set per unique pair of
-    particle types.
+    available energy shifting and smoothing modes.
 
     .. py:attribute:: params
 
@@ -990,9 +968,7 @@ class Moliere(Pair):
       \right)^{2/3}}`, where :math:`a_0` is the Bohr radius (in distance units)
 
     See `Pair` for details on how forces are calculated and the available
-    energy shifting and smoothing modes. Use `params` dictionary to set
-    potential coefficients. The coefficients must be set per unique pair of
-    particle types.
+    energy shifting and smoothing modes.
 
     .. py:attribute:: params
 
@@ -1069,8 +1045,7 @@ class ZBL(Pair):
       :math:`a_0` is the Bohr radius (in distance units)
 
     See `Pair` for details on how forces are calculated. Note ZBL does not
-    support energy shifting or smoothing. Use `params` dictionary to set
-    potential coefficients.
+    support energy shifting or smoothing.
 
     .. py:attribute:: params
 
@@ -1135,9 +1110,7 @@ class Mie(Pair):
         \end{eqnarray*}
 
     `Pair` for details on how forces are calculated and the available energy
-    shifting and smoothing modes. Use the `params` dictionary to set potential
-    coefficients. The coefficients must be set per unique pair of particle
-    types.
+    shifting and smoothing modes.
 
     .. py:attribute:: params
 
@@ -1217,9 +1190,7 @@ class ReactionField(Pair):
     where :math:`q_i` and :math:`q_j` are the charges of the particle pair.
 
     See `Pair` for details on how forces are calculated and the available
-    energy shifting and smoothing modes.  Use the `params` dictionary to set
-    potential coefficients. The coefficients must be set per unique pair of
-    particle types.
+    energy shifting and smoothing modes.
 
     .. py:attribute:: params
 
@@ -1370,8 +1341,7 @@ class Buckingham(Pair):
         \end{eqnarray*}
 
     See `Pair` for details on how forces are calculated and the available
-    energy shifting and smoothing modes.  Use the `params` dictionary to set
-    potential coefficients.
+    energy shifting and smoothing modes.
 
     .. py:attribute:: params
 
@@ -1427,8 +1397,7 @@ class LJ1208(Pair):
         \end{eqnarray*}
 
     See `Pair` for details on how forces are calculated and the available
-    energy shifting and smoothing modes.  Use the `params` dictionary to set
-    potential coefficients.
+    energy shifting and smoothing modes.
 
     .. py:attribute:: params
 
@@ -1483,9 +1452,7 @@ class LJ0804(Pair):
         \end{eqnarray*}
 
     See `Pair` for details on how forces are calculated and the
-    available energy shifting and smoothing modes.  Use the `params` dictionary
-    to set potential coefficients. The coefficients must be set per
-    unique pair of particle types.
+    available energy shifting and smoothing modes.
 
     .. py:attribute:: params
 
@@ -1553,9 +1520,7 @@ class Fourier(Pair):
         is calculated to enforce close to zero value at r_cut.
 
     See `Pair` for details on how forces are calculated and the available
-    energy shifting and smoothing modes. Use `params` dictionary to set
-    potential coefficients. The coefficients must be set per unique pair of
-    particle types.
+    energy shifting and smoothing modes.
 
     .. py:attribute:: params
 
@@ -1609,9 +1574,7 @@ class OPP(Pair):
         \end{equation*}
 
     See `Pair` for details on how forces are calculate. Note OPP does not
-    support energy shifting or smoothing.  Use `params` dictionary to set
-    potential coefficients. The coefficients must be set per unique pair
-    of particle types.
+    support energy shifting or smoothing.
 
     The potential comes from Marek Mihalkovič and C. L. Henley 2012
     `paper link`_.
@@ -1682,9 +1645,7 @@ class TWF(Pair):
         \end{equation}
 
     See `hoomd.md.pair.Pair` for details on how forces are calculated and the
-    available energy shifting and smoothing modes.  Use `params` dictionary
-    to set potential coefficients. The coefficients must be set per
-    unique pair of particle types.
+    available energy shifting and smoothing modes.
 
     The potential comes from Pieter Rein ten Wolde and Daan Frenkel 1997
     `paper link`_.

--- a/hoomd/md/pair/pair.py
+++ b/hoomd/md/pair/pair.py
@@ -806,9 +806,9 @@ class DPDLJ(Pair):
     of the dpd thermostat pair force with other integrators will result in
     unphysical behavior.
 
-    DPDLJ does not support smoothing with ``mode="xplor"``. See `Pair` for details on
-    how forces are calculated and the available energy shifting
-    and smoothing modes.
+    DPDLJ does not support smoothing with ``mode="xplor"``.
+    See `Pair` for details on how forces are calculated and the
+    available energy shifting and smoothing modes.
 
     .. py:attribute:: params
 

--- a/hoomd/md/pair/pair.py
+++ b/hoomd/md/pair/pair.py
@@ -116,7 +116,7 @@ class Pair(force.Force):
         *mode*, *optional*: defaults to ``none``.
         Possible values: ``none``, ``shift``, ``xplor``
 
-        Type: ``str``
+        Type: `str`
     """
 
     def __init__(self, nlist, r_cut=None, r_on=0., mode='none'):
@@ -806,7 +806,7 @@ class DPDLJ(Pair):
     of the dpd thermostat pair force with other integrators will result in
     unphysical behavior.
 
-    DPDLJ does not support xplor smoothing mode. See Pair for details on
+    DPDLJ does not support xplor smoothing mode. See `Pair` for details on
     how forces are calculated and the available energy shifting
     and smoothing modes.
 

--- a/hoomd/md/pair/pair.py
+++ b/hoomd/md/pair/pair.py
@@ -112,7 +112,7 @@ class Pair(force.Force):
         `float`])
 
     .. py:attribute:: mode
-        
+
         *mode*, *optional*: defaults to ``none``.
         Possible values: ``none``, ``shift``, ``xplor``
 
@@ -822,10 +822,10 @@ class DPDLJ(Pair):
     be set per unique pair of particle types.
 
     To use the DPD thermostat, an `hoomd.md.methods.NVE` integrator
-    must be applied to the system and the user must specify a temperature.  Use
+    must be applied to the system and the user must specify a temperature. Use
     of the dpd thermostat pair force with other integrators will result in
     unphysical behavior.
-   
+    
     DPDLJ does not support xplor smoothing mode. See Pair for details on
     how forces are calculated and the available energy shifting
     and smoothing modes.

--- a/sphinx-doc/credits.rst
+++ b/sphinx-doc/credits.rst
@@ -4,6 +4,7 @@ Credits
 The following people have contributed to the to HOOMD-blue:
 
 * Aaron Keys, University of Michigan
+* Alain Kadar, University of Michigan
 * Alex Travesset, Iowa State University and Ames Laboratory
 * Alex Yang, Vanderbilt University
 * Alexander Hudson


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should based on *maint*. -->
<!-- New features should based on *master*. -->

## Description
Added ``mode`` attribute to Pair base class. Also formatted mode attribute in each pair potential

## Motivation and context
Mode attribute was missing in ``md.pair.Pair`` documentation. There were also inconsistencies in pair potentials documentation.

<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves #974 

## How has this been tested?
Documentation was locally rendered in HTML.

## Change log
```
Added mode attribute to documentation
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [ ] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
