### PR TITLE
Testing GitHub Actions running on Jetstream

### DIFF
--- a/.github/workflows/make_workflows.py
+++ b/.github/workflows/make_workflows.py
@@ -31,16 +31,12 @@ if __name__ == '__main__':
     for name, configuration in configurations.items():
         for entry in configuration:
             if entry['config'].startswith('[cuda'):
-                entry['runner'] = "[self-hosted,GPU]"
+                entry['runner'] = "[self-hosted,Jetstream-GPU]"
                 # device options needed to access the GPU devices on the runners
                 # because the nvidia container toolkit is built without cgroups
                 # support:
                 # https://aur.archlinux.org/packages/nvidia-container-toolkit
-                entry['docker_options'] = "--gpus=all --device /dev/nvidia0 " \
-                    "--device /dev/nvidia1 " \
-                    "--device /dev/nvidia-uvm " \
-                    "--device /dev/nvidia-uvm-tools " \
-                    "--device /dev/nvidiactl"
+                entry['docker_options'] = "--gpus=all"
             else:
                 entry['runner'] = "ubuntu-latest"
                 entry['docker_options'] = ""

--- a/.github/workflows/templates/test.yml
+++ b/.github/workflows/templates/test.yml
@@ -34,7 +34,7 @@ env:
     runs-on: ${{ matrix.runner }}
     container:
       image: << container_prefix >>-${{ matrix.config[0] }}
-      options: ${{ matrix.docker_options }}
+      options: ${{ matrix.docker_options }} -e CUDA_VISIBLE_DEVICES
     <% else %>
     runs-on: ubuntu-latest
     container:

--- a/.github/workflows/templates/test.yml
+++ b/.github/workflows/templates/test.yml
@@ -34,7 +34,7 @@ env:
     runs-on: ${{ matrix.runner }}
     container:
       image: << container_prefix >>-${{ matrix.config[0] }}
-      options: ${{ matrix.docker_options }} -e CUDA_VISIBLE_DEVICES
+      options: ${{ matrix.docker_options }}
     <% else %>
     runs-on: ubuntu-latest
     container:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,8 +56,8 @@ jobs:
         include:
         - {config: [clang11_py39, mpi, tbb, jit], runner: ubuntu-latest, docker_options: '' }
         - {config: [gcc10_py39], runner: ubuntu-latest, docker_options: '' }
-        - {config: [cuda11_gcc9_py38, mpi], runner: [self-hosted,GPU], docker_options: '--gpus=all --device /dev/nvidia0 --device /dev/nvidia1 --device /dev/nvidia-uvm --device /dev/nvidia-uvm-tools --device /dev/nvidiactl' }
-        - {config: [cuda11_gcc9_py38], runner: [self-hosted,GPU], docker_options: '--gpus=all --device /dev/nvidia0 --device /dev/nvidia1 --device /dev/nvidia-uvm --device /dev/nvidia-uvm-tools --device /dev/nvidiactl' }
+        - {config: [cuda11_gcc9_py38, mpi], runner: [self-hosted,Jetstream-GPU], docker_options: '--gpus=all' }
+        - {config: [cuda11_gcc9_py38], runner: [self-hosted,Jetstream-GPU], docker_options: '--gpus=all' }
 
     env:
       CXXFLAGS: '-Werror'
@@ -119,14 +119,14 @@ jobs:
     runs-on: ${{ matrix.runner }}
     container:
       image: glotzerlab/ci:2021.05-${{ matrix.config[0] }}
-      options: ${{ matrix.docker_options }} -e CUDA_VISIBLE_DEVICES
+      options: ${{ matrix.docker_options }}
     strategy:
       matrix:
         include:
         - {config: [clang11_py39, mpi, tbb, jit], runner: ubuntu-latest, docker_options: '' }
         - {config: [gcc10_py39], runner: ubuntu-latest, docker_options: '' }
-        - {config: [cuda11_gcc9_py38, mpi], runner: [self-hosted,GPU], docker_options: '--gpus=all --device /dev/nvidia0 --device /dev/nvidia1 --device /dev/nvidia-uvm --device /dev/nvidia-uvm-tools --device /dev/nvidiactl' }
-        - {config: [cuda11_gcc9_py38], runner: [self-hosted,GPU], docker_options: '--gpus=all --device /dev/nvidia0 --device /dev/nvidia1 --device /dev/nvidia-uvm --device /dev/nvidia-uvm-tools --device /dev/nvidiactl' }
+        - {config: [cuda11_gcc9_py38, mpi], runner: [self-hosted,Jetstream-GPU], docker_options: '--gpus=all' }
+        - {config: [cuda11_gcc9_py38], runner: [self-hosted,Jetstream-GPU], docker_options: '--gpus=all' }
 
     steps:
     - name: Clean workspace
@@ -162,14 +162,14 @@ jobs:
     runs-on: ${{ matrix.runner }}
     container:
       image: glotzerlab/ci:2021.05-${{ matrix.config[0] }}
-      options: ${{ matrix.docker_options }} -e CUDA_VISIBLE_DEVICES
+      options: ${{ matrix.docker_options }}
     strategy:
       matrix:
         include:
         - {config: [clang11_py39, mpi, tbb, jit], runner: ubuntu-latest, docker_options: '' }
         - {config: [gcc10_py39], runner: ubuntu-latest, docker_options: '' }
-        - {config: [cuda11_gcc9_py38, mpi], runner: [self-hosted,GPU], docker_options: '--gpus=all --device /dev/nvidia0 --device /dev/nvidia1 --device /dev/nvidia-uvm --device /dev/nvidia-uvm-tools --device /dev/nvidiactl' }
-        - {config: [cuda11_gcc9_py38], runner: [self-hosted,GPU], docker_options: '--gpus=all --device /dev/nvidia0 --device /dev/nvidia1 --device /dev/nvidia-uvm --device /dev/nvidia-uvm-tools --device /dev/nvidiactl' }
+        - {config: [cuda11_gcc9_py38, mpi], runner: [self-hosted,Jetstream-GPU], docker_options: '--gpus=all' }
+        - {config: [cuda11_gcc9_py38], runner: [self-hosted,Jetstream-GPU], docker_options: '--gpus=all' }
 
     steps:
     - name: Clean workspace
@@ -198,14 +198,14 @@ jobs:
     runs-on: ${{ matrix.runner }}
     container:
       image: glotzerlab/ci:2021.05-${{ matrix.config[0] }}
-      options: ${{ matrix.docker_options }} -e CUDA_VISIBLE_DEVICES
+      options: ${{ matrix.docker_options }}
     strategy:
       matrix:
         include:
         - {config: [clang11_py39, mpi, tbb, jit], runner: ubuntu-latest, docker_options: '' }
         - {config: [gcc10_py39], runner: ubuntu-latest, docker_options: '' }
-        - {config: [cuda11_gcc9_py38, mpi], runner: [self-hosted,GPU], docker_options: '--gpus=all --device /dev/nvidia0 --device /dev/nvidia1 --device /dev/nvidia-uvm --device /dev/nvidia-uvm-tools --device /dev/nvidiactl' }
-        - {config: [cuda11_gcc9_py38], runner: [self-hosted,GPU], docker_options: '--gpus=all --device /dev/nvidia0 --device /dev/nvidia1 --device /dev/nvidia-uvm --device /dev/nvidia-uvm-tools --device /dev/nvidiactl' }
+        - {config: [cuda11_gcc9_py38, mpi], runner: [self-hosted,Jetstream-GPU], docker_options: '--gpus=all' }
+        - {config: [cuda11_gcc9_py38], runner: [self-hosted,Jetstream-GPU], docker_options: '--gpus=all' }
 
     if: ${{ contains(github.event.pull_request.labels.*.name, 'validate') }}
     steps:
@@ -235,7 +235,7 @@ jobs:
     strategy:
       matrix:
         include:
-        - {config: [cuda10_gcc7_py37], runner: [self-hosted,GPU], docker_options: '--gpus=all --device /dev/nvidia0 --device /dev/nvidia1 --device /dev/nvidia-uvm --device /dev/nvidia-uvm-tools --device /dev/nvidiactl' }
+        - {config: [cuda10_gcc7_py37], runner: [self-hosted,Jetstream-GPU], docker_options: '--gpus=all' }
         - {config: [clang10_py38, jit], runner: ubuntu-latest, docker_options: '' }
         - {config: [gcc9_py38], runner: ubuntu-latest, docker_options: '' }
         - {config: [clang9_py38, jit], runner: ubuntu-latest, docker_options: '' }
@@ -305,11 +305,11 @@ jobs:
     runs-on: ${{ matrix.runner }}
     container:
       image: glotzerlab/ci:2021.05-${{ matrix.config[0] }}
-      options: ${{ matrix.docker_options }} -e CUDA_VISIBLE_DEVICES
+      options: ${{ matrix.docker_options }}
     strategy:
       matrix:
         include:
-        - {config: [cuda10_gcc7_py37], runner: [self-hosted,GPU], docker_options: '--gpus=all --device /dev/nvidia0 --device /dev/nvidia1 --device /dev/nvidia-uvm --device /dev/nvidia-uvm-tools --device /dev/nvidiactl' }
+        - {config: [cuda10_gcc7_py37], runner: [self-hosted,Jetstream-GPU], docker_options: '--gpus=all' }
         - {config: [clang10_py38, jit], runner: ubuntu-latest, docker_options: '' }
         - {config: [gcc9_py38], runner: ubuntu-latest, docker_options: '' }
         - {config: [clang9_py38, jit], runner: ubuntu-latest, docker_options: '' }
@@ -355,11 +355,11 @@ jobs:
     runs-on: ${{ matrix.runner }}
     container:
       image: glotzerlab/ci:2021.05-${{ matrix.config[0] }}
-      options: ${{ matrix.docker_options }} -e CUDA_VISIBLE_DEVICES
+      options: ${{ matrix.docker_options }}
     strategy:
       matrix:
         include:
-        - {config: [cuda10_gcc7_py37], runner: [self-hosted,GPU], docker_options: '--gpus=all --device /dev/nvidia0 --device /dev/nvidia1 --device /dev/nvidia-uvm --device /dev/nvidia-uvm-tools --device /dev/nvidiactl' }
+        - {config: [cuda10_gcc7_py37], runner: [self-hosted,Jetstream-GPU], docker_options: '--gpus=all' }
         - {config: [clang10_py38, jit], runner: ubuntu-latest, docker_options: '' }
         - {config: [gcc9_py38], runner: ubuntu-latest, docker_options: '' }
         - {config: [clang9_py38, jit], runner: ubuntu-latest, docker_options: '' }

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -119,7 +119,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
     container:
       image: glotzerlab/ci:2021.05-${{ matrix.config[0] }}
-      options: ${{ matrix.docker_options }}
+      options: ${{ matrix.docker_options }} -e CUDA_VISIBLE_DEVICES
     strategy:
       matrix:
         include:
@@ -162,7 +162,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
     container:
       image: glotzerlab/ci:2021.05-${{ matrix.config[0] }}
-      options: ${{ matrix.docker_options }}
+      options: ${{ matrix.docker_options }} -e CUDA_VISIBLE_DEVICES
     strategy:
       matrix:
         include:
@@ -198,7 +198,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
     container:
       image: glotzerlab/ci:2021.05-${{ matrix.config[0] }}
-      options: ${{ matrix.docker_options }}
+      options: ${{ matrix.docker_options }} -e CUDA_VISIBLE_DEVICES
     strategy:
       matrix:
         include:
@@ -305,7 +305,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
     container:
       image: glotzerlab/ci:2021.05-${{ matrix.config[0] }}
-      options: ${{ matrix.docker_options }}
+      options: ${{ matrix.docker_options }} -e CUDA_VISIBLE_DEVICES
     strategy:
       matrix:
         include:
@@ -355,7 +355,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
     container:
       image: glotzerlab/ci:2021.05-${{ matrix.config[0] }}
-      options: ${{ matrix.docker_options }}
+      options: ${{ matrix.docker_options }} -e CUDA_VISIBLE_DEVICES
     strategy:
       matrix:
         include:


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should based on *maint*. -->
<!-- New features should based on *master*. -->

## Description

<!-- Describe your changes in detail. -->
Switch from the GPU runners to the Jetstream-GPU runners in GitHub Actions.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
This PR tests the feasibility of using Jetstream cloud provided resources for executing the GPU tests.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
Change the `GPU` label in the actions workflows to `Jetstream-GPU` and make other related configuration changes.

TODO: 
- [ ] Shelve runners when not in use
- [ ] Launch runners when needed

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
