### PR TITLE
Fix problems with __eq__ in data model

### DIFF
--- a/hoomd/conftest.py
+++ b/hoomd/conftest.py
@@ -324,10 +324,28 @@ def logging_check(cls, expected_namespace, expected_loggables):
         check_loggable(cls, name, properties)
 
 
+def equality_check(a, b):
+    """Check equality between to instances of _HOOMDBaseObject."""
+    if not isinstance(a, hoomd.operation._HOOMDGetSetAttrBase):
+        return a == b
+    if type(a) != type(b):
+        return False
+    b_keys = b.__dict__.keys()
+    for attr in a.__dict__:
+        if attr in a._skip_for_equality:
+            continue
+        if isinstance(a.__dict__[attr], hoomd.operation._HOOMDGetSetAttrBase):
+            if not equality_check(a.__dict__[attr], b.__dict__[attr]):
+                return False
+        elif (attr not in b_keys or a.__dict__[attr] != b.__dict__[attr]):
+            return False
+    return True
+
+
 def pickling_check(instance):
     """Test that an instance can be pickled and unpickled."""
     pkled_instance = pickle.loads(pickle.dumps(instance))
-    assert instance == pkled_instance
+    assert equality_check(instance, pkled_instance)
 
 
 def operation_pickling_check(instance, sim):

--- a/hoomd/custom/custom_operation.py
+++ b/hoomd/custom/custom_operation.py
@@ -145,7 +145,7 @@ class _InternalCustomOperation(CustomOperation,
 
     def __getattr__(self, attr):
         if attr in self._disallowed_attrs:
-            raise AttributeError("{} object {} has not attribute {}.".format(
+            raise AttributeError("{} object {} has no attribute {}.".format(
                 type(self), self, attr))
         else:
             return super().__getattr__(attr)
@@ -162,3 +162,7 @@ class _InternalCustomOperation(CustomOperation,
             key: value.update_cls(self.__class__)
             for key, value in self._export_dict.items()
         }
+
+    @property
+    def action(self):
+        raise AttributeError(f"Object {self} has no attribute 'action'.")

--- a/hoomd/data/parameterdicts.py
+++ b/hoomd/data/parameterdicts.py
@@ -269,9 +269,16 @@ class _ValidatedDefaultDict(MutableMapping):
     def __eq__(self, other):
         if not isinstance(other, _ValidatedDefaultDict):
             return NotImplemented
-        return (self.default == other.default
-                and set(self.keys()) == set(other.keys())
-                and np.all(self[key] == other[key] for key in self.keys()))
+        if self.default != other.default:
+            return False
+        if set(self.keys()) != set(other.keys()):
+            return False
+        if isinstance(self.default, dict):
+            return all(
+                np.all(self[type_][key] == other[type_][key])
+                for type_ in self
+                for key in self[type_])
+        return all(np.all(self[type_] == other[type_]) for type_ in self)
 
     @property
     def default(self):
@@ -492,7 +499,7 @@ class ParameterDict(MutableMapping):
         if not isinstance(other, ParameterDict):
             return NotImplemented
         return (set(self.keys()) == set(other.keys()) and np.all(
-            np.all(self[key] == other[key]) for key in self.keys()))
+            [np.all(self[key] == other[key]) for key in self.keys()]))
 
     def update(self, other):
         """Add keys and values to the dictionary."""

--- a/hoomd/hpmc/pytest/test_compute_sdf.py
+++ b/hoomd/hpmc/pytest/test_compute_sdf.py
@@ -66,13 +66,13 @@ def test_after_attaching(valid_args, simulation_factory,
 
     sim.run(10)
     if not np.isnan(sdf.sdf).all():
-        assert sim.state.snapshot.communicator.rank == 0
+        assert sim.device.communicator.rank == 0
         assert isinstance(sdf.sdf, np.ndarray)
         assert len(sdf.sdf) > 0
         assert isinstance(sdf.betaP, float)
         assert not np.isclose(sdf.betaP, 0)
     else:
-        assert sim.state.snapshot.communicator.rank > 0
+        assert sim.device.communicator.rank > 0
         assert sdf.betaP is None
 
 
@@ -187,7 +187,7 @@ def test_values(simulation_factory, lattice_snapshot_factory):
     sim.run(6000)
 
     sdf_data = np.asarray(sdf_log.data)
-    if sim.state.snapshot.communicator.rank == 0:
+    if sim.device.communicator.rank == 0:
         # skip the first frame in averaging, then check that all values are
         # within 3 error bars of the reference avg. This seems sufficient to get
         # good test results even with different seeds or GPU runs

--- a/hoomd/hpmc/pytest/test_shape.py
+++ b/hoomd/hpmc/pytest/test_shape.py
@@ -168,19 +168,19 @@ def test_overlaps_sphere(device, sphere_overlap_args, simulation_factory,
     assert mc.overlaps > 0
 
     # Should not overlap when spheres are larger than one diameter apart
-    s = sim.state.snapshot
+    s = sim.state.get_snapshot()
     if s.communicator.rank == 0:
         s.particles.position[0] = (0, 0, 0)
         s.particles.position[1] = (0, diameter * 1.1, 0)
-    sim.state.snapshot = s
+    sim.state.set_snapshot(s)
     assert mc.overlaps == 0
 
     # Should barely overlap when spheres are exactly than one diameter apart
-    s = sim.state.snapshot
+    s = sim.state.get_snapshot()
     if s.communicator.rank == 0:
         s.particles.position[0] = (0, 0, 0)
         s.particles.position[1] = (0, diameter * 0.9999, 0)
-    sim.state.snapshot = s
+    sim.state.set_snapshot(s)
     assert mc.overlaps == 1
 
 
@@ -201,32 +201,32 @@ def test_overlaps_ellipsoid(device, simulation_factory,
     for abc in abc_list:
         # Should barely overlap when ellipsoids are exactly than one diameter
         # apart
-        s = sim.state.snapshot
+        s = sim.state.get_snapshot()
         if s.communicator.rank == 0:
             s.particles.position[0] = (0, 0, 0)
             s.particles.position[1] = (abc[0] * 0.9 * 2, abc[1] * 0.9 * 2,
                                        abc[2] * 0.9 * 2)
-        sim.state.snapshot = s
+        sim.state.set_snapshot(s)
         assert mc.overlaps == 1
 
         # Should not overlap when ellipsoids are larger than one diameter apart
-        s = sim.state.snapshot
+        s = sim.state.get_snapshot()
         if s.communicator.rank == 0:
             s.particles.position[0] = (0, 0, 0)
             s.particles.position[1] = (abc[0] * 1.15 * 2, abc[1] * 1.15 * 2,
                                        abc[2] * 1.15 * 2)
-        sim.state.snapshot = s
+        sim.state.set_snapshot(s)
         assert mc.overlaps == 0
 
     # Line up ellipsoids where they aren't overlapped, and then rotate one so
     # they overlap
-    s = sim.state.snapshot
+    s = sim.state.get_snapshot()
     if s.communicator.rank == 0:
         s.particles.position[0] = (0, 0, 0)
         s.particles.position[1] = (a * 1.1 * 2, 0, 0)
         s.particles.orientation[1] = tuple(
             np.array([1, 0, 0.45, 0]) / (1.2025**0.5))
-    sim.state.snapshot = s
+    sim.state.set_snapshot(s)
     assert mc.overlaps > 0
 
 
@@ -263,26 +263,26 @@ def test_overlaps_polygons(device, polygon_overlap_args, simulation_factory,
 
     # Place center of shape 2 on each of shape 1's vertices
     for vert in mc.shape["A"]["vertices"]:
-        s = sim.state.snapshot
+        s = sim.state.get_snapshot()
         if s.communicator.rank == 0:
             s.particles.position[0] = (0, 0, 0)
             s.particles.position[1] = (vert[0], vert[1], 0)
-        sim.state.snapshot = s
+        sim.state.set_snapshot(s)
         assert mc.overlaps > 0
 
-    s = sim.state.snapshot
+    s = sim.state.get_snapshot()
     if s.communicator.rank == 0:
         s.particles.position[0] = (0, 0, 0)
         s.particles.position[1] = (0, 1.05, 0)
-    sim.state.snapshot = s
+    sim.state.set_snapshot(s)
     assert mc.overlaps == 0
 
     # Rotate one of the shapes so they will overlap
-    s = sim.state.snapshot
+    s = sim.state.get_snapshot()
     if s.communicator.rank == 0:
         s.particles.orientation[1] = tuple(
             np.array([1, 0, 0, 0.45]) / (1.2025**0.5))
-    sim.state.snapshot = s
+    sim.state.set_snapshot(s)
     assert mc.overlaps > 0
 
 
@@ -340,32 +340,32 @@ def test_overlaps_polyhedra(device, polyhedron_overlap_args, simulation_factory,
 
     # Place center of shape 2 on each of shape 1's vertices
     for vert in mc.shape["A"]["vertices"]:
-        s = sim.state.snapshot
+        s = sim.state.get_snapshot()
         if s.communicator.rank == 0:
             s.particles.position[0] = (0, 0, 0)
             s.particles.position[1] = vert
-        sim.state.snapshot = s
+        sim.state.set_snapshot(s)
         assert mc.overlaps > 0
 
-    s = sim.state.snapshot
+    s = sim.state.get_snapshot()
     if s.communicator.rank == 0:
         s.particles.position[0] = (0, 0, 0)
         s.particles.position[1] = (0, 0.9, 0)
-    sim.state.snapshot = s
+    sim.state.set_snapshot(s)
     assert mc.overlaps > 0
 
-    s = sim.state.snapshot
+    s = sim.state.get_snapshot()
     if s.communicator.rank == 0:
         s.particles.position[0] = (0, 0, 0)
         s.particles.position[1] = (0, 1.1, 0)
-    sim.state.snapshot = s
+    sim.state.set_snapshot(s)
     assert mc.overlaps == 0
 
     # Rotate one of the polyhedra so they will overlap
-    s = sim.state.snapshot
+    s = sim.state.get_snapshot()
     if s.communicator.rank == 0:
         s.particles.orientation[1] = tuple(np.array([1, 1, 1, 0]) / (3**0.5))
-    sim.state.snapshot = s
+    sim.state.set_snapshot(s)
     assert mc.overlaps > 0
 
 
@@ -396,34 +396,34 @@ def test_overlaps_spheropolygon(device, spheropolygon_overlap_args,
 
     # Place center of shape 2 on each of shape 1's vertices
     for vert in mc.shape["A"]["vertices"]:
-        s = sim.state.snapshot
+        s = sim.state.get_snapshot()
         if s.communicator.rank == 0:
             s.particles.position[0] = (0, 0, 0)
             s.particles.position[1] = (vert[0], vert[1], 0)
-        sim.state.snapshot = s
+        sim.state.set_snapshot(s)
         assert mc.overlaps > 0
 
     # Place shapes where they wouldn't overlap w/o sweep radius
-    s = sim.state.snapshot
+    s = sim.state.get_snapshot()
     if s.communicator.rank == 0:
         s.particles.position[0] = (0, 0, 0)
         s.particles.position[1] = (0, 1.2, 0)
-    sim.state.snapshot = s
+    sim.state.set_snapshot(s)
     assert mc.overlaps > 0
 
-    s = sim.state.snapshot
+    s = sim.state.get_snapshot()
     if s.communicator.rank == 0:
         s.particles.position[0] = (0, 0, 0)
         s.particles.position[1] = (0, 1.3, 0)
-    sim.state.snapshot = s
+    sim.state.set_snapshot(s)
     assert mc.overlaps == 0
 
     # Rotate one of the shapes so they will overlap
-    s = sim.state.snapshot
+    s = sim.state.get_snapshot()
     if s.communicator.rank == 0:
         s.particles.orientation[1] = tuple(
             np.array([1, 0, 0, 0.45]) / (1.2025**0.5))
-    sim.state.snapshot = s
+    sim.state.set_snapshot(s)
     assert mc.overlaps > 0
 
 
@@ -454,32 +454,32 @@ def test_overlaps_spheropolyhedron(device, spheropolyhedron_overlap_args,
 
     # Place center of shape 2 on each of shape 1's vertices
     for vert in mc.shape["A"]["vertices"]:
-        s = sim.state.snapshot
+        s = sim.state.get_snapshot()
         if s.communicator.rank == 0:
             s.particles.position[0] = (0, 0, 0)
             s.particles.position[1] = vert
-        sim.state.snapshot = s
+        sim.state.set_snapshot(s)
         assert mc.overlaps > 0
 
-    s = sim.state.snapshot
+    s = sim.state.get_snapshot()
     if s.communicator.rank == 0:
         s.particles.position[0] = (0, 0, 0)
         s.particles.position[1] = (0, 1.2, 0)
-    sim.state.snapshot = s
+    sim.state.set_snapshot(s)
     assert mc.overlaps > 0
 
-    s = sim.state.snapshot
+    s = sim.state.get_snapshot()
     if s.communicator.rank == 0:
         s.particles.position[0] = (0, 0, 0)
         s.particles.position[1] = (0, 1.5, 0)
-    sim.state.snapshot = s
+    sim.state.set_snapshot(s)
     assert mc.overlaps == 0
 
     # Rotate one of the polyhedra so they will overlap
-    s = sim.state.snapshot
+    s = sim.state.get_snapshot()
     if s.communicator.rank == 0:
         s.particles.orientation[1] = tuple(np.array([1, 1, 1, 0]) / (3**0.5))
-    sim.state.snapshot = s
+    sim.state.set_snapshot(s)
     assert mc.overlaps > 0
 
 
@@ -531,27 +531,27 @@ def test_overlaps_union(device, union_overlap_args, simulation_factory,
     test_orientations = test_orientations.T
     # Shapes are stacked in z direction
     for i in range(len(test_positions)):
-        s = sim.state.snapshot
+        s = sim.state.get_snapshot()
         if s.communicator.rank == 0:
             s.particles.position[0] = (0, 0, 0)
             s.particles.position[1] = test_positions[i]
             s.particles.orientation[1] = (1, 0, 0, 0)
-        sim.state.snapshot = s
+        sim.state.set_snapshot(s)
         assert mc.overlaps == 0
 
         # Slightly rotate union about x or y axis so they overlap
         if s.communicator.rank == 0:
             s.particles.orientation[1] = test_orientations[i]
-        sim.state.snapshot = s
+        sim.state.set_snapshot(s)
 
         assert mc.overlaps > 0
 
     for pos in [(0.9, 0, 0), (0, 0.9, 0), (0, 0, 1.1)]:
-        s = sim.state.snapshot
+        s = sim.state.get_snapshot()
         if s.communicator.rank == 0:
             s.particles.position[0] = (0, 0, 0)
             s.particles.position[1] = pos
-        sim.state.snapshot = s
+        sim.state.set_snapshot(s)
         assert mc.overlaps > 0
 
 
@@ -580,32 +580,32 @@ def test_overlaps_faceted_ellipsoid(device, simulation_factory,
     for abc in abc_list:
         # Should barely overlap when ellipsoids are exactly than one diameter
         # apart
-        s = sim.state.snapshot
+        s = sim.state.get_snapshot()
         if s.communicator.rank == 0:
             s.particles.position[0] = (0, 0, 0)
             s.particles.position[1] = (abc[0] * 0.9 * 2, abc[1] * 0.9 * 2,
                                        abc[2] * 0.9 * 2)
-        sim.state.snapshot = s
+        sim.state.set_snapshot(s)
         assert mc.overlaps == 1
 
         # Should not overlap when ellipsoids are larger than one diameter apart
-        s = sim.state.snapshot
+        s = sim.state.get_snapshot()
         if s.communicator.rank == 0:
             s.particles.position[0] = (0, 0, 0)
             s.particles.position[1] = (abc[0] * 1.15 * 2, abc[1] * 1.15 * 2,
                                        abc[2] * 1.15 * 2)
-        sim.state.snapshot = s
+        sim.state.set_snapshot(s)
         assert mc.overlaps == 0
 
     # Line up ellipsoids where they aren't overlapped, and then rotate one so
     # they overlap
-    s = sim.state.snapshot
+    s = sim.state.get_snapshot()
     if s.communicator.rank == 0:
         s.particles.position[0] = (0, 0, 0)
         s.particles.position[1] = (a * 1.1 * 2, 0, 0)
         s.particles.orientation[1] = tuple(
             np.array([1, 0, 0.45, 0]) / (1.2025**0.5))
-    sim.state.snapshot = s
+    sim.state.set_snapshot(s)
     assert mc.overlaps > 0
 
 
@@ -620,18 +620,18 @@ def test_overlaps_sphinx(device, simulation_factory,
     sim.operations._schedule()
     assert mc.overlaps == 0
 
-    s = sim.state.snapshot
+    s = sim.state.get_snapshot()
     if s.communicator.rank == 0:
         s.particles.position[0] = (0, 0, 0)
         s.particles.position[1] = (0.74, 0, 0)
-    sim.state.snapshot = s
+    sim.state.set_snapshot(s)
     assert mc.overlaps > 0
 
-    s = sim.state.snapshot
+    s = sim.state.get_snapshot()
     if s.communicator.rank == 0:
         s.particles.position[0] = (0, 0, 0)
         s.particles.position[1] = (0.76, 0, 0)
-    sim.state.snapshot = s
+    sim.state.set_snapshot(s)
     assert mc.overlaps == 0
 
 

--- a/hoomd/md/pytest/test_angle.py
+++ b/hoomd/md/pytest/test_angle.py
@@ -51,7 +51,7 @@ def triplet_snapshot_factory(device):
         theta_rad = theta_deg * (np.pi / 180)
         s = hoomd.Snapshot(device.communicator)
         N = 3
-        if s.exists:
+        if s.communicator.rank == 0:
             box = [L, L, L, 0, 0, 0]
             if dimensions == 2:
                 box[2] = 0

--- a/hoomd/md/pytest/test_aniso_pair.py
+++ b/hoomd/md/pytest/test_aniso_pair.py
@@ -320,9 +320,9 @@ def test_run(simulation_factory, lattice_snapshot_factory, pair_potential):
     integrator.methods.append(md.methods.Langevin(hoomd.filter.All(), kT=1))
     sim.operations.integrator = integrator
     for nsteps in [3, 5, 10]:
-        old_snap = sim.state.snapshot
+        old_snap = sim.state.get_snapshot()
         sim.run(nsteps)
-        new_snap = sim.state.snapshot
+        new_snap = sim.state.get_snapshot()
         if new_snap.communicator.rank == 0:
             assert not np.allclose(new_snap.particles.position,
                                    old_snap.particles.position)
@@ -359,13 +359,13 @@ def test_aniso_force_computes(make_two_particle_simulation,
                     [0.70738827, 0.0, 0.0, 0.70682518]]
     for i, (distance,
             orientation) in enumerate(zip(particle_distances, orientations)):
-        snap = sim.state.snapshot
+        snap = sim.state.get_snapshot()
         # Set up proper distances and orientations
         if snap.communicator.rank == 0:
             snap.particles.position[0] = [0, 0, .1]
             snap.particles.position[1] = [0, 0, distance + .1]
             snap.particles.orientation[1] = orientation
-        sim.state.snapshot = snap
+        sim.state.set_snapshot(snap)
 
         # Grab all quantities to test for accuracy
         sim_energies = sim.operations.integrator.forces[0].energies

--- a/hoomd/md/pytest/test_constrain_distance.py
+++ b/hoomd/md/pytest/test_constrain_distance.py
@@ -127,7 +127,7 @@ def test_basic_simulation(simulation_factory, polymer_snapshot_factory):
     sim.state.thermalize_particle_momenta(filter=hoomd.filter.All(), kT=1.0)
     sim.run(100)
 
-    snap = sim.state.snapshot
+    snap = sim.state.get_snapshot()
 
     if snap.communicator.rank == 0:
         # compute bond lengths in unwrapped particle coordinates

--- a/hoomd/md/pytest/test_external.py
+++ b/hoomd/md/pytest/test_external.py
@@ -120,7 +120,7 @@ def test_forces_and_energies(simulation_factory, lattice_snapshot_factory,
         sim.run(10)
 
         # test energies
-        new_snap = sim.state.snapshot
+        new_snap = sim.state.get_snapshot()
         forces = sim.operations.integrator.forces[0].forces
         energies = sim.operations.integrator.forces[0].energies
         if new_snap.communicator.rank == 0:

--- a/hoomd/md/pytest/test_filter_md.py
+++ b/hoomd/md/pytest/test_filter_md.py
@@ -127,7 +127,7 @@ def test_custom_filter(make_filter_snapshot, simulation_factory):
     langevin = md.methods.Langevin(charge_filter, 1.0)
     sim.operations += md.Integrator(0.005, methods=[langevin])
     sim.run(100)
-    snap = sim.state.snapshot
+    snap = sim.state.get_snapshot()
     if snap.communicator.rank == 0:
         assert not np.allclose(snap.particles.position[negative_charge_ind],
                                original_positions)

--- a/hoomd/md/pytest/test_gsd.py
+++ b/hoomd/md/pytest/test_gsd.py
@@ -130,7 +130,7 @@ def test_write_gsd_mode(create_md_sim, hoomd_snapshot, tmp_path,
     snapshot_list = []
     for _ in range(5):
         sim.run(1)
-        snap = sim.state.snapshot
+        snap = sim.state.get_snapshot()
         if snap.communicator.rank == 0:
             snapshot_list.append(snap)
 
@@ -146,7 +146,7 @@ def test_write_gsd_mode(create_md_sim, hoomd_snapshot, tmp_path,
     snap_list = []
     for _ in range(5):
         sim.run(1)
-        snap = sim.state.snapshot
+        snap = sim.state.get_snapshot()
         if snap.communicator.rank == 0:
             snap_list.append(snap)
     if sim.device.communicator.rank == 0:
@@ -220,7 +220,7 @@ def test_write_gsd_truncate(create_md_sim, tmp_path):
     sim.operations.writers.append(gsd_writer)
 
     sim.run(2)
-    snapshot = sim.state.snapshot
+    snapshot = sim.state.get_snapshot()
 
     if snapshot.communicator.rank == 0:
         with gsd.hoomd.open(name=filename, mode='rb') as traj:
@@ -243,7 +243,7 @@ def test_write_gsd_dynamic(simulation_factory, create_md_sim, tmp_path):
     position_list = []
     for _ in range(5):
         sim.run(1)
-        snap = sim.state.snapshot
+        snap = sim.state.get_snapshot()
         if snap.communicator.rank == 0:
             position_list.append(snap.particles.position)
             velocity_list.append(snap.particles.velocity)
@@ -277,7 +277,7 @@ def test_write_gsd_dynamic(simulation_factory, create_md_sim, tmp_path):
     angmom_list = []
     for _ in range(5):
         sim.run(1)
-        snap = sim.state.snapshot
+        snap = sim.state.get_snapshot()
         if snap.communicator.rank == 0:
             velocity_list.append(snap.particles.velocity)
             angmom_list.append(snap.particles.angmom)
@@ -305,7 +305,7 @@ def test_write_gsd_dynamic(simulation_factory, create_md_sim, tmp_path):
         snap.particles.diameter[:] = N_particles * [0.2]
         snap.particles.charge[:] = N_particles * [0]
 
-    sim.state.snapshot = snap
+    sim.state.set_snapshot(snap)
 
     sim.operations.writers.clear()
     gsd_writer = hoomd.write.GSD(filename=filename,
@@ -340,13 +340,13 @@ def test_write_gsd_dynamic(simulation_factory, create_md_sim, tmp_path):
                                            atol=1.5e-07)
 
     # test dynamic=['topology']
-    snap = sim.state.snapshot
+    snap = sim.state.get_snapshot()
     if snap.communicator.rank == 0:
         snap.bonds.N = 3
         snap.bonds.typeid[2] = 0
         snap.bonds.group[2] = [10, 11]
 
-    sim.state.snapshot = snap
+    sim.state.set_snapshot(snap)
 
     gsd_writer = hoomd.write.GSD(filename=filename,
                                  trigger=hoomd.trigger.Periodic(1),

--- a/hoomd/md/pytest/test_rigid.py
+++ b/hoomd/md/pytest/test_rigid.py
@@ -132,7 +132,7 @@ def test_create_bodies(simulation_factory, two_particle_snapshot_factory,
     sim = simulation_factory(initial_snapshot)
 
     rigid.create_bodies(sim.state)
-    snapshot = sim.state.snapshot
+    snapshot = sim.state.get_snapshot()
     if snapshot.communicator.rank == 0:
         check_bodies(snapshot, valid_body_definition)
 
@@ -205,7 +205,7 @@ def test_running_simulation(simulation_factory, two_particle_snapshot_factory,
     rigid.create_bodies(sim.state)
     sim.operations += integrator
     sim.run(5)
-    snapshot = sim.state.snapshot
+    snapshot = sim.state.get_snapshot()
     if sim.device.communicator.rank == 0:
         check_bodies(snapshot, valid_body_definition)
 

--- a/hoomd/md/pytest/test_zero_momentum.py
+++ b/hoomd/md/pytest/test_zero_momentum.py
@@ -45,7 +45,7 @@ def test_momentum_is_zero(simulation_factory, two_particle_snapshot_factory):
     sim.operations.add(zm)
 
     sim.run(1)
-    snap = sim.state.snapshot
+    snap = sim.state.get_snapshot()
     if snap.communicator.rank == 0:
         masses = snap.particles.mass
         velocities = snap.particles.velocity

--- a/hoomd/operation.py
+++ b/hoomd/operation.py
@@ -30,6 +30,10 @@ class _HOOMDGetSetAttrBase:
         _param_dict (ParameterDict): The `ParameterDict` for the class/instance.
         _typeparam_dict (dict[str, TypeParameter]): A dict of all the
             TypeParameters for the class/instance.
+        _skip_for_equality (set[str]): The attribute names to not use for
+        equality checks. This will not effect attributes that exist due to
+        ``__getattr__`` such as those from ``_param_dict`` or
+        ``_typeparam_dict``.
     """
     _reserved_default_attrs = dict(_param_dict=ParameterDict,
                                    _typeparam_dict=dict)

--- a/hoomd/operation.py
+++ b/hoomd/operation.py
@@ -31,9 +31,9 @@ class _HOOMDGetSetAttrBase:
         _typeparam_dict (dict[str, TypeParameter]): A dict of all the
             TypeParameters for the class/instance.
         _skip_for_equality (set[str]): The attribute names to not use for
-        equality checks. This will not effect attributes that exist due to
-        ``__getattr__`` such as those from ``_param_dict`` or
-        ``_typeparam_dict``.
+            equality checks used during tests. This will not effect attributes
+            that exist due to ``__getattr__`` such as those from ``_param_dict``
+            or ``_typeparam_dict``.
     """
     _reserved_default_attrs = dict(_param_dict=ParameterDict,
                                    _typeparam_dict=dict)
@@ -98,16 +98,6 @@ class _HOOMDGetSetAttrBase:
         except TypeError:
             raise ValueError("To set {}, you must use a dictionary "
                              "with types as keys.".format(attr))
-
-    def __eq__(self, other):
-        other_keys = other.__dict__.keys()
-        for attr in self.__dict__:
-            if attr in self._skip_for_equality:
-                continue
-            if (attr not in other_keys
-                    or self.__dict__[attr] != other.__dict__[attr]):
-                return False
-        return True
 
 
 class _DependencyRelation:

--- a/hoomd/operation.py
+++ b/hoomd/operation.py
@@ -35,6 +35,8 @@ class _HOOMDGetSetAttrBase:
                                    _typeparam_dict=dict)
     _override_setattr = set()
 
+    _skip_for_equality = set()
+
     def __getattr__(self, attr):
         if attr in self._reserved_default_attrs.keys():
             default = self._reserved_default_attrs[attr]
@@ -94,12 +96,16 @@ class _HOOMDGetSetAttrBase:
                              "with types as keys.".format(attr))
 
     def __eq__(self, other):
-        if not isinstance(other, _HOOMDGetSetAttrBase):
-            return NotImplemented
-        return (self._param_dict == other._param_dict and all(
-            set(self._typeparam_dict.keys()) == set(other._typeparam_dict.keys(
-            )) and self._typeparam_dict[k] == other._typeparam_dict[k]
-            for k in self._typeparam_dict))
+        other_keys = other.__dict__.keys()
+        for attr in self.__dict__:
+            if attr in self._skip_for_equality:
+                continue
+            print(f"attr={attr}, {self.__dict__[attr]}, {other.__dict__[attr]}",
+                  self.__dict__[attr] == other.__dict__[attr])
+            if (attr not in other_keys
+                    or self.__dict__[attr] != other.__dict__[attr]):
+                return False
+        return True
 
 
 class _DependencyRelation:
@@ -188,10 +194,7 @@ class _HOOMDBaseObject(_HOOMDGetSetAttrBase,
         '_dependencies': list
     }
 
-    _skip_for_equality = {
-        '_cpp_obj', '_dependent_list', '_param_dict', '_typeparam_dict',
-        '_simulation'
-    }
+    _skip_for_equality = {'_cpp_obj', '_dependent_list', '_simulation'}
     _remove_for_pickling = ('_simulation', '_cpp_obj')
 
     def _getattr_param(self, attr):
@@ -215,16 +218,6 @@ class _HOOMDBaseObject(_HOOMDGetSetAttrBase,
                 self._param_dict[attr] = old_value
                 raise AttributeError("{} cannot be set after cpp"
                                      " initialization".format(attr))
-
-    def __eq__(self, other):
-        other_keys = other.__dict__.keys()
-        for key in self.__dict__.keys():
-            if key in self._skip_for_equality:
-                continue
-            elif (key not in other_keys
-                  or self.__dict__[key] != other.__dict__[key]):
-                return False
-        return super().__eq__(other)
 
     def _detach(self):
         if self._attached:

--- a/hoomd/operation.py
+++ b/hoomd/operation.py
@@ -104,8 +104,6 @@ class _HOOMDGetSetAttrBase:
         for attr in self.__dict__:
             if attr in self._skip_for_equality:
                 continue
-            print(f"attr={attr}, {self.__dict__[attr]}, {other.__dict__[attr]}",
-                  self.__dict__[attr] == other.__dict__[attr])
             if (attr not in other_keys
                     or self.__dict__[attr] != other.__dict__[attr]):
                 return False

--- a/hoomd/pytest/test_dcd.py
+++ b/hoomd/pytest/test_dcd.py
@@ -24,7 +24,7 @@ def test_write(simulation_factory, two_particle_snapshot_factory, tmp_path):
     sim.operations.add(dcd_dump)
     positions = []
 
-    snap = sim.state.snapshot
+    snap = sim.state.get_snapshot()
     if snap.communicator.rank == 0:
         position1 = np.asarray(snap.particles.position[0])
         position2 = np.asarray(snap.particles.position[1])

--- a/hoomd/pytest/test_filter.py
+++ b/hoomd/pytest/test_filter.py
@@ -70,19 +70,19 @@ def test_type_filter(make_filter_snapshot, simulation_factory, type_indices):
     assert A_filter(sim.state) == list(range(N))
     assert B_filter(sim.state) == []
 
-    s = sim.state.snapshot
+    s = sim.state.get_snapshot()
     if s.communicator.rank == 0:
         set_types(s, range(N), particle_types, "B")
-    sim.state.snapshot = s
+    sim.state.set_snapshot(s)
     assert A_filter(sim.state) == []
     assert B_filter(sim.state) == list(range(N))
 
     A_indices, B_indices = type_indices
-    s = sim.state.snapshot
+    s = sim.state.get_snapshot()
     if s.communicator.rank == 0:
         set_types(s, A_indices, particle_types, "A")
         set_types(s, B_indices, particle_types, "B")
-    sim.state.snapshot = s
+    sim.state.set_snapshot(s)
     assert A_filter(sim.state) == A_indices
     assert B_filter(sim.state) == B_indices
     assert AB_filter(sim.state) == list(range(N))
@@ -129,12 +129,12 @@ def test_intersection(make_filter_snapshot, simulation_factory, set_indices):
     filter_snapshot = make_filter_snapshot(n=N, particle_types=particle_types)
     sim = simulation_factory(filter_snapshot)
     A_indices, B_indices, C_indices = set_indices
-    s = sim.state.snapshot
+    s = sim.state.get_snapshot()
     if s.communicator.rank == 0:
         set_types(s, A_indices, particle_types, "A")
         set_types(s, B_indices, particle_types, "B")
         set_types(s, C_indices, particle_types, "C")
-    sim.state.snapshot = s
+    sim.state.set_snapshot(s)
 
     for type_combo in combinations(particle_types, 2):
         combo_filter = Type(type_combo)
@@ -154,12 +154,12 @@ def test_union(make_filter_snapshot, simulation_factory, set_indices):
     filter_snapshot = make_filter_snapshot(n=N, particle_types=particle_types)
     sim = simulation_factory(filter_snapshot)
     A_indices, B_indices, C_indices = set_indices
-    s = sim.state.snapshot
+    s = sim.state.get_snapshot()
     if s.communicator.rank == 0:
         set_types(s, A_indices, particle_types, "A")
         set_types(s, B_indices, particle_types, "B")
         set_types(s, C_indices, particle_types, "C")
-    sim.state.snapshot = s
+    sim.state.set_snapshot(s)
 
     for type_combo in combinations(particle_types, 2):
         filter1 = Type([type_combo[0]])
@@ -175,12 +175,12 @@ def test_difference(make_filter_snapshot, simulation_factory, set_indices):
     filter_snapshot = make_filter_snapshot(n=N, particle_types=particle_types)
     sim = simulation_factory(filter_snapshot)
     A_indices, B_indices, C_indices = set_indices
-    s = sim.state.snapshot
+    s = sim.state.get_snapshot()
     if s.communicator.rank == 0:
         set_types(s, A_indices, particle_types, "A")
         set_types(s, B_indices, particle_types, "B")
         set_types(s, C_indices, particle_types, "C")
-    sim.state.snapshot = s
+    sim.state.set_snapshot(s)
 
     for type_combo in combinations(particle_types, 2):
         combo_filter = Type(type_combo)

--- a/hoomd/pytest/test_local_snapshot.py
+++ b/hoomd/pytest/test_local_snapshot.py
@@ -438,7 +438,7 @@ class TestLocalSnapshots:
                                    global_property):
         section_name, prop_name, prop_dict = global_property
         sim = base_simulation()
-        snapshot = sim.state.snapshot
+        snapshot = sim.state.get_snapshot()
 
         mpi_comm = MPI.COMM_WORLD
 
@@ -485,7 +485,7 @@ class TestLocalSnapshots:
         for lcl_snapshot_attr in self.get_snapshot_attr(sim):
             with getattr(sim.state, lcl_snapshot_attr):
                 with pytest.raises(RuntimeError):
-                    sim.state.snapshot = base_snapshot
+                    sim.state.set_snapshot(base_snapshot)
 
     @pytest.fixture
     def base_simulation(self, simulation_factory, base_snapshot):

--- a/hoomd/pytest/test_simulation.py
+++ b/hoomd/pytest/test_simulation.py
@@ -169,7 +169,7 @@ def test_state_from_gsd(device, simulation_factory, lattice_snapshot_factory,
     sim = simulation_factory(
         lattice_snapshot_factory(n=snap_params[0],
                                  particle_types=snap_params[1]))
-    snap = sim.state.snapshot
+    snap = sim.state.get_snapshot()
     snapshot_dict = {}
     snapshot_dict[0] = snap
 
@@ -179,7 +179,7 @@ def test_state_from_gsd(device, simulation_factory, lattice_snapshot_factory,
     box = sim.state.box
     for step in range(1, nsteps):
         particle_type = np.random.choice(snap_params[1])
-        snap = update_positions(sim.state.snapshot)
+        snap = update_positions(sim.state.get_snapshot())
         set_types(snap, random_inds(snap_params[0]), snap_params[1],
                   particle_type)
 
@@ -194,7 +194,7 @@ def test_state_from_gsd(device, simulation_factory, lattice_snapshot_factory,
         sim.create_state_from_gsd(filename, frame=step)
         assert box == sim.state.box
 
-        assert_equivalent_snapshots(snap, sim.state.snapshot)
+        assert_equivalent_snapshots(snap, sim.state.get_snapshot())
 
 
 @skip_gsd
@@ -205,13 +205,13 @@ def test_state_from_gsd_snapshot(simulation_factory, lattice_snapshot_factory,
     sim = simulation_factory(
         lattice_snapshot_factory(n=snap_params[0],
                                  particle_types=snap_params[1]))
-    snap = sim.state.snapshot
+    snap = sim.state.get_snapshot()
     snap = make_gsd_snapshot(snap)
     gsd_snapshot_list = [snap]
     box = sim.state.box
     for _ in range(1, nsteps):
         particle_type = np.random.choice(snap_params[1])
-        snap = update_positions(sim.state.snapshot)
+        snap = update_positions(sim.state.get_snapshot())
         set_types(snap, random_inds(snap_params[0]), snap_params[1],
                   particle_type)
         snap = make_gsd_snapshot(snap)
@@ -221,7 +221,7 @@ def test_state_from_gsd_snapshot(simulation_factory, lattice_snapshot_factory,
         sim = hoomd.Simulation(device)
         sim.create_state_from_snapshot(snap)
         assert box == sim.state.box
-        assert_equivalent_snapshots(snap, sim.state.snapshot)
+        assert_equivalent_snapshots(snap, sim.state.get_snapshot())
 
 
 def test_writer_order(simulation_factory, two_particle_snapshot_factory):

--- a/hoomd/pytest/test_state.py
+++ b/hoomd/pytest/test_state.py
@@ -150,7 +150,7 @@ def test_get_snapshot(simulation_factory, snap):
     sim = simulation_factory()
     sim.create_state_from_snapshot(snap)
 
-    snap2 = sim.state.snapshot
+    snap2 = sim.state.get_snapshot()
     assert_snapshots_equal(snap, snap2)
 
 
@@ -167,9 +167,9 @@ def test_modify_snapshot(simulation_factory, snap):
         snap.pairs.N = snap.pairs.N // 4
         snap.constraints.N = snap.constraints.N // 4
 
-    sim.state.snapshot = snap
+    sim.state.set_snapshot(snap)
 
-    snap2 = sim.state.snapshot
+    snap2 = sim.state.get_snapshot()
     assert_snapshots_equal(snap, snap2)
 
 
@@ -179,7 +179,7 @@ def test_thermalize_particle_velocity(simulation_factory,
     sim = simulation_factory(snap)
     sim.state.thermalize_particle_momenta(filter=hoomd.filter.All(), kT=1.5)
 
-    snapshot = sim.state.snapshot
+    snapshot = sim.state.get_snapshot()
     if snapshot.communicator.rank == 0:
         v = snapshot.particles.velocity[:]
         m = snapshot.particles.mass[:]
@@ -206,7 +206,7 @@ def test_thermalize_angular_momentum(simulation_factory,
     sim = simulation_factory(snap)
     sim.state.thermalize_particle_momenta(filter=hoomd.filter.All(), kT=1.5)
 
-    snapshot = sim.state.snapshot
+    snapshot = sim.state.get_snapshot()
     if snapshot.communicator.rank == 0:
         # Note: this conversion assumes that all particles have (1, 0, 0, 0)
         # orientations.

--- a/hoomd/pytest/test_table.py
+++ b/hoomd/pytest/test_table.py
@@ -198,6 +198,27 @@ def test_only_string_and_scalar_quantities(device):
         hoomd.write.Table(1, logger, output)
 
 
+def test_eq(device, logger):
+    output = StringIO("")
+    table_writer = hoomd.write.Table(1, logger, output)
+    table_writer_copy = hoomd.write.Table(1, logger, output)
+    assert table_writer == table_writer_copy
+    # Test that _comm doesn't matter for __eq__
+    table_writer._comm = device.communicator
+    assert table_writer == table_writer_copy
+    # Test that trigger does matter
+    table_writer_copy.trigger = 10
+    assert table_writer != table_writer_copy
+    # Test that output does matter
+    new_output = StringIO("")
+    table_writer_copy = hoomd.write.Table(1, logger, new_output)
+    assert table_writer != table_writer_copy
+    # Test that logger matters for equality
+    table_writer_copy = hoomd.write.Table(1, hoomd.logging.Logger(["scalar"]),
+                                          output)
+    assert table_writer != table_writer_copy
+
+
 def test_pickling(simulation_factory, two_particle_snapshot_factory, logger):
     sim = simulation_factory(two_particle_snapshot_factory())
     table = hoomd.write.Table(1, logger)

--- a/hoomd/pytest/test_table.py
+++ b/hoomd/pytest/test_table.py
@@ -45,6 +45,17 @@ def expected_values():
     }
 
 
+def test_invalid_attrs(logger):
+    output = StringIO("")
+    table_writer = hoomd.write.Table(1, logger, output)
+    with pytest.raises(AttributeError):
+        table_writer.action
+    with pytest.raises(AttributeError):
+        table_writer.detach
+    with pytest.raises(AttributeError):
+        table_writer.attach
+
+
 @pytest.mark.serial
 def test_header_generation(device, logger):
     output = StringIO("")

--- a/hoomd/pytest/test_table.py
+++ b/hoomd/pytest/test_table.py
@@ -198,27 +198,6 @@ def test_only_string_and_scalar_quantities(device):
         hoomd.write.Table(1, logger, output)
 
 
-def test_eq(device, logger):
-    output = StringIO("")
-    table_writer = hoomd.write.Table(1, logger, output)
-    table_writer_copy = hoomd.write.Table(1, logger, output)
-    assert table_writer == table_writer_copy
-    # Test that _comm doesn't matter for __eq__
-    table_writer._comm = device.communicator
-    assert table_writer == table_writer_copy
-    # Test that trigger does matter
-    table_writer_copy.trigger = 10
-    assert table_writer != table_writer_copy
-    # Test that output does matter
-    new_output = StringIO("")
-    table_writer_copy = hoomd.write.Table(1, logger, new_output)
-    assert table_writer != table_writer_copy
-    # Test that logger matters for equality
-    table_writer_copy = hoomd.write.Table(1, hoomd.logging.Logger(["scalar"]),
-                                          output)
-    assert table_writer != table_writer_copy
-
-
 def test_pickling(simulation_factory, two_particle_snapshot_factory, logger):
     sim = simulation_factory(two_particle_snapshot_factory())
     table = hoomd.write.Table(1, logger)

--- a/hoomd/write/table.py
+++ b/hoomd/write/table.py
@@ -144,6 +144,15 @@ class _Formatter:
         else:
             return self._str_format.format(value, width=column_width)
 
+    def __eq__(self, other):
+        if not isinstance(other, _Formatter):
+            return NotImplemented
+        return (self.pretty == other.pretty
+                and self.precision == other.precision
+                and self.max_decimals_pretty == other.max_decimals_pretty
+                and self._num_format == other._num_format
+                and self._str_format == other._str_format)
+
 
 class _TableInternal(_InternalAction):
     """Implements the logic for a simple text based logger backend.
@@ -163,6 +172,8 @@ class _TableInternal(_InternalAction):
         Action.Flags.ROTATIONAL_KINETIC_ENERGY, Action.Flags.PRESSURE_TENSOR,
         Action.Flags.EXTERNAL_FIELD_VIRIAL
     ]
+
+    _skip_for_equality = {"_comm"}
 
     def __init__(self,
                  logger,


### PR DESCRIPTION

<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should based on *maint*. -->
<!-- New features should based on *master*. -->

## Description

Tackles a problem recently found in the mailing list regarding a false positive when checking equality between two `hoomd.write.Table` instances. This fixes the existing problem, as well as improves the implementation of `__eq__` for the data model generally.

The PR also removes all current warnings when running `pytest`. This wasn't necessary, but a mindless change for the most part, so I have added it as well.
<!-- Describe your changes in detail. -->

## Motivation and context

Fixes the reported bug and helps prevent others in the future by making `__eq__` behave better.
<!--- Why is this change required? What problem does it solve? -->

## How has this been tested?

The existing tests pass which rely on the `==` operator.
<!--- Please describe in detail how you tested your changes. -->

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
Fixed: Fixed errors related to equality checks between HOOMD operations.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
