### PR TITLE
Import optional modules based on build configuration

### DIFF
--- a/hoomd/CMakeLists.txt
+++ b/hoomd/CMakeLists.txt
@@ -32,6 +32,12 @@ else()
     set(_dem_built "False")
 endif()
 
+if (BUILD_METAL)
+    set(_metal_built "True")
+else()
+    set(_metal_built "False")
+endif()
+
 if (BUILD_MPCD)
     set(_mpcd_built "True")
 else()

--- a/hoomd/CMakeLists.txt
+++ b/hoomd/CMakeLists.txt
@@ -7,6 +7,37 @@ install(FILES ${HOOMD_BINARY_DIR}/hoomd/include/HOOMDVersion.h
         DESTINATION ${PYTHON_SITE_INSTALL_DIR}/include
         )
 
+# translate cmake true/false to Python
+if (BUILD_MD)
+    set(_md_built "True")
+else()
+    set(_md_built "False")
+endif()
+
+if (BUILD_MD)
+    set(_md_built "True")
+else()
+    set(_md_built "False")
+endif()
+
+if (BUILD_HPMC)
+    set(_hpmc_built "True")
+else()
+    set(_hpmc_built "False")
+endif()
+
+if (BUILD_DEM)
+    set(_dem_built "True")
+else()
+    set(_dem_built "False")
+endif()
+
+if (BUILD_MPCD)
+    set(_mpcd_built "True")
+else()
+    set(_mpcd_built "False")
+endif()
+
 configure_file (version_config.py.in ${HOOMD_BINARY_DIR}/hoomd/version_config.py)
 install(FILES ${HOOMD_BINARY_DIR}/hoomd/version_config.py
         DESTINATION ${PYTHON_SITE_INSTALL_DIR}

--- a/hoomd/__init__.py
+++ b/hoomd/__init__.py
@@ -29,6 +29,8 @@ if version.hpmc_built:
     from hoomd import hpmc
 if version.dem_built:
     from hoomd import dem
+# if version.metal_built:
+#     from hoomd import metal
 # if version.mpcd_built:
 #     from hoomd import mpcd
 

--- a/hoomd/__init__.py
+++ b/hoomd/__init__.py
@@ -23,23 +23,14 @@ from hoomd import communicator
 from hoomd import util
 from hoomd import write
 from hoomd import _hoomd
-try:
+if version.md_built:
     from hoomd import md
-except ImportError:
-    pass
-try:
+if version.hpmc_built:
     from hoomd import hpmc
-except ImportError:
-    pass
-try:
+if version.dem_built:
     from hoomd import dem
-except ImportError:
-    pass
-# TODO: enable this import after updating MPCD to the new API
-# try:
+# if version.mpcd_built:
 #     from hoomd import mpcd
-# except ImportError:
-#     pass
 
 from hoomd.simulation import Simulation
 from hoomd.state import State

--- a/hoomd/version.py
+++ b/hoomd/version.py
@@ -12,6 +12,8 @@ Attributes:
     cxx_compiler (str): Name and version of the C++ compiler used to build
         HOOMD.
 
+    dem_built (bool): ``True`` when the `dem` package is built.
+
     git_branch (str):  Name of the git branch used when compiling this build.
 
     git_sha1 (str):  SHA1 of the git commit used when compiling this build.
@@ -23,7 +25,13 @@ Attributes:
     gpu_platform (str): Name of the GPU platform this build was compiled
         against.
 
+    hpmc_built (bool): ``True`` when the `hpmc` package is built.
+
     install_dir (str): The installation directory.
+
+    md_built (bool): ``True`` when the `md` package is built.
+
+    mpcd_built (bool): ``True`` when the `mpcd` package is built.
 
     mpi_enabled (bool): ``True`` when this build supports MPI parallel runs.
 
@@ -41,11 +49,19 @@ try:
     compile_date = hoomd.version_config.compile_date
     git_branch = hoomd.version_config.git_branch
     git_sha1 = hoomd.version_config.git_sha1
+    md_built = hoomd.version_config.md_built
+    hpmc_built = hoomd.version_config.hpmc_built
+    dem_built = hoomd.version_config.dem_built
+    mpcd_built = hoomd.version_config.mpcd_built
 except ImportError:
     # Allow sphinx docs to build when missing CMake generated python files
     compile_date = "n/a"
     git_branch = "n/a"
     git_sha1 = "n/a"
+    md_built = "n/a"
+    hpmc_built = "n/a"
+    dem_built = "n/a"
+    mpcd_built = "n/a"
 
 version = _hoomd.BuildInfo.getVersion()
 compile_flags = _hoomd.BuildInfo.getCompileFlags()

--- a/hoomd/version.py
+++ b/hoomd/version.py
@@ -12,7 +12,7 @@ Attributes:
     cxx_compiler (str): Name and version of the C++ compiler used to build
         HOOMD.
 
-    dem_built (bool): ``True`` when the `dem` package is built.
+    dem_built (bool): ``True`` when the `dem` component is built.
 
     git_branch (str):  Name of the git branch used when compiling this build.
 
@@ -25,13 +25,15 @@ Attributes:
     gpu_platform (str): Name of the GPU platform this build was compiled
         against.
 
-    hpmc_built (bool): ``True`` when the `hpmc` package is built.
+    hpmc_built (bool): ``True`` when the `hpmc` component is built.
 
     install_dir (str): The installation directory.
 
-    md_built (bool): ``True`` when the `md` package is built.
+    metal_built (bool): ``True`` when the `metal` component is built.
 
-    mpcd_built (bool): ``True`` when the `mpcd` package is built.
+    md_built (bool): ``True`` when the `md` component is built.
+
+    mpcd_built (bool): ``True`` when the `mpcd` component is built.
 
     mpi_enabled (bool): ``True`` when this build supports MPI parallel runs.
 
@@ -53,6 +55,7 @@ try:
     hpmc_built = hoomd.version_config.hpmc_built
     dem_built = hoomd.version_config.dem_built
     mpcd_built = hoomd.version_config.mpcd_built
+    metal_built = hoomd.version_config.metal_built
 except ImportError:
     # Allow sphinx docs to build when missing CMake generated python files
     compile_date = "n/a"
@@ -62,6 +65,7 @@ except ImportError:
     hpmc_built = "n/a"
     dem_built = "n/a"
     mpcd_built = "n/a"
+    metal_built = "n/a"
 
 version = _hoomd.BuildInfo.getVersion()
 compile_flags = _hoomd.BuildInfo.getCompileFlags()

--- a/hoomd/version_config.py.in
+++ b/hoomd/version_config.py.in
@@ -7,3 +7,11 @@ compile_date = "${COMPILE_DATE}"
 git_branch = "${HOOMD_GIT_REFSPEC}"
 
 git_sha1 = "${HOOMD_GIT_SHA1}"
+
+md_built = ${_md_built}
+
+hpmc_built = ${_hpmc_built}
+
+dem_built = ${_dem_built}
+
+mpcd_built = ${_mpcd_built}

--- a/hoomd/version_config.py.in
+++ b/hoomd/version_config.py.in
@@ -15,3 +15,5 @@ hpmc_built = ${_hpmc_built}
 dem_built = ${_dem_built}
 
 mpcd_built = ${_mpcd_built}
+
+metal_built = ${_metal_built}


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should based on *maint*. -->
<!-- New features should based on *master*. -->

## Description

<!-- Describe your changes in detail. -->
Use the CMake build configuration for `BUILD_HPMC`, `BUILD_MD`, etc.. to determine when to import these packages.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Recently, I helped @tommy-waltmann find an `ImportError` that was masked by the current `try/except ImportError` block. With the new code, that error would no longer be masked.

This also fixes another problem I have had at times. When I build HOOMD with all packages enabled, then change the build settings to disable a module, the old built package is still left in the build directory. Sometimes this leads to errors when the old package is not ABI compatible with the rest of the build, but `__init__.py` still tried to import it because the files are there.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
I manually tested each of the `BUILD_` settings in the ON and OFF configuration locally. We have no CI tests for this and I do not want to add that many additional CI configurations just to test all the possible ON/OFF combinations.

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->
The new docs for the variables appear in the documentation.

## Change log

<!-- Propose a change log entry. -->
```
*Added*

- ``dem_built``, ``hpmc_built``, ``md_built``, and ``mpcd_built`` to ``hoomd.version`` - flags that indicate when optional submodules have been built.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
