### PR TITLE
Fix the ThermdynamicQuantities.volume property

### DIFF
--- a/hoomd/md/ComputeThermo.h
+++ b/hoomd/md/ComputeThermo.h
@@ -323,7 +323,8 @@ class PYBIND11_EXPORT ComputeThermo : public Compute
     /// Get the box volume (or area in 2D)
     const Scalar getVolume()
         {
-        return m_sysdef->getParticleData()->getGlobalBox().getVolume();
+        bool two_d = m_sysdef->getNDimensions() == 2;
+        return m_sysdef->getParticleData()->getGlobalBox().getVolume(two_d);
         }
 
     protected:

--- a/hoomd/md/compute.py
+++ b/hoomd/md/compute.py
@@ -265,15 +265,14 @@ class ThermodynamicQuantities(_Thermo):
         """:math:`N`, number of particles in the group."""
         return self._cpp_obj.num_particles
 
-    @log
+    @log(requires_run=True)
     def volume(self):
-        """:math:`V`, volume of the simulation box \
-        :math:`[\\mathrm{length}^{2}] in 2D and \
-        :math:`[\\mathrm{length}^{2}] in 3D`."""
-        if self._attached:
-            return self._cpp_obj.volume
-        else:
-            return None
+        """:math:`V`, volume of the simulation box (area in 2D) \
+        :math:`[\\mathrm{length}^{d}]`.
+
+        Where :math:`d` is the dimensionality of the system.
+        """
+        return self._cpp_obj.volume
 
 
 class HarmonicAveragedThermodynamicQuantities(Compute):


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should based on *maint*. -->
<!-- New features should based on *master*. -->

## Description

<!-- Describe your changes in detail. -->
Fix the documentation for `ThermdynamicQuantities.volume`. Also fix the property to return the area in 2D simulations.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
The documentation was not rendering correctly and the area was always returning 0.

<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves #1055 

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
Added unit tests. Built the documentation.

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
- Bug where ``ThermdynamicQuantities.volume`` gave 0 in 2D simulations.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
