### PR TITLE
Move trigger to first argument where possible

### DIFF
--- a/hoomd/custom/custom_operation.py
+++ b/hoomd/custom/custom_operation.py
@@ -45,7 +45,7 @@ class CustomOperation(_TriggeredOperation, metaclass=_AbstractLoggable):
         """C++ Class to use for attaching."""
         raise NotImplementedError
 
-    def __init__(self, action, trigger=1):
+    def __init__(self, trigger, action):
         if not isinstance(action, Action):
             raise ValueError("action must be a subclass of "
                              "hoomd.custom_action.custom.Action.")
@@ -157,7 +157,7 @@ class _InternalCustomOperation(CustomOperation,
         pass
 
     def __init__(self, trigger, *args, **kwargs):
-        super().__init__(self._internal_class(*args, **kwargs), trigger)
+        super().__init__(trigger, self._internal_class(*args, **kwargs))
         self._export_dict = {
             key: value.update_cls(self.__class__)
             for key, value in self._export_dict.items()

--- a/hoomd/pytest/test_dcd.py
+++ b/hoomd/pytest/test_dcd.py
@@ -7,7 +7,8 @@ import numpy as np
 def test_attach(simulation_factory, two_particle_snapshot_factory, tmp_path):
     filename = tmp_path / "temporary_test_file.dcd"
     sim = simulation_factory(two_particle_snapshot_factory())
-    dcd_dump = hoomd.write.DCD(filename, hoomd.trigger.Periodic(1))
+    dcd_dump = hoomd.write.DCD(filename=filename,
+                               trigger=hoomd.trigger.Periodic(1))
     sim.operations.add(dcd_dump)
     sim.run(10)
 
@@ -20,7 +21,8 @@ def test_write(simulation_factory, two_particle_snapshot_factory, tmp_path):
     dcd_reader = garnett.reader.DCDFileReader()
     filename = tmp_path / "temporary_test_file.dcd"
     sim = simulation_factory(two_particle_snapshot_factory())
-    dcd_dump = hoomd.write.DCD(filename, hoomd.trigger.Periodic(1))
+    dcd_dump = hoomd.write.DCD(filename=filename,
+                               trigger=hoomd.trigger.Periodic(1))
     sim.operations.add(dcd_dump)
     positions = []
 
@@ -44,5 +46,6 @@ def test_write(simulation_factory, two_particle_snapshot_factory, tmp_path):
 def test_pickling(simulation_factory, two_particle_snapshot_factory, tmp_path):
     filename = tmp_path / "temporary_test_file.dcd"
     sim = simulation_factory(two_particle_snapshot_factory())
-    dcd_dump = hoomd.write.DCD(filename, hoomd.trigger.Periodic(1))
+    dcd_dump = hoomd.write.DCD(filename=filename,
+                               trigger=hoomd.trigger.Periodic(1))
     operation_pickling_check(dcd_dump, sim)

--- a/hoomd/pytest/test_simulation.py
+++ b/hoomd/pytest/test_simulation.py
@@ -366,9 +366,12 @@ def test_operations_setting(simulation_factory, lattice_snapshot_factory):
 
     operations = hoomd.Operations()
     # Add some operations to test the setting
-    operations += hoomd.update.BoxResize(hoomd.Box.cube(10), hoomd.Box.cube(20),
-                                         hoomd.variant.Ramp(0, 1, 0, 100), 40)
-    operations += hoomd.write.GSD("foo.gsd", 10)
+    operations += hoomd.update.BoxResize(trigger=40,
+                                         box1=hoomd.Box.cube(10),
+                                         box2=hoomd.Box.cube(20),
+                                         variant=hoomd.variant.Ramp(
+                                             0, 1, 0, 100))
+    operations += hoomd.write.GSD(filename="foo.gsd", trigger=10)
     operations += hoomd.write.Table(10, logger=hoomd.logging.Logger(['scalar']))
     operations.tuners.clear()
     # Check setting before scheduling
@@ -377,11 +380,12 @@ def test_operations_setting(simulation_factory, lattice_snapshot_factory):
     sim.run(0)
     # Check setting after scheduling
     new_operations = hoomd.Operations()
-    new_operations += hoomd.update.BoxResize(hoomd.Box.cube(300),
-                                             hoomd.Box.cube(20),
-                                             hoomd.variant.Ramp(0, 1, 0, 100),
-                                             80)
-    new_operations += hoomd.write.GSD("bar.gsd", 20)
+    new_operations += hoomd.update.BoxResize(trigger=80,
+                                             box1=hoomd.Box.cube(300),
+                                             box2=hoomd.Box.cube(20),
+                                             variant=hoomd.variant.Ramp(
+                                                 0, 1, 0, 100))
+    new_operations += hoomd.write.GSD(filename="bar.gsd", trigger=20)
     new_operations += hoomd.write.Table(20,
                                         logger=hoomd.logging.Logger(['scalar']))
     check_operation_setting(sim, sim.operations, new_operations)

--- a/hoomd/update/box_resize.py
+++ b/hoomd/update/box_resize.py
@@ -32,13 +32,13 @@ class BoxResize(Updater):
         properly in HPMC.
 
     Args:
+        trigger (hoomd.trigger.Trigger): The trigger to activate this updater.
         box1 (hoomd.Box): The box associated with the minimum of the
             passed variant.
         box2 (hoomd.Box): The box associated with the maximum of the
             passed variant.
         variant (hoomd.variant.Variant): A variant used to interpolate between
             the two boxes.
-        trigger (hoomd.trigger.Trigger): The trigger to activate this updater.
         filter (hoomd.filter.ParticleFilter): The subset of particle positions
             to update.
 
@@ -54,7 +54,7 @@ class BoxResize(Updater):
             update.
     """
 
-    def __init__(self, box1, box2, variant, trigger, filter=All()):
+    def __init__(self, trigger, box1, box2, variant, filter=All()):
         params = ParameterDict(box1=OnlyTypes(Box,
                                               preprocess=box_preprocessing),
                                box2=OnlyTypes(Box,

--- a/hoomd/write/dcd.py
+++ b/hoomd/write/dcd.py
@@ -14,8 +14,8 @@ class DCD(Writer):
     """Writes simulation snapshots in the DCD format.
 
     Args:
-        filename (str): File name to write.
         trigger (hoomd.trigger.Periodic): Select the timesteps to write.
+        filename (str): File name to write.
         filter (hoomd.filter.ParticleFilter): Select the particles to write.
             Defaults to `hoomd.filter.All`.
         overwrite (bool): When False, (the default) an existing DCD file will be
@@ -74,8 +74,8 @@ class DCD(Writer):
     """
 
     def __init__(self,
-                 filename,
                  trigger,
+                 filename,
                  filter=All(),
                  overwrite=False,
                  unwrap_full=False,

--- a/hoomd/write/gsd.py
+++ b/hoomd/write/gsd.py
@@ -31,8 +31,8 @@ class GSD(Writer):
     r"""Write simulation trajectories in the GSD format.
 
     Args:
-        filename (str): File name to write.
         trigger (hoomd.trigger.Trigger): Select the timesteps to write.
+        filename (str): File name to write.
         filter (hoomd.filter.ParticleFilter): Select the particles to write.
             Defaults to `hoomd.filter.All`.
         mode (str): The file open mode. Defaults to ``'ab'``.
@@ -144,8 +144,8 @@ class GSD(Writer):
     """
 
     def __init__(self,
-                 filename,
                  trigger,
+                 filename,
                  filter=All(),
                  mode='ab',
                  truncate=False,


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should based on *maint*. -->
<!-- New features should based on *master*. -->

## Description

<!-- Describe your changes in detail. -->
Place the trigger argument first when possible.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Trigger is a common argument for updaters, it should be placed first when possible in the argument list. See #630 for details.

<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves #630

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
Executed unit tests. Ensured that documented arguments are in the correct order.

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
Changed:

- [breaking] Moved `trigger` to first argument position in `hoomd.update.BoxResize`, `hoomd.write.DCD`, and `hoomd.write.GSD`.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
