### PR TITLE
Fix compiling error in ForceComposite.cc

### DIFF
--- a/hoomd/md/ForceComposite.cc
+++ b/hoomd/md/ForceComposite.cc
@@ -605,8 +605,8 @@ void ForceComposite::createRigidBodies()
         unsigned int central_particle_tag = 0;
         for (unsigned int particle_tag = 0; particle_tag < n_without_constituent; ++particle_tag)
             {
-            assert(snap.type[i] < ntypes);
-            assert(snap.body[i] == NO_BODY);
+            assert(snap.type[particle_tag] < ntypes);
+            assert(snap.body[particle_tag] == NO_BODY);
 
             // If the length of the body definition is zero it must be a free body because all
             // constituent particles have been removed.

--- a/hoomd/md/ForceComposite.cc
+++ b/hoomd/md/ForceComposite.cc
@@ -605,7 +605,7 @@ void ForceComposite::createRigidBodies()
         unsigned int central_particle_tag = 0;
         for (unsigned int particle_tag = 0; particle_tag < n_without_constituent; ++particle_tag)
             {
-            assert(snap.type[particle_tag] < ntypes);
+            assert(snap.type[particle_tag] < m_pdata->getNTypes());
             assert(snap.body[particle_tag] == NO_BODY);
 
             // If the length of the body definition is zero it must be a free body because all

--- a/hoomd/md/ForceComposite.cc
+++ b/hoomd/md/ForceComposite.cc
@@ -545,7 +545,6 @@ void ForceComposite::createRigidBodies()
 
     // take a snapshot on rank 0
     m_pdata->takeSnapshot(snap);
-    unsigned int ntypes = m_pdata->getNTypes();
     bool remove_existing_bodies = false;
     unsigned int n_constituent_particles = 0;
     unsigned int n_free_bodies = 0;

--- a/hoomd/md/ForceComposite.cc
+++ b/hoomd/md/ForceComposite.cc
@@ -545,6 +545,7 @@ void ForceComposite::createRigidBodies()
 
     // take a snapshot on rank 0
     m_pdata->takeSnapshot(snap);
+    unsigned int ntypes = m_pdata->getNTypes();
     bool remove_existing_bodies = false;
     unsigned int n_constituent_particles = 0;
     unsigned int n_free_bodies = 0;


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should based on *maint*. -->
<!-- New features should based on *master*. -->

## Description

<!-- Describe your changes in detail. -->
I changed two assert statements to use the correct variable for the particle index and also defined an `ntypes` variable that was used in one of the assert statements.
## Motivation and context
The `ForceComposite.cc` file does not compile because of two undefined variables being used.
<!--- Why is this change required? What problem does it solve? -->

<!-- Replace ??? with the issue number that this pull request resolves. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
The code now compiles and the tests in `test_rigid.py` all pass.
<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```

```

## Checklist:

- [X] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [X] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [X] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
