### PR TITLE
More explicit inlcludes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
     name: Build release tarball
     runs-on: ubuntu-latest
     container:
-      image: glotzerlab/ci:2021.05-ubuntu20.04
+      image: glotzerlab/ci:2021.07-ubuntu20.04
 
     steps:
       - name: Checkout

--- a/.github/workflows/templates/configurations.yml
+++ b/.github/workflows/templates/configurations.yml
@@ -4,7 +4,7 @@
 # - The build options are `mpi`, `tbb`, and `jit`.
 unit_test_configurations:
 - config: "[clang11_py39, mpi, tbb, jit]"
-- config: "[gcc10_py39]"
+- config: "[gcc11_py39]"
 - config: "[cuda11_gcc9_py38, mpi]"
 - config: "[cuda11_gcc9_py38]"
 
@@ -13,13 +13,14 @@ unit_test_configurations:
 # `unit_test_configurations`
 validate_configurations:
 - config: "[clang11_py39, mpi, tbb, jit]"
-- config: "[gcc10_py39]"
+- config: "[gcc11_py39]"
 - config: "[cuda11_gcc9_py38, mpi]"
 - config: "[cuda11_gcc9_py38]"
 
 # Configurations to build and test only rarely, such as just before a release.
 # There should be no overlap between this list and `unit_test_configurations`
 release_test_configurations:
+- config: "[gcc10_py39]"
 - config: "[cuda10_gcc7_py37]"
 - config: "[clang10_py38, jit]"
 - config: "[gcc9_py38]"

--- a/.github/workflows/templates/workflow.yml
+++ b/.github/workflows/templates/workflow.yml
@@ -1,5 +1,5 @@
 <% block name %><% endblock %>
-<% set container_prefix="glotzerlab/ci:2021.05" %>
+<% set container_prefix="glotzerlab/ci:2021.07" %>
 
 <% block concurrency %>
 concurrency:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,12 +50,12 @@ jobs:
     name: Build [${{ join(matrix.config, '_') }}]
     runs-on: ubuntu-latest
     container:
-      image: glotzerlab/ci:2021.05-${{ matrix.config[0] }}
+      image: glotzerlab/ci:2021.07-${{ matrix.config[0] }}
     strategy:
       matrix:
         include:
         - {config: [clang11_py39, mpi, tbb, jit], runner: ubuntu-latest, docker_options: '' }
-        - {config: [gcc10_py39], runner: ubuntu-latest, docker_options: '' }
+        - {config: [gcc11_py39], runner: ubuntu-latest, docker_options: '' }
         - {config: [cuda11_gcc9_py38, mpi], runner: [self-hosted,GPU], docker_options: '--gpus=all --device /dev/nvidia0 --device /dev/nvidia1 --device /dev/nvidia-uvm --device /dev/nvidia-uvm-tools --device /dev/nvidiactl' }
         - {config: [cuda11_gcc9_py38], runner: [self-hosted,GPU], docker_options: '--gpus=all --device /dev/nvidia0 --device /dev/nvidia1 --device /dev/nvidia-uvm --device /dev/nvidia-uvm-tools --device /dev/nvidiactl' }
 
@@ -118,13 +118,13 @@ jobs:
     needs: build
     runs-on: ${{ matrix.runner }}
     container:
-      image: glotzerlab/ci:2021.05-${{ matrix.config[0] }}
+      image: glotzerlab/ci:2021.07-${{ matrix.config[0] }}
       options: ${{ matrix.docker_options }} -e CUDA_VISIBLE_DEVICES
     strategy:
       matrix:
         include:
         - {config: [clang11_py39, mpi, tbb, jit], runner: ubuntu-latest, docker_options: '' }
-        - {config: [gcc10_py39], runner: ubuntu-latest, docker_options: '' }
+        - {config: [gcc11_py39], runner: ubuntu-latest, docker_options: '' }
         - {config: [cuda11_gcc9_py38, mpi], runner: [self-hosted,GPU], docker_options: '--gpus=all --device /dev/nvidia0 --device /dev/nvidia1 --device /dev/nvidia-uvm --device /dev/nvidia-uvm-tools --device /dev/nvidiactl' }
         - {config: [cuda11_gcc9_py38], runner: [self-hosted,GPU], docker_options: '--gpus=all --device /dev/nvidia0 --device /dev/nvidia1 --device /dev/nvidia-uvm --device /dev/nvidia-uvm-tools --device /dev/nvidiactl' }
 
@@ -161,13 +161,13 @@ jobs:
     needs: build
     runs-on: ${{ matrix.runner }}
     container:
-      image: glotzerlab/ci:2021.05-${{ matrix.config[0] }}
+      image: glotzerlab/ci:2021.07-${{ matrix.config[0] }}
       options: ${{ matrix.docker_options }} -e CUDA_VISIBLE_DEVICES
     strategy:
       matrix:
         include:
         - {config: [clang11_py39, mpi, tbb, jit], runner: ubuntu-latest, docker_options: '' }
-        - {config: [gcc10_py39], runner: ubuntu-latest, docker_options: '' }
+        - {config: [gcc11_py39], runner: ubuntu-latest, docker_options: '' }
         - {config: [cuda11_gcc9_py38, mpi], runner: [self-hosted,GPU], docker_options: '--gpus=all --device /dev/nvidia0 --device /dev/nvidia1 --device /dev/nvidia-uvm --device /dev/nvidia-uvm-tools --device /dev/nvidiactl' }
         - {config: [cuda11_gcc9_py38], runner: [self-hosted,GPU], docker_options: '--gpus=all --device /dev/nvidia0 --device /dev/nvidia1 --device /dev/nvidia-uvm --device /dev/nvidia-uvm-tools --device /dev/nvidiactl' }
 
@@ -197,13 +197,13 @@ jobs:
     needs: build
     runs-on: ${{ matrix.runner }}
     container:
-      image: glotzerlab/ci:2021.05-${{ matrix.config[0] }}
+      image: glotzerlab/ci:2021.07-${{ matrix.config[0] }}
       options: ${{ matrix.docker_options }} -e CUDA_VISIBLE_DEVICES
     strategy:
       matrix:
         include:
         - {config: [clang11_py39, mpi, tbb, jit], runner: ubuntu-latest, docker_options: '' }
-        - {config: [gcc10_py39], runner: ubuntu-latest, docker_options: '' }
+        - {config: [gcc11_py39], runner: ubuntu-latest, docker_options: '' }
         - {config: [cuda11_gcc9_py38, mpi], runner: [self-hosted,GPU], docker_options: '--gpus=all --device /dev/nvidia0 --device /dev/nvidia1 --device /dev/nvidia-uvm --device /dev/nvidia-uvm-tools --device /dev/nvidiactl' }
         - {config: [cuda11_gcc9_py38], runner: [self-hosted,GPU], docker_options: '--gpus=all --device /dev/nvidia0 --device /dev/nvidia1 --device /dev/nvidia-uvm --device /dev/nvidia-uvm-tools --device /dev/nvidiactl' }
 
@@ -231,10 +231,11 @@ jobs:
     name: Build [${{ join(matrix.config, '_') }}]
     runs-on: ubuntu-latest
     container:
-      image: glotzerlab/ci:2021.05-${{ matrix.config[0] }}
+      image: glotzerlab/ci:2021.07-${{ matrix.config[0] }}
     strategy:
       matrix:
         include:
+        - {config: [gcc10_py39], runner: ubuntu-latest, docker_options: '' }
         - {config: [cuda10_gcc7_py37], runner: [self-hosted,GPU], docker_options: '--gpus=all --device /dev/nvidia0 --device /dev/nvidia1 --device /dev/nvidia-uvm --device /dev/nvidia-uvm-tools --device /dev/nvidiactl' }
         - {config: [clang10_py38, jit], runner: ubuntu-latest, docker_options: '' }
         - {config: [gcc9_py38], runner: ubuntu-latest, docker_options: '' }
@@ -304,11 +305,12 @@ jobs:
     needs: build_release
     runs-on: ${{ matrix.runner }}
     container:
-      image: glotzerlab/ci:2021.05-${{ matrix.config[0] }}
+      image: glotzerlab/ci:2021.07-${{ matrix.config[0] }}
       options: ${{ matrix.docker_options }} -e CUDA_VISIBLE_DEVICES
     strategy:
       matrix:
         include:
+        - {config: [gcc10_py39], runner: ubuntu-latest, docker_options: '' }
         - {config: [cuda10_gcc7_py37], runner: [self-hosted,GPU], docker_options: '--gpus=all --device /dev/nvidia0 --device /dev/nvidia1 --device /dev/nvidia-uvm --device /dev/nvidia-uvm-tools --device /dev/nvidiactl' }
         - {config: [clang10_py38, jit], runner: ubuntu-latest, docker_options: '' }
         - {config: [gcc9_py38], runner: ubuntu-latest, docker_options: '' }
@@ -354,11 +356,12 @@ jobs:
     needs: build_release
     runs-on: ${{ matrix.runner }}
     container:
-      image: glotzerlab/ci:2021.05-${{ matrix.config[0] }}
+      image: glotzerlab/ci:2021.07-${{ matrix.config[0] }}
       options: ${{ matrix.docker_options }} -e CUDA_VISIBLE_DEVICES
     strategy:
       matrix:
         include:
+        - {config: [gcc10_py39], runner: ubuntu-latest, docker_options: '' }
         - {config: [cuda10_gcc7_py37], runner: [self-hosted,GPU], docker_options: '--gpus=all --device /dev/nvidia0 --device /dev/nvidia1 --device /dev/nvidia-uvm --device /dev/nvidia-uvm-tools --device /dev/nvidiactl' }
         - {config: [clang10_py38, jit], runner: ubuntu-latest, docker_options: '' }
         - {config: [gcc9_py38], runner: ubuntu-latest, docker_options: '' }

--- a/BUILDING.rst
+++ b/BUILDING.rst
@@ -70,7 +70,7 @@ Install prerequisites
 
 **General requirements:**
 
-- C++14 capable compiler (tested with ``gcc`` 7, 8, 9, 10 / ``clang`` 6, 7, 8, 9, 10, 11)
+- C++14 capable compiler (tested with ``gcc`` 7, 8, 9, 10, 11 / ``clang`` 6, 7, 8, 9, 10, 11)
 - Python >= 3.6
 - NumPy >= 1.7
 - pybind11 >= 2.2

--- a/hoomd/Analyzer.h
+++ b/hoomd/Analyzer.h
@@ -21,9 +21,9 @@
 #include "SharedSignal.h"
 #include "SystemDefinition.h"
 
+#include <limits>
 #include <memory>
 #include <typeinfo>
-#include <limits>
 
 /*! \ingroup hoomd_lib
     @{

--- a/hoomd/Analyzer.h
+++ b/hoomd/Analyzer.h
@@ -21,7 +21,6 @@
 #include "SharedSignal.h"
 #include "SystemDefinition.h"
 
-#include <limits>
 #include <memory>
 #include <typeinfo>
 

--- a/hoomd/Analyzer.h
+++ b/hoomd/Analyzer.h
@@ -23,6 +23,7 @@
 
 #include <memory>
 #include <typeinfo>
+#include <limits>
 
 /*! \ingroup hoomd_lib
     @{

--- a/hoomd/DCDDumpWriter.cc
+++ b/hoomd/DCDDumpWriter.cc
@@ -15,6 +15,7 @@
 #include "Communicator.h"
 #endif
 
+#include <limits>
 #include <stdexcept>
 
 namespace py = pybind11;

--- a/hoomd/GSDDumpWriter.cc
+++ b/hoomd/GSDDumpWriter.cc
@@ -13,6 +13,7 @@
 #include <pybind11/numpy.h>
 #include <pybind11/stl_bind.h>
 
+#include <limits>
 #include <list>
 #include <sstream>
 #include <stdexcept>

--- a/hoomd/md/PotentialPair.h
+++ b/hoomd/md/PotentialPair.h
@@ -18,6 +18,7 @@
 #include "hoomd/GlobalArray.h"
 #include "hoomd/HOOMDMath.h"
 #include "hoomd/Index1D.h"
+#include "hoomd/managed_allocator.h"
 #include "hoomd/md/EvaluatorPairLJ.h"
 
 #ifdef ENABLE_HIP


### PR DESCRIPTION
## Description
A very minor PR.
Adds some explicit includes in files which have caused issues for me when compiling. Any others that contributors have run into are welcome to be added here.


## Motivation and context

The <limits> standard library is not included automatically as of GCC11 https://www.gnu.org/software/gcc/gcc-11/porting_to.html#header-dep-changes. The same seems to be true of clang but I don't know at what version that changed. This portion could likely be backported into the maint branch, so I split it into a separate commit. 

The other minor include relates to the changing of param values storage for pair potentials changing to a std::vector rather than GlobalArray. If there are no other errors in the file, it doesn't seem to make a difference including it or not, but if there are errors it generates many which obfuscates the actual cause.

## How has this been tested?
It's just extra includes to help the compiler. No testing needed.


## Checklist:

- [X] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [X] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [X] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
