### PR TITLE
Warn users on source import

### DIFF
--- a/hoomd/__init__.py
+++ b/hoomd/__init__.py
@@ -19,9 +19,10 @@ if ((pathlib.Path(__file__).parent / 'CMakeLists.txt').exists()
     print("""Compile the package and import from the build directory or install
 the package and import from the Python environment.
 
-To run pytest, compile and execute `python3 -m pytest <build-directory>/hoomd`
-or install and execute, ensure your current working directory is outside the
-hoomd source directory and run `python3 -m pytest --pyargs hoomd`.
+To run pytest, either:
+(1) compile then execute `python3 -m pytest <build-directory>/hoomd` or
+(2) compile and install. Then, ensuring your current working directory is outside the
+hoomd source directory, execute `python3 -m pytest --pyargs hoomd`.
 """,
           file=sys.stderr)
 

--- a/hoomd/__init__.py
+++ b/hoomd/__init__.py
@@ -8,7 +8,22 @@
 simulations using HOOMD.
 """
 import sys
+import pathlib
 import os
+
+if ((pathlib.Path(__file__).parent / 'CMakeLists.txt').exists()
+        and 'SPHINX' not in os.environ):
+    print("It appears that hoomd is being imported from the source directory:")
+    print(pathlib.Path(__file__).parent)
+    print()
+    print("""Compile the package and import from the build directory or install
+the package and import from the Python environment.
+
+To run pytest, compile and execute `python3 -m pytest <build-directory>/hoomd`
+or install and execute, ensure your current working directory is outside the
+hoomd source directory and run `python3 -m pytest --pyargs hoomd`.
+""",
+          file=sys.stderr)
 
 from hoomd import version
 from hoomd import trigger

--- a/hoomd/__init__.py
+++ b/hoomd/__init__.py
@@ -21,8 +21,8 @@ the package and import from the Python environment.
 
 To run pytest, either:
 (1) compile then execute `python3 -m pytest <build-directory>/hoomd` or
-(2) compile and install. Then, ensuring your current working directory is outside the
-hoomd source directory, execute `python3 -m pytest --pyargs hoomd`.
+(2) compile and install. Then, ensuring your current working directory is
+outside the hoomd source directory, execute `python3 -m pytest --pyargs hoomd`.
 """,
           file=sys.stderr)
 

--- a/sphinx-doc/conf.py
+++ b/sphinx-doc/conf.py
@@ -11,6 +11,8 @@ sphinx_ver = tuple(map(int, sphinx.__version__.split('.')))
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 sys.path.insert(0, os.path.abspath('..'))
 
+os.environ['SPHINX'] = '1'
+
 # TEMPORARY
 # TODO: remove this when 3.0 is closer to completion
 # stop warning about invalid references

--- a/sphinx-doc/testing.rst
+++ b/sphinx-doc/testing.rst
@@ -26,14 +26,20 @@ should execute in less than 10 minutes.
 Running tests
 -------------
 
-Execute the following commands to run the tests:
+Change to the build directory and execute the following commands to run the tests:
 
 * ``ctest`` - Executes C++ tests
 * ``python3 -m pytest hoomd``
 
-CTest_ must be run in the build directory. When you run pytest_ outside of the build
-directory, it will the test ``hoomd`` package that Python imports (which may not be the version just
-built).
+pytest_ may be run outside the build directory by:
+* Passing a full path to the build: ``python3 -m pytest <build-directory>/hoomd``
+* After installing to an environment: ``python3 -m pytest --pyargs hoomd``
+
+.. note::
+
+    ``python3 -m pytest --pyargs hoomd`` tests the hoomd installation it finds by `import hoomd`,
+    which may not be the one you just built. You must also change to a directory outside the
+    source, otherwise ``import hoomd`` attempts to import the uncompiled source.
 
 .. seealso::
 
@@ -53,7 +59,7 @@ configured before running ``ctest``.
 pytest_ tests may also be executed with MPI with 2 ranks. pytest_ does not natively support
 MPI. Execute it with the provided wrapper script in the build directory::
 
-    mpirun -n 2 hoomd/pytest/pytest-openmpi.sh -v -x hoomd
+    mpirun -n 2 build/hoomd/hoomd/pytest/pytest-openmpi.sh -v -x build/hoomd
 
 The wrapper script displays the outout of rank 0 and redirects rank 1's output to a file. Inspect
 this file when a test fails on rank 1. This will result in an ``MPI_ABORT`` on rank 0 (assuming the
@@ -77,12 +83,19 @@ Running validation tests
 Longer running validation tests do not execute by default. Run these with the ``--validate`` command
 line option to pytest::
 
-    $ python3 -m pytest hoomd --validate -m validate
-    $ mpirun -n 2 hoomd/pytest/pytest-openmpi.sh hoomd -v -x -ra --validate -m validate
+    $ python3 -m pytest build/hoomd --validate -m validate
+    $ mpirun -n 2 hoomd/pytest/pytest-openmpi.sh build/hoomd -v -x -ra --validate -m validate
 
 .. note::
 
     The ``-m validate`` option selects *only* the validation tests.
+
+.. note::
+
+    To run validation tests on an installed ``hoomd`` package, you need to specify additional
+    options::
+
+        python3 -m pytest --pyargs hoomd -p hoomd.pytest_plugin_validate -m validate --validate
 
 Implementing tests
 ------------------


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should based on *maint*. -->
<!-- New features should based on *master*. -->

## Description

<!-- Describe your changes in detail. -->
* Issue a warning when users attempt to import hoomd from the source directory.
* Make the testing documentation consistent with the build documentation - in that it doesn't assume the user has changed directories unless they are required to do so (for ctest).
* Document additional pytest invocation options that users and developers may want to be aware of.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
A number of developers recently reported being confused at the behavior of pytest in hoomd. This at least provides a helpful warning when this occurs. HOOMD is a package with many compiled components, so pytest cannot run with the default discovery in a clean source directory as the authors designed. Due to our use of pytest plugins in conftest.py, `pytest` also cannot run with default test discovery in the build directory. The user must specify some option (either a path to the build directory or `--pyargs hoomd`) to indicate where to find the hoomd package to test.

I was unable to determine a configuration that allowed a bare `pytest` to execute tests either from the source or build directories. The closest I got was to add a `pytest.ini` with the contents:
```
[pytest]
addopts = hoomd
```
but adding this file broke several other invocation methods, including the ones that allow you to execute the tests from the source dir by specifying a full path to the build dir.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
I tested all the documented pytest invocation methods locally.

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
*Changed*

- Warn users when hoomd is imported from the source directory.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
