### PR TITLE
Misc mpi fixes

### DIFF
--- a/hoomd/ExecutionConfiguration.cc
+++ b/hoomd/ExecutionConfiguration.cc
@@ -478,7 +478,7 @@ void ExecutionConfiguration::setupStats()
                 m_concurrent = false;
                 }
 
-            m_active_device_descriptions.push_back(describeGPU(idev, m_dev_prop[idev]));
+            m_active_device_descriptions.push_back(describeGPU(m_gpu_id[idev], m_dev_prop[idev]));
             }
 
         // initialize dev_prop with device properties of first device for now


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should based on *maint*. -->
<!-- New features should based on *master*. -->

## Description

<!-- Describe your changes in detail. -->
Fix a few minor issues with MPI simulations.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
1. HOOMD was incorrectly identifying GPU ids.
2. `from_gsd_snapshot` required that the user read the GSD file on all MPI ranks
3. On a 2 GPU test system, MPI rank 1 was initializing a CUDA context on GPU 0

<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves #1033

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
I tested that all of these issues are fixed on `brett`. These are not issues that are straightforward test in pytest.

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
*Changed:*

- ``from_gsd_snapshot`` only accesses the GSD snapshot on MPI rank 0.

*Fixed:*

- Correctly identify GPUs by ID in ``GPU.devices``.
- Don't initialize contexts on extra GPUs on MPI ranks.
- Support 2D inputs in ``from_gsd_snapshot``.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
