### PR TITLE
Separate RATTLE integrator methods

### DIFF
--- a/hoomd/md/methods.py
+++ b/hoomd/md/methods.py
@@ -55,20 +55,15 @@ class MethodRATTLE(Method):
 
     def __init__(self, manifold_constraint, tolerance):
 
-        if manifold_constraint is None and tolerance != 1e-6:
-            raise TypeError(
-                "The tolerance for RATTLE integration has been changed but "
-                "manifold_constraint is not specified!")
         param_dict = ParameterDict(manifold_constraint=OnlyTypes(
-            Manifold, allow_none=True),
+            Manifold, allow_none=False),
                                    tolerance=float(tolerance))
         param_dict['manifold_constraint'] = manifold_constraint
         # set defaults
         self._param_dict.update(param_dict)
 
     def _add(self, sim):
-        if self.manifold_constraint is not None:
-            self.manifold_constraint._add(sim)
+        self.manifold_constraint._add(sim)
         super()._add(sim)
 
     def _attach_constraint(self, sim):
@@ -712,8 +707,8 @@ class NPH(Method):
         return self._cpp_obj.getBarostatEnergy(self._simulation.timestep)
 
 
-class NVE(MethodRATTLE):
-    r"""NVE Integration via Velocity-Verlet with or without RATTLE.
+class NVE(Method):
+    r"""NVE Integration via Velocity-Verlet.
 
     Args:
         filter (`hoomd.filter.ParticleFilter`): Subset of particles on which to
@@ -722,17 +717,8 @@ class NVE(MethodRATTLE):
         limit (None or `float`): Enforce that no particle moves more than a
             distance of a limit in a single time step. Defaults to None
 
-        manifold_constraint (:py:mod:`hoomd.md.manifold.Manifold`): Manifold
-            constraint. Defaults to None.
-
-        tolerance (`float`): Defines the tolerated error particles are
-            allowed to deviate from the manifold in terms of the implicit
-            function.  This is only used if RATTLE algorithm is triggered.
-            Defaults to 1e-6
-
     `NVE` performs constant volume, constant energy simulations using
-    the standard Velocity-Verlet method. If a manifold constraint is set,
-    the RATTLE algorithm is used additionally. For poor initial conditions that
+    the standard Velocity-Verlet method. For poor initial conditions that
     include overlapping atoms, a limit can be specified to the movement a
     particle is allowed to make in one time step. After a few thousand time
     steps with the limit set, the system should be in a safe state to continue
@@ -746,10 +732,77 @@ class NVE(MethodRATTLE):
         nve = hoomd.md.methods.NVE(filter=hoomd.filter.All())
         integrator = hoomd.md.Integrator(dt=0.005, methods=[nve], forces=[lj])
 
-    Examples of using ``manifold_constraint``::
+    Attributes:
+        filter (hoomd.filter.ParticleFilter): Subset of particles on which to
+            apply this method.
+
+        limit (None or float): Enforce that no particle moves more than a
+            distance of a limit in a single time step. Defaults to None
+
+    """
+
+    def __init__(self, filter, limit=None):
+
+        # store metadata
+        param_dict = ParameterDict(
+            filter=ParticleFilter,
+            limit=OnlyTypes(float, allow_none=True),
+            zero_force=OnlyTypes(bool, allow_none=False),
+        )
+        param_dict.update(dict(filter=filter, limit=limit, zero_force=False))
+
+        # set defaults
+        self._param_dict.update(param_dict)
+
+    def _attach(self):
+
+        sim = self._simulation
+        # initialize the reflected c++ class
+        if isinstance(sim.device, hoomd.device.CPU):
+            self._cpp_obj = _md.TwoStepNVE(sim.state._cpp_sys_def,
+                                           sim.state._get_group(self.filter),
+                                           False)
+        else:
+            self._cpp_obj = _md.TwoStepNVEGPU(sim.state._cpp_sys_def,
+                                              sim.state._get_group(self.filter))
+
+        # Attach param_dict and typeparam_dict
+        super()._attach()
+
+
+class NVERattle(MethodRATTLE):
+    r"""NVE Integration via Velocity-Verlet with RATTLE constraint.
+
+    Args:
+        filter (`hoomd.filter.ParticleFilter`): Subset of particles on which to
+         apply this method.
+
+        manifold_constraint (:py:mod:`hoomd.md.manifold.Manifold`): Manifold
+            constraint.
+
+        limit (None or `float`): Enforce that no particle moves more than a
+            distance of a limit in a single time step. Defaults to None
+
+        tolerance (`float`): Defines the tolerated error particles are
+            allowed to deviate from the manifold in terms of the implicit
+            function.  This is only used if RATTLE algorithm is triggered.
+            Defaults to 1e-6
+
+    `NVERattle` performs constant volume, constant energy simulations using
+    the standard Velocity-Verlet method. The particles are constrained to a
+    manifold by using the RATTLE algorithm. For poor initial conditions that
+    include overlapping atoms, a limit can be specified to the movement a
+    particle is allowed to make in one time step. After a few thousand time
+    steps with the limit set, the system should be in a safe state to continue
+    with unconstrained integration.
+
+    .. todo::
+        Update when zero momentum updater is added.
+
+    Examples::
 
         sphere = hoomd.md.manifold.Sphere(r=10)
-        nve_rattle = hoomd.md.methods.NVE(
+        nve_rattle = hoomd.md.methods.NVERattle(
             filter=hoomd.filter.All(),maifold=sphere)
         integrator = hoomd.md.Integrator(
             dt=0.005, methods=[nve_rattle], forces=[lj])
@@ -759,12 +812,12 @@ class NVE(MethodRATTLE):
         filter (hoomd.filter.ParticleFilter): Subset of particles on which to
             apply this method.
 
-        limit (None or float): Enforce that no particle moves more than a
-            distance of a limit in a single time step. Defaults to None
-
         manifold_constraint (hoomd.md.manifold.Manifold): Manifold constraint
             which is used by and as a trigger for the RATTLE algorithm of this
-            method. Defaults to None.
+            method.
+
+        limit (None or float): Enforce that no particle moves more than a
+            distance of a limit in a single time step. Defaults to None
 
         tolerance (float): Defines the tolerated error particles are allowed to
             deviate from the manifold in terms of the implicit function.
@@ -774,8 +827,8 @@ class NVE(MethodRATTLE):
 
     def __init__(self,
                  filter,
+                 manifold_constraint,
                  limit=None,
-                 manifold_constraint=None,
                  tolerance=0.000001):
 
         # store metadata
@@ -793,40 +846,29 @@ class NVE(MethodRATTLE):
 
     def _attach(self):
 
-        sim = self._simulation
-        if self.manifold_constraint is None:
-            # initialize the reflected c++ class
-            if isinstance(sim.device, hoomd.device.CPU):
-                self._cpp_obj = _md.TwoStepNVE(
-                    sim.state._cpp_sys_def, sim.state._get_group(self.filter),
-                    False)
-            else:
-                self._cpp_obj = _md.TwoStepNVEGPU(
-                    sim.state._cpp_sys_def, sim.state._get_group(self.filter))
+        self._attach_constraint(self._simulation)
+
+        # initialize the reflected c++ class
+        if isinstance(self._simulation.device, hoomd.device.CPU):
+            my_class = getattr(
+                _md, 'TwoStepRATTLENVE'
+                + self.manifold_constraint.__class__.__name__)
         else:
-            self._attach_constraint(sim)
+            my_class = getattr(
+                _md, 'TwoStepRATTLENVE'
+                + self.manifold_constraint.__class__.__name__ + 'GPU')
 
-            # initialize the reflected c++ class
-            if isinstance(sim.device, hoomd.device.CPU):
-                my_class = getattr(
-                    _md, 'TwoStepRATTLENVE'
-                    + self.manifold_constraint.__class__.__name__)
-            else:
-                my_class = getattr(
-                    _md, 'TwoStepRATTLENVE'
-                    + self.manifold_constraint.__class__.__name__ + 'GPU')
-
-            self._cpp_obj = my_class(
-                self._simulation.state._cpp_sys_def,
-                self._simulation.state._get_group(self.filter),
-                self.manifold_constraint._cpp_obj, False, self.tolerance)
+        self._cpp_obj = my_class(self._simulation.state._cpp_sys_def,
+                                 self._simulation.state._get_group(self.filter),
+                                 self.manifold_constraint._cpp_obj, False,
+                                 self.tolerance)
 
         # Attach param_dict and typeparam_dict
         super()._attach()
 
 
-class Langevin(MethodRATTLE):
-    r"""Langevin dynamics with or without RATTLE.
+class Langevin(Method):
+    r"""Langevin dynamics.
 
     Args:
         filter (`hoomd.filter.ParticleFilter`): Subset of particles to
@@ -846,14 +888,6 @@ class Langevin(MethodRATTLE):
             energy conservation can then be monitored by adding
             ``langevin_reservoir_energy_groupname`` to the logged quantities.
             Defaults to False :math:`[\mathrm{energy}]`.
-
-        manifold_constraint (:py:mod:`hoomd.md.manifold.Manifold`): Manifold
-            constraint. Defaults to None.
-
-        tolerance (`float`): Defines the tolerated error particles are allowed
-            to deviate from the manifold in terms of the implicit function.
-            This is only used if RATTLE algorithm is triggered.
-            Defaults to 1e-6
 
     .. rubric:: Translational degrees of freedom
 
@@ -876,8 +910,7 @@ class Langevin(MethodRATTLE):
     or 3).  The magnitude of the random force is chosen via the
     fluctuation-dissipation theorem to be consistent with the specified drag and
     temperature, :math:`T`.  When :math:`kT=0`, the random force
-    :math:`\vec{F}_\mathrm{R}=0`. If a manifold constraint is set,
-    the RATTLE algorithm is used additionally.
+    :math:`\vec{F}_\mathrm{R}=0`.
 
     Langevin dynamics includes the acceleration term in the Langevin equation
     and is useful for gently thermalizing systems using a small gamma. This
@@ -910,22 +943,11 @@ class Langevin(MethodRATTLE):
         integrator = hoomd.md.Integrator(dt=0.001, methods=[langevin],
         forces=[lj])
 
-    Examples of using ``manifold_constraint``::
-
-        sphere = hoomd.md.manifold.Sphere(r=10)
-        langevin_rattle = hoomd.md.methods.Langevin(
-            filter=hoomd.filter.All(), kT=0.2, manifold_constraint=sphere,
-            seed=1, alpha=1.0)
-
     Examples of using ``gamma`` or ``gamma_r`` on drag coefficient::
 
         langevin = hoomd.md.methods.Langevin(filter=hoomd.filter.All(), kT=0.2)
         langevin.gamma.default = 2.0
         langevin.gamma_r.default = [1.0,2.0,3.0]
-
-        sphere = hoomd.md.manifold.Sphere(r=10)
-        langevin_rattle = hoomd.md.methods.Langevin(filter=hoomd.filter.All(),
-        kT=0.2, manifold_constraint = sphere, seed=1, alpha=1.0)
 
     Attributes:
         filter (hoomd.filter.ParticleFilter): Subset of particles to
@@ -939,9 +961,173 @@ class Langevin(MethodRATTLE):
             :math:`[\mathrm{mass} \cdot \mathrm{length}^{-1}
             \cdot \mathrm{time}^{-1}]`. Defaults to None.
 
+        gamma (TypeParameter[ ``particle type``, `float` ]): The drag
+            coefficient can be directly set instead of the ratio of particle
+            diameter (:math:`\gamma = \alpha d_i`). The type of ``gamma``
+            parameter is either positive float or zero
+            :math:`[\mathrm{mass} \cdot \mathrm{time}^{-1}]`.
+
+        gamma_r (TypeParameter[``particle type``,[`float`, `float` , `float`]]):
+            The rotational drag coefficient can be set. The type of ``gamma_r``
+            parameter is a tuple of three float. The type of each element of
+            tuple is either positive float or zero
+            :math:`[\mathrm{mass} \cdot \mathrm{time}^{-1}]`.
+
+    """
+
+    def __init__(self, filter, kT, alpha=None, tally_reservoir_energy=False):
+
+        # store metadata
+        param_dict = ParameterDict(
+            filter=ParticleFilter,
+            kT=Variant,
+            alpha=OnlyTypes(float, allow_none=True),
+            tally_reservoir_energy=bool(tally_reservoir_energy),
+        )
+        param_dict.update(dict(kT=kT, alpha=alpha, filter=filter))
+        # set defaults
+        self._param_dict.update(param_dict)
+
+        gamma = TypeParameter('gamma',
+                              type_kind='particle_types',
+                              param_dict=TypeParameterDict(1., len_keys=1))
+
+        gamma_r = TypeParameter('gamma_r',
+                                type_kind='particle_types',
+                                param_dict=TypeParameterDict((1., 1., 1.),
+                                                             len_keys=1))
+
+        self._extend_typeparam([gamma, gamma_r])
+
+    def _add(self, simulation):
+        """Add the operation to a simulation.
+
+        Langevin uses RNGs. Warn the user if they did not set the seed.
+        """
+        if simulation is not None:
+            simulation._warn_if_seed_unset()
+
+        super()._add(simulation)
+
+    def _attach(self):
+
+        sim = self._simulation
+        if isinstance(sim.device, hoomd.device.CPU):
+            my_class = _md.TwoStepLangevin
+        else:
+            my_class = _md.TwoStepLangevinGPU
+
+        self._cpp_obj = my_class(sim.state._cpp_sys_def,
+                                 sim.state._get_group(self.filter), self.kT)
+
+        # Attach param_dict and typeparam_dict
+        super()._attach()
+
+
+class LangevinRattle(MethodRATTLE):
+    r"""Langevin dynamics with RATTLE constraint.
+
+    Args:
+        filter (`hoomd.filter.ParticleFilter`): Subset of particles to
+            apply this method to.
+
+        kT (`hoomd.variant.Variant` or `float`): Temperature of the
+            simulation :math:`[\mathrm{energy}]`.
+
+        manifold_constraint (:py:mod:`hoomd.md.manifold.Manifold`): Manifold
+            constraint.
+
+        alpha (`float`): When set, use :math:`\alpha d_i` for the drag
+            coefficient where :math:`d_i` is particle diameter
+            :math:`[\mathrm{mass} \cdot
+            \mathrm{length}^{-1} \cdot \mathrm{time}^{-1}]`.
+            Defaults to None.
+
+        tally_reservoir_energy (`bool`): If true, the energy exchange
+            between the thermal reservoir and the particles is tracked. Total
+            energy conservation can then be monitored by adding
+            ``langevin_reservoir_energy_groupname`` to the logged quantities.
+            Defaults to False :math:`[\mathrm{energy}]`.
+
+        tolerance (`float`): Defines the tolerated error particles are allowed
+            to deviate from the manifold in terms of the implicit function.
+            This is only used if RATTLE algorithm is triggered.
+            Defaults to 1e-6
+
+    .. rubric:: Translational degrees of freedom
+
+    `LangevinRattle` integrates particles forward in time according to the
+    Langevin equations of motion:
+
+    .. math::
+
+        m \frac{d\vec{v}}{dt} = \vec{F}_\mathrm{C} - \gamma \cdot \vec{v} +
+        \vec{F}_\mathrm{R} + \lambda\vec{F}_\mathrm{M}
+
+        \langle \vec{F}_\mathrm{R} \rangle = 0
+
+        \langle |\vec{F}_\mathrm{R}|^2 \rangle = 2 d kT \gamma / \delta t
+
+    where :math:`\vec{F}_\mathrm{C}` is the force on the particle from all
+    potentials and constraint forces, :math:`\gamma` is the drag coefficient,
+    :math:`\vec{v}` is the particle's velocity, :math:`\vec{F}_\mathrm{R}` is a
+    uniform random force, :math:`\vec{F}_\mathrm{M}` is the manifold constraint
+    calculated via the RATTLE algorithm, and :math:`d` is the dimensionality of
+    the system (2 or 3).  The magnitude of the random force is chosen via the
+    fluctuation-dissipation theorem to be consistent with the specified drag and
+    temperature, :math:`T`.  When :math:`kT=0`, the random force
+    :math:`\vec{F}_\mathrm{R}=0`.
+
+    Langevin dynamics includes the acceleration term in the Langevin equation
+    and is useful for gently thermalizing systems using a small gamma. This
+    assumption is valid when underdamped: :math:`\frac{m}{\gamma} \gg \delta t`.
+    Use `BrownianRattle` if your system is not underdamped.
+
+    `LangevinRattle` uses the same integrator as `LangevinRattle` with the
+    additional force term :math:`+ \lambda \vec{F}_\mathrm{M}` that keeps the
+    particles on the manifold constraint.
+
+    You can specify :math:`\gamma` in two ways:
+
+    1. Specify :math:`\alpha` which scales the particle diameter to
+       :math:`\gamma = \alpha d_i`. The units of :math:`\alpha` are
+       mass / distance / time.
+    2. After the method object is created, specify the
+       attribute ``gamma`` and ``gamma_r`` for rotational damping or random
+       torque to assign them directly, with independent values for each
+       particle type in the system.
+
+    Warning:
+        When restarting a simulation, the energy of the reservoir will be reset
+        to zero.
+
+        sphere = hoomd.md.manifold.Sphere(r=10)
+        langevin_rattle = hoomd.md.methods.LangevinRattle(
+            filter=hoomd.filter.All(), kT=0.2, manifold_constraint=sphere,
+            seed=1, alpha=1.0)
+
+    Examples of using ``gamma`` or ``gamma_r`` on drag coefficient::
+
+        sphere = hoomd.md.manifold.Sphere(r=10)
+        langevin_rattle = hoomd.md.methods.LangevinRattle(
+        filter=hoomd.filter.All(), kT=0.2,
+        manifold_constraint = sphere, seed=1, alpha=1.0)
+
+    Attributes:
+        filter (hoomd.filter.ParticleFilter): Subset of particles to
+            apply this method to.
+
+        kT (hoomd.variant.Variant): Temperature of the
+            simulation :math:`[\mathrm{energy}]`.
+
         manifold_constraint (hoomd.md.manifold.Manifold): Manifold constraint
             which is used by and as a trigger for the RATTLE algorithm of this
-            method. Defaults to None.
+            method.
+
+        alpha (float): When set, use :math:`\alpha d_i` for the drag
+            coefficient where :math:`d_i` is particle diameter
+            :math:`[\mathrm{mass} \cdot \mathrm{length}^{-1}
+            \cdot \mathrm{time}^{-1}]`. Defaults to None.
 
         tolerance (float): Defines the tolerated error particles are allowed
             to deviate from the manifold in terms of the implicit function.
@@ -964,9 +1150,9 @@ class Langevin(MethodRATTLE):
     def __init__(self,
                  filter,
                  kT,
+                 manifold_constraint,
                  alpha=None,
                  tally_reservoir_energy=False,
-                 manifold_constraint=None,
                  tolerance=0.000001):
 
         # store metadata
@@ -1006,37 +1192,28 @@ class Langevin(MethodRATTLE):
     def _attach(self):
 
         sim = self._simulation
-        if self.manifold_constraint is None:
-            if isinstance(sim.device, hoomd.device.CPU):
-                my_class = _md.TwoStepLangevin
-            else:
-                my_class = _md.TwoStepLangevinGPU
+        self._attach_constraint(sim)
 
-            self._cpp_obj = my_class(sim.state._cpp_sys_def,
-                                     sim.state._get_group(self.filter), self.kT)
+        if isinstance(sim.device, hoomd.device.CPU):
+            my_class = getattr(
+                _md, 'TwoStepRATTLELangevin'
+                + self.manifold_constraint.__class__.__name__)
         else:
-            self._attach_constraint(sim)
+            my_class = getattr(
+                _md, 'TwoStepRATTLELangevin'
+                + self.manifold_constraint.__class__.__name__ + 'GPU')
 
-            if isinstance(sim.device, hoomd.device.CPU):
-                my_class = getattr(
-                    _md, 'TwoStepRATTLELangevin'
-                    + self.manifold_constraint.__class__.__name__)
-            else:
-                my_class = getattr(
-                    _md, 'TwoStepRATTLELangevin'
-                    + self.manifold_constraint.__class__.__name__ + 'GPU')
+        self._cpp_obj = my_class(sim.state._cpp_sys_def,
+                                 sim.state._get_group(self.filter),
+                                 self.manifold_constraint._cpp_obj, self.kT,
+                                 self.tolerance)
 
-            self._cpp_obj = my_class(sim.state._cpp_sys_def,
-                                     sim.state._get_group(self.filter),
-                                     self.manifold_constraint._cpp_obj, self.kT,
-                                     self.tolerance)
-
-            # Attach param_dict and typeparam_dict
+        # Attach param_dict and typeparam_dict
         super()._attach()
 
 
-class Brownian(MethodRATTLE):
-    r"""Brownian dynamics with and without RATTLE.
+class Brownian(Method):
+    r"""Brownian dynamics.
 
     Args:
         filter (`hoomd.filter.ParticleFilter`): Subset of particles to
@@ -1050,13 +1227,6 @@ class Brownian(MethodRATTLE):
             Defaults to None
             :math:`[\mathrm{mass} \cdot \mathrm{length}^{-1}
             \cdot \mathrm{time}^{-1}]`.
-
-        manifold_constraint (:py:mod:`hoomd.md.manifold.Manifold`): Manifold
-            constraint. Defaults to None.
-
-        tolerance (`float`): Defines the toleraated error particles are allowed
-            to deviate from the manifold in terms of the implicit function.
-            This is only used if RATTLE algorithm is triggered. Defaults to 1e-6
 
     `Brownian` integrates particles forward in time according to the overdamped
     Langevin equations of motion, sometimes called Brownian dynamics, or the
@@ -1082,8 +1252,7 @@ class Brownian(MethodRATTLE):
     the particle's velocity, and :math:`d` is the dimensionality of the system.
     The magnitude of the random force is chosen via the fluctuation-dissipation
     theorem to be consistent with the specified drag and temperature, :math:`T`.
-    When :math:`kT=0`, the random force :math:`\vec{F}_\mathrm{R}=0`. If a
-    manifold constraint is set, the RATTLE algorithm is used additionally.
+    When :math:`kT=0`, the random force :math:`\vec{F}_\mathrm{R}=0`.
 
     `Brownian` uses the integrator from I. Snook, The Langevin and Generalised
     Langevin Approach to the Dynamics of Atomic, Polymeric and Colloidal
@@ -1121,14 +1290,6 @@ class Brownian(MethodRATTLE):
         integrator = hoomd.md.Integrator(dt=0.001, methods=[brownian],
         forces=[lj])
 
-    Examples of using ``manifold_constraint``::
-
-        sphere = hoomd.md.manifold.Sphere(r=10)
-        brownian_rattle = hoomd.md.methods.Brownian(filter=hoomd.filter.All(),
-        kT=0.2, manifold_constraint=sphere, seed=1, alpha=1.0)
-        integrator = hoomd.md.Integrator(dt=0.001, methods=[brownian_rattle],
-        forces=[lj])
-
     Examples of using ``gamma`` pr ``gamma_r`` on drag coefficient::
 
         brownian = hoomd.md.methods.Brownian(filter=hoomd.filter.All(), kT=0.2)
@@ -1148,9 +1309,173 @@ class Brownian(MethodRATTLE):
             :math:`[\mathrm{mass} \cdot \mathrm{length}^{-1}
             \cdot \mathrm{time}^{-1}]`. Defaults to None.
 
+        gamma (TypeParameter[ ``particle type``, `float` ]): The drag
+            coefficient can be directly set instead of the ratio of particle
+            diameter (:math:`\gamma = \alpha d_i`). The type of ``gamma``
+            parameter is either positive float or zero
+            :math:`[\mathrm{mass} \cdot \mathrm{time}^{-1}]`.
+
+        gamma_r (TypeParameter[``particle type``, [`float`, `float`, `float`]]):
+            The rotational drag coefficient can be set. The type of ``gamma_r``
+            parameter is a tuple of three float. The type of each element of
+            tuple is either positive float or zero
+            :math:`[\mathrm{force} \cdot \mathrm{length} \cdot
+            \mathrm{radian}^{-1} \cdot \mathrm{time}^{-1}]`.
+    """
+
+    def __init__(self, filter, kT, alpha=None):
+
+        # store metadata
+        param_dict = ParameterDict(
+            filter=ParticleFilter,
+            kT=Variant,
+            alpha=OnlyTypes(float, allow_none=True),
+        )
+        param_dict.update(dict(kT=kT, alpha=alpha, filter=filter))
+
+        # set defaults
+        self._param_dict.update(param_dict)
+
+        gamma = TypeParameter('gamma',
+                              type_kind='particle_types',
+                              param_dict=TypeParameterDict(1., len_keys=1))
+
+        gamma_r = TypeParameter('gamma_r',
+                                type_kind='particle_types',
+                                param_dict=TypeParameterDict((1., 1., 1.),
+                                                             len_keys=1))
+        self._extend_typeparam([gamma, gamma_r])
+
+    def _add(self, simulation):
+        """Add the operation to a simulation.
+
+        Brownian uses RNGs. Warn the user if they did not set the seed.
+        """
+        if simulation is not None:
+            simulation._warn_if_seed_unset()
+
+        super()._add(simulation)
+
+    def _attach(self):
+
+        sim = self._simulation
+        if isinstance(sim.device, hoomd.device.CPU):
+            self._cpp_obj = _md.TwoStepBD(sim.state._cpp_sys_def,
+                                          sim.state._get_group(self.filter),
+                                          self.kT)
+        else:
+            self._cpp_obj = _md.TwoStepBDGPU(sim.state._cpp_sys_def,
+                                             sim.state._get_group(self.filter),
+                                             self.kT)
+
+        # Attach param_dict and typeparam_dict
+        super()._attach()
+
+
+class BrownianRattle(MethodRATTLE):
+    r"""Brownian dynamics with RATTLE constraint.
+
+    Args:
+        filter (`hoomd.filter.ParticleFilter`): Subset of particles to
+            apply this method to.
+
+        kT (`hoomd.variant.Variant` or `float`): Temperature of the
+            simulation :math:`[\mathrm{energy}]`.
+
+        manifold_constraint (:py:mod:`hoomd.md.manifold.Manifold`): Manifold
+            constraint.
+
+        alpha (`float`): When set, use :math:`\alpha d_i` for the
+            drag coefficient where :math:`d_i` is particle diameter.
+            Defaults to None
+            :math:`[\mathrm{mass} \cdot \mathrm{length}^{-1}
+            \cdot \mathrm{time}^{-1}]`.
+
+        tolerance (`float`): Defines the toleraated error particles are allowed
+            to deviate from the manifold in terms of the implicit function.
+            This is only used if RATTLE algorithm is triggered. Defaults to 1e-6
+
+    `BrownianRattle` integrates particles forward in time according to the
+    overdamped Langevin equations of motion, sometimes called Brownian dynamics,
+    or the diffusive limit.
+
+    .. math::
+
+        \frac{d\vec{x}}{dt} = \frac{\vec{F}_\mathrm{C} +
+        \vec{F}_\mathrm{R} + \lambda\vec{F}_\mathrm{M}}{\gamma}
+
+        \langle \vec{F}_\mathrm{R} \rangle = 0
+
+        \langle |\vec{F}_\mathrm{R}|^2 \rangle = 2 d k T \gamma / \delta t
+
+        \langle \vec{v}(t) \rangle = 0
+
+        \langle |\vec{v}(t)|^2 \rangle = d k T / m
+
+
+    where :math:`\vec{F}_\mathrm{C}` is the force on the particle from all
+    potentials and constraint forces, :math:`\gamma` is the drag coefficient,
+    :math:`\vec{F}_\mathrm{R}` is a uniform random force,
+    :math:`\vec{F}_\mathrm{M}` is the manifold constraint calculated via the
+    RATTLE algorithm, :math:`\vec{v}` is the particle's velocity, and
+    :math:`d` is the dimensionality of the system. The magnitude of the random
+    force is chosen via the fluctuation-dissipation theorem to be consistent
+    with the specified drag and temperature, :math:`T`. When :math:`kT=0`,
+    the random force :math:`\vec{F}_\mathrm{R}=0`.
+
+    `BrownianRattle` uses the integrator from I. Snook, The Langevin and
+    Generalised Langevin Approach to the Dynamics of Atomic, Polymeric and
+    Colloidal Systems, 2007, section 6.2.5 `link`_, with the exception that
+    :math:`\vec{F}_\mathrm{R}` is drawn from a uniform random number
+    distribution.
+
+    .. _link: http://dx.doi.org/10.1016/B978-0-444-52129-3.50028-6
+
+    In Brownian dynamics, particle velocities are completely decoupled from
+    positions. At each time step, `BrownianRattle` draws a new velocity
+    distribution consistent with the current set temperature so that
+    `hoomd.compute.thermo` will report appropriate temperatures and
+    pressures if logged or needed by other commands.
+
+    Brownian dynamics neglects the acceleration term in the Langevin equation.
+    This assumption is valid when overdamped:
+    :math:`\frac{m}{\gamma} \ll \delta t`. Use `Langevin` if your
+    system is not overdamped.
+
+    You can specify :math:`\gamma` in two ways:
+
+    1. Specify :math:`\alpha` which scales the particle diameter to
+       :math:`\gamma = \alpha d_i`. The units of :math:`\alpha` are mass /
+       distance / time.
+    2. After the method object is created, specify the attribute ``gamma``
+       and ``gamma_r`` for rotational damping or random torque to assign them
+       directly, with independent values for each particle type in the
+       system.
+
+    Examples of using ``manifold_constraint``::
+
+        sphere = hoomd.md.manifold.Sphere(r=10)
+        brownian_rattle = hoomd.md.methods.BrownianRattle(
+        filter=hoomd.filter.All(), kT=0.2, manifold_constraint=sphere,
+        seed=1, alpha=1.0)
+        integrator = hoomd.md.Integrator(dt=0.001, methods=[brownian_rattle],
+        forces=[lj])
+
+    Attributes:
+        filter (hoomd.filter.ParticleFilter): Subset of particles to
+            apply this method to.
+
+        kT (hoomd.variant.Variant): Temperature of the
+            simulation :math:`[\mathrm{energy}]`.
+
         manifold_constraint (hoomd.md.manifold.Manifold): Manifold constraint
             which is used by and as a trigger for the RATTLE algorithm of this
-            method. Defaults to None.
+            method.
+
+        alpha (float): When set, use :math:`\alpha d_i` for the drag
+            coefficient where :math:`d_i` is particle diameter
+            :math:`[\mathrm{mass} \cdot \mathrm{length}^{-1}
+            \cdot \mathrm{time}^{-1}]`. Defaults to None.
 
         tolerance (float): Defines the tolerated error particles are allowed to
             deviate from the manifold in terms of the implicit function.
@@ -1173,7 +1498,7 @@ class Brownian(MethodRATTLE):
     def __init__(self,
                  filter,
                  kT,
-                 manifold_constraint=None,
+                 manifold_constraint,
                  tolerance=0.000001,
                  alpha=None):
 
@@ -1213,31 +1538,21 @@ class Brownian(MethodRATTLE):
     def _attach(self):
 
         sim = self._simulation
-        if self.manifold_constraint is None:
-            if isinstance(sim.device, hoomd.device.CPU):
-                self._cpp_obj = _md.TwoStepBD(sim.state._cpp_sys_def,
-                                              sim.state._get_group(self.filter),
-                                              self.kT)
-            else:
-                self._cpp_obj = _md.TwoStepBDGPU(
-                    sim.state._cpp_sys_def, sim.state._get_group(self.filter),
-                    self.kT)
+        self._attach_constraint(sim)
+
+        if isinstance(sim.device, hoomd.device.CPU):
+            my_class = getattr(
+                _md,
+                'TwoStepRATTLEBD' + self.manifold_constraint.__class__.__name__)
         else:
-            self._attach_constraint(sim)
+            my_class = getattr(
+                _md, 'TwoStepRATTLEBD'
+                + self.manifold_constraint.__class__.__name__ + 'GPU')
 
-            if isinstance(sim.device, hoomd.device.CPU):
-                my_class = getattr(
-                    _md, 'TwoStepRATTLEBD'
-                    + self.manifold_constraint.__class__.__name__)
-            else:
-                my_class = getattr(
-                    _md, 'TwoStepRATTLEBD'
-                    + self.manifold_constraint.__class__.__name__ + 'GPU')
-
-            self._cpp_obj = my_class(sim.state._cpp_sys_def,
-                                     sim.state._get_group(self.filter),
-                                     self.manifold_constraint._cpp_obj, self.kT,
-                                     self.tolerance)
+        self._cpp_obj = my_class(sim.state._cpp_sys_def,
+                                 sim.state._get_group(self.filter),
+                                 self.manifold_constraint._cpp_obj, self.kT,
+                                 self.tolerance)
 
         # Attach param_dict and typeparam_dict
         super()._attach()

--- a/hoomd/md/pytest/test_manifolds.py
+++ b/hoomd/md/pytest/test_manifolds.py
@@ -111,7 +111,7 @@ def test_attributes_attached(simulation_factory, two_particle_snapshot_factory,
 
     all_ = hoomd.filter.All()
     surface = manifold_base_params.surface(**manifold_base_params.setup_params)
-    method = hoomd.md.methods.NVE(filter=all_)
+    method = hoomd.md.methods.NVE(filter=all_, manifold_constraint=surface)
 
     sim = simulation_factory(two_particle_snapshot_factory())
     sim.operations.integrator = hoomd.md.Integrator(0.005, methods=[method])

--- a/hoomd/md/pytest/test_manifolds.py
+++ b/hoomd/md/pytest/test_manifolds.py
@@ -111,7 +111,8 @@ def test_attributes_attached(simulation_factory, two_particle_snapshot_factory,
 
     all_ = hoomd.filter.All()
     surface = manifold_base_params.surface(**manifold_base_params.setup_params)
-    method = hoomd.md.methods.NVE(filter=all_, manifold_constraint=surface)
+    method = hoomd.md.methods.NVERattle(filter=all_,
+                                        manifold_constraint=surface)
 
     sim = simulation_factory(two_particle_snapshot_factory())
     sim.operations.integrator = hoomd.md.Integrator(0.005, methods=[method])
@@ -130,8 +131,8 @@ def test_pickling(manifold_base_params, simulation_factory,
                   two_particle_snapshot_factory):
     sim = simulation_factory(two_particle_snapshot_factory())
     manifold = manifold_base_params.surface(**manifold_base_params.setup_params)
-    nve = hoomd.md.methods.NVE(filter=hoomd.filter.All(),
-                               manifold_constraint=manifold)
+    nve = hoomd.md.methods.NVERattle(filter=hoomd.filter.All(),
+                                     manifold_constraint=manifold)
     integrator = hoomd.md.Integrator(0.005, methods=[nve])
     sim.operations += integrator
     pickling_check(manifold)

--- a/sphinx-doc/module-md-methods.rst
+++ b/sphinx-doc/module-md-methods.rst
@@ -9,10 +9,13 @@ md.methods
     :nosignatures:
 
     Brownian
+    BrownianRattle
     Langevin
+    LangevinRattle
     NPH
     NPT
     NVE
+    NVERattle
     NVT
 
 
@@ -23,8 +26,11 @@ md.methods
     :members: Method,
               MethodRATTLE,
               Brownian,
+              BrownianRattle,
               Langevin,
+              LangevinRattle,
               NPH,
               NPT,
               NVE,
+              NVERattle,
               NVT


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should based on *maint*. -->
<!-- New features should based on *master*. -->

## Description

I put all rattle integrators in separate classes to make sure that integrator methods can be removed from the simulation.  

<!-- Describe your changes in detail. -->

## Motivation and context



<!--- Why is this change required? What problem does it solve? -->

<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves #998 and #1052

## How has this been tested?

Tests have been updated to the new changes.
<!--- Please describe in detail how you tested your changes. -->

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```

```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
