### PR TITLE
More explicit inlcludes

### DIFF
--- a/hoomd/Analyzer.h
+++ b/hoomd/Analyzer.h
@@ -23,6 +23,7 @@
 
 #include <memory>
 #include <typeinfo>
+#include <limits>
 
 /*! \ingroup hoomd_lib
     @{

--- a/hoomd/md/PotentialPair.h
+++ b/hoomd/md/PotentialPair.h
@@ -18,6 +18,7 @@
 #include "hoomd/GlobalArray.h"
 #include "hoomd/HOOMDMath.h"
 #include "hoomd/Index1D.h"
+#include "hoomd/managed_allocator.h"
 #include "hoomd/md/EvaluatorPairLJ.h"
 
 #ifdef ENABLE_HIP


### PR DESCRIPTION
## Description
A very minor PR.
Adds some explicit includes in files which have caused issues for me when compiling. Any others that contributors have run into are welcome to be added here.


## Motivation and context

The <limits> standard library is not included automatically as of GCC11 https://www.gnu.org/software/gcc/gcc-11/porting_to.html#header-dep-changes. The same seems to be true of clang but I don't know at what version that changed. This portion could likely be backported into the maint branch, so I split it into a separate commit. 

The other minor include relates to the changing of param values storage for pair potentials changing to a std::vector rather than GlobalArray. If there are no other errors in the file, it doesn't seem to make a difference including it or not, but if there are errors it generates many which obfuscates the actual cause.

## How has this been tested?
It's just extra includes to help the compiler. No testing needed.


## Checklist:

- [X] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [X] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [X] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
