### PR TITLE
Update HPMC move size tuner documentation for multitype systems

### DIFF
--- a/hoomd/hpmc/tune/move_size.py
+++ b/hoomd/hpmc/tune/move_size.py
@@ -322,37 +322,7 @@ class MoveSize(_InternalCustomTuner):
         approach the target value, while the per-type acceptance ratios may not
         be close to the target value. This requires creating move size tuners
         for each type and leveraging the ``ignore_statistics`` flag of the shape
-        property of the HPMC integrator; see below for an example.
-
-    ::
-
-        mc_tuners = {}
-        for ptype in sim.state.particle_types:
-            mc_tuners[ptype] = hoomd.hpmc.tune.MoveSize.scale_solver(
-                moves=['a', 'd'],
-                target=0.2,
-                types=[ptype],
-                trigger=hoomd.trigger.Periodic(1),
-                max_translation_move=2*max_r,
-                max_rotation_move=1.0,
-            )
-            # get shape params, modify, and re-set
-            td = mc.shape[ptype]
-            td['ignore_statistics'] = True
-            mc.shape[ptype] = td
-
-        # now loop through and only acknowledge statistics of 1 type at a time
-        for acknowledged_type in sim.state.particle_types:
-            sim.operations.tuners.append(mc_tuners[acknowledged_type])
-            td = mc.shape[acknowledged_type]
-            td['ignore_statistics'] = False
-            mc.shape[acknowledged_type] = td
-            for _ in range(10):
-                sim.run(10)
-            td = mc.shape[acknowledged_type]
-            td['ignore_statistics'] = True
-            mc.shape[acknowledged_type] = td
-            sim.operations.tuners.remove(mc_tuners[acknowledged_type])
+        property of the HPMC integrator.
 
     """
     _internal_class = _InternalMoveSize

--- a/hoomd/hpmc/tune/move_size.py
+++ b/hoomd/hpmc/tune/move_size.py
@@ -320,9 +320,10 @@ class MoveSize(_InternalCustomTuner):
         acceptance ratio. Otherwise, the *global* acceptance ratio, a weighted
         average of the acceptance ratios for each individual particle type, will
         approach the target value, while the per-type acceptance ratios may not
-        be close to the target value. This requires creating move size tuners
-        for each type and leveraging the ``ignore_statistics`` flag of the shape
-        property of the HPMC integrator.
+        be close to the target value. This requires setting the ``types`` attribute
+        to be one type at a type while setting the ``ignore_statistics`` flag of
+        the shape property of the HPMC integrator for all other types to
+        ``True``.
 
     """
     _internal_class = _InternalMoveSize

--- a/hoomd/hpmc/tune/move_size.py
+++ b/hoomd/hpmc/tune/move_size.py
@@ -320,10 +320,10 @@ class MoveSize(_InternalCustomTuner):
         acceptance ratio. Otherwise, the *global* acceptance ratio, a weighted
         average of the acceptance ratios for each individual particle type, will
         approach the target value, while the per-type acceptance ratios may not
-        be close to the target value. This requires setting the ``types`` attribute
-        to be one type at a time while setting the ``ignore_statistics`` flag of
-        the shape property of the HPMC integrator for all other types to
-        ``True``.
+        be close to the target value. This requires setting the ``types``
+        attribute to be one type at a time while setting the
+        ``ignore_statistics`` flag of the shape property of the HPMC integrator
+        for all other types to ``True``.
 
     """
     _internal_class = _InternalMoveSize

--- a/hoomd/hpmc/tune/move_size.py
+++ b/hoomd/hpmc/tune/move_size.py
@@ -265,14 +265,16 @@ class _InternalMoveSize(_InternalAction):
 class MoveSize(_InternalCustomTuner):
     """Tunes HPMCIntegrator move sizes to targeted acceptance rate.
 
-    For most common creation of a `MoveSize` tuner see `MoveSize.secant_solver`
-    and `MoveSize.scale_solver` respectively.
+    Direct instantiation of this class requires a `hoomd.tune.SolverStep` that
+    determines how move sizes are updated. This class also provides class
+    methods to create a `MoveSize` tuner with built-in solvers; see
+    `MoveSize.secant_solver` and `MoveSize.scale_solver`.
 
     Args:
         trigger (hoomd.trigger.Trigger): ``Trigger`` to determine when to run
             the tuner.
         moves (list[str]): A list of types of moves to tune. Available options
-            are 'a' and 'd'.
+            are ``'a'`` and ``'d'``.
         target (float): The acceptance rate for trial moves that is desired. The
             value should be between 0 and 1.
         solver (`hoomd.tune.SolverStep`): A solver that tunes move sizes to
@@ -289,7 +291,7 @@ class MoveSize(_InternalCustomTuner):
         trigger (hoomd.trigger.Trigger): ``Trigger`` to determine when to run
             the tuner.
         moves (list[str]): A list of types of moves to tune. Available options
-            are 'a' and 'd'.
+            are ``'a'`` and ``'d'``.
         target (float): The acceptance rate for trial moves that is desired. The
             value should be between 0 and 1.
         solver (hoomd.tune.SolverStep): A solver that tunes move sizes to
@@ -372,7 +374,7 @@ class MoveSize(_InternalCustomTuner):
             trigger (hoomd.trigger.Trigger): ``Trigger`` to determine when to
                 run the tuner.
             moves (list[str]): A list of types of moves to tune. Available
-                options are 'a' and 'd'.
+                options are ``'a'`` and ``'d'``.
             target (float): The acceptance rate for trial moves that is desired.
                 The value should be between 0 and 1.
             types (list[str]): A list of string particle types to tune the
@@ -392,6 +394,12 @@ class MoveSize(_InternalCustomTuner):
                 considered tuned. The tolerance should not be too much lower
                 than the default of 0.01 as acceptance rates can vary
                 significantly at typical tuning rates.
+
+        Note:
+            Increasing ``gamma`` towards 1 does not necessarily speed up
+            convergence and can slow it down. In addition, large values of
+            ``gamma`` can make the solver unstable, especially when tuning
+            frequently.
         """
         solver = ScaleSolver(max_scale, gamma, 'negative', tol)
         return cls(trigger, moves, target, solver, types, max_translation_move,
@@ -417,7 +425,7 @@ class MoveSize(_InternalCustomTuner):
             trigger (hoomd.trigger.Trigger): ``Trigger`` to determine when to
                 run the tuner.
             moves (list[str]): A list of types of moves to tune. Available
-                options are 'a' and 'd'.
+                options are ``'a'`` and ``'d'``.
             target (float): The acceptance rate for trial moves that is desired.
                 The value should be between 0 and 1.
             types (list[str]): A list of string
@@ -441,8 +449,8 @@ class MoveSize(_InternalCustomTuner):
 
         Note:
             Increasing ``gamma`` towards 1 does not necessarily speed up
-            convergence and can slow it done. In addition, large values of
-            ``gamma`` can make the solver unstable especially when tuning
+            convergence and can slow it down. In addition, large values of
+            ``gamma`` can make the solver unstable, especially when tuning
             frequently.
         """
         solver = SecantSolver(gamma, tol)

--- a/hoomd/hpmc/tune/move_size.py
+++ b/hoomd/hpmc/tune/move_size.py
@@ -314,7 +314,7 @@ class MoveSize(_InternalCustomTuner):
         requiring checking periodic images.
 
     Note:
-        In systems containing nonmonodisperse particle shapes and/or sizes, move
+        In systems containing disparate particle shapes and/or sizes, move
         sizes for the different types should be tuned independently so that the
         acceptances rates for the different particles are each near the target
         acceptance ratio. Otherwise, the *global* acceptance ratio, a weighted

--- a/hoomd/hpmc/tune/move_size.py
+++ b/hoomd/hpmc/tune/move_size.py
@@ -321,7 +321,7 @@ class MoveSize(_InternalCustomTuner):
         average of the acceptance ratios for each individual particle type, will
         approach the target value, while the per-type acceptance ratios may not
         be close to the target value. This requires setting the ``types`` attribute
-        to be one type at a type while setting the ``ignore_statistics`` flag of
+        to be one type at a time while setting the ``ignore_statistics`` flag of
         the shape property of the HPMC integrator for all other types to
         ``True``.
 

--- a/sphinx-doc/module-hpmc-tune.rst
+++ b/sphinx-doc/module-hpmc-tune.rst
@@ -16,7 +16,7 @@ hpmc.tune
     :synopsis: Tuners for HPMC.
     :members:
 
-    .. autoclass:: MoveSize(trigger, moves, target, solver, types=None, max_move_size=None)
+    .. autoclass:: MoveSize
         :members: secant_solver, scale_solver
 
         .. method:: tuned()

--- a/sphinx-doc/module-hpmc-tune.rst
+++ b/sphinx-doc/module-hpmc-tune.rst
@@ -16,7 +16,7 @@ hpmc.tune
     :synopsis: Tuners for HPMC.
     :members:
 
-    .. autoclass:: MoveSize
+    .. autoclass:: MoveSize(trigger, moves, target, solver, types=None, max_move_size=None)
         :members: secant_solver, scale_solver
 
         .. method:: tuned()


### PR DESCRIPTION
## Description

Add an example into the MoveSize tuner documentation about how to tune for multiple particle types.

## Motivation and context

This shows how to tune move sizes for particle types independently, which important for systems with large particle size and/or shape polydispersity.

## How has this been tested?

Built docs locally.

## Change log

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
