### PR TITLE
Unify msg_file

### DIFF
--- a/hoomd/Messenger.cc
+++ b/hoomd/Messenger.cc
@@ -83,10 +83,6 @@ Messenger::Messenger(std::shared_ptr<MPIConfiguration> mpi_config) : m_mpi_confi
     assert(m_mpi_config);
     if (m_mpi_config->getRank() != 0)
         m_notice_level = 0;
-
-#ifdef ENABLE_MPI
-    m_shared_filename = "";
-#endif
     }
 
 Messenger::Messenger(const Messenger& msg)
@@ -105,10 +101,6 @@ Messenger::Messenger(const Messenger& msg)
     m_notice_level = msg.m_notice_level;
 
     m_mpi_config = msg.m_mpi_config;
-
-#ifdef ENABLE_MPI
-    m_shared_filename = msg.m_shared_filename;
-#endif
     }
 
 Messenger& Messenger::operator=(Messenger& msg)
@@ -127,10 +119,6 @@ Messenger& Messenger::operator=(Messenger& msg)
     m_notice_level = msg.m_notice_level;
 
     m_mpi_config = msg.m_mpi_config;
-
-#ifdef ENABLE_MPI
-    m_shared_filename = msg.m_shared_filename;
-#endif
 
     return *this;
     }
@@ -320,7 +308,23 @@ void Messenger::noticeStr(unsigned int level, const std::string& msg)
 */
 void Messenger::openFile(const std::string& fname)
     {
-    m_file_out = std::shared_ptr<std::ostream>(new ofstream(fname.c_str()));
+    #ifdef ENABLE_MPI
+    if (m_mpi_config->getNRanks() > 1)
+        {
+        // open the shared file
+        m_streambuf_out = std::make_shared<mpi_io>(m_mpi_config->getCommunicator(), fname);
+        m_file_out = std::make_shared<std::ostream>(m_streambuf_out.get());
+        }
+    else
+        {
+        // open the file
+        m_file_out = std::make_shared<std::ofstream>(fname.c_str());
+        }
+    #else
+    m_file_out = std::make_shared<std::ofstream>(fname.c_str());
+    #endif
+
+    // update the error, warning, and notice streams
     m_file_err = std::shared_ptr<std::ostream>();
     m_err_stream = m_file_out.get();
     m_warning_stream = m_file_out.get();
@@ -377,29 +381,6 @@ void Messenger::reopenPythonIfNeeded()
             }
         }
     }
-
-#ifdef ENABLE_MPI
-/*! Open a shared file for error, warning, and notice streams
-
-    A suffix .rank (where rank is the partition number)
-    is appended to the filename
-*/
-void Messenger::openSharedFile()
-    {
-    std::ostringstream oss;
-    bcast(m_shared_filename, 0, m_mpi_config->getCommunicator());
-    oss << m_shared_filename << "." << m_mpi_config->getPartition();
-    m_streambuf_out = std::shared_ptr<std::streambuf>(
-        new mpi_io((const MPI_Comm&)m_mpi_config->getCommunicator(), oss.str()));
-
-    // now update the error, warning, and notice streams
-    m_file_out = std::shared_ptr<std::ostream>(new std::ostream(m_streambuf_out.get()));
-    m_file_err = std::shared_ptr<std::ostream>();
-    m_err_stream = m_file_out.get();
-    m_warning_stream = m_file_out.get();
-    m_notice_stream = m_file_out.get();
-    }
-#endif
 
 /*! Any open file is closed. stdout is opened again for notices and stderr for warnings and errors.
  */
@@ -480,8 +461,5 @@ void export_Messenger(py::module& m)
         .def("setWarningPrefix", &Messenger::setWarningPrefix)
         .def("openFile", &Messenger::openFile)
         .def("openPython", &Messenger::openPython)
-#ifdef ENABLE_MPI
-        .def("setSharedFile", &Messenger::setSharedFile)
-#endif
         .def("openStd", &Messenger::openStd);
     }

--- a/hoomd/Messenger.cc
+++ b/hoomd/Messenger.cc
@@ -308,11 +308,15 @@ void Messenger::noticeStr(unsigned int level, const std::string& msg)
 */
 void Messenger::openFile(const std::string& fname)
     {
-    #ifdef ENABLE_MPI
+#ifdef ENABLE_MPI
     if (m_mpi_config->getNRanks() > 1)
         {
         // open the shared file
-        m_streambuf_out = std::make_shared<mpi_io>(m_mpi_config->getCommunicator(), fname);
+        std::string broadcast_fname = fname;
+        bcast(broadcast_fname, 0, m_mpi_config->getCommunicator());
+
+        m_streambuf_out
+            = std::make_shared<mpi_io>(m_mpi_config->getCommunicator(), broadcast_fname);
         m_file_out = std::make_shared<std::ostream>(m_streambuf_out.get());
         }
     else
@@ -320,9 +324,9 @@ void Messenger::openFile(const std::string& fname)
         // open the file
         m_file_out = std::make_shared<std::ofstream>(fname.c_str());
         }
-    #else
+#else
     m_file_out = std::make_shared<std::ofstream>(fname.c_str());
-    #endif
+#endif
 
     // update the error, warning, and notice streams
     m_file_err = std::shared_ptr<std::ostream>();

--- a/hoomd/Messenger.h
+++ b/hoomd/Messenger.h
@@ -251,18 +251,6 @@ class PYBIND11_EXPORT Messenger
     //! Reopen the python streams if sys.stdout/err changes
     void reopenPythonIfNeeded();
 
-#ifdef ENABLE_MPI
-    //! Request logging of notices, warning and errors into shared log file
-    /*! \param fname The filenam
-     */
-    void setSharedFile(const std::string& fname)
-        {
-        m_shared_filename = fname;
-
-        openSharedFile();
-        }
-#endif
-
     //! Open stdout and stderr again, closing any open file
     void openStd();
 
@@ -289,13 +277,6 @@ class PYBIND11_EXPORT Messenger
     pybind11::module m_sys;      //!< sys module
     pybind11::object m_pystdout; //!< Currently bound python sys.stdout
     pybind11::object m_pystderr; //!< Currently bound python sys.stderr
-
-#ifdef ENABLE_MPI
-    std::string m_shared_filename; //!< Filename of shared log file
-
-    //! Open a shared file for error, warning, and notice streams
-    void openSharedFile();
-#endif
     };
 
 //! Exports Messenger to python

--- a/hoomd/device.py
+++ b/hoomd/device.py
@@ -4,7 +4,6 @@
 """Choose which hardware device(s) should execute the simulation."""
 
 import contextlib
-import os
 import hoomd
 from hoomd import _hoomd
 
@@ -79,7 +78,9 @@ class Device:
 
         Note:
             All MPI ranks within a given partition must open the same file.
-            Different partitions may open separate files. For example:
+            To ensure this, the given file name on rank 0 is broadcast to the
+            other ranks. Different partitions may open separate files. For
+            example:
 
             .. code::
 

--- a/hoomd/hpmc/update.py
+++ b/hoomd/hpmc/update.py
@@ -354,8 +354,9 @@ class MuVT(Updater):
 
     Gibbs ensemble simulations are also supported, where particles and volumeare
     swapped between two or more boxes.  Every box correspond to one MPI
-    partition, and can therefore run on multiple ranks. See ``hoomd.comm`` and
-    the --nrank command line option for how to split a MPI task into partitions.
+    partition, and can therefore run on multiple ranks. Use the
+    ``ranks_per_partition`` argument of `hoomd.communicator.Communicator` to
+    enable partitioned simulations.
 
     Note:
         Multiple Gibbs ensembles are also supported in a single parallel job,

--- a/hoomd/pytest/test_device.py
+++ b/hoomd/pytest/test_device.py
@@ -47,17 +47,6 @@ def test_common_properties(device, tmp_path):
                               msg_file=str(tmp_path / "example2.txt"),
                               num_cpu_threads=10)
 
-    # MPI conditional stuff
-    if hoomd.version.mpi_enabled:
-        # make sure we can pass a communciator
-        com = hoomd.communicator.Communicator(nrank=1)
-        assert device_type(communicator=com).communicator.num_ranks == 1
-        # make sure we can pass a shared_msg_file
-        device_type(shared_msg_file=str(tmp_path / "shared.txt"))
-    else:
-        with pytest.raises(RuntimeError):
-            device_type(shared_msg_file=str(tmp_path / "shared.txt"))
-
 
 def _assert_gpu_properties(dev, mem_traceback, gpu_error_checking):
     """Assert properties specific to GPU objects are correct."""


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should based on *maint*. -->
<!-- New features should based on *master*. -->

## Description

<!-- Describe your changes in detail. -->
Remove `shared_msg_file` and make `msg_file` always use the `shared_msg_file` behavior.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
There is no need to have two options that both accomplish essentially the same effect. There is only one rare use case detailed in #1005 that this removes, but there are workarounds.

The ``nrank`` change is somewhat disconnected from this pull request, but I made it here because I realized the confusing nature of the name ``nrank`` when I wrote the example for ``msg_file`` and partitions.

<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves #1005 

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
Unit tests pass. I also ran a local simulation using partitions and ensured that the new example code works as intended.

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
Removed:

- [breaking] ``shared_msg_file`` option to ``Device``. ``msg_file`` now has the same behavior as ``shared_msg_file``

Changed:

- [breaking] Rename ``nrank`` to ``ranks_per_partition`` in ``Communicator``.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
