### PR TITLE
Fix debug mode tests

### DIFF
--- a/hoomd/ExecutionConfiguration.h
+++ b/hoomd/ExecutionConfiguration.h
@@ -124,11 +124,7 @@ class PYBIND11_EXPORT ExecutionConfiguration
     //! Returns true if CUDA error checking is enabled
     bool isCUDAErrorCheckingEnabled() const
         {
-#ifndef NDEBUG
-        return true;
-#else
         return m_hip_error_checking;
-#endif
         }
 
     //! Sets the hip error checking mode

--- a/hoomd/md/NeighborList.cc
+++ b/hoomd/md/NeighborList.cc
@@ -366,6 +366,19 @@ void NeighborList::compute(uint64_t timestep)
     if (m_prof)
         m_prof->push("Neighbor");
 
+    // when the number of particles in the system changes, rebuild the exclusion list
+    if (m_need_reallocate_exlist)
+        {
+        clearExclusions();
+        std::set<std::string> exclusions_copy(m_exclusions);
+        for (const std::string& exclusion : exclusions_copy)
+            {
+            setSingleExclusion(exclusion);
+            }
+
+        m_need_reallocate_exlist = false;
+        }
+
     // take care of some updates if things have changed since construction
     if (m_force_update)
         {
@@ -1838,7 +1851,6 @@ void export_NeighborList(py::module& m)
         .def("getSmallestRebuild", &NeighborList::getSmallestRebuild)
         .def("getNumUpdates", &NeighborList::getNumUpdates)
         .def("getNumExclusions", &NeighborList::getNumExclusions)
-        .def("wantExclusions", &NeighborList::wantExclusions)
 #ifdef ENABLE_MPI
         .def("setCommunicator", &NeighborList::setCommunicator)
 #endif

--- a/hoomd/md/NeighborList.h
+++ b/hoomd/md/NeighborList.h
@@ -343,48 +343,8 @@ class PYBIND11_EXPORT NeighborList : public Compute
     //! Gives an estimate of the number of nearest neighbors per particle
     virtual Scalar estimateNNeigh();
 
-    // @}
-    //! \name Handle exclusions
-    // @{
-
     //! Exclude a pair of particles from being added to the neighbor list
     void addExclusion(unsigned int tag1, unsigned int tag2);
-
-    //! Clear all existing exclusions
-    void clearExclusions();
-
-    //! Collect some statistics on exclusions.
-    void countExclusions();
-
-    //! Get number of exclusions involving n particles
-    /*! \param n Size of the exclusion
-     * \returns Number of excluded particles
-     */
-    unsigned int getNumExclusions(unsigned int size);
-
-    //! Add an exclusion for every bond in the ParticleData
-    void addExclusionsFromBonds();
-
-    //! Add exclusions from angles
-    void addExclusionsFromAngles();
-
-    //! Add exclusions from dihedrals
-    void addExclusionsFromDihedrals();
-
-    //! Add an exclusion for every bond in the ConstraintData
-    void addExclusionsFromConstraints();
-
-    //! Add an exclusion for every pair in the ParticleData
-    void addExclusionsFromPairs();
-
-    //! Test if an exclusion has been made
-    bool isExcluded(unsigned int tag1, unsigned int tag2);
-
-    //! Add an exclusion for every 1,3 pair
-    void addOneThreeExclusionsFromTopology();
-
-    //! Add an exclusion for every 1,4 pair
-    void addOneFourExclusionsFromTopology();
 
     //! Enable/disable body filtering
     virtual void setFilterBody(bool filter_body)
@@ -399,6 +359,16 @@ class PYBIND11_EXPORT NeighborList : public Compute
             }
         forceUpdate();
         }
+
+
+    //! Collect some statistics on exclusions.
+    void countExclusions();
+
+    //! Get number of exclusions involving n particles
+    /*! \param n Size of the exclusion
+     * \returns Number of excluded particles
+     */
+    unsigned int getNumExclusions(unsigned int size);
 
     //! Test if body filtering is set
     virtual bool getFilterBody()
@@ -665,6 +635,33 @@ class PYBIND11_EXPORT NeighborList : public Compute
         {
         m_need_reallocate_exlist = true;
         }
+
+    //! Clear all existing exclusions
+    void clearExclusions();
+
+    //! Add an exclusion for every bond in the ParticleData
+    void addExclusionsFromBonds();
+
+    //! Add exclusions from angles
+    void addExclusionsFromAngles();
+
+    //! Add exclusions from dihedrals
+    void addExclusionsFromDihedrals();
+
+    //! Add an exclusion for every bond in the ConstraintData
+    void addExclusionsFromConstraints();
+
+    //! Add an exclusion for every pair in the ParticleData
+    void addExclusionsFromPairs();
+
+    //! Test if an exclusion has been made
+    bool isExcluded(unsigned int tag1, unsigned int tag2);
+
+    //! Add an exclusion for every 1,3 pair
+    void addOneThreeExclusionsFromTopology();
+
+    //! Add an exclusion for every 1,4 pair
+    void addOneFourExclusionsFromTopology();
 
 #ifdef ENABLE_HIP
     GPUPartition m_last_gpu_partition; //!< The partition at the time of the last memory hints

--- a/hoomd/md/NeighborList.h
+++ b/hoomd/md/NeighborList.h
@@ -340,11 +340,6 @@ class PYBIND11_EXPORT NeighborList : public Compute
         return m_exclusions_set;
         }
 
-    bool wantExclusions()
-        {
-        return m_need_reallocate_exlist;
-        }
-
     //! Gives an estimate of the number of nearest neighbors per particle
     virtual Scalar estimateNNeigh();
 

--- a/hoomd/md/NeighborList.h
+++ b/hoomd/md/NeighborList.h
@@ -530,7 +530,7 @@ class PYBIND11_EXPORT NeighborList : public Compute
     Index2D m_ex_list_indexer;               //!< Indexer for accessing the exclusion list
     Index2D m_ex_list_indexer_tag;           //!< Indexer for accessing the by-tag exclusion list
     bool m_exclusions_set;                   //!< True if any exclusions have been set
-    bool m_need_reallocate_exlist; //!< True if global exclusion list needs to be reallocated
+    bool m_n_particles_changed; //!< True if global exclusion list needs to be reallocated
 
     //! Return true if we are supposed to do a distance check in this time step
     bool shouldCheckDistance(uint64_t timestep);
@@ -633,11 +633,11 @@ class PYBIND11_EXPORT NeighborList : public Compute
     //! Method to be called when the global particle number changes
     void slotGlobalParticleNumberChange()
         {
-        m_need_reallocate_exlist = true;
+        m_n_particles_changed = true;
         }
 
     //! Clear all existing exclusions
-    void clearExclusions();
+    void resizeAndClearExclusions();
 
     //! Add an exclusion for every bond in the ParticleData
     void addExclusionsFromBonds();

--- a/hoomd/md/NeighborList.h
+++ b/hoomd/md/NeighborList.h
@@ -360,7 +360,6 @@ class PYBIND11_EXPORT NeighborList : public Compute
         forceUpdate();
         }
 
-
     //! Collect some statistics on exclusions.
     void countExclusions();
 


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should based on *maint*. -->
<!-- New features should based on *master*. -->

## Description

<!-- Describe your changes in detail. -->
- Regenerate the exclusion list data arrays when the number of particles changes
- Allow setting the gpu error checking mode in debug builds.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
These changes fix asserts thrown when running `pytest hoomd` in a Debug build.

<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves #1029

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
I tested this locally with a Debug build of HOOMD.

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
- Update neighbor list exclusions after the number of particles changes.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
