### PR TITLE
Fix bug in domain decomposition for 2D systems

### DIFF
--- a/hoomd/DomainDecomposition.cc
+++ b/hoomd/DomainDecomposition.cc
@@ -346,9 +346,13 @@ bool DomainDecomposition::findDecomposition(unsigned int nranks,
     bool is2D = L.z == 0.0;
     double min_surface_area; // surface area in 3D, perimeter length in 2D
     if (is2D)
+        {
         min_surface_area = L.x * (double)(nranks - 1);
+        }
     else
+        {
         min_surface_area = L.x * L.z * (double)(nranks - 1);
+        }
 
     unsigned int nx_in = nx;
     unsigned int ny_in = ny;
@@ -358,8 +362,16 @@ bool DomainDecomposition::findDecomposition(unsigned int nranks,
 
     // initial guess
     nx = 1;
-    ny = nranks;
-    nz = 1;
+    if (is2D)
+        {
+        ny = nranks;
+        nz = 1;
+        }
+    else
+        {
+        ny = 1;
+        nz = nranks;
+        }
 
     for (unsigned int nx_try = 1; nx_try <= nranks; nx_try++)
         {
@@ -379,13 +391,14 @@ bool DomainDecomposition::findDecomposition(unsigned int nranks,
                     continue;
                 double surface_area;
                 if (is2D)
+                    {
                     surface_area = L.x * (ny_try - 1) + L.y * (nx_try - 1);
+                    }
                 else
                     {
                     surface_area = L.x * L.y * (double)(nz_try - 1)
                                    + L.x * L.z * (double)(ny_try - 1)
                                    + L.y * L.z * (double)(nx_try - 1);
-
                     }
                 if (surface_area < min_surface_area || !found_decomposition)
                     {

--- a/hoomd/DomainDecomposition.cc
+++ b/hoomd/DomainDecomposition.cc
@@ -344,7 +344,7 @@ bool DomainDecomposition::findDecomposition(unsigned int nranks,
     // Calculate the number of sub-domains in every direction
     // by minimizing the surface area between domains at constant number of domains
     bool is2D = L.z == 0.0;
-    double min_surface_area;  // surface area in 3D, perimeter length in 2D
+    double min_surface_area; // surface area in 3D, perimeter length in 2D
     if (is2D)
         min_surface_area = L.x * (double)(nranks - 1);
     else
@@ -360,7 +360,6 @@ bool DomainDecomposition::findDecomposition(unsigned int nranks,
     nx = 1;
     ny = nranks;
     nz = 1;
-
 
     for (unsigned int nx_try = 1; nx_try <= nranks; nx_try++)
         {
@@ -384,8 +383,8 @@ bool DomainDecomposition::findDecomposition(unsigned int nranks,
                 else
                     {
                     surface_area = L.x * L.y * (double)(nz_try - 1)
-                                 + L.x * L.z * (double)(ny_try - 1)
-                                 + L.y * L.z * (double)(nx_try - 1);
+                                  + L.x * L.z * (double)(ny_try - 1)
+                                  + L.y * L.z * (double)(nx_try - 1);
 
                     }
                 if (surface_area < min_surface_area || !found_decomposition)

--- a/hoomd/DomainDecomposition.cc
+++ b/hoomd/DomainDecomposition.cc
@@ -340,11 +340,15 @@ bool DomainDecomposition::findDecomposition(unsigned int nranks,
     {
     assert(L.x > 0);
     assert(L.y > 0);
-    assert(L.z > 0);
 
     // Calculate the number of sub-domains in every direction
     // by minimizing the surface area between domains at constant number of domains
-    double min_surface_area = L.x * L.y * (double)(nranks - 1);
+    bool is2D = L.z == 0.0;
+    double min_surface_area;  // surface area in 3D, perimeter length in 2D
+    if (is2D)
+        min_surface_area = L.x * (double)(nranks - 1);
+    else
+        min_surface_area = L.x * L.z * (double)(nranks - 1);
 
     unsigned int nx_in = nx;
     unsigned int ny_in = ny;
@@ -354,8 +358,9 @@ bool DomainDecomposition::findDecomposition(unsigned int nranks,
 
     // initial guess
     nx = 1;
-    ny = 1;
-    nz = nranks;
+    ny = nranks;
+    nz = 1;
+
 
     for (unsigned int nx_try = 1; nx_try <= nranks; nx_try++)
         {
@@ -371,9 +376,19 @@ bool DomainDecomposition::findDecomposition(unsigned int nranks,
                     continue;
                 if (nx_try * ny_try * nz_try != nranks)
                     continue;
-                double surface_area = L.x * L.y * (double)(nz_try - 1)
-                                      + L.x * L.z * (double)(ny_try - 1)
-                                      + L.y * L.z * (double)(nx_try - 1);
+                if (is2D && nz_try > 1)
+                    continue;
+                double surface_area;
+                if (is2D)
+                    surface_area = L.x * (ny_try - 1) + L.y * (nx_try - 1);
+                else
+                    {
+                    surface_area = L.x * L.y * (double)(nz_try - 1)
+                                 + L.x * L.z * (double)(ny_try - 1)
+                                 + L.y * L.z * (double)(nx_try - 1);
+
+                    }
+                std::cout << "nx_try = " << nx_try << "; ny_try = " << ny_try << "; surface_area = " << surface_area << std::endl;
                 if (surface_area < min_surface_area || !found_decomposition)
                     {
                     nx = nx_try;

--- a/hoomd/DomainDecomposition.cc
+++ b/hoomd/DomainDecomposition.cc
@@ -383,8 +383,8 @@ bool DomainDecomposition::findDecomposition(unsigned int nranks,
                 else
                     {
                     surface_area = L.x * L.y * (double)(nz_try - 1)
-                                  + L.x * L.z * (double)(ny_try - 1)
-                                  + L.y * L.z * (double)(nx_try - 1);
+                                   + L.x * L.z * (double)(ny_try - 1)
+                                   + L.y * L.z * (double)(nx_try - 1);
 
                     }
                 if (surface_area < min_surface_area || !found_decomposition)

--- a/hoomd/DomainDecomposition.cc
+++ b/hoomd/DomainDecomposition.cc
@@ -388,7 +388,6 @@ bool DomainDecomposition::findDecomposition(unsigned int nranks,
                                  + L.y * L.z * (double)(nx_try - 1);
 
                     }
-                std::cout << "nx_try = " << nx_try << "; ny_try = " << ny_try << "; surface_area = " << surface_area << std::endl;
                 if (surface_area < min_surface_area || !found_decomposition)
                     {
                     nx = nx_try;


### PR DESCRIPTION
Due to the new convention in v3 where systems are considered 2D if `Lz =
0`, the domain decomposition is broken for 2D systems.
This commit addresses that change.
In 3D, the domain decomposition is chosen as the one that minimizes the
surface area between the domains.
In 2D, we choose the decomposition that minimizes the linear perimeter
between domains.

## Description

Modifies the generation of the domain decomposition to properly handle 2D boxes now that the 2D-ness is implied by having a box with `Lz = 0`.

## Motivation and context

Inefficient domain decomposition != good.

Resolves #1038 

## How has this been tested?

I tested with the script posted in #1038, and it generates a `sqrt(n) x sqrt(n) x 1` decomposition instead of an `1 x n x 1` decomposition.

## Change log

```
- Fixes domain decomposition for 2D systems
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
