### PR TITLE
Improve MD documentation.

### DIFF
--- a/hoomd/md/angle.py
+++ b/hoomd/md/angle.py
@@ -38,7 +38,7 @@ class Angle(Force):
 class Harmonic(Angle):
     r"""Harmonic angle potential.
 
-    The command angle.harmonic specifies a harmonic potential energy between
+    :py:class:`Harmonic` specifies a harmonic potential energy between
     every triplet of particles with an angle specified between them.
 
     .. math::
@@ -52,10 +52,10 @@ class Harmonic(Angle):
             The parameter of the harmonic bonds for each particle type.
             The dictionary has the following keys:
 
-            * ``k`` (`float`, **required**) - potential constant
+            * ``k`` (`float`, **required**) - potential constant :math:`k`
               :math:`[\mathrm{energy} \cdot \mathrm{radians}^{-2}]`
 
-            * ``t0`` (`float`, **required**) - rest angle
+            * ``t0`` (`float`, **required**) - rest angle :math:`\theta_0`
               :math:`[\mathrm{radians}]`
 
     Examples::
@@ -77,7 +77,7 @@ class Harmonic(Angle):
 class Cosinesq(Angle):
     r"""Cosine squared angle potential.
 
-    The command angle.cosinesq specifies a cosine squared potential energy
+    :py:class:`Cosinesq` specifies a cosine squared potential energy
     between every triplet of particles with an angle specified between them.
 
     .. math::
@@ -94,8 +94,8 @@ class Cosinesq(Angle):
             The parameter of the harmonic bonds for each particle type.
             The dictionary has the following keys:
 
-            * ``k`` (`float`, **required**) - potential constant
-              :math:`[\mathrm{energy} \cdot \mathrm{radians}^{-2}]`
+            * ``k`` (`float`, **required**) - potential constant :math:`k`
+              :math:`[\mathrm{energy}]`
 
             * ``t0`` (`float`, **required**) - rest angle :math:`\theta_0`
               :math:`[\mathrm{radians}]`

--- a/hoomd/md/bond.py
+++ b/hoomd/md/bond.py
@@ -46,8 +46,7 @@ class Harmonic(Bond):
 
         V(r) = \frac{1}{2} k \left( r - r_0 \right)^2
 
-    where :math:`\vec{r}` is the vector pointing from one particle to the other
-    in the bond.
+    where :math:`r` is the distance from one particle to the other in the bond.
 
     Attributes:
         params (TypeParameter[``bond type``, dict]):
@@ -85,9 +84,9 @@ class FENE(Bond):
         V(r) = - \frac{1}{2} k r_0^2 \ln \left( 1 - \left( \frac{r -
                \Delta}{r_0} \right)^2 \right) + V_{\mathrm{WCA}}(r)
 
-    where :math:`\vec{r}` is the vector pointing from one particle to the other
-    in the bond, :math:`\Delta = (d_i + d_j)/2 - 1`, :math:`d_i` is the diameter
-    of particle :math:`i`, and
+    where :math:`r` is the distance from one particle to the other in the bond,
+    :math:`\Delta = (d_i + d_j)/2 - 1`, :math:`d_i` is the diameter of particle
+    :math:`i`, and
 
     .. math::
         :nowrap:
@@ -175,11 +174,11 @@ class table(force._force):  # noqa - Will be renamed when updated for v3
                    = & 0                    & r \ge r_{\mathrm{max}} \\
         \end{eqnarray*}
 
-    where :math:`\vec{r}` is the vector pointing from one particle to the other
-    in the bond.  Care should be taken to define the range of the bond so that
-    it is not possible for the distance between two bonded particles to be
-    outside the specified range.  On the CPU, this will throw an error.  On the
-    GPU, this will throw an error if GPU error checking is enabled.
+    where :math:`r` is the distance from one particle to the other in the bond.
+    Care should be taken to define the range of the bond so that it is not
+    possible for the distance between two bonded particles to be outside the
+    specified range. On the CPU, this will throw an error. On the GPU, this
+    will throw an error if GPU error checking is enabled.
 
     :math:`F_{\mathrm{user}}(r)` and :math:`V_{\mathrm{user}}(r)` are evaluated
     on *width* grid points between :math:`r_{\mathrm{min}}` and
@@ -389,19 +388,18 @@ class Tether(Bond):
     :py:class:`Tether` specifies a Tethering potential energy between two
     particles in each defined bond.
 
-    The tethered network is described in Refs.
-    `Gompper, G. & Kroll, D. M. in Statistical Mechanics of Membranes and
-    Surfaces 2nd edn (eds Nelson, D. R. et al.) 359-426 (World Scientific, 2004)
-    <https://www.worldscientific.com/worldscibooks/10.1142/5473>`_ and `Noguchi
-    , H. & Gompper, G., Phys. Rev. E 72 011901 (2005)
-    <https://link.aps.org/doi/10.1103/PhysRevE.72.011901>`_.
+    The tethered network is described in Refs. `Gompper, G. & Kroll, D. M.
+    Statistical Mechanics of Membranes and Surfaces 2nd edn (eds Nelson, D. R.
+    et al.) 359-426 (World Scientific, 2004)
+    <https://www.worldscientific.com/worldscibooks/10.1142/5473>`__ and
+    `Noguchi, H. & Gompper, G., Phys. Rev. E 72 011901 (2005)
+    <https://link.aps.org/doi/10.1103/PhysRevE.72.011901>`__.
 
     .. math::
 
         V(r) = V_{\mathrm{att}}(r) + V_{\mathrm{rep}}(r)
 
-    where :math:`\vec{r}` is the vector pointing from one particle to the other
-    in the bond.
+    where :math:`r` is the distance from one particle to the other in the bond.
 
     .. math::
         :nowrap:

--- a/hoomd/md/bond.py
+++ b/hoomd/md/bond.py
@@ -95,9 +95,9 @@ class FENE(Bond):
         \begin{eqnarray*}
         V_{\mathrm{WCA}}(r)  = & 4 \varepsilon \left[ \left( \frac{\sigma}{r -
                                  \Delta} \right)^{12} - \left( \frac{\sigma}{r -
-                                 \Delta} \right)^{6} \right]  + \varepsilon
+                                 \Delta} \right)^{6} \right]  + \varepsilon;
                                & r-\Delta < 2^{\frac{1}{6}}\sigma\\
-                             = & 0
+                             = & 0;
                                & r-\Delta \ge 2^{\frac{1}{6}}\sigma
         \end{eqnarray*}
 
@@ -163,11 +163,11 @@ class table(force._force):  # noqa - Will be renamed when updated for v3
         :nowrap:
 
         \begin{eqnarray*}
-        \vec{F}(\vec{r})     = & 0
+        \vec{F}(\vec{r})     = & 0;
                                & r < r_{\mathrm{min}} \\
-                             = & F_{\mathrm{user}}(r)\hat{r}
+                             = & F_{\mathrm{user}}(r)\hat{r};
                                & r < r_{\mathrm{max}} \\
-                             = & 0
+                             = & 0;
                                & r \ge r_{\mathrm{max}} \\
                              \\
         V(r)       = & 0                    & r < r_{\mathrm{min}} \\
@@ -407,18 +407,18 @@ class Tether(Bond):
         :nowrap:
 
         \begin{eqnarray*}
-        V_{\mathrm{att}}(r)  = & k_b \frac{exp(1/(l_{c0}-r)}{l_{max}-r}
+        V_{\mathrm{att}}(r)  = & k_b \frac{exp(1/(l_{c0}-r)}{l_{max}-r};
                                 & r > l_{c0}\\
-                                = & 0
+                                = & 0;
                                 & r \leq l_{c0}
         \end{eqnarray*}
 
     .. math::
 
         \begin{eqnarray*}
-        V_{\mathrm{rep}}(r)  = & k_b \frac{exp(1/(r-l_{c1})}{r-l_{min}}
+        V_{\mathrm{rep}}(r)  = & k_b \frac{exp(1/(r-l_{c1})}{r-l_{min}};
                                 & r < l_{c1}\\
-                                = & 0
+                                = & 0;
                                 & r \ge l_{c1}
         \end{eqnarray*}
 

--- a/hoomd/md/compute.py
+++ b/hoomd/md/compute.py
@@ -104,10 +104,11 @@ class ThermodynamicQuantities(_Thermo):
 
           .. math::
 
-              P_{ij} = \\left[  \\sum_{k \\in \\mathrm{filter}} m_k \\vec{v}_{k,i} \\cdot
-              \\vec{v}_{k,j} + \\sum_{k \\in \\mathrm{filter}} \\sum_{l} \\frac{1}{2}
-              \\left(\\vec{r}_{kl,i} \\cdot \\vec{F}_{kl,j} + \\vec{r}_{kl,j} \\cdot
-              \\vec{F}_{kl, i} \\right) \\right]/V
+              P_{ij} = \\left[\\sum_{k \\in \\mathrm{filter}} m_k
+              \\vec{v}_{k,i} \\cdot \\vec{v}_{k,j} + \\sum_{k \\in
+              \\mathrm{filter}} \\sum_{l} \\frac{1}{2} \\left(\\vec{r}_{kl,i}
+              \\cdot \\vec{F}_{kl,j} + \\vec{r}_{kl,j} \\cdot \\vec{F}_{kl,i}
+              \\right) \\right]/V
 
         where :math:`V` is the total simulation box volume (or area in 2D).
         """

--- a/hoomd/md/compute.py
+++ b/hoomd/md/compute.py
@@ -104,9 +104,9 @@ class ThermodynamicQuantities(_Thermo):
 
           .. math::
 
-              P_{ij} = \\left[  \\sum_{k \\in \\mathrm{filter}} m_k v_{k,i}
-              v_{k,j} + \\sum_{k \\in \\mathrm{filter}} \\sum_{l} \\frac{1}{2}
-              \\left(\\vec{r}_{kl,i} \\vec{F}_{kl,j} + \\vec{r}_{kl,j}
+              P_{ij} = \\left[  \\sum_{k \\in \\mathrm{filter}} m_k \\vec{v}_{k,i} \\cdot
+              \\vec{v}_{k,j} + \\sum_{k \\in \\mathrm{filter}} \\sum_{l} \\frac{1}{2}
+              \\left(\\vec{r}_{kl,i} \\cdot \\vec{F}_{kl,j} + \\vec{r}_{kl,j} \\cdot
               \\vec{F}_{kl, i} \\right) \\right]/V
 
         where :math:`V` is the total simulation box volume (or area in 2D).
@@ -291,7 +291,7 @@ class HarmonicAveragedThermodynamicQuantities(Compute):
     of particles and calculates harmonically mapped average (HMA) properties
     of those particles when requested. HMA computes properties more precisely
     (with less variance) for atomic crystals in NVT simulations.  The presence
-    of dffusion (vacancy hopping, etc.) will prevent HMA from providing
+    of diffusion (vacancy hopping, etc.) will prevent HMA from providing
     improvement.  HMA tracks displacements from the lattice positions, which
     are saved either during first call to `Simulation.run` or when the compute
     is first added to the simulation, whichever occurs last.

--- a/hoomd/md/constrain.py
+++ b/hoomd/md/constrain.py
@@ -91,7 +91,7 @@ class Distance(Constraint):
 
     Note:
         `tolerance` sets the tolerance to detect constraint violations and
-        issue warning message. It does not influence the computation of the
+        issue a warning message. It does not influence the computation of the
         constraint force.
 
     Attributes:
@@ -175,7 +175,7 @@ class Rigid(Constraint):
     .. rubric:: Thermodynamic quantities of bodies
 
     HOOMD computes thermodynamic quantities (temperature, kinetic energy,
-    etc...) appropriately when there are rigid bodies present in the system.
+    etc.) appropriately when there are rigid bodies present in the system.
     When it does so, it ignores all constituent particles and computes the
     translational and rotational energies of the central particles, which
     represent the whole body.
@@ -209,7 +209,7 @@ class Rigid(Constraint):
         - ``diameters`` (list[float]): List of diameters of constituent
           particles
 
-        Type: `TypeParameter[``particle_type``, `dict`]
+        Type: `TypeParameter` [``particle_type``, `dict`]
 
     .. caution::
         The constituent particle type must exist.
@@ -262,7 +262,7 @@ class Rigid(Constraint):
         R"""Create rigid bodies from central particles in state.
 
         Args:
-            state (hoomd.State): the state to add rigid bodies too.
+            state (hoomd.State): The state in which to create rigid bodies.
         """
         if self._attached:
             raise RuntimeError(

--- a/hoomd/md/dihedral.py
+++ b/hoomd/md/dihedral.py
@@ -2,20 +2,20 @@
 # This file is part of the HOOMD-blue project, released under the BSD 3-Clause
 # License.
 
-"""Dihedral potentials.
+r"""Dihedral potentials.
 
 Dihedrals add forces between specified quadruplets of particles and used to
 model rotation about chemical bonds.
 
 By themselves, dihedrals that have been specified in an input file do nothing.
-Only when you specify an dihedral force (i.e. dihedral.harmonic), are forces
+Only when you specify an dihedral force (e.g. `dihedral.Harmonic`), are forces
 actually calculated between the listed particles.
 
 Important: There are multiple conventions pertaining to the dihedral angle (phi)
 in the literature. HOOMD utilizes the convention shown in the following figure,
 where vectors are defined from the central particles to the outer particles.
-These vectors correspond to a stretched state (phi=180 deg) when they are
-anti-parallel and a compact state (phi=0 deg) when they are parallel.
+These vectors correspond to a stretched state (:math:`\phi = 180` degrees) when they are
+anti-parallel and a compact state (:math:`\phi = 0`) when they are parallel.
 
 .. image:: dihedral-angle-definition.png
     :width: 400 px
@@ -67,21 +67,21 @@ class Harmonic(Dihedral):
 
     .. math::
 
-        V(r) = \frac{1}{2}k \left( 1 + d \cos\left(n * \phi(r) - \phi_0 \right)
+        V(\phi) = \frac{1}{2}k \left( 1 + d \cos\left(n \phi - \phi_0 \right)
                \right)
 
-    where :math:`\phi` is angle between two sides of the dihedral.
+    where :math:`\phi` is the angle between two sides of the dihedral.
 
     Attributes:
         params (`TypeParameter` [``dihedral type``, `dict`]):
             The parameter of the harmonic bonds for each dihedral type. The
             dictionary has the following keys:
 
-            * ``k`` (`float`, **required**) - potential constant
+            * ``k`` (`float`, **required**) - potential constant :math:`k`
               :math:`[\mathrm{energy}]`
-            * ``d`` (`float`, **required**) - sign factor
-            * ``n`` (`int`, **required**) - angle multiplicity factor
-            * ``phi0`` (`float`, **required**) - phase shift
+            * ``d`` (`float`, **required**) - sign factor :math:`d`
+            * ``n`` (`int`, **required**) - angle multiplicity factor :math:`n`
+            * ``phi0`` (`float`, **required**) - phase shift :math:`\phi_0`
               :math:`[\mathrm{radians}]`
 
     Examples::
@@ -322,17 +322,17 @@ class OPLS(Dihedral):
 
     .. math::
 
-        V(r) = \frac{1}{2}k_1 \left( 1 + \cos\left(\phi \right) \right) +
-               \frac{1}{2}k_2 \left( 1 - \cos\left(2 \phi \right) \right)
-               + \frac{1}{2}k_3 \left( 1 + \cos\left(3 \phi \right) \right) +
-               \frac{1}{2}k_4 \left( 1 - \cos\left(4 \phi \right) \right)
+        V(\phi) = \frac{1}{2}k_1 \left( 1 + \cos\left(\phi \right) \right) +
+                  \frac{1}{2}k_2 \left( 1 - \cos\left(2 \phi \right) \right) +
+                  \frac{1}{2}k_3 \left( 1 + \cos\left(3 \phi \right) \right) +
+                  \frac{1}{2}k_4 \left( 1 - \cos\left(4 \phi \right) \right)
 
     where :math:`\phi` is the angle between two sides of the dihedral and
     :math:`k_n` are the force coefficients in the Fourier series (in energy
     units).
 
     Attributes:
-        params (TypeParameter[``dihedral type``, dict]):
+        params (`TypeParameter` [``dihedral type``, `dict`]):
             The parameter of the OPLS bonds for each particle type.
             The dictionary has the following keys:
 

--- a/hoomd/md/dihedral.py
+++ b/hoomd/md/dihedral.py
@@ -14,8 +14,9 @@ actually calculated between the listed particles.
 Important: There are multiple conventions pertaining to the dihedral angle (phi)
 in the literature. HOOMD utilizes the convention shown in the following figure,
 where vectors are defined from the central particles to the outer particles.
-These vectors correspond to a stretched state (:math:`\phi = 180` degrees) when they are
-anti-parallel and a compact state (:math:`\phi = 0`) when they are parallel.
+These vectors correspond to a stretched state (:math:`\phi = 180` degrees) when
+they are anti-parallel and a compact state (:math:`\phi = 0`) when they are
+parallel.
 
 .. image:: dihedral-angle-definition.png
     :width: 400 px

--- a/hoomd/md/external/field.py
+++ b/hoomd/md/external/field.py
@@ -64,7 +64,7 @@ class Periodic(Field):
             :math:`[\\mathrm{energy}]`.
         * ``i`` (`int`, **required**) - :math:`\\vec{b}_i`, :math:`i=0, 1, 2`, \
             is the simulation box's reciprocal lattice vector in the :math:`i` \
-            direction :math:`[\\mathrm{length}^{-1}]`.
+            direction :math:`[\\mathrm{dimensionless}]`.
         * ``w`` (`float`, **required**) - The interface width :math:`w` \
             relative to the distance :math:`2\\pi/|\\mathbf{b_i}|` between \
             planes in the :math:`i`-direction :math:`[\\mathrm{dimensionless}]`.

--- a/hoomd/md/external/field.py
+++ b/hoomd/md/external/field.py
@@ -15,12 +15,14 @@ from hoomd.data.typeparam import TypeParameter
 
 
 class Field(force.Force):
-    """Common external field potential documentation.
+    """Constructs the external field potential.
 
-    Users should not invoke `Field` directly. Documentation common to all
-    external field potentials is located here. External potentials represent
-    forces which are applied to all particles in the simulation by an external
-    agent.
+    External potentials represent forces which are applied to all particles in
+    the simulation by an external agent.
+
+    Note:
+        `Field` is the base class for all external field potentials.
+        Users should not instantiate this class directly.
     """
 
     def _attach(self):
@@ -48,7 +50,7 @@ class Periodic(Field):
 
     .. math::
 
-       V(\\vec{r}) = A * \\tanh\\left[\\frac{1}{2 \\pi p w} \\cos\\left(
+       V(\\vec{r}) = A \\tanh\\left[\\frac{1}{2 \\pi p w} \\cos\\left(
        p \\vec{b}_i\\cdot\\vec{r}\\right)\\right]
 
     The coefficients above must be set per unique particle type.
@@ -62,7 +64,7 @@ class Periodic(Field):
             :math:`[\\mathrm{energy}]`.
         * ``i`` (`int`, **required**) - :math:`\\vec{b}_i`, :math:`i=0, 1, 2`, \
             is the simulation box's reciprocal lattice vector in the :math:`i` \
-            direction :math:`[\\mathrm{dimensionless}]`.
+            direction :math:`[\\mathrm{length}^{-1}]`.
         * ``w`` (`float`, **required**) - The interface width :math:`w` \
             relative to the distance :math:`2\\pi/|\\mathbf{b_i}|` between \
             planes in the :math:`i`-direction :math:`[\\mathrm{dimensionless}]`.
@@ -107,10 +109,9 @@ class Electric(Field):
 
     .. py:attribute:: E
 
-        The electric field vector, :math:`E`, as a tuple (i.e.
-        :math:`(E_x, E_y, E_z)`) \
-        :math:`[\\mathrm{energy} \\cdot \\mathrm{charge}^{-1} \\cdot \
-        \\mathrm{length^{-1}}]`.
+        The electric field vector :math:`\\vec{E}` as a tuple
+        :math:`(E_x, E_y, E_z)` :math:`[\\mathrm{energy} \\cdot
+        \\mathrm{charge}^{-1} \\cdot \\mathrm{length^{-1}}]`.
 
         Type: `TypeParameter` [``particle_type``, `tuple` [`float`, `float`,
         `float`]]

--- a/hoomd/md/many_body.py
+++ b/hoomd/md/many_body.py
@@ -33,10 +33,10 @@ class Triplet(Force):
 
         \begin{eqnarray}
         \vec{F_i}
-            =& -\nabla V(\vec r_{ij}, \vec r_{ik})
+            =& -\nabla V(\vec r_{ij}, \vec r_{ik});
              & r_{ij} < r_{\mathrm{cut}}
                 \textrm{ and } r_{ik} < r_{\mathrm{cut}} \\
-           =& 0 & else
+           =& 0; & otherwise
         \end{eqnarray}
 
     Where
@@ -272,7 +272,7 @@ class RevCross(Triplet):
         V_{ij}(r)  =  4 \varepsilon \left[
             \left( \dfrac{ \sigma}{r_{ij}} \right)^{2n}
             - \left( \dfrac{ \sigma}{r_{ij}} \right)^{n}
-        \right] \qquad r<r_{cut}
+        \right]; \qquad r < r_{cut}
         \end{eqnarray*}
 
     Then an additional three-body repulsion is evaluated to compensate the bond
@@ -297,8 +297,8 @@ class RevCross(Triplet):
             \begin{eqnarray*}
             \hat{v}^{ \left( 2b \right)}_{ij}\left(\vec{r}_{ij}\right) =
             \begin{cases}
-            1 & r \le r_{min} \\
-            - \dfrac{v_{ij}\left(\vec{r}_{ij}\right)}{\epsilon}
+            1; & r \le r_{min} \\
+            - \dfrac{v_{ij}\left(\vec{r}_{ij}\right)}{\epsilon};
               & r > r_{min} \\
             \end{cases}
             \end{eqnarray*}

--- a/hoomd/md/pair/aniso.py
+++ b/hoomd/md/pair/aniso.py
@@ -168,9 +168,9 @@ class GayBerne(AnisotropicPair):
 
         \begin{eqnarray*}
         V_{\mathrm{GB}}(\vec r, \vec e_i, \vec e_j)
-            = & 4 \varepsilon \left[ \zeta^{-12} - \zeta^{-6} \right]
+            = & 4 \varepsilon \left[ \zeta^{-12} - \zeta^{-6} \right];
             & \zeta < \zeta_{\mathrm{cut}} \\
-            = & 0 & \zeta \ge \zeta_{\mathrm{cut}} \\
+            = & 0; & \zeta \ge \zeta_{\mathrm{cut}} \\
         \end{eqnarray*}
 
     .. math::

--- a/hoomd/md/pair/pair.py
+++ b/hoomd/md/pair/pair.py
@@ -34,8 +34,8 @@ class Pair(force.Force):
         :nowrap:
 
         \begin{eqnarray*}
-        \vec{F}  = & -\nabla V(r) & r < r_{\mathrm{cut}} \\
-                  = & 0           & r \ge r_{\mathrm{cut}} \\
+        \vec{F}  = & -\nabla V(r); & r < r_{\mathrm{cut}} \\
+                  = & 0;           & r \ge r_{\mathrm{cut}} \\
         \end{eqnarray*}
 
     where :math:`\vec{r}` is the vector pointing from one particle to the other
@@ -45,12 +45,12 @@ class Pair(force.Force):
         :nowrap:
 
         \begin{eqnarray*}
-        V(r)  = & V_{\mathrm{pair}}(r) & \mathrm{mode\ is\ no\_shift} \\
-              = & V_{\mathrm{pair}}(r) - V_{\mathrm{pair}}(r_{\mathrm{cut}})
+        V(r)  = & V_{\mathrm{pair}}(r); & \mathrm{mode\ is\ no\_shift} \\
+              = & V_{\mathrm{pair}}(r) - V_{\mathrm{pair}}(r_{\mathrm{cut}});
               & \mathrm{mode\ is\ shift} \\
-              = & S(r) \cdot V_{\mathrm{pair}}(r) & \mathrm{mode\ is\
+              = & S(r) \cdot V_{\mathrm{pair}}(r); & \mathrm{mode\ is\
               xplor\ and\ } r_{\mathrm{on}} < r_{\mathrm{cut}} \\
-              = & V_{\mathrm{pair}}(r) - V_{\mathrm{pair}}(r_{\mathrm{cut}})
+              = & V_{\mathrm{pair}}(r) - V_{\mathrm{pair}}(r_{\mathrm{cut}});
               & \mathrm{mode\ is\ xplor\ and\ } r_{\mathrm{on}} \ge
               r_{\mathrm{cut}}
         \end{eqnarray*}
@@ -61,13 +61,13 @@ class Pair(force.Force):
         :nowrap:
 
         \begin{eqnarray*}
-        S(r) = & 1 & r < r_{\mathrm{on}} \\
+        S(r) = & 1; & r < r_{\mathrm{on}} \\
              = & \frac{(r_{\mathrm{cut}}^2 - r^2)^2 \cdot
              (r_{\mathrm{cut}}^2 + 2r^2 -
              3r_{\mathrm{on}}^2)}{(r_{\mathrm{cut}}^2 -
-             r_{\mathrm{on}}^2)^3}
+             r_{\mathrm{on}}^2)^3};
                & r_{\mathrm{on}} \le r \le r_{\mathrm{cut}} \\
-             = & 0 & r > r_{\mathrm{cut}} \\
+             = & 0; & r > r_{\mathrm{cut}} \\
          \end{eqnarray*}
 
     and :math:`V_{\mathrm{pair}}(r)` is the specific pair potential chosen by
@@ -233,8 +233,8 @@ class LJ(Pair):
         \begin{eqnarray*}
         V_{\mathrm{LJ}}(r)  = & 4 \varepsilon \left[ \left(
         \frac{\sigma}{r} \right)^{12} - \left( \frac{\sigma}{r}
-        \right)^{6} \right] & r < r_{\mathrm{cut}} \\
-        = & 0 & r \ge r_{\mathrm{cut}} \\
+        \right)^{6} \right]; & r < r_{\mathrm{cut}} \\
+        = & 0; & r \ge r_{\mathrm{cut}} \\
         \end{eqnarray*}
 
     See `Pair` for details on how forces are calculated and the available
@@ -286,9 +286,9 @@ class Gauss(Pair):
 
         \begin{eqnarray*}
         V_{\mathrm{gauss}}(r)  = & \varepsilon \exp \left[ -\frac{1}{2}
-                                  \left( \frac{r}{\sigma} \right)^2 \right]
+                                  \left( \frac{r}{\sigma} \right)^2 \right];
                                   & r < r_{\mathrm{cut}} \\
-                                 = & 0 & r \ge r_{\mathrm{cut}} \\
+                                 = & 0; & r \ge r_{\mathrm{cut}} \\
         \end{eqnarray*}
 
     See `Pair` for details on how forces are calculated and the available
@@ -344,9 +344,9 @@ class SLJ(Pair):
         V_{\mathrm{SLJ}}(r)  = & 4 \varepsilon \left[ \left(
                                 \frac{\sigma}{r - \Delta} \right)^{12} -
                                 \left( \frac{\sigma}{r - \Delta}
-                                \right)^{6} \right] & r < (r_{\mathrm{cut}}
+                                \right)^{6} \right]; & r < (r_{\mathrm{cut}}
                                 + \Delta) \\
-                             = & 0 & r \ge (r_{\mathrm{cut}} + \Delta) \\
+                             = & 0; & r \ge (r_{\mathrm{cut}} + \Delta) \\
         \end{eqnarray*}
 
     where :math:`\Delta = (d_i + d_j)/2 - 1` and :math:`d_i` is the diameter of
@@ -429,8 +429,8 @@ class Yukawa(Pair):
 
         \begin{eqnarray*}
           V_{\mathrm{yukawa}}(r) = & \varepsilon \frac{ \exp \left(
-          -\kappa r \right) }{r} & r < r_{\mathrm{cut}} \\
-                                  = & 0 & r \ge r_{\mathrm{cut}} \\
+          -\kappa r \right) }{r}; & r < r_{\mathrm{cut}} \\
+                                  = & 0; & r \ge r_{\mathrm{cut}} \\
         \end{eqnarray*}
 
     See `Pair` for details on how forces are calculated and the available
@@ -486,9 +486,9 @@ class Ewald(Pair):
                                     \exp(\alpha r) \\
                                     + \mathrm{erfc}\left(\kappa r -
                                     \frac{\alpha}{2 \kappa}\right)
-                                    \exp(-\alpha r)\right]
+                                    \exp(-\alpha r)\right];
                                     & r < r_{\mathrm{cut}} \\
-                            = & 0 & r \ge r_{\mathrm{cut}} \\
+                            = & 0; & r \ge r_{\mathrm{cut}} \\
         \end{eqnarray*}
 
     Call `md.long_range.pppm.make_pppm_coulomb_forces` to create an instance
@@ -551,10 +551,10 @@ class Table(Pair):
         :nowrap:
 
         \\begin{eqnarray*}
-        \\vec{F}(\\vec{r}) = & 0 & r < r_{\\mathrm{min}} \\\\
-                           = & F(r)\\hat{r}
+        \\vec{F}(\\vec{r}) = & 0; & r < r_{\\mathrm{min}} \\\\
+                           = & F(r)\\hat{r};
                              & r_{\\mathrm{min}} \\le r < r_{\\mathrm{max}} \\\\
-                           = & 0 & r \\ge r_{\\mathrm{max}} \\\\
+                           = & 0; & r \\ge r_{\\mathrm{max}} \\\\
         \\end{eqnarray*}
 
     and the potential :math:`V(r)` is:
@@ -563,10 +563,10 @@ class Table(Pair):
         :nowrap:
 
         \\begin{eqnarray*}
-        V(r) = & 0 & r < r_{\\mathrm{min}} \\\\
-             = & V(r)
+        V(r) = & 0; & r < r_{\\mathrm{min}} \\\\
+             = & V(r);
                & r_{\\mathrm{min}} \\le r < r_{\\mathrm{max}} \\\\
-             = & 0 & r \\ge r_{\\mathrm{max}} \\\\
+             = & 0; & r \\ge r_{\\mathrm{max}} \\\\
         \\end{eqnarray*}
 
     where :math:`\\vec{r}` is the vector pointing from one particle to the other
@@ -636,8 +636,8 @@ class Morse(Pair):
         \begin{eqnarray*}
         V_{\mathrm{morse}}(r) = & D_0 \left[ \exp \left(-2\alpha\left(
             r-r_0\right)\right) -2\exp \left(-\alpha\left(r-r_0\right)
-            \right) \right] & r < r_{\mathrm{cut}} \\
-            = & 0 & r \ge r_{\mathrm{cut}} \\
+            \right) \right]; & r < r_{\mathrm{cut}} \\
+            = & 0; & r \ge r_{\mathrm{cut}} \\
         \end{eqnarray*}
 
     See `Pair` for details on how forces are calculated and the available
@@ -713,9 +713,9 @@ class DPD(Pair):
         :nowrap:
 
         \begin{eqnarray*}
-        w(r_{ij}) = &\left( 1 - r/r_{\mathrm{cut}} \right)
+        w(r_{ij}) = &\left( 1 - r/r_{\mathrm{cut}} \right);
         & r < r_{\mathrm{cut}} \\
-                  = & 0 & r \ge r_{\mathrm{cut}} \\
+                  = & 0; & r \ge r_{\mathrm{cut}} \\
         \end{eqnarray*}
 
     where :math:`\hat r_{ij}` is a normalized vector from particle i to
@@ -800,9 +800,9 @@ class DPDConservative(Pair):
         \begin{eqnarray*}
         V_{\mathrm{DPD-C}}(r) = & A \cdot \left( r_{\mathrm{cut}} - r
           \right) - \frac{1}{2} \cdot \frac{A}{r_{\mathrm{cut}}} \cdot
-          \left(r_{\mathrm{cut}}^2 - r^2 \right)
+          \left(r_{\mathrm{cut}}^2 - r^2 \right);
           & r < r_{\mathrm{cut}} \\
-                              = & 0 & r \ge r_{\mathrm{cut}} \\
+                              = & 0; & r \ge r_{\mathrm{cut}} \\
         \end{eqnarray*}
 
 
@@ -881,18 +881,18 @@ class DPDLJ(Pair):
         \begin{eqnarray*}
         V_{\mathrm{LJ}}(r) = & 4 \varepsilon \left[ \left(
             \frac{\sigma}{r} \right)^{12} -
-             \left( \frac{\sigma}{r} \right)^{6} \right]
+             \left( \frac{\sigma}{r} \right)^{6} \right];
             & r < r_{\mathrm{cut}} \\
-                            = & 0 & r \ge r_{\mathrm{cut}} \\
+                            = & 0; & r \ge r_{\mathrm{cut}} \\
         \end{eqnarray*}
 
     .. math::
         :nowrap:
 
         \begin{eqnarray*}
-        w(r_{ij}) = &\left( 1 - r/r_{\mathrm{cut}} \right)
+        w(r_{ij}) = &\left( 1 - r/r_{\mathrm{cut}} \right);
             & r < r_{\mathrm{cut}} \\
-                  = & 0 & r \ge r_{\mathrm{cut}} \\
+                  = & 0; & r \ge r_{\mathrm{cut}} \\
         \end{eqnarray*}
 
     where :math:`\hat r_{ij}` is a normalized vector from particle i to
@@ -991,8 +991,8 @@ class ForceShiftedLJ(Pair):
         \begin{eqnarray*}
         V(r) = & 4 \varepsilon \left[ \left( \frac{\sigma}{r}
           \right)^{12} - \left( \frac{\sigma}{r} \right)^{6}
-          \right] + \Delta V(r) & r < r_{\mathrm{cut}}\\
-             = & 0 & r \ge r_{\mathrm{cut}} \\
+          \right] + \Delta V(r); & r < r_{\mathrm{cut}}\\
+             = & 0; & r \ge r_{\mathrm{cut}} \\
         \end{eqnarray*}
 
     .. math::
@@ -1052,9 +1052,9 @@ class Moliere(Pair):
           = & \frac{Z_i Z_j e^2}{4 \pi \epsilon_0 r_{ij}} \left[ 0.35 \exp
           \left( -0.3 \frac{r_{ij}}{a_F} \right) + \\
           0.55 \exp \left( -1.2 \frac{r_{ij}}{a_F} \right) + 0.10 \exp
-          \left( -6.0 \frac{r_{ij}}{a_F} \right) \right]
+          \left( -6.0 \frac{r_{ij}}{a_F} \right) \right];
           & r < r_{\mathrm{cut}} \\
-          = & 0 & r > r_{\mathrm{cut}} \\
+          = & 0; & r > r_{\mathrm{cut}} \\
         \end{eqnarray*}
 
     Where each parameter is defined as:
@@ -1134,9 +1134,9 @@ class ZBL(Pair):
           \exp \left( -3.2 \frac{r_{ij}}{a_F} \right) \\
           + 0.5099 \exp \left( -0.9423 \frac{r_{ij}}{a_F} \right) \\
           + 0.2802 \exp \left( -0.4029 \frac{r_{ij}}{a_F} \right) \\
-          + 0.02817 \exp \left( -0.2016 \frac{r_{ij}}{a_F} \right) \right],
+          + 0.02817 \exp \left( -0.2016 \frac{r_{ij}}{a_F} \right) \right];
           & r < r_{\mathrm{cut}} \\
-          = & 0, & r > r_{\mathrm{cut}} \\
+          = & 0; & r > r_{\mathrm{cut}} \\
         \end{eqnarray*}
 
     Where each parameter is defined as:
@@ -1213,8 +1213,8 @@ class Mie(Pair):
           = & \left( \frac{n}{n-m} \right) {\left( \frac{n}{m}
           \right)}^{\frac{m}{n-m}} \varepsilon \left[ \left(
           \frac{\sigma}{r} \right)^{n} - \left( \frac{\sigma}{r}
-          \right)^{m} \right] & r < r_{\mathrm{cut}} \\
-          = & 0 & r \ge r_{\mathrm{cut}} \\
+          \right)^{m} \right]; & r < r_{\mathrm{cut}} \\
+          = & 0; & r \ge r_{\mathrm{cut}} \\
         \end{eqnarray*}
 
     See `Pair` for details on how forces are calculated and the available
@@ -1282,8 +1282,8 @@ class ExpandedMie(Pair):
           \\right)}^{\\frac{m}{n-m}} \\varepsilon \\left[ \\left(
           \\frac{\\sigma}{r-\\Delta} \\right)^{n} - \\left( \\frac
           {\\sigma}{r-\\Delta}
-          \\right)^{m} \\right] & r < r_{\\mathrm{cut}} \\\\
-          = & 0 & r \\ge r_{\\mathrm{cut}} \\\\
+          \\right)^{m} \\right]; & r < r_{\\mathrm{cut}} \\\\
+          = & 0; & r \\ge r_{\\mathrm{cut}} \\\\
         \\end{eqnarray*}
 
     See `Pair` for details on how forces are calculated and the available energy
@@ -1438,9 +1438,9 @@ class DLVO(Pair):
             + \log \left(
             \frac{r^2 - (a_1+a_2)^2}{r^2 - (a_1-a_2)^2} \right) \right]
             & \\
-            & + \frac{a_1 a_2}{a_1+a_2} Z e^{-\kappa(r - (a_1+a_2))}
+            & + \frac{a_1 a_2}{a_1+a_2} Z e^{-\kappa(r - (a_1+a_2))};
             & r < (r_{\mathrm{cut}} + \Delta) \\
-            = & 0 & r \ge (r_{\mathrm{cut}} + \Delta)
+            = & 0; & r \ge (r_{\mathrm{cut}} + \Delta)
         \end{eqnarray*}
 
     where :math:`a_i` is the radius of particle :math:`i`, :math:`\Delta = (d_i
@@ -1518,8 +1518,8 @@ class Buckingham(Pair):
 
         \begin{eqnarray*}
         V_{\mathrm{Buckingham}}(r) = & A \exp\left(-\frac{r}{\rho}\right)
-          - \frac{C}{r^6} & r < r_{\mathrm{cut}} \\
-          = & 0 & r \ge r_{\mathrm{cut}} \\
+          - \frac{C}{r^6}; & r < r_{\mathrm{cut}} \\
+          = & 0; & r \ge r_{\mathrm{cut}} \\
         \end{eqnarray*}
 
     See `Pair` for details on how forces are calculated and the available
@@ -1574,9 +1574,9 @@ class LJ1208(Pair):
         \begin{eqnarray*}
         V_{\mathrm{LJ}}(r)
           = & 4 \varepsilon \left[ \left( \frac{\sigma}{r} \right)^{12} -
-          \left( \frac{\sigma}{r} \right)^{8} \right]
+          \left( \frac{\sigma}{r} \right)^{8} \right];
           & r < r_{\mathrm{cut}} \\
-          = & 0 & r \ge r_{\mathrm{cut}} \\
+          = & 0; & r \ge r_{\mathrm{cut}} \\
         \end{eqnarray*}
 
     See `Pair` for details on how forces are calculated and the available
@@ -1629,9 +1629,9 @@ class LJ0804(Pair):
         \begin{eqnarray*}
         V_{\mathrm{LJ}}(r)
           = & 4 \varepsilon \left[ \left( \frac{\sigma}{r} \right)^{8} -
-          \left( \frac{\sigma}{r} \right)^{4} \right]
+          \left( \frac{\sigma}{r} \right)^{4} \right];
           & r < r_{\mathrm{cut}} \\
-          = & 0 & r \ge r_{\mathrm{cut}} \\
+          = & 0: & r \ge r_{\mathrm{cut}} \\
         \end{eqnarray*}
 
     See `Pair` for details on how forces are calculated and the available
@@ -1686,9 +1686,9 @@ class Fourier(Pair):
         V_{\mathrm{Fourier}}(r)
           = & \frac{1}{r^{12}} + \frac{1}{r^2}\sum_{n=1}^4
           [a_n cos(\frac{n \pi r}{r_{cut}}) +
-          b_n sin(\frac{n \pi r}{r_{cut}})]
+          b_n sin(\frac{n \pi r}{r_{cut}})];
           & r < r_{\mathrm{cut}}  \\
-          = & 0 & r \ge r_{\mathrm{cut}} \\
+          = & 0; & r \ge r_{\mathrm{cut}} \\
         \end{eqnarray*}
 
         where:

--- a/hoomd/md/special_pair.py
+++ b/hoomd/md/special_pair.py
@@ -60,9 +60,9 @@ class LJ(SpecialPair):
         \begin{eqnarray*}
         V_{\mathrm{LJ}}(r)  = & 4 \varepsilon
             \left[ \left( \frac{\sigma}{r} \right)^{12} -
-                   \left( \frac{\sigma}{r} \right)^{6} \right]
+                   \left( \frac{\sigma}{r} \right)^{6} \right];
                               & r < r_{\mathrm{cut}} \\
-                            = & 0 & r \ge r_{\mathrm{cut}} \\
+                            = & 0; & r \ge r_{\mathrm{cut}} \\
         \end{eqnarray*}
 
     where :math:`\vec{r}` is the vector pointing from one particle to the other
@@ -122,9 +122,9 @@ class Coulomb(SpecialPair):
 
         \begin{eqnarray*}
         V_{\mathrm{Coulomb}}(r)  = & \alpha \cdot
-                                     \left[ \frac{q_{a}q_{b}}{r} \right]
+                                     \left[ \frac{q_{a}q_{b}}{r} \right];
                                    & r < r_{\mathrm{cut}} \\
-                                 = & 0 & r \ge r_{\mathrm{cut}} \\
+                                 = & 0; & r \ge r_{\mathrm{cut}} \\
         \end{eqnarray*}
 
     where :math:`\vec{r}` is the vector pointing from one particle to the other

--- a/hoomd/md/wall.py
+++ b/hoomd/md/wall.py
@@ -514,9 +514,9 @@ class wallpotential(external.field.Field):
         :nowrap:
 
         \begin{eqnarray*}
-        \vec{F}  = & -\nabla V(r) & 0 \le r < r_{\mathrm{cut}} \\
-                 = & 0 & r \ge r_{\mathrm{cut}} \\
-                 = & 0 & r < 0
+        \vec{F}  = & -\nabla V(r); & 0 \le r < r_{\mathrm{cut}} \\
+                 = & 0; & r \ge r_{\mathrm{cut}} \\
+                 = & 0; & r < 0
         \end{eqnarray*}
 
     For inside=False (open) half-spaces:
@@ -525,9 +525,9 @@ class wallpotential(external.field.Field):
         :nowrap:
 
         \begin{eqnarray*}
-        \vec{F}  = & -\nabla V(r) & 0 < r < r_{\mathrm{cut}} \\
-                 = & 0 & r \ge r_{\mathrm{cut}} \\
-                 = & 0 & r \le 0
+        \vec{F}  = & -\nabla V(r); & 0 < r < r_{\mathrm{cut}} \\
+                 = & 0; & r \ge r_{\mathrm{cut}} \\
+                 = & 0; & r \le 0
         \end{eqnarray*}
 
     .. rubric: Extrapolated Mode:
@@ -545,8 +545,8 @@ class wallpotential(external.field.Field):
         :nowrap:
 
         \begin{eqnarray*}
-        V_{\mathrm{extrap}}(r) =& V(r) &, r > r_{\rm extrap} \\
-             =& V(r_{\rm extrap}) + (r_{\rm extrap}-r)\vec{F}(r_{\rm extrap}) \cdot \vec{n}&, r \le r_{\rm extrap}
+        V_{\mathrm{extrap}}(r) =& V(r); & r > r_{\rm extrap} \\
+             =& V(r_{\rm extrap}) + (r_{\rm extrap}-r)\vec{F}(r_{\rm extrap}) \cdot \vec{n}; & r \le r_{\rm extrap}
         \end{eqnarray*}
 
     where :math:`\vec{n}` is the normal into the active half-space.
@@ -556,8 +556,8 @@ class wallpotential(external.field.Field):
         :nowrap:
 
         \begin{eqnarray*}
-        \vec{F}(r) =& \vec{F}_{\rm pair}(r) &, r > r_{\rm extrap} \\
-                =& \vec{F}_{\rm pair}(r_{\rm extrap}) &, r \le r_{\rm extrap}
+        \vec{F}(r) =& \vec{F}_{\rm pair}(r); & r > r_{\rm extrap} \\
+                =& \vec{F}_{\rm pair}(r_{\rm extrap}); & r \le r_{\rm extrap}
         \end{eqnarray*}
 
     where :math:`\vec{F}_{\rm pair}` is given by the gradient of the pair force
@@ -566,8 +566,8 @@ class wallpotential(external.field.Field):
         :nowrap:
 
         \begin{eqnarray*}
-        \vec{F}_{\rm pair}(r) =& -\nabla V_{\rm pair}(r) &, r < r_{\rm cut} \\
-                           =& 0 &, r \ge r_{\mathrm{cut}}
+        \vec{F}_{\rm pair}(r) =& -\nabla V_{\rm pair}(r); & r < r_{\rm cut} \\
+                           =& 0; & r \ge r_{\mathrm{cut}}
         \end{eqnarray*}
 
     In other words, if :math:`r_{\rm extrap}` is chosen so that the pair force would point into the active half-space,

--- a/sphinx-doc/conf.py
+++ b/sphinx-doc/conf.py
@@ -28,7 +28,7 @@ napoleon_include_special_with_doc = True
 
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3', None),
-    'numpy': ('https://docs.scipy.org/doc/numpy', None),
+    'numpy': ('https://numpy.org/doc/stable', None),
     'gsd': ('https://gsd.readthedocs.io/en/stable/', None)
 }
 autodoc_docstring_signature = True


### PR DESCRIPTION
## Description
This PR fixes a number of issues in the documentation. I was reading through the MD docs to familiarize myself with features I don't use very often. As I was reading, I fixed up issues with formulas, units, and LaTeX/sphinx formatting. I edited `md.angle` through `md.external` and stopped at `md.force`, with the exception of separating function cases with semicolons, which I standardized for all instances of the LaTeX command `eqnarray` in the `md` subdirectory.

- Improve angle docs.
- Use semicolons to separate all function cases.
- Update NumPy intersphinx link.
- r is a distance, no vector needed.
- Improve docs in constrain module.
- Fix pressure tensor formula.
- Fix formulas and formatting in dihedral documentation.
- Improve documentation and fix formulas/units for external field potentials.

## Motivation and context

Improves documentation.

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
