### PR TITLE
Use size_t for the number of shared memory bytes.

### DIFF
--- a/hoomd/CommunicatorGPU.cu
+++ b/hoomd/CommunicatorGPU.cu
@@ -394,7 +394,7 @@ void gpu_make_ghost_exchange_plan(unsigned int* d_plan,
 
     unsigned int block_size = 256;
     unsigned int n_blocks = N / block_size + 1;
-    unsigned int shared_bytes = (unsigned int)(2 * sizeof(Scalar3) * ntypes);
+    const size_t shared_bytes = 2 * sizeof(Scalar3) * ntypes;
 
     hipLaunchKernelGGL(gpu_make_ghost_exchange_plan_kernel,
                        dim3(n_blocks),

--- a/hoomd/hpmc/ComputeFreeVolumeGPU.cuh
+++ b/hoomd/hpmc/ComputeFreeVolumeGPU.cuh
@@ -392,10 +392,10 @@ hipError_t gpu_hpmc_free_volume(const hpmc_free_volume_args_t& args,
     dim3 threads(args.stride, args.group_size, n_groups);
     dim3 grid(args.n_sample / n_groups + 1, 1, 1);
 
-    unsigned int shared_bytes
-        = (unsigned int)(args.num_types * sizeof(typename Shape::param_type)
+    size_t shared_bytes
+        = args.num_types * sizeof(typename Shape::param_type)
                          + n_groups * sizeof(unsigned int)
-                         + args.overlap_idx.getNumElements() * sizeof(unsigned int));
+                         + args.overlap_idx.getNumElements() * sizeof(unsigned int);
 
     unsigned int max_extra_bytes = static_cast<unsigned int>(args.devprop.sharedMemPerBlock
                                                              - attr.sharedSizeBytes - shared_bytes);
@@ -407,7 +407,7 @@ hipError_t gpu_hpmc_free_volume(const hpmc_free_volume_args_t& args,
         {
         d_params[i].allocate_shared(ptr, available_bytes);
         }
-    unsigned int extra_bytes = max_extra_bytes - available_bytes;
+    const unsigned int extra_bytes = max_extra_bytes - available_bytes;
 
     shared_bytes += extra_bytes;
 

--- a/hoomd/hpmc/ComputeFreeVolumeGPU.cuh
+++ b/hoomd/hpmc/ComputeFreeVolumeGPU.cuh
@@ -392,10 +392,9 @@ hipError_t gpu_hpmc_free_volume(const hpmc_free_volume_args_t& args,
     dim3 threads(args.stride, args.group_size, n_groups);
     dim3 grid(args.n_sample / n_groups + 1, 1, 1);
 
-    size_t shared_bytes
-        = args.num_types * sizeof(typename Shape::param_type)
-                         + n_groups * sizeof(unsigned int)
-                         + args.overlap_idx.getNumElements() * sizeof(unsigned int);
+    size_t shared_bytes = args.num_types * sizeof(typename Shape::param_type)
+                          + n_groups * sizeof(unsigned int)
+                          + args.overlap_idx.getNumElements() * sizeof(unsigned int);
 
     unsigned int max_extra_bytes = static_cast<unsigned int>(args.devprop.sharedMemPerBlock
                                                              - attr.sharedSizeBytes - shared_bytes);

--- a/hoomd/hpmc/IntegratorHPMCMonoGPU.cuh
+++ b/hoomd/hpmc/IntegratorHPMCMonoGPU.cuh
@@ -414,7 +414,7 @@ void narrow_phase_launcher(const hpmc_args_t& args,
 
         size_t shared_bytes
             = n_groups * (2 * sizeof(unsigned int) + sizeof(Scalar4) + sizeof(Scalar3))
-                             + max_queue_size * 2 * sizeof(unsigned int) + min_shared_bytes;
+              + max_queue_size * 2 * sizeof(unsigned int) + min_shared_bytes;
 
         if (min_shared_bytes >= args.devprop.sharedMemPerBlock)
             throw std::runtime_error("Insufficient shared memory for HPMC kernel: reduce number of "
@@ -438,7 +438,7 @@ void narrow_phase_launcher(const hpmc_args_t& args,
             max_queue_size = n_groups * tpp;
 
             shared_bytes = n_groups * (2 * sizeof(unsigned int) + sizeof(Scalar4) + sizeof(Scalar3))
-                + max_queue_size * 2 * sizeof(unsigned int) + min_shared_bytes;
+                           + max_queue_size * 2 * sizeof(unsigned int) + min_shared_bytes;
             }
 
         // determine dynamically allocated shared memory size

--- a/hoomd/hpmc/IntegratorHPMCMonoGPU.cuh
+++ b/hoomd/hpmc/IntegratorHPMCMonoGPU.cuh
@@ -412,10 +412,9 @@ void narrow_phase_launcher(const hpmc_args_t& args,
             = static_cast<unsigned int>(args.num_types * sizeof(typename Shape::param_type)
                                         + args.overlap_idx.getNumElements() * sizeof(unsigned int));
 
-        unsigned int shared_bytes
-            = (unsigned int)(n_groups
-                                 * (2 * sizeof(unsigned int) + sizeof(Scalar4) + sizeof(Scalar3))
-                             + max_queue_size * 2 * sizeof(unsigned int) + min_shared_bytes);
+        size_t shared_bytes
+            = n_groups * (2 * sizeof(unsigned int) + sizeof(Scalar4) + sizeof(Scalar3))
+                             + max_queue_size * 2 * sizeof(unsigned int) + min_shared_bytes;
 
         if (min_shared_bytes >= args.devprop.sharedMemPerBlock)
             throw std::runtime_error("Insufficient shared memory for HPMC kernel: reduce number of "
@@ -438,9 +437,8 @@ void narrow_phase_launcher(const hpmc_args_t& args,
             n_groups = run_block_size / (tpp * overlap_threads);
             max_queue_size = n_groups * tpp;
 
-            shared_bytes = static_cast<unsigned int>(
-                n_groups * (2 * sizeof(unsigned int) + sizeof(Scalar4) + sizeof(Scalar3))
-                + max_queue_size * 2 * sizeof(unsigned int) + min_shared_bytes);
+            shared_bytes = n_groups * (2 * sizeof(unsigned int) + sizeof(Scalar4) + sizeof(Scalar3))
+                + max_queue_size * 2 * sizeof(unsigned int) + min_shared_bytes;
             }
 
         // determine dynamically allocated shared memory size

--- a/hoomd/hpmc/IntegratorHPMCMonoGPUDepletants.cuh
+++ b/hoomd/hpmc/IntegratorHPMCMonoGPUDepletants.cuh
@@ -702,14 +702,13 @@ void depletants_launcher(const hpmc_args_t& args,
         unsigned int max_queue_size = n_groups * tpp;
         unsigned int max_depletant_queue_size = n_groups;
 
-        const unsigned int min_shared_bytes
-            = static_cast<unsigned int>(args.num_types * sizeof(typename Shape::param_type)
-                                        + args.overlap_idx.getNumElements() * sizeof(unsigned int));
+        const size_t min_shared_bytes
+            = args.num_types * sizeof(typename Shape::param_type)
+                                        + args.overlap_idx.getNumElements() * sizeof(unsigned int);
 
-        unsigned int shared_bytes = static_cast<unsigned int>(
-            n_groups * (sizeof(Scalar4) + sizeof(Scalar3))
+        size_t shared_bytes = n_groups * (sizeof(Scalar4) + sizeof(Scalar3))
             + max_queue_size * 2 * sizeof(unsigned int)
-            + max_depletant_queue_size * sizeof(unsigned int) + min_shared_bytes);
+            + max_depletant_queue_size * sizeof(unsigned int) + min_shared_bytes;
 
         if (min_shared_bytes >= args.devprop.sharedMemPerBlock)
             throw std::runtime_error("Insufficient shared memory for HPMC kernel: reduce number of "
@@ -729,10 +728,9 @@ void depletants_launcher(const hpmc_args_t& args,
             max_queue_size = n_groups * tpp;
             max_depletant_queue_size = n_groups;
 
-            shared_bytes = static_cast<unsigned int>(
-                n_groups * (sizeof(Scalar4) + sizeof(Scalar3))
+            shared_bytes = n_groups * (sizeof(Scalar4) + sizeof(Scalar3))
                 + max_queue_size * 2 * sizeof(unsigned int)
-                + max_depletant_queue_size * sizeof(unsigned int) + min_shared_bytes);
+                + max_depletant_queue_size * sizeof(unsigned int) + min_shared_bytes;
             }
 
         // determine dynamically requested shared memory

--- a/hoomd/hpmc/IntegratorHPMCMonoGPUDepletants.cuh
+++ b/hoomd/hpmc/IntegratorHPMCMonoGPUDepletants.cuh
@@ -702,13 +702,12 @@ void depletants_launcher(const hpmc_args_t& args,
         unsigned int max_queue_size = n_groups * tpp;
         unsigned int max_depletant_queue_size = n_groups;
 
-        const size_t min_shared_bytes
-            = args.num_types * sizeof(typename Shape::param_type)
+        const size_t min_shared_bytes = args.num_types * sizeof(typename Shape::param_type)
                                         + args.overlap_idx.getNumElements() * sizeof(unsigned int);
 
         size_t shared_bytes = n_groups * (sizeof(Scalar4) + sizeof(Scalar3))
-            + max_queue_size * 2 * sizeof(unsigned int)
-            + max_depletant_queue_size * sizeof(unsigned int) + min_shared_bytes;
+                              + max_queue_size * 2 * sizeof(unsigned int)
+                              + max_depletant_queue_size * sizeof(unsigned int) + min_shared_bytes;
 
         if (min_shared_bytes >= args.devprop.sharedMemPerBlock)
             throw std::runtime_error("Insufficient shared memory for HPMC kernel: reduce number of "
@@ -729,8 +728,8 @@ void depletants_launcher(const hpmc_args_t& args,
             max_depletant_queue_size = n_groups;
 
             shared_bytes = n_groups * (sizeof(Scalar4) + sizeof(Scalar3))
-                + max_queue_size * 2 * sizeof(unsigned int)
-                + max_depletant_queue_size * sizeof(unsigned int) + min_shared_bytes;
+                           + max_queue_size * 2 * sizeof(unsigned int)
+                           + max_depletant_queue_size * sizeof(unsigned int) + min_shared_bytes;
             }
 
         // determine dynamically requested shared memory

--- a/hoomd/hpmc/IntegratorHPMCMonoGPUDepletantsAuxilliaryPhase1.cuh
+++ b/hoomd/hpmc/IntegratorHPMCMonoGPUDepletantsAuxilliaryPhase1.cuh
@@ -696,13 +696,13 @@ void depletants_launcher_phase1(const hpmc_args_t& args,
         unsigned int max_queue_size = n_groups * tpp;
         unsigned int max_depletant_queue_size = n_groups;
 
-        const size_t min_shared_bytes
-            = args.num_types * sizeof(typename Shape::param_type)
+        const size_t min_shared_bytes = args.num_types * sizeof(typename Shape::param_type)
                                         + args.overlap_idx.getNumElements() * sizeof(unsigned int);
 
         size_t shared_bytes = n_groups * (sizeof(Scalar4) + sizeof(Scalar3) + sizeof(unsigned int))
-            + max_queue_size * 2 * sizeof(unsigned int)
-            + max_depletant_queue_size * 2 * sizeof(unsigned int) + min_shared_bytes;
+                              + max_queue_size * 2 * sizeof(unsigned int)
+                              + max_depletant_queue_size * 2 * sizeof(unsigned int)
+                              + min_shared_bytes;
 
         if (min_shared_bytes >= args.devprop.sharedMemPerBlock)
             throw std::runtime_error("Insufficient shared memory for HPMC kernel: reduce number of "
@@ -721,8 +721,8 @@ void depletants_launcher_phase1(const hpmc_args_t& args,
             max_depletant_queue_size = n_groups;
 
             shared_bytes = n_groups * (sizeof(Scalar4) + sizeof(Scalar3) + sizeof(unsigned int))
-                + max_queue_size * 2 * sizeof(unsigned int)
-                + max_depletant_queue_size * 2 * sizeof(unsigned int) + min_shared_bytes;
+                           + max_queue_size * 2 * sizeof(unsigned int)
+                           + max_depletant_queue_size * 2 * sizeof(unsigned int) + min_shared_bytes;
             }
 
         // determine dynamically requested shared memory

--- a/hoomd/hpmc/IntegratorHPMCMonoGPUDepletantsAuxilliaryPhase1.cuh
+++ b/hoomd/hpmc/IntegratorHPMCMonoGPUDepletantsAuxilliaryPhase1.cuh
@@ -696,14 +696,13 @@ void depletants_launcher_phase1(const hpmc_args_t& args,
         unsigned int max_queue_size = n_groups * tpp;
         unsigned int max_depletant_queue_size = n_groups;
 
-        const unsigned int min_shared_bytes
-            = static_cast<unsigned int>(args.num_types * sizeof(typename Shape::param_type)
-                                        + args.overlap_idx.getNumElements() * sizeof(unsigned int));
+        const size_t min_shared_bytes
+            = args.num_types * sizeof(typename Shape::param_type)
+                                        + args.overlap_idx.getNumElements() * sizeof(unsigned int);
 
-        unsigned int shared_bytes = static_cast<unsigned int>(
-            n_groups * (sizeof(Scalar4) + sizeof(Scalar3) + sizeof(unsigned int))
+        size_t shared_bytes = n_groups * (sizeof(Scalar4) + sizeof(Scalar3) + sizeof(unsigned int))
             + max_queue_size * 2 * sizeof(unsigned int)
-            + max_depletant_queue_size * 2 * sizeof(unsigned int) + min_shared_bytes);
+            + max_depletant_queue_size * 2 * sizeof(unsigned int) + min_shared_bytes;
 
         if (min_shared_bytes >= args.devprop.sharedMemPerBlock)
             throw std::runtime_error("Insufficient shared memory for HPMC kernel: reduce number of "
@@ -721,10 +720,9 @@ void depletants_launcher_phase1(const hpmc_args_t& args,
             max_queue_size = n_groups * tpp;
             max_depletant_queue_size = n_groups;
 
-            shared_bytes = static_cast<unsigned int>(
-                n_groups * (sizeof(Scalar4) + sizeof(Scalar3) + sizeof(unsigned int))
+            shared_bytes = n_groups * (sizeof(Scalar4) + sizeof(Scalar3) + sizeof(unsigned int))
                 + max_queue_size * 2 * sizeof(unsigned int)
-                + max_depletant_queue_size * 2 * sizeof(unsigned int) + min_shared_bytes);
+                + max_depletant_queue_size * 2 * sizeof(unsigned int) + min_shared_bytes;
             }
 
         // determine dynamically requested shared memory

--- a/hoomd/hpmc/IntegratorHPMCMonoGPUDepletantsAuxilliaryPhase2.cuh
+++ b/hoomd/hpmc/IntegratorHPMCMonoGPUDepletantsAuxilliaryPhase2.cuh
@@ -733,15 +733,13 @@ void depletants_launcher_phase2(const hpmc_args_t& args,
         unsigned int max_queue_size = n_groups * tpp;
         unsigned int max_depletant_queue_size = n_groups;
 
-        const unsigned int min_shared_bytes
-            = static_cast<unsigned int>(args.num_types * sizeof(typename Shape::param_type)
-                                        + args.overlap_idx.getNumElements() * sizeof(unsigned int));
+        const size_t min_shared_bytes = args.num_types * sizeof(typename Shape::param_type)
+                                        + args.overlap_idx.getNumElements() * sizeof(unsigned int);
 
-        unsigned int shared_bytes = static_cast<unsigned int>(
-            n_groups * (sizeof(Scalar4) + sizeof(Scalar3) + sizeof(unsigned int))
+        size_t shared_bytes = n_groups * (sizeof(Scalar4) + sizeof(Scalar3) + sizeof(unsigned int))
             + max_queue_size * 2 * sizeof(unsigned int)
             + max_depletant_queue_size * 2 * sizeof(unsigned int)
-            + n_groups * auxilliary_args.max_len * sizeof(unsigned int) + min_shared_bytes);
+            + n_groups * auxilliary_args.max_len * sizeof(unsigned int) + min_shared_bytes;
 
         if (min_shared_bytes >= args.devprop.sharedMemPerBlock)
             throw std::runtime_error("Insufficient shared memory for HPMC kernel: reduce number of "
@@ -759,11 +757,10 @@ void depletants_launcher_phase2(const hpmc_args_t& args,
             max_queue_size = n_groups * tpp;
             max_depletant_queue_size = n_groups;
 
-            shared_bytes = static_cast<unsigned int>(
-                n_groups * (sizeof(Scalar4) + sizeof(Scalar3) + sizeof(unsigned int))
+            shared_bytes = n_groups * (sizeof(Scalar4) + sizeof(Scalar3) + sizeof(unsigned int))
                 + max_queue_size * 2 * sizeof(unsigned int)
                 + max_depletant_queue_size * 2 * sizeof(unsigned int)
-                + n_groups * auxilliary_args.max_len * sizeof(unsigned int) + min_shared_bytes);
+                + n_groups * auxilliary_args.max_len * sizeof(unsigned int) + min_shared_bytes;
             }
 
         // determine dynamically requested shared memory

--- a/hoomd/hpmc/IntegratorHPMCMonoGPUDepletantsAuxilliaryPhase2.cuh
+++ b/hoomd/hpmc/IntegratorHPMCMonoGPUDepletantsAuxilliaryPhase2.cuh
@@ -737,9 +737,10 @@ void depletants_launcher_phase2(const hpmc_args_t& args,
                                         + args.overlap_idx.getNumElements() * sizeof(unsigned int);
 
         size_t shared_bytes = n_groups * (sizeof(Scalar4) + sizeof(Scalar3) + sizeof(unsigned int))
-            + max_queue_size * 2 * sizeof(unsigned int)
-            + max_depletant_queue_size * 2 * sizeof(unsigned int)
-            + n_groups * auxilliary_args.max_len * sizeof(unsigned int) + min_shared_bytes;
+                              + max_queue_size * 2 * sizeof(unsigned int)
+                              + max_depletant_queue_size * 2 * sizeof(unsigned int)
+                              + n_groups * auxilliary_args.max_len * sizeof(unsigned int)
+                              + min_shared_bytes;
 
         if (min_shared_bytes >= args.devprop.sharedMemPerBlock)
             throw std::runtime_error("Insufficient shared memory for HPMC kernel: reduce number of "
@@ -758,9 +759,10 @@ void depletants_launcher_phase2(const hpmc_args_t& args,
             max_depletant_queue_size = n_groups;
 
             shared_bytes = n_groups * (sizeof(Scalar4) + sizeof(Scalar3) + sizeof(unsigned int))
-                + max_queue_size * 2 * sizeof(unsigned int)
-                + max_depletant_queue_size * 2 * sizeof(unsigned int)
-                + n_groups * auxilliary_args.max_len * sizeof(unsigned int) + min_shared_bytes;
+                           + max_queue_size * 2 * sizeof(unsigned int)
+                           + max_depletant_queue_size * 2 * sizeof(unsigned int)
+                           + n_groups * auxilliary_args.max_len * sizeof(unsigned int)
+                           + min_shared_bytes;
             }
 
         // determine dynamically requested shared memory

--- a/hoomd/hpmc/IntegratorHPMCMonoGPUMoves.cuh
+++ b/hoomd/hpmc/IntegratorHPMCMonoGPUMoves.cuh
@@ -295,7 +295,7 @@ void hpmc_gen_moves(const hpmc_args_t& args, const typename Shape::param_type* p
         // choose a block size based on the max block size by regs (max_block_size) and include
         // dynamic shared memory usage
         unsigned int block_size = min(args.block_size, (unsigned int)max_block_size);
-        unsigned int shared_bytes
+        size_t shared_bytes
             = args.num_types * (sizeof(typename Shape::param_type) + 2 * sizeof(Scalar));
 
         if (shared_bytes + attr.sharedSizeBytes >= args.devprop.sharedMemPerBlock)
@@ -351,7 +351,7 @@ void hpmc_gen_moves(const hpmc_args_t& args, const typename Shape::param_type* p
         // choose a block size based on the max block size by regs (max_block_size) and include
         // dynamic shared memory usage
         unsigned int block_size = min(args.block_size, (unsigned int)max_block_size);
-        unsigned int shared_bytes
+        size_t shared_bytes
             = args.num_types * (sizeof(typename Shape::param_type) + 2 * sizeof(Scalar));
 
         if (shared_bytes + attr.sharedSizeBytes >= args.devprop.sharedMemPerBlock)

--- a/hoomd/hpmc/UpdaterClustersGPU.cuh
+++ b/hoomd/hpmc/UpdaterClustersGPU.cuh
@@ -522,9 +522,8 @@ void cluster_overlaps_launcher(const cluster_args_t& args,
             = static_cast<unsigned int>(args.num_types * sizeof(typename Shape::param_type)
                                         + args.overlap_idx.getNumElements() * sizeof(unsigned int));
 
-        unsigned int shared_bytes = static_cast<unsigned int>(
-            n_groups * (2 * sizeof(unsigned int) + sizeof(Scalar4) + sizeof(Scalar3))
-            + max_queue_size * 2 * sizeof(unsigned int) + min_shared_bytes);
+        size_t shared_bytes = n_groups * (2 * sizeof(unsigned int) + sizeof(Scalar4) + sizeof(Scalar3))
+            + max_queue_size * 2 * sizeof(unsigned int) + min_shared_bytes;
 
         if (min_shared_bytes >= args.devprop.sharedMemPerBlock)
             throw std::runtime_error("Insufficient shared memory for HPMC kernel: reduce number of "
@@ -547,9 +546,8 @@ void cluster_overlaps_launcher(const cluster_args_t& args,
             n_groups = run_block_size / (tpp * overlap_threads);
             max_queue_size = n_groups * tpp;
 
-            shared_bytes = static_cast<unsigned int>(
-                n_groups * (2 * sizeof(unsigned int) + sizeof(Scalar4) + sizeof(Scalar3))
-                + max_queue_size * 2 * sizeof(unsigned int) + min_shared_bytes);
+            shared_bytes = n_groups * (2 * sizeof(unsigned int) + sizeof(Scalar4) + sizeof(Scalar3))
+                + max_queue_size * 2 * sizeof(unsigned int) + min_shared_bytes;
             }
 
         // determine dynamically allocated shared memory size
@@ -723,7 +721,7 @@ void transform_particles(const clusters_transform_args_t& args,
     // setup the grid to run the kernel
     unsigned int run_block_size = min(args.block_size, (unsigned int)max_block_size);
 
-    unsigned int shared_bytes = sizeof(typename Shape::param_type) * args.num_types;
+    const size_t shared_bytes = sizeof(typename Shape::param_type) * args.num_types;
 
     dim3 threads(run_block_size, 1, 1);
 

--- a/hoomd/hpmc/UpdaterClustersGPU.cuh
+++ b/hoomd/hpmc/UpdaterClustersGPU.cuh
@@ -522,8 +522,9 @@ void cluster_overlaps_launcher(const cluster_args_t& args,
             = static_cast<unsigned int>(args.num_types * sizeof(typename Shape::param_type)
                                         + args.overlap_idx.getNumElements() * sizeof(unsigned int));
 
-        size_t shared_bytes = n_groups * (2 * sizeof(unsigned int) + sizeof(Scalar4) + sizeof(Scalar3))
-            + max_queue_size * 2 * sizeof(unsigned int) + min_shared_bytes;
+        size_t shared_bytes
+            = n_groups * (2 * sizeof(unsigned int) + sizeof(Scalar4) + sizeof(Scalar3))
+              + max_queue_size * 2 * sizeof(unsigned int) + min_shared_bytes;
 
         if (min_shared_bytes >= args.devprop.sharedMemPerBlock)
             throw std::runtime_error("Insufficient shared memory for HPMC kernel: reduce number of "
@@ -547,7 +548,7 @@ void cluster_overlaps_launcher(const cluster_args_t& args,
             max_queue_size = n_groups * tpp;
 
             shared_bytes = n_groups * (2 * sizeof(unsigned int) + sizeof(Scalar4) + sizeof(Scalar3))
-                + max_queue_size * 2 * sizeof(unsigned int) + min_shared_bytes;
+                           + max_queue_size * 2 * sizeof(unsigned int) + min_shared_bytes;
             }
 
         // determine dynamically allocated shared memory size

--- a/hoomd/hpmc/UpdaterClustersGPUDepletants.cuh
+++ b/hoomd/hpmc/UpdaterClustersGPUDepletants.cuh
@@ -835,8 +835,8 @@ void clusters_depletants_launcher(const cluster_args_t& args,
                                         + args.overlap_idx.getNumElements() * sizeof(unsigned int));
 
         size_t shared_bytes = n_groups * (sizeof(Scalar4) + sizeof(Scalar3) + sizeof(unsigned int))
-            + max_queue_size * 2 * sizeof(unsigned int)
-            + max_depletant_queue_size * sizeof(unsigned int) + min_shared_bytes;
+                              + max_queue_size * 2 * sizeof(unsigned int)
+                              + max_depletant_queue_size * sizeof(unsigned int) + min_shared_bytes;
 
         if (min_shared_bytes >= args.devprop.sharedMemPerBlock)
             throw std::runtime_error("Insufficient shared memory for HPMC kernel: reduce number of "

--- a/hoomd/hpmc/UpdaterClustersGPUDepletants.cuh
+++ b/hoomd/hpmc/UpdaterClustersGPUDepletants.cuh
@@ -834,10 +834,9 @@ void clusters_depletants_launcher(const cluster_args_t& args,
             = static_cast<unsigned int>(args.num_types * sizeof(typename Shape::param_type)
                                         + args.overlap_idx.getNumElements() * sizeof(unsigned int));
 
-        unsigned int shared_bytes = static_cast<unsigned int>(
-            n_groups * (sizeof(Scalar4) + sizeof(Scalar3) + sizeof(unsigned int))
+        size_t shared_bytes = n_groups * (sizeof(Scalar4) + sizeof(Scalar3) + sizeof(unsigned int))
             + max_queue_size * 2 * sizeof(unsigned int)
-            + max_depletant_queue_size * sizeof(unsigned int) + min_shared_bytes);
+            + max_depletant_queue_size * sizeof(unsigned int) + min_shared_bytes;
 
         if (min_shared_bytes >= args.devprop.sharedMemPerBlock)
             throw std::runtime_error("Insufficient shared memory for HPMC kernel: reduce number of "

--- a/hoomd/jit/PatchEnergyJITGPU.cc
+++ b/hoomd/jit/PatchEnergyJITGPU.cc
@@ -39,13 +39,12 @@ void PatchEnergyJITGPU::computePatchEnergyGPU(const gpu_args_t& args, hipStream_
 
     unsigned int max_queue_size = n_groups * tpp;
 
-    const unsigned int min_shared_bytes = args.num_types * sizeof(Scalar);
+    const size_t min_shared_bytes = args.num_types * sizeof(Scalar);
 
-    unsigned int shared_bytes
-        = n_groups
-              * (sizeof(unsigned int) + 2 * sizeof(Scalar4) + 2 * sizeof(Scalar3)
-                 + 2 * sizeof(Scalar) + 2 * sizeof(float))
-          + max_queue_size * 2 * sizeof(unsigned int) + min_shared_bytes;
+    size_t shared_bytes = n_groups
+                              * (sizeof(unsigned int) + 2 * sizeof(Scalar4) + 2 * sizeof(Scalar3)
+                                 + 2 * sizeof(Scalar) + 2 * sizeof(float))
+                          + max_queue_size * 2 * sizeof(unsigned int) + min_shared_bytes;
 
     if (min_shared_bytes >= devprop.sharedMemPerBlock)
         throw std::runtime_error("Insufficient shared memory for HPMC kernel: reduce number of "
@@ -69,11 +68,10 @@ void PatchEnergyJITGPU::computePatchEnergyGPU(const gpu_args_t& args, hipStream_
         n_groups = run_block_size / (tpp * eval_threads);
         max_queue_size = n_groups * tpp;
 
-        shared_bytes
-            = (unsigned int)(n_groups
-                                 * (sizeof(unsigned int) + 2 * sizeof(Scalar4) + 2 * sizeof(Scalar3)
-                                    + 2 * sizeof(Scalar) + 2 * sizeof(float))
-                             + max_queue_size * 2 * sizeof(unsigned int) + min_shared_bytes);
+        shared_bytes = n_groups
+                           * (sizeof(unsigned int) + 2 * sizeof(Scalar4) + 2 * sizeof(Scalar3)
+                              + 2 * sizeof(Scalar) + 2 * sizeof(float))
+                       + max_queue_size * 2 * sizeof(unsigned int) + min_shared_bytes;
         }
 
     dim3 thread(eval_threads, n_groups, tpp);

--- a/hoomd/jit/PatchEnergyJITUnionGPU.cc
+++ b/hoomd/jit/PatchEnergyJITUnionGPU.cc
@@ -104,15 +104,13 @@ void PatchEnergyJITUnionGPU::computePatchEnergyGPU(const gpu_args_t& args, hipSt
     unsigned int n_groups = run_block_size / (tpp * eval_threads);
     unsigned int max_queue_size = n_groups * tpp;
 
-    const unsigned int min_shared_bytes
-        = (unsigned int)(args.num_types * sizeof(Scalar)
-                         + m_d_union_params.size() * sizeof(jit::union_params_t));
+    const size_t min_shared_bytes
+        = args.num_types * sizeof(Scalar) + m_d_union_params.size() * sizeof(jit::union_params_t);
 
-    unsigned int shared_bytes
-        = (unsigned int)(n_groups
-                             * (sizeof(unsigned int) + 2 * sizeof(Scalar4) + 2 * sizeof(Scalar3)
-                                + 2 * sizeof(Scalar) + 2 * sizeof(float))
-                         + max_queue_size * 2 * sizeof(unsigned int) + min_shared_bytes);
+    size_t shared_bytes = n_groups
+                              * (sizeof(unsigned int) + 2 * sizeof(Scalar4) + 2 * sizeof(Scalar3)
+                                 + 2 * sizeof(Scalar) + 2 * sizeof(float))
+                          + max_queue_size * 2 * sizeof(unsigned int) + min_shared_bytes;
 
     if (min_shared_bytes >= devprop.sharedMemPerBlock)
         throw std::runtime_error("Insufficient shared memory for HPMC kernel: reduce number of "
@@ -137,11 +135,10 @@ void PatchEnergyJITUnionGPU::computePatchEnergyGPU(const gpu_args_t& args, hipSt
 
         max_queue_size = n_groups * tpp;
 
-        shared_bytes
-            = (unsigned int)(n_groups
-                                 * (sizeof(unsigned int) + 2 * sizeof(Scalar4) + 2 * sizeof(Scalar3)
-                                    + 2 * sizeof(Scalar) + 2 * sizeof(float))
-                             + max_queue_size * 2 * sizeof(unsigned int) + min_shared_bytes);
+        shared_bytes = n_groups
+                           * (sizeof(unsigned int) + 2 * sizeof(Scalar4) + 2 * sizeof(Scalar3)
+                              + 2 * sizeof(Scalar) + 2 * sizeof(float))
+                       + max_queue_size * 2 * sizeof(unsigned int) + min_shared_bytes;
         }
 
     // allocate some extra shared mem to store union shape parameters

--- a/hoomd/md/AnisoPotentialPairGPU.cuh
+++ b/hoomd/md/AnisoPotentialPairGPU.cuh
@@ -428,10 +428,9 @@ struct AnisoPairForceComputeKernel
             unsigned int block_size = pair_args.block_size;
 
             Index2D typpair_idx(pair_args.ntypes);
-            size_t shared_bytes
-                = (2 * sizeof(Scalar) + sizeof(typename evaluator::param_type))
-                                     * typpair_idx.getNumElements()
-                                 + sizeof(typename evaluator::shape_type) * pair_args.ntypes;
+            size_t shared_bytes = (2 * sizeof(Scalar) + sizeof(typename evaluator::param_type))
+                                      * typpair_idx.getNumElements()
+                                  + sizeof(typename evaluator::shape_type) * pair_args.ntypes;
 
             static unsigned int max_block_size = UINT_MAX;
             hipFuncAttributes attr;

--- a/hoomd/md/AnisoPotentialPairGPU.cuh
+++ b/hoomd/md/AnisoPotentialPairGPU.cuh
@@ -428,10 +428,10 @@ struct AnisoPairForceComputeKernel
             unsigned int block_size = pair_args.block_size;
 
             Index2D typpair_idx(pair_args.ntypes);
-            unsigned int shared_bytes
-                = (unsigned int)((2 * sizeof(Scalar) + sizeof(typename evaluator::param_type))
+            size_t shared_bytes
+                = (2 * sizeof(Scalar) + sizeof(typename evaluator::param_type))
                                      * typpair_idx.getNumElements()
-                                 + sizeof(typename evaluator::shape_type) * pair_args.ntypes);
+                                 + sizeof(typename evaluator::shape_type) * pair_args.ntypes;
 
             static unsigned int max_block_size = UINT_MAX;
             hipFuncAttributes attr;

--- a/hoomd/md/ComputeThermoGPU.cu
+++ b/hoomd/md/ComputeThermoGPU.cu
@@ -559,7 +559,7 @@ hipError_t gpu_compute_thermo_partial(Scalar* d_properties,
         dim3 grid(nwork / args.block_size + 1, 1, 1);
         dim3 threads(args.block_size, 1, 1);
 
-        unsigned int shared_bytes = (unsigned int)(sizeof(Scalar3) * args.block_size);
+        size_t shared_bytes = sizeof(Scalar3) * args.block_size;
 
         hipLaunchKernelGGL(gpu_compute_thermo_partial_sums,
                            dim3(grid),
@@ -582,7 +582,7 @@ hipError_t gpu_compute_thermo_partial(Scalar* d_properties,
             {
             assert(args.d_scratch_pressure_tensor);
 
-            shared_bytes = (unsigned int)(6 * sizeof(Scalar) * args.block_size);
+            shared_bytes = 6 * sizeof(Scalar) * args.block_size;
 
             // run the kernel
             hipLaunchKernelGGL(gpu_compute_pressure_tensor_partial_sums,
@@ -608,7 +608,7 @@ hipError_t gpu_compute_thermo_partial(Scalar* d_properties,
             {
             assert(args.d_scratch_pressure_tensor);
 
-            shared_bytes = (unsigned int)(sizeof(Scalar) * args.block_size);
+            shared_bytes = sizeof(Scalar) * args.block_size;
 
             // run the kernel
             hipLaunchKernelGGL(gpu_compute_rotational_ke_partial_sums,
@@ -676,7 +676,7 @@ hipError_t gpu_compute_thermo_final(Scalar* d_properties,
     dim3 grid = dim3(1, 1, 1);
     dim3 threads = dim3(final_block_size, 1, 1);
 
-    unsigned int shared_bytes = (unsigned int)(sizeof(Scalar4) * final_block_size);
+    size_t shared_bytes = sizeof(Scalar4) * final_block_size;
 
     Scalar external_virial
         = Scalar(1.0 / 3.0)
@@ -701,7 +701,7 @@ hipError_t gpu_compute_thermo_final(Scalar* d_properties,
 
     if (compute_pressure_tensor)
         {
-        shared_bytes = (unsigned int)(6 * sizeof(Scalar) * final_block_size);
+        shared_bytes = 6 * sizeof(Scalar) * final_block_size;
         // run the kernel
         hipLaunchKernelGGL(gpu_compute_pressure_tensor_final_sums,
                            dim3(grid),

--- a/hoomd/md/ComputeThermoHMAGPU.cu
+++ b/hoomd/md/ComputeThermoHMAGPU.cu
@@ -283,7 +283,7 @@ hipError_t gpu_compute_thermo_hma_partial(Scalar4* d_pos,
         dim3 grid(nwork / args.block_size + 1, 1, 1);
         dim3 threads(args.block_size, 1, 1);
 
-        unsigned int shared_bytes = (unsigned int)(sizeof(Scalar3) * args.block_size);
+        const size_t shared_bytes = sizeof(Scalar3) * args.block_size;
 
         gpu_compute_thermo_hma_partial_sums<<<grid, threads, shared_bytes>>>(args.d_scratch,
                                                                              box,
@@ -341,7 +341,7 @@ hipError_t gpu_compute_thermo_hma_final(Scalar* d_properties,
     dim3 grid = dim3(1, 1, 1);
     dim3 threads = dim3(final_block_size, 1, 1);
 
-    unsigned int shared_bytes = (unsigned int)(sizeof(Scalar3) * final_block_size);
+    const size_t shared_bytes = sizeof(Scalar3) * final_block_size;
 
     Scalar external_virial
         = Scalar(1.0 / 3.0)

--- a/hoomd/md/ForceCompositeGPU.cu
+++ b/hoomd/md/ForceCompositeGPU.cu
@@ -493,18 +493,16 @@ hipError_t gpu_rigid_force(Scalar4* d_force,
         unsigned int window_size = run_block_size / n_bodies_per_block;
         unsigned int thread_mask = window_size - 1;
 
-        unsigned int shared_bytes
-            = (unsigned int)(run_block_size * (sizeof(Scalar4) + sizeof(Scalar3))
-                             + n_bodies_per_block * (sizeof(Scalar4) + 3 * sizeof(unsigned int)));
+        size_t shared_bytes = run_block_size * (sizeof(Scalar4) + sizeof(Scalar3))
+                              + n_bodies_per_block * (sizeof(Scalar4) + 3 * sizeof(unsigned int));
 
         while (shared_bytes + attr.sharedSizeBytes >= dev_prop.sharedMemPerBlock)
             {
             // block size is power of two
             run_block_size /= 2;
 
-            shared_bytes = (unsigned int)(run_block_size * (sizeof(Scalar4) + sizeof(Scalar3))
-                                          + n_bodies_per_block
-                                                * (sizeof(Scalar4) + 3 * sizeof(unsigned int)));
+            shared_bytes = run_block_size * (sizeof(Scalar4) + sizeof(Scalar3))
+                           + n_bodies_per_block * (sizeof(Scalar4) + 3 * sizeof(unsigned int));
 
             window_size = run_block_size / n_bodies_per_block;
             thread_mask = window_size - 1;
@@ -598,18 +596,16 @@ hipError_t gpu_rigid_virial(Scalar* d_virial,
         unsigned int window_size = run_block_size / n_bodies_per_block;
         unsigned int thread_mask = window_size - 1;
 
-        unsigned int shared_bytes
-            = (unsigned int)(6 * run_block_size * sizeof(Scalar)
-                             + n_bodies_per_block * (sizeof(Scalar4) + 3 * sizeof(unsigned int)));
+        size_t shared_bytes = 6 * run_block_size * sizeof(Scalar)
+                              + n_bodies_per_block * (sizeof(Scalar4) + 3 * sizeof(unsigned int));
 
         while (shared_bytes + attr.sharedSizeBytes >= dev_prop.sharedMemPerBlock)
             {
             // block size is power of two
             run_block_size /= 2;
 
-            shared_bytes = (unsigned int)(6 * run_block_size * sizeof(Scalar)
-                                          + n_bodies_per_block
-                                                * (sizeof(Scalar4) + 3 * sizeof(unsigned int)));
+            shared_bytes = 6 * run_block_size * sizeof(Scalar)
+                           + n_bodies_per_block * (sizeof(Scalar4) + 3 * sizeof(unsigned int));
 
             window_size = run_block_size / n_bodies_per_block;
             thread_mask = window_size - 1;

--- a/hoomd/md/NeighborListGPU.cu
+++ b/hoomd/md/NeighborListGPU.cu
@@ -104,7 +104,7 @@ hipError_t gpu_nlist_needs_update_check_new(unsigned int* d_result,
                                             const unsigned int checkn,
                                             const GPUPartition& gpu_partition)
     {
-    const unsigned int shared_bytes = (unsigned int)sizeof(Scalar) * ntypes;
+    const size_t shared_bytes = sizeof(Scalar) * ntypes;
 
     unsigned int block_size = 128;
 
@@ -454,7 +454,7 @@ hipError_t gpu_nlist_build_head_list(unsigned int* d_head_list,
         }
 
     unsigned int run_block_size = min(block_size, max_block_size);
-    unsigned int shared_bytes = (unsigned int)(ntypes * sizeof(unsigned int));
+    const size_t shared_bytes = ntypes * sizeof(unsigned int);
 
     // initialize each particle with its number of neighbors
     hipLaunchKernelGGL((gpu_nlist_init_head_list_kernel),

--- a/hoomd/md/PPPMForceComputeGPU.cu
+++ b/hoomd/md/PPPMForceComputeGPU.cu
@@ -360,7 +360,7 @@ void gpu_assign_particles(const uint3 mesh_dim,
 
         unsigned int nwork = range.second - range.first;
         unsigned int n_blocks = nwork / run_block_size + 1;
-        unsigned int shared_bytes = (unsigned int)(order * (2 * order + 1) * sizeof(Scalar));
+        const size_t shared_bytes = order * (2 * order + 1) * sizeof(Scalar);
 
         hipLaunchKernelGGL((gpu_assign_particles_kernel),
                            dim3(n_blocks),
@@ -736,7 +736,7 @@ void gpu_compute_forces(const unsigned int N,
 
         unsigned int nwork = range.second - range.first;
         unsigned int n_blocks = nwork / run_block_size + 1;
-        unsigned int shared_bytes = (unsigned int)(order * (2 * order + 1) * sizeof(Scalar));
+        const size_t shared_bytes = order * (2 * order + 1) * sizeof(Scalar);
 
         hipLaunchKernelGGL(
             (gpu_compute_forces_kernel),

--- a/hoomd/md/PotentialBondGPU.cuh
+++ b/hoomd/md/PotentialBondGPU.cuh
@@ -265,8 +265,7 @@ hipError_t gpu_compute_bond_forces(const bond_args_t& bond_args,
     dim3 grid(bond_args.N / run_block_size + 1, 1, 1);
     dim3 threads(run_block_size, 1, 1);
 
-    unsigned int shared_bytes
-        = (unsigned int)(sizeof(typename evaluator::param_type) * bond_args.n_bond_types);
+    const size_t shared_bytes = sizeof(typename evaluator::param_type) * bond_args.n_bond_types;
 
     // run the kernel
     hipLaunchKernelGGL(gpu_compute_bond_forces_kernel<evaluator>,

--- a/hoomd/md/PotentialPairDPDThermoGPU.cuh
+++ b/hoomd/md/PotentialPairDPDThermoGPU.cuh
@@ -369,9 +369,8 @@ struct DPDForceComputeKernel
             unsigned int block_size = args.block_size;
 
             Index2D typpair_idx(args.ntypes);
-            const size_t shared_bytes
-                = (sizeof(Scalar) + sizeof(typename evaluator::param_type))
-                                 * typpair_idx.getNumElements();
+            const size_t shared_bytes = (sizeof(Scalar) + sizeof(typename evaluator::param_type))
+                                        * typpair_idx.getNumElements();
 
             static unsigned int max_block_size = UINT_MAX;
             if (max_block_size == UINT_MAX)

--- a/hoomd/md/PotentialPairDPDThermoGPU.cuh
+++ b/hoomd/md/PotentialPairDPDThermoGPU.cuh
@@ -369,9 +369,9 @@ struct DPDForceComputeKernel
             unsigned int block_size = args.block_size;
 
             Index2D typpair_idx(args.ntypes);
-            unsigned int shared_bytes
-                = (unsigned int)((sizeof(Scalar) + sizeof(typename evaluator::param_type))
-                                 * typpair_idx.getNumElements());
+            const size_t shared_bytes
+                = (sizeof(Scalar) + sizeof(typename evaluator::param_type))
+                                 * typpair_idx.getNumElements();
 
             static unsigned int max_block_size = UINT_MAX;
             if (max_block_size == UINT_MAX)

--- a/hoomd/md/PotentialPairGPU.cuh
+++ b/hoomd/md/PotentialPairGPU.cuh
@@ -409,9 +409,9 @@ struct PairForceComputeKernel
             unsigned int block_size = pair_args.block_size;
 
             Index2D typpair_idx(pair_args.ntypes);
-            unsigned int shared_bytes
-                = (unsigned int)((2 * sizeof(Scalar) + sizeof(typename evaluator::param_type))
-                                 * typpair_idx.getNumElements());
+            const size_t shared_bytes
+                = (2 * sizeof(Scalar) + sizeof(typename evaluator::param_type))
+                                 * typpair_idx.getNumElements();
 
             static unsigned int max_block_size = UINT_MAX;
             if (max_block_size == UINT_MAX)

--- a/hoomd/md/PotentialPairGPU.cuh
+++ b/hoomd/md/PotentialPairGPU.cuh
@@ -411,7 +411,7 @@ struct PairForceComputeKernel
             Index2D typpair_idx(pair_args.ntypes);
             const size_t shared_bytes
                 = (2 * sizeof(Scalar) + sizeof(typename evaluator::param_type))
-                                 * typpair_idx.getNumElements();
+                  * typpair_idx.getNumElements();
 
             static unsigned int max_block_size = UINT_MAX;
             if (max_block_size == UINT_MAX)

--- a/hoomd/md/PotentialTersoffGPU.cuh
+++ b/hoomd/md/PotentialTersoffGPU.cuh
@@ -937,19 +937,19 @@ template<class evaluator, unsigned int compute_virial, int tpp> struct TersoffCo
 
             // size shared bytes
             Index2D typpair_idx(pair_args.ntypes);
-            unsigned int shared_bytes
-                = (unsigned int)((sizeof(Scalar) + sizeof(typename evaluator::param_type))
+            size_t shared_bytes
+                = (sizeof(Scalar) + sizeof(typename evaluator::param_type))
                                      * typpair_idx.getNumElements()
-                                 + pair_args.ntypes * run_block_size * sizeof(Scalar));
+                                 + pair_args.ntypes * run_block_size * sizeof(Scalar);
 
             while (shared_bytes + kernel_shared_bytes >= pair_args.devprop.sharedMemPerBlock)
                 {
                 run_block_size -= pair_args.devprop.warpSize;
 
                 shared_bytes
-                    = (unsigned int)((sizeof(Scalar) + sizeof(typename evaluator::param_type))
+                    = (sizeof(Scalar) + sizeof(typename evaluator::param_type))
                                          * typpair_idx.getNumElements()
-                                     + pair_args.ntypes * run_block_size * sizeof(Scalar));
+                                     + pair_args.ntypes * run_block_size * sizeof(Scalar);
                 }
 
             // zero the forces

--- a/hoomd/md/PotentialTersoffGPU.cuh
+++ b/hoomd/md/PotentialTersoffGPU.cuh
@@ -937,19 +937,17 @@ template<class evaluator, unsigned int compute_virial, int tpp> struct TersoffCo
 
             // size shared bytes
             Index2D typpair_idx(pair_args.ntypes);
-            size_t shared_bytes
-                = (sizeof(Scalar) + sizeof(typename evaluator::param_type))
-                                     * typpair_idx.getNumElements()
-                                 + pair_args.ntypes * run_block_size * sizeof(Scalar);
+            size_t shared_bytes = (sizeof(Scalar) + sizeof(typename evaluator::param_type))
+                                      * typpair_idx.getNumElements()
+                                  + pair_args.ntypes * run_block_size * sizeof(Scalar);
 
             while (shared_bytes + kernel_shared_bytes >= pair_args.devprop.sharedMemPerBlock)
                 {
                 run_block_size -= pair_args.devprop.warpSize;
 
-                shared_bytes
-                    = (sizeof(Scalar) + sizeof(typename evaluator::param_type))
-                                         * typpair_idx.getNumElements()
-                                     + pair_args.ntypes * run_block_size * sizeof(Scalar);
+                shared_bytes = (sizeof(Scalar) + sizeof(typename evaluator::param_type))
+                                   * typpair_idx.getNumElements()
+                               + pair_args.ntypes * run_block_size * sizeof(Scalar);
                 }
 
             // zero the forces

--- a/hoomd/mpcd/SlitPoreGeometryFillerGPU.cu
+++ b/hoomd/mpcd/SlitPoreGeometryFillerGPU.cu
@@ -170,7 +170,7 @@ cudaError_t slit_pore_draw_particles(Scalar4* d_pos,
 
     unsigned int run_block_size = min(block_size, max_block_size);
     dim3 grid(N_tot / run_block_size + 1);
-    const unsigned int shared_bytes = (unsigned int)(num_boxes * (sizeof(Scalar4) + sizeof(uint2)));
+    const size_t shared_bytes = num_boxes * (sizeof(Scalar4) + sizeof(uint2));
     kernel::slit_pore_draw_particles<<<grid, run_block_size, shared_bytes>>>(d_pos,
                                                                              d_vel,
                                                                              d_tag,


### PR DESCRIPTION
## Description

Use `size_t` for the number of shared memory bytes for most (all?) kernels.

I did a find/replace for `unsigned int shared_bytes` so it's possible that I missed some kernels where the variable names are different. I also added `const` to some instances of `shared_bytes`, where appropriate.

## Motivation and context

I was seeing compiler warnings when building HOOMD. These arose from the implicit casts of `unsigned int` to `long unsigned int` (the same as `size_t` on my system) for amounts of shared memory passed to CUDA kernels. Several places in the source code use explicit C-style casts `(unsigned int)(value)` or `static_cast<unsigned int>(value)` to avoid this kind of warning, but the actual data is probably best represented as `size_t`. Most of the places where this is used call `sizeof(T)`, which returns `size_t`, and the [HIP programming guide](https://rocmdocs.amd.com/en/latest/Programming_Guides/HIP-GUIDE.html) also says this value should be `size_t` when passed to the kernel run function.

This code path last changed in #809, which added the explicit casts in several places. It is likely that the new warnings I saw were from other PRs that were merged since then.


Sample warnings:

```
[356/525] Building CUDA object hoomd/hpmc/CMakeFiles/_hpmc.dir/kernel_gen_moves_ShapeSphere.cu.o
../hoomd/hpmc/IntegratorHPMCMonoGPUMoves.cuh: In instantiation of ‘void hpmc::gpu::hpmc_gen_moves(const hpmc::gpu::hpmc_args_t&, const typename Shape::param_type*) [with Shape = hpmc::ShapeSphere; typename Shape::param_type = hpmc::SphereParams]’:
hoomd/hpmc/kernel_gen_moves_ShapeSphere.cu:30:109:   required from here
../hoomd/hpmc/IntegratorHPMCMonoGPUMoves.cuh:298:43: warning: conversion from ‘long unsigned int’ to ‘unsigned int’ may change value [-Wconversion]
  298 |         unsigned int shared_bytes
      |                         ~~~~~~~~~         ^
../hoomd/hpmc/IntegratorHPMCMonoGPUMoves.cuh:354:43: warning: conversion from ‘long unsigned int’ to ‘unsigned int’ may change value [-Wconversion]
  354 |         unsigned int shared_bytes
      |                         ~~~~~~~~~         ^

...

[426/525] Building CUDA object hoomd/hpmc/CMakeFiles/_hpmc.dir/kernel_cluster_transform_ShapeSphere.cu.o
../hoomd/hpmc/UpdaterClustersGPU.cuh: In instantiation of ‘void hpmc::gpu::transform_particles(const hpmc::gpu::clusters_transform_args_t&, const typename Shape::param_type*) [with Shape = hpmc::ShapeSphere; typename Shape::param_type = hpmc::SphereParams]’:
hoomd/hpmc/kernel_cluster_transform_ShapeSphere.cu:30:130:   required from here
../hoomd/hpmc/UpdaterClustersGPU.cuh:726:60: warning: conversion from ‘long unsigned int’ to ‘unsigned int’ may change value [-Wconversion]
  726 |     unsigned int shared_bytes = sizeof(typename Shape::param_type) * args.num_types;
      |                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~
```

## How has this been tested?

HOOMD builds without warnings now.

Compiler versions tested
```
gcc (Ubuntu 9.3.0-17ubuntu1~20.04) 9.3.0
nvcc: release 11.0, V11.0.221
```
****
## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
