### PR TITLE
Make array documentation consistent in docs

### DIFF
--- a/hoomd/box.py
+++ b/hoomd/box.py
@@ -247,7 +247,7 @@ class Box:
     # Length based properties
     @property
     def L(self):  # noqa: N802 - allow function name
-        """(3) `numpy.ndarray` of `float`: The box lengths, ``[Lx, Ly, Lz]`` \
+        """(3, ) `numpy.ndarray` of `float`: The box lengths, ``[Lx, Ly, Lz]`` \
         :math:`[\\mathrm{length}]`.
 
         Can be set with a float which sets all lengths, or a length 3 vector.
@@ -300,7 +300,7 @@ class Box:
     # Box tilt based properties
     @property
     def tilts(self):
-        """(3) `numpy.ndarray` of `float`: The box tilts, ``[xy, xz, yz]``.
+        """(3, ) `numpy.ndarray` of `float`: The box tilts, ``[xy, xz, yz]``.
 
         Can be set using one tilt for all axes or three tilts. If the box is 2D
         ``xz`` and ``yz`` will automatically be set to zero.
@@ -348,7 +348,7 @@ class Box:
     # Misc. properties
     @property
     def periodic(self):
-        """(3) `numpy.ndarray` of `bool`: The periodicity of each dimension."""
+        """(3, ) `numpy.ndarray` of `bool`: The periodicity of each dimension."""
         return _vec3_to_array(self._cpp_obj.getPeriodic(), bool)
 
     @property
@@ -416,7 +416,7 @@ class Box:
         modified.
 
         Args:
-            s (float or Sequence[float]): scale factors in each dimension. If a
+            s (float or list[float]): scale factors in each dimension. If a
                 single float is given then scale all dimensions by s; otherwise,
                 s must be a sequence of 3 values used to scale each dimension.
 

--- a/hoomd/box.py
+++ b/hoomd/box.py
@@ -348,7 +348,8 @@ class Box:
     # Misc. properties
     @property
     def periodic(self):
-        """(3, ) `numpy.ndarray` of `bool`: The periodicity of each dimension."""
+        """(3, ) `numpy.ndarray` of `bool`: The periodicity of each \
+        dimension."""
         return _vec3_to_array(self._cpp_obj.getPeriodic(), bool)
 
     @property

--- a/hoomd/device.py
+++ b/hoomd/device.py
@@ -102,7 +102,7 @@ class Device:
 
     @property
     def devices(self):
-        """List[str]: Descriptions of the active hardware devices."""
+        """list[str]: Descriptions of the active hardware devices."""
         return self._cpp_exec_conf.getActiveDevices()
 
     @property
@@ -146,7 +146,7 @@ class GPU(Device):
     """Select a GPU or GPU(s) to execute simulations.
 
     Args:
-        gpu_ids (List[int]): List of GPU ids to use. Set to `None` to let the
+        gpu_ids (list[int]): List of GPU ids to use. Set to `None` to let the
             driver auto-select a GPU.
 
         num_cpu_threads (int): Number of TBB threads. Set to `None` to
@@ -268,7 +268,7 @@ class GPU(Device):
         """Get the available GPU devices.
 
         Returns:
-            List[str]: Descriptions of the available devices (if any).
+            list[str]: Descriptions of the available devices (if any).
         """
         return list(_hoomd.ExecutionConfiguration.getCapableDevices())
 
@@ -277,7 +277,7 @@ class GPU(Device):
         """Get messages describing the reasons why devices are unavailable.
 
         Returns:
-            List[str]: Messages indicating why some devices are unavailable
+            list[str]: Messages indicating why some devices are unavailable
             (if any).
         """
         return list(_hoomd.ExecutionConfiguration.getScanMessages())

--- a/hoomd/hpmc/compute.py
+++ b/hoomd/hpmc/compute.py
@@ -176,9 +176,7 @@ class SDF(Compute):
     @log(category='sequence', requires_run=True)
     def sdf(self):
         """(*N_bins*,) `numpy.ndarray` of `float`): :math:`s[i]` - The scale \
-        distribution function :math:`[\\mathrm{probability\\ density}]`.
-
-        """
+        distribution function :math:`[\\mathrm{probability\\ density}]`."""
         self._cpp_obj.compute(self._simulation.timestep)
         return self._cpp_obj.sdf
 

--- a/hoomd/hpmc/compute.py
+++ b/hoomd/hpmc/compute.py
@@ -175,14 +175,16 @@ class SDF(Compute):
 
     @log(category='sequence', requires_run=True)
     def sdf(self):
-        """:math:`s[i]` - The scale distribution function \
-        :math:`[\\mathrm{probability\\ density}]`."""
+        """(*N_bins*,) `numpy.ndarray` of `float`): :math:`s[i]` - The scale \
+        distribution function :math:`[\\mathrm{probability\\ density}]`.
+
+        """
         self._cpp_obj.compute(self._simulation.timestep)
         return self._cpp_obj.sdf
 
     @log(requires_run=True)
     def betaP(self):  # noqa: N802 - allow function name
-        """Beta times pressure in NVT simulations \
+        """float: Beta times pressure in NVT simulations \
         :math:`\\left[ \\mathrm{length}^{-d} \\right]`.
 
         Use a polynomial curve fit of degree 5 to estimate

--- a/hoomd/md/integrate.py
+++ b/hoomd/md/integrate.py
@@ -208,16 +208,16 @@ class Integrator(_DynamicIntegrator):
     Attributes:
         dt (float): Integrator time step size :math:`[\\mathrm{time}]`.
 
-        methods (List[hoomd.md.methods.Method]): List of integration methods.
+        methods (list[hoomd.md.methods.Method]): List of integration methods.
             Each integration method can be applied to only a specific subset of
             particles.
 
-        forces (List[hoomd.md.force.Force]): List of forces applied to
+        forces (list[hoomd.md.force.Force]): List of forces applied to
             the particles in the system. All the forces are summed together.
 
         aniso (str): Whether rotational degrees of freedom are integrated.
 
-        constraints (List[hoomd.md.constrain.Constraint]): List of
+        constraints (list[hoomd.md.constrain.Constraint]): List of
             constraint forces applied to the particles in the system.
 
         rigid (hoomd.md.constrain.Rigid): The rigid body definition for the

--- a/hoomd/md/methods.py
+++ b/hoomd/md/methods.py
@@ -376,12 +376,12 @@ class NPT(Method):
         tau (float): Coupling constant for the thermostat
             :math:`[\mathrm{time}]`.
 
-        S (List[hoomd.variant.Variant]): Stress components set
+        S (list[hoomd.variant.Variant]): Stress components set
             point for the barostat.
             In Voigt notation,
             :math:`[S_{xx}, S_{yy}, S_{zz}, S_{yz}, S_{xz}, S_{xy}]`
             :math:`[\mathrm{pressure}]`. Stress can be reset after the method
-            object is created. For example, an isoropic pressure can be set by
+            object is created. For example, an isotropic pressure can be set by
             ``npt.S = 4.``
 
         tauS (float): Coupling constant for the barostat
@@ -390,7 +390,7 @@ class NPT(Method):
         couple (str): Couplings of diagonal elements of the stress tensor,
             can be "none", "xy", "xz","yz", or "all".
 
-        box_dof(List[bool]): Box degrees of freedom with six boolean elements
+        box_dof(list[bool]): Box degrees of freedom with six boolean elements
             corresponding to x, y, z, xy, xz, yz, each.
 
         rescale_all (bool): if True, rescale all particles, not only those in

--- a/hoomd/snapshot.py
+++ b/hoomd/snapshot.py
@@ -113,41 +113,41 @@ class Snapshot:
             particles.types (list[str]):
                 Names of the particle types.
 
-            particles.position ((*N*, 3) `numpy.ndarray` of ``numpy.float32``):
+            particles.position ((*N*, 3) `numpy.ndarray` of `float`):
                 Particle position :math:`[\\mathrm{length}]`.
 
             particles.orientation ((*N*, 4) `numpy.ndarray` of \
-                ``numpy.float32``):
+                `float`):
                 Particle orientation.
 
-            particles.typeid ((*N*, ) `numpy.ndarray` of ``numpy.uint32``):
+            particles.typeid ((*N*, ) `numpy.ndarray` of ``uint32``):
                 Particle type id.
 
-            particles.mass ((*N*, ) `numpy.ndarray` of ``numpy.float32``):
+            particles.mass ((*N*, ) `numpy.ndarray` of `float`):
                 Particle mass :math:`[\\mathrm{mass}]`.
 
-            particles.charge ((*N*, ) `numpy.ndarray` of ``numpy.float32``):
+            particles.charge ((*N*, ) `numpy.ndarray` of `float`):
                 Particle charge :math:`[\\mathrm{charge}]`.
 
-            particles.diameter ((*N*, ) `numpy.ndarray` of ``numpy.float32``):
+            particles.diameter ((*N*, ) `numpy.ndarray` of `float`):
                 Particle diameter :math:`[\\mathrm{length}]`.
 
-            particles.body ((*N*, ) `numpy.ndarray` of ``numpy.int32``):
+            particles.body ((*N*, ) `numpy.ndarray` of ``int32``):
                 Particle body.
 
             particles.moment_inertia ((*N*, 3) `numpy.ndarray` of \
-                ``numpy.float32``):
+                `float`):
                 Particle moment of inertia :math:`[\\mathrm{mass} \\cdot
                 \\mathrm{length}^2]`.
 
-            particles.velocity ((*N*, 3) `numpy.ndarray` of ``numpy.float32``):
+            particles.velocity ((*N*, 3) `numpy.ndarray` of `float`):
                 Particle velocity :math:`[\\mathrm{velocity}]`.
 
-            particles.angmom ((*N*, 4) `numpy.ndarray` of ``numpy.float32``):
+            particles.angmom ((*N*, 4) `numpy.ndarray` of `float`):
                 Particle angular momentum :math:`[\\mathrm{mass} \\cdot
                 \\mathrm{velocity} \\cdot \\mathrm{length}]`.
 
-            particles.image ((*N*, 3) `numpy.ndarray` of ``numpy.int32``):
+            particles.image ((*N*, 3) `numpy.ndarray` of ``int32``):
                 Particle image.
 
         Note:
@@ -167,10 +167,10 @@ class Snapshot:
 
             bonds.types (list[str]): Names of the bond types
 
-            bonds.typeid ((*N*,) `numpy.ndarray` of ``numpy.uint32``):
+            bonds.typeid ((*N*,) `numpy.ndarray` of ``uint32``):
                 Bond type id.
 
-            bonds.group ((*N*, 2) `numpy.ndarray` of ``numpy.uint32``):
+            bonds.group ((*N*, 2) `numpy.ndarray` of ``uint32``):
                 Tags of the particles in the bond.
 
         Note:
@@ -190,10 +190,10 @@ class Snapshot:
 
             angles.types (list[str]): Names of the angle types
 
-            angles.typeid ((*N*,) `numpy.ndarray` of ``numpy.uint32``):
+            angles.typeid ((*N*,) `numpy.ndarray` of ``uint32``):
                 Angle type id.
 
-            angles.group ((*N*, 3) `numpy.ndarray` of ``numpy.uint32``):
+            angles.group ((*N*, 3) `numpy.ndarray` of ``uint32``):
                 Tags of the particles in the angle.
 
         Note:
@@ -213,10 +213,10 @@ class Snapshot:
 
             dihedrals.types (list[str]): Names of the dihedral types
 
-            dihedrals.typeid ((*N*,) `numpy.ndarray` of ``numpy.uint32``):
+            dihedrals.typeid ((*N*,) `numpy.ndarray` of ``uint32``):
                 Dihedral type id.
 
-            dihedrals.group ((*N*, 4) `numpy.ndarray` of ``numpy.uint32``):
+            dihedrals.group ((*N*, 4) `numpy.ndarray` of ``uint32``):
                 Tags of the particles in the dihedral.
 
         Note:
@@ -236,10 +236,10 @@ class Snapshot:
 
             impropers.types (list[str]): Names of the improper types
 
-            impropers.typeid ((*N*,) `numpy.ndarray` of ``numpy.uint32``):
+            impropers.typeid ((*N*,) `numpy.ndarray` of ``uint32``):
                 Improper type id.
 
-            impropers.group ((*N*, 4) `numpy.ndarray` of ``numpy.uint32``):
+            impropers.group ((*N*, 4) `numpy.ndarray` of ``uint32``):
                 Tags of the particles in the improper.
 
         Note:
@@ -259,10 +259,10 @@ class Snapshot:
 
             pairs.types (list[str]): Names of the special pair types
 
-            pairs.typeid ((*N*,) `numpy.ndarray` of ``numpy.uint32``):
+            pairs.typeid ((*N*,) `numpy.ndarray` of ``uint32``):
                 Special pair type id.
 
-            pairs.group ((*N*, 2) `numpy.ndarray` of ``numpy.uint32``):
+            pairs.group ((*N*, 2) `numpy.ndarray` of ``uint32``):
                 Tags of the particles in the special pair.
 
         Note:
@@ -280,10 +280,10 @@ class Snapshot:
         Attributes:
             constraints.N (int): Number of constraints.
 
-            constraints.value ((*N*, ) `numpy.ndarray` of ``numpy.float32``):
+            constraints.value ((*N*, ) `numpy.ndarray` of `float`):
                 Constraint length.
 
-            constraints.group ((*N*, *2*) `numpy.ndarray` of ``numpy.uint32``):
+            constraints.group ((*N*, *2*) `numpy.ndarray` of ``uint32``):
                 Tags of the particles in the constraint.
 
         Note:

--- a/hoomd/trigger.py
+++ b/hoomd/trigger.py
@@ -296,7 +296,7 @@ class And(_hoomd.AndTrigger, Trigger):
                     hoomd.trigger.Periodic(100)])
 
     Attributes:
-        triggers (List[hoomd.trigger.Trigger]): List of triggers.
+        triggers (list[hoomd.trigger.Trigger]): List of triggers.
     """
 
     def __init__(self, triggers):


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should based on *maint*. -->
<!-- New features should based on *master*. -->

## Description

<!-- Describe your changes in detail. -->
Make sphinx documentation of array quantities consistent

* lists are documented at list[type]
* numpy arrays as discussed in #638

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
The documentation should be consistent.

<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves #638

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
I rendered the sphinx docs locally and checked that each modification renders correctly.

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
Improved documentation.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
