### PR TITLE
Allow r_cut to be zero

### DIFF
--- a/hoomd/md/pair/pair.py
+++ b/hoomd/md/pair/pair.py
@@ -11,8 +11,7 @@ from hoomd.md.nlist import NList
 from hoomd.data.parameterdicts import ParameterDict, TypeParameterDict
 from hoomd.data.typeparam import TypeParameter
 import numpy as np
-from hoomd.data.typeconverter import (OnlyFrom, OnlyTypes, positive_real,
-                                      nonnegative_real)
+from hoomd.data.typeconverter import (OnlyFrom, OnlyTypes, nonnegative_real)
 
 validate_nlist = OnlyTypes(NList)
 
@@ -126,8 +125,9 @@ class Pair(force.Force):
 
     def __init__(self, nlist, default_r_cut=None, default_r_on=0., mode='none'):
         self._nlist = validate_nlist(nlist)
-        tp_r_cut = TypeParameter('r_cut', 'particle_types',
-                                 TypeParameterDict(positive_real, len_keys=2))
+        tp_r_cut = TypeParameter(
+            'r_cut', 'particle_types',
+            TypeParameterDict(nonnegative_real, len_keys=2))
         if default_r_cut is not None:
             tp_r_cut.default = default_r_cut
         tp_r_on = TypeParameter('r_on', 'particle_types',

--- a/hoomd/md/pytest/test_potential.py
+++ b/hoomd/md/pytest/test_potential.py
@@ -52,6 +52,9 @@ def _assert_equivalent_parameter_dicts(param_dict1, param_dict2):
 def test_rcut(simulation_factory, two_particle_snapshot_factory):
     lj = md.pair.LJ(nlist=md.nlist.Cell(), default_r_cut=2.5)
     assert lj.r_cut.default == 2.5
+    # ensure 0 is a valid value for r_cut
+    lj.r_cut[("A", "A")] = 0.0
+    lj.r_cut[("A", "A")] = 2.5
 
     lj.params[('A', 'A')] = {'sigma': 1, 'epsilon': 0.5}
     with pytest.raises(TypeConversionError):


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should based on *maint*. -->
<!-- New features should based on *master*. -->

## Description

Allow `r_cut` to be 0 which is useful to ensure for particular type pairs that
the interaction will not result in nan's or undefined behavior for using 0's in the pair potential
parameters.
<!-- Describe your changes in detail. -->

## Motivation and context

Fixes an issue @bdice had.
<!--- Why is this change required? What problem does it solve? -->


## How has this been tested?

Has not, but I could add a test that ensures that 0 is allowed in one of `Pair`'s subclasses.
<!--- Please describe in detail how you tested your changes. -->

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
Fixed: `hoomd.md.pair.Pair` `r_cut` type parameter can be set to 0.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
