### PR TITLE
Add md.pair.TWF to the documentation

### DIFF
--- a/hoomd/md/pair/pair.py
+++ b/hoomd/md/pair/pair.py
@@ -1602,10 +1602,10 @@ class OPP(Pair):
     coefficients. The coefficients must be set per unique pair of particle
     types.
 
-    The potential comes from Marek Mihalkovič and C. L. Henley 2012
-    `paper link`_.
+    The potential comes from `Marek Mihalkovič and C. L. Henley 2012`_.
 
-    .. _paper link: https://dx.doi.org/10.1103/PhysRevB.85.092102
+    .. _Marek Mihalkovič and C. L. Henley 2012:
+       https://dx.doi.org/10.1103/PhysRevB.85.092102
 
     .. py:attribute:: params
 
@@ -1675,10 +1675,10 @@ class TWF(Pair):
     to set potential coefficients. The coefficients must be set per
     unique pair of particle types.
 
-    The potential comes from Pieter Rein ten Wolde and Daan Frenkel 1997
-    `paper link`_.
+    The potential comes from `Pieter Rein ten Wolde and Daan Frenkel 1997`_.
 
-    .. _paper link: https://dx.doi.org/10.1126/science.277.5334.1975
+    .. _Pieter Rein ten Wolde and Daan Frenkel 1997:
+       https://dx.doi.org/10.1126/science.277.5334.1975
 
     .. py:attribute:: params
 

--- a/sphinx-doc/module-md-pair.rst
+++ b/sphinx-doc/module-md-pair.rst
@@ -27,6 +27,7 @@ md.pair
     OPP
     ReactionField
     SLJ
+    TWF
     Yukawa
     ZBL
 
@@ -53,6 +54,7 @@ md.pair
         OPP,
         ReactionField,
         SLJ,
+        TWF,
         Yukawa,
         ZBL
 


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should based on *maint*. -->
<!-- New features should based on *master*. -->

## Description

<!-- Describe your changes in detail. -->
Add md.pair.TWF to the documentation

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Implemented pair potentials should appear in the documentation.

I needed to make unique paper links because `paper link` appeared twice with different URLs which is invalid restructured text.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
I verified that the sphinx documentation included TWF locally.

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
- Add ``md.pair.TWF`` to the documentation.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
