### PR TITLE
Remove print statement from PPPM parameters.

### DIFF
--- a/hoomd/md/long_range/pppm.py
+++ b/hoomd/md/long_range/pppm.py
@@ -234,7 +234,6 @@ class Coulomb(Force):
             for b in particle_types:
                 self._pair_force.params[(a, b)] = dict(kappa=kappa, alpha=alpha)
                 self._pair_force.r_cut[(a, b)] = rcut
-                print("Setting ewald params for", a, b)
 
         self._cpp_obj.setParams(Nx, Ny, Nz, order, kappa, rcut, alpha)
 


### PR DESCRIPTION
## Description

There was a print statement left over from debugging recent changes to PPPM in HOOMD v3. This silences it. 🙊

Introduced in #1066 / 3e38bd060483fce065cf0061f39030e014410786.

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
