### PR TITLE
Document test dependencies

### DIFF
--- a/hoomd/md/pytest/test_rigid.py
+++ b/hoomd/md/pytest/test_rigid.py
@@ -14,6 +14,7 @@ import hoomd.md as md
 
 skip_rowan = pytest.mark.skipif(skip_rowan, reason="rowan cannot be imported.")
 
+
 @pytest.fixture
 def valid_body_definition():
     return {

--- a/hoomd/md/pytest/test_rigid.py
+++ b/hoomd/md/pytest/test_rigid.py
@@ -2,11 +2,17 @@ from collections.abc import Sequence
 
 import numpy as np
 import pytest
-import rowan
+
+try:
+    import rowan
+    skip_rowan = False
+except ImportError:
+    skip_rowan = True
 
 import hoomd
 import hoomd.md as md
 
+skip_rowan = pytest.mark.skipif(skip_rowan, reason="rowan cannot be imported.")
 
 @pytest.fixture
 def valid_body_definition():
@@ -113,6 +119,7 @@ def check_bodies(snapshot, definition):
                           definition["orientations"][i])
 
 
+@skip_rowan
 def test_create_bodies(simulation_factory, two_particle_snapshot_factory,
                        valid_body_definition):
     rigid = md.constrain.Rigid()
@@ -174,6 +181,7 @@ def test_error_on_invalid_body(simulation_factory,
         sim.run(0)
 
 
+@skip_rowan
 def test_running_simulation(simulation_factory, two_particle_snapshot_factory,
                             valid_body_definition):
     rigid = md.constrain.Rigid()

--- a/sphinx-doc/testing.rst
+++ b/sphinx-doc/testing.rst
@@ -23,6 +23,17 @@ should run long enough to ensure reasonable sampling, but not too long. These
 test run in a CI environment on every pull request. Individual validation tests
 should execute in less than 10 minutes.
 
+Requirements
+------------
+
+The following Python packages are required to execute tests. Some tests will be skipped when
+optional requirements are missing.
+
+- gsd (optional)
+- mpi4py (optional)
+- pytest
+- rowan (optional)
+
 Running tests
 -------------
 

--- a/sphinx-doc/testing.rst
+++ b/sphinx-doc/testing.rst
@@ -33,6 +33,7 @@ optional requirements are missing.
 - mpi4py (optional)
 - pytest
 - rowan (optional)
+- CuPy
 
 Running tests
 -------------

--- a/sphinx-doc/testing.rst
+++ b/sphinx-doc/testing.rst
@@ -33,7 +33,7 @@ optional requirements are missing.
 - mpi4py (optional)
 - pytest
 - rowan (optional)
-- CuPy
+- CuPy (optional)
 
 Running tests
 -------------


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should based on *maint*. -->
<!-- New features should based on *master*. -->

## Description

<!-- Describe your changes in detail. -->
- Make rowan an optional dependency for tests.
- Document the Python packages needed to run unit tests.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Users expect all dependencies to be documented. Users find it convenient when they don't need to install too many additional dependencies just to run tests.

<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves #1042 

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
I ran tests locally in a virtual environment without `rowan`.

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
Changed:

- rowan is now an optional dependency when running unit tests.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
