### PR TITLE
Document cases where properties return None

### DIFF
--- a/hoomd/hpmc/compute.py
+++ b/hoomd/hpmc/compute.py
@@ -176,7 +176,12 @@ class SDF(Compute):
     @log(category='sequence', requires_run=True)
     def sdf(self):
         """:math:`s[i]` - The scale distribution function \
-        :math:`[\\mathrm{probability\\ density}]`."""
+        :math:`[\\mathrm{probability\\ density}]`.
+
+        Attention:
+            In MPI parallel execution, the array is available on rank 0 only.
+            `sdf` is `None` on ranks >= 1.
+        """
         self._cpp_obj.compute(self._simulation.timestep)
         return self._cpp_obj.sdf
 
@@ -193,6 +198,10 @@ class SDF(Compute):
 
         where :math:`d` is the dimensionality of the system, :math:`\\rho` is
         the number density, and :math:`\\beta = \\frac{1}{kT}`.
+
+        Attention:
+            In MPI parallel execution, `betaP` is available on rank 0 only.
+            `betaP` is `None` on ranks >= 1.
         """
         if not numpy.isnan(self.sdf).all():
             # get the values to fit

--- a/hoomd/hpmc/integrate.py
+++ b/hoomd/hpmc/integrate.py
@@ -224,7 +224,8 @@ class HPMCIntegrator(BaseIntegrator):
         the particles with tags ``i`` and ``j``.
 
         Attention:
-            `map_overlaps` does not support MPI parallel simulations.
+            `map_overlaps` does not support MPI parallel simulations. It returns
+            `None` when there is more than one MPI rank.
         """
         if self._simulation.device.communicator.num_ranks > 1:
             return None

--- a/hoomd/hpmc/update.py
+++ b/hoomd/hpmc/update.py
@@ -141,7 +141,8 @@ class BoxMC(Updater):
 
         Note:
             The counts are reset to 0 at the start of each call to
-            `hoomd.Simulation.run`.
+            `hoomd.Simulation.run`. Before the first call to `Simulation.run`,
+            `counter` is `None`.
         """
         if not self._attached:
             return None
@@ -152,7 +153,7 @@ class BoxMC(Updater):
     def volume_moves(self):
         """tuple[int, int]: The accepted and rejected volume and length moves.
 
-        (0, 0) when not attached.
+        (0, 0) before the first call to `Simulation.run`.
         """
         counter = self.counter
         if counter is None:
@@ -168,7 +169,7 @@ class BoxMC(Updater):
     def shear_moves(self):
         """tuple[int, int]: The accepted and rejected shear moves.
 
-        (0, 0) when not attached.
+        (0, 0) before the first call to `Simulation.run`.
         """
         counter = self.counter
         if counter is None:
@@ -180,7 +181,7 @@ class BoxMC(Updater):
     def aspect_moves(self):
         """tuple[int, int]: The accepted and rejected aspect moves.
 
-        (0, 0) when not attached.
+        (0, 0) before the first call to `Simulation.run`.
         """
         counter = self.counter
         if counter is None:

--- a/hoomd/md/force.py
+++ b/hoomd/md/force.py
@@ -36,8 +36,7 @@ class Force(_HOOMDBaseObject):
     @log(requires_run=True)
     def energy(self):
         """float: Total contribution to the potential energy of the system \
-        :math:`[\\mathrm{energy}]`.
-        """
+        :math:`[\\mathrm{energy}]`."""
         self._cpp_obj.compute(self._simulation.timestep)
         return self._cpp_obj.calcEnergySum()
 
@@ -56,8 +55,7 @@ class Force(_HOOMDBaseObject):
     @log(requires_run=True)
     def additional_energy(self):
         """float: Additional energy term not included in `energies` \
-        :math:`[\\mathrm{energy}]`.
-        """
+        :math:`[\\mathrm{energy}]`."""
         self._cpp_obj.compute(self._simulation.timestep)
         return self._cpp_obj.getExternalEnergy()
 

--- a/hoomd/md/force.py
+++ b/hoomd/md/force.py
@@ -36,35 +36,52 @@ class Force(_HOOMDBaseObject):
     @log(requires_run=True)
     def energy(self):
         """float: Total contribution to the potential energy of the system \
-        :math:`[\\mathrm{energy}]`."""
+        :math:`[\\mathrm{energy}]`.
+        """
         self._cpp_obj.compute(self._simulation.timestep)
         return self._cpp_obj.calcEnergySum()
 
     @log(category="particle", requires_run=True)
     def energies(self):
         """(*N_particles*, ) `numpy.ndarray` of ``float``: Energy \
-        contribution from each particle :math:`[\\mathrm{energy}]`."""
+        contribution from each particle :math:`[\\mathrm{energy}]`.
+
+        Attention:
+            In MPI parallel execution, the array is available on rank 0 only.
+            `energies` is `None` on ranks >= 1.
+        """
         self._cpp_obj.compute(self._simulation.timestep)
         return self._cpp_obj.getEnergies()
 
     @log(requires_run=True)
     def additional_energy(self):
         """float: Additional energy term not included in `energies` \
-        :math:`[\\mathrm{energy}]`."""
+        :math:`[\\mathrm{energy}]`.
+        """
         self._cpp_obj.compute(self._simulation.timestep)
         return self._cpp_obj.getExternalEnergy()
 
     @log(category="particle", requires_run=True)
     def forces(self):
         """(*N_particles*, 3) `numpy.ndarray` of ``float``: The \
-        force applied to each particle :math:`[\\mathrm{force}]`."""
+        force applied to each particle :math:`[\\mathrm{force}]`.
+
+        Attention:
+            In MPI parallel execution, the array is available on rank 0 only.
+            `forces` is `None` on ranks >= 1.
+        """
         self._cpp_obj.compute(self._simulation.timestep)
         return self._cpp_obj.getForces()
 
     @log(category="particle", requires_run=True)
     def torques(self):
         """(*N_particles*, 3) `numpy.ndarray` of ``float``: The torque applied \
-        to each particle :math:`[\\mathrm{force} \\cdot \\mathrm{length}]`."""
+        to each particle :math:`[\\mathrm{force} \\cdot \\mathrm{length}]`.
+
+        Attention:
+            In MPI parallel execution, the array is available on rank 0 only.
+            `torques` is `None` on ranks >= 1.
+        """
         self._cpp_obj.compute(self._simulation.timestep)
         return self._cpp_obj.getTorques()
 
@@ -75,6 +92,18 @@ class Force(_HOOMDBaseObject):
 
         The 6 elements form the upper-triangular virial tensor in the order:
         xx, xy, xz, yy, yz, zz.
+
+        Attention:
+            To improve performance `Force` objects only compute virials when
+            needed. When not computed, `virials` is `None`. Virials are computed
+            on every step when using a `md.methods.NPT` or `md.methods.NPH`
+            integrator, on steps where a writer is triggered (such as
+            `write.GSD` which may log pressure or virials), or when
+            `Simulation.always_compute_pressure` is `True`.
+
+        Attention:
+            In MPI parallel execution, the array is available on rank 0 only.
+            `virials` is `None` on ranks >= 1.
         """
         self._cpp_obj.compute(self._simulation.timestep)
         return self._cpp_obj.getVirials()

--- a/hoomd/update/box_resize.py
+++ b/hoomd/update/box_resize.py
@@ -85,6 +85,7 @@ class BoxResize(Updater):
 
         Returns:
             Box: The box used at the given timestep.
+            `None` before the first call to `Simulation.run`.
         """
         if self._attached:
             timestep = int(timestep)


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should based on *maint*. -->
<!-- New features should based on *master*. -->

## Description

<!-- Describe your changes in detail. -->
Add documentation blocks to call out cases where properties and/or loggables return `None`.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
HOOMD returns array quantities on the root rank only to reduce memory usage and communication. In most cases this is fine, as logging is only performed on the root rank. When a user accesses the property directly, they need to be aware of this behavior so they can add the appropriate conditions.

<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves #1064

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
I rendered the sphinx docs locally.

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
Improved documentation.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
