### PR TITLE
Fix Integrator and Neighbor List detaching

### DIFF
--- a/hoomd/data/syncedlist.py
+++ b/hoomd/data/syncedlist.py
@@ -172,7 +172,7 @@ class SyncedList(MutableSequence):
 
     @property
     def _synced(self):
-        """Has a cpp_list object means that we are currently syncing."""
+        """Has a _synced_list object means that we are currently syncing."""
         return hasattr(self, "_synced_list")
 
     def _handle_int(self, integer):

--- a/hoomd/data/syncedlist.py
+++ b/hoomd/data/syncedlist.py
@@ -42,6 +42,16 @@ def identity(obj):
     return obj
 
 
+class _SimulationPlaceHolder:
+    """Used to ensure objects are not added to two locations at once."""
+
+    def __init__(self, obj):
+        self._id = id(obj)
+
+    def __eq__(self, other):
+        return isinstance(other, type(self)) and self._id == other._id
+
+
 class SyncedList(MutableSequence):
     """Provides syncing and validation for a Python and C++ list.
 
@@ -93,7 +103,7 @@ class SyncedList(MutableSequence):
             self._validate = validation
 
         self._to_synced_list_conversion = to_synced_list
-        self._simulation = None
+        self._simulation = _SimulationPlaceHolder(self)
         self._list = []
         if iterable is not None:
             for it in iterable:
@@ -243,7 +253,7 @@ class SyncedList(MutableSequence):
         if self._attach_members:
             for item in self:
                 self._detach_value(item)
-        del self._simulation
+        self._simulation = _SimulationPlaceHolder(self)
         del self._synced_list
 
     def __getstate__(self):

--- a/hoomd/hpmc/integrate.py
+++ b/hoomd/hpmc/integrate.py
@@ -166,7 +166,7 @@ class HPMCIntegrator(BaseIntegrator):
 
         HPMC uses RNGs. Warn the user if they did not set the seed.
         """
-        if simulation is not None:
+        if isinstance(simulation, hoomd.Simulation):
             simulation._warn_if_seed_unset()
 
         super()._add(simulation)

--- a/hoomd/hpmc/update.py
+++ b/hoomd/hpmc/update.py
@@ -109,7 +109,7 @@ class BoxMC(Updater):
 
         HPMC uses RNGs. Warn the user if they did not set the seed.
         """
-        if simulation is not None:
+        if isinstance(simulation, hoomd.Simulation):
             simulation._warn_if_seed_unset()
 
         super()._add(simulation)
@@ -527,7 +527,7 @@ class Clusters(Updater):
 
         HPMC uses RNGs. Warn the user if they did not set the seed.
         """
-        if simulation is not None:
+        if isinstance(simulation, hoomd.Simulation):
             simulation._warn_if_seed_unset()
 
         super()._add(simulation)
@@ -665,7 +665,7 @@ class QuickCompress(Updater):
 
         HPMC uses RNGs. Warn the user if they did not set the seed.
         """
-        if simulation is not None:
+        if isinstance(simulation, hoomd.Simulation):
             simulation._warn_if_seed_unset()
 
         super()._add(simulation)

--- a/hoomd/md/force.py
+++ b/hoomd/md/force.py
@@ -400,7 +400,7 @@ class Active(Force):
 
         Active forces use RNGs. Warn the user if they did not set the seed.
         """
-        if simulation is not None:
+        if isinstance(simulation, hoomd.Simulation):
             simulation._warn_if_seed_unset()
 
         super()._add(simulation)
@@ -512,7 +512,7 @@ class ActiveOnManifold(Force):
 
         Active forces use RNGs. Warn the user if they did not set the seed.
         """
-        if simulation is not None:
+        if isinstance(simulation, hoomd.Simulation):
             simulation._warn_if_seed_unset()
 
         if self.manifold_constraint is not None:

--- a/hoomd/md/integrate.py
+++ b/hoomd/md/integrate.py
@@ -62,6 +62,19 @@ class _DynamicIntegrator(BaseIntegrator):
             self.rigid._attach()
             self._cpp_obj.rigid = self.rigid._cpp_obj
 
+    def _detach(self):
+        self.forces._unsync()
+        self.methods._unsync()
+        self.constraints._unsync()
+        if self.rigid is not None:
+            self.rigid._detach()
+        super()._detach()
+
+    def _remove(self):
+        if self.rigid is not None:
+            self.rigid._detach()
+        super()._remove()
+
     def _add(self, simulation):
         super()._add(simulation)
         if self.rigid is not None:

--- a/hoomd/md/methods/methods.py
+++ b/hoomd/md/methods/methods.py
@@ -23,15 +23,7 @@ class Method(_HOOMDBaseObject):
     Note:
         Users should use the subclasses and not instantiate `Method` directly.
     """
-
-    def _detach(self):
-        if self._attached:
-            self._unapply_typeparam_dict()
-            self._update_param_dict()
-
-            self._cpp_obj = None
-            self._notify_disconnect(self._simulation)
-        return self
+    pass
 
 
 class NVT(Method):

--- a/hoomd/md/methods/methods.py
+++ b/hoomd/md/methods/methods.py
@@ -844,7 +844,7 @@ class Langevin(Method):
 
         Langevin uses RNGs. Warn the user if they did not set the seed.
         """
-        if simulation is not None:
+        if isinstance(simulation, hoomd.Simulation):
             simulation._warn_if_seed_unset()
 
         super()._add(simulation)
@@ -1003,7 +1003,7 @@ class Brownian(Method):
 
         Brownian uses RNGs. Warn the user if they did not set the seed.
         """
-        if simulation is not None:
+        if isinstance(simulation, hoomd.Simulation):
             simulation._warn_if_seed_unset()
 
         super()._add(simulation)

--- a/hoomd/md/methods/rattle.py
+++ b/hoomd/md/methods/rattle.py
@@ -287,7 +287,7 @@ class Langevin(MethodRATTLE):
 
         Langevin uses RNGs. Warn the user if they did not set the seed.
         """
-        if simulation is not None:
+        if isinstance(simulation, hoomd.Simulation):
             simulation._warn_if_seed_unset()
 
         super()._add(simulation)
@@ -426,7 +426,7 @@ class Brownian(MethodRATTLE):
 
         Brownian uses RNGs. Warn the user if they did not set the seed.
         """
-        if simulation is not None:
+        if isinstance(simulation, hoomd.Simulation):
             simulation._warn_if_seed_unset()
 
         super()._add(simulation)

--- a/hoomd/md/nlist.py
+++ b/hoomd/md/nlist.py
@@ -108,6 +108,16 @@ class NList(_HOOMDBaseObject):
         """
         return self._cpp_obj.getSmallestRebuild()
 
+    def _remove_dependent(self, obj):
+        print("Removing dependent...")
+        super()._remove_dependent(obj)
+        if len(self._dependents) == 0:
+            if self._attached:
+                self._detach()
+                self._remove()
+            if self._added:
+                self._remove()
+
     # TODO need to add tuning Updater for NList
 
 

--- a/hoomd/md/nlist.py
+++ b/hoomd/md/nlist.py
@@ -114,6 +114,7 @@ class NList(_HOOMDBaseObject):
             if self._attached:
                 self._detach()
                 self._remove()
+                return
             if self._added:
                 self._remove()
 

--- a/hoomd/md/nlist.py
+++ b/hoomd/md/nlist.py
@@ -109,7 +109,6 @@ class NList(_HOOMDBaseObject):
         return self._cpp_obj.getSmallestRebuild()
 
     def _remove_dependent(self, obj):
-        print("Removing dependent...")
         super()._remove_dependent(obj)
         if len(self._dependents) == 0:
             if self._attached:

--- a/hoomd/md/nlist.py
+++ b/hoomd/md/nlist.py
@@ -82,12 +82,6 @@ class NList(_HOOMDBaseObject):
             :math:`[\mathrm{length}]`.
     """
 
-    _remove_for_pickling = _HOOMDBaseObject._remove_for_pickling + (
-        '_cpp_cell',)
-    _skip_for_equality = _HOOMDBaseObject._skip_for_equality | {
-        '_cpp_cell',
-    }
-
     def __init__(self, buffer, exclusions, rebuild_check_delay, diameter_shift,
                  check_dist, max_diameter):
 

--- a/hoomd/md/pair/pair.py
+++ b/hoomd/md/pair/pair.py
@@ -185,6 +185,8 @@ class Pair(force.Force):
                                    "different simulation.".format(type(self)))
         if not self.nlist._attached:
             self.nlist._attach()
+        # We don't need to worry about the neighbor list shifting once attached
+        # making this safe.
         self._add_dependency(self.nlist)
         if isinstance(self._simulation.device, hoomd.device.CPU):
             cls = getattr(_md, self._cpp_class_name)

--- a/hoomd/md/pair/pair.py
+++ b/hoomd/md/pair/pair.py
@@ -185,6 +185,7 @@ class Pair(force.Force):
                                    "different simulation.".format(type(self)))
         if not self.nlist._attached:
             self.nlist._attach()
+        self._add_dependency(self.nlist)
         if isinstance(self._simulation.device, hoomd.device.CPU):
             cls = getattr(_md, self._cpp_class_name)
             self.nlist._cpp_obj.setStorageMode(

--- a/hoomd/md/pair/pair.py
+++ b/hoomd/md/pair/pair.py
@@ -778,7 +778,7 @@ class DPD(Pair):
 
         DPD uses RNGs. Warn the user if they did not set the seed.
         """
-        if simulation is not None:
+        if isinstance(simulation, hoomd.Simulation):
             simulation._warn_if_seed_unset()
 
         super()._add(simulation)
@@ -962,7 +962,7 @@ class DPDLJ(Pair):
 
         DPDLJ uses RNGs. Warn the user if they did not set the seed.
         """
-        if simulation is not None:
+        if isinstance(simulation, hoomd.Simulation):
             simulation._warn_if_seed_unset()
 
         super()._add(simulation)

--- a/hoomd/md/pair/pair.py
+++ b/hoomd/md/pair/pair.py
@@ -4,6 +4,9 @@
 
 """Pair potentials."""
 
+import copy
+import warnings
+
 import hoomd
 from hoomd.md import _md
 from hoomd.md import force
@@ -175,6 +178,35 @@ class Pair(force.Force):
         # above and raise an error if they occur.
         return self._cpp_obj.computeEnergyBetweenSets(tags1, tags2)
 
+    def _add(self, simulation):
+        # if nlist was associated with multiple pair forces and is still
+        # attached, we need to deepcopy existing nlist.
+        nlist = self._nlist
+        if (not self._attached and nlist._attached
+                and nlist._simulation != simulation):
+            warnings.warn(
+                f"{self} object is creating a new equivalent neighbor list."
+                f" This is happending since the force is moving to a new "
+                f"simulation. To supress the warning explicitly set new nlist.",
+                RuntimeWarning)
+            self._nlist = copy.deepcopy(nlist)
+        # We need to check if the force is added since if it is not then this is
+        # being called by a SyncedList object and a disagreement between the
+        # simulation and nlist._simulation is an error. If the force is added
+        # then the nlist is compatible. We cannot just check the nlist's _added
+        # property because _add is also called when the SyncedList is synced.
+        elif (not self._added and nlist._added
+              and nlist._simulation != simulation):
+            raise RuntimeError(
+                f"NeighborList associated with {self} is associated with "
+                f"another simulation.")
+        super()._add(simulation)
+        # this ideopotent given the above check.
+        self._nlist._add(simulation)
+        # This is ideopotent, but we need to ensure that if we change
+        # neighbor list when not attached we handle correctly.
+        self._add_dependency(self._nlist)
+
     def _attach(self):
         # create the c++ mirror class
         if not self._nlist._added:
@@ -185,9 +217,6 @@ class Pair(force.Force):
                                    "different simulation.".format(type(self)))
         if not self.nlist._attached:
             self.nlist._attach()
-        # We don't need to worry about neighbor list assignment once attached
-        # making this safe.
-        self._add_dependency(self.nlist)
         if isinstance(self._simulation.device, hoomd.device.CPU):
             cls = getattr(_md, self._cpp_class_name)
             self.nlist._cpp_obj.setStorageMode(
@@ -210,8 +239,14 @@ class Pair(force.Force):
     def nlist(self, value):
         if self._attached:
             raise RuntimeError("nlist cannot be set after scheduling.")
-        else:
-            self._nlist = validate_nlist(value)
+        nlist = validate_nlist(value)
+        if self._added:
+            if nlist._added and self._simulation != nlist._simulation:
+                raise RuntimeError(
+                    "Neighbor lists and forces must belong to the same "
+                    "simulation or SyncedList.")
+            self._nlist._add(self._simulation)
+        self._nlist = nlist
 
     @property
     def _children(self):

--- a/hoomd/md/pair/pair.py
+++ b/hoomd/md/pair/pair.py
@@ -185,7 +185,7 @@ class Pair(force.Force):
                                    "different simulation.".format(type(self)))
         if not self.nlist._attached:
             self.nlist._attach()
-        # We don't need to worry about the neighbor list shifting once attached
+        # We don't need to worry about neighbor list assignment once attached
         # making this safe.
         self._add_dependency(self.nlist)
         if isinstance(self._simulation.device, hoomd.device.CPU):

--- a/hoomd/md/pytest/test_integrate.py
+++ b/hoomd/md/pytest/test_integrate.py
@@ -1,0 +1,50 @@
+import pytest
+
+import hoomd
+import hoomd.md as md
+
+
+def make_simulation(simulation_factory, two_particle_snapshot_factory):
+
+    def sim_factory(particle_types=['A'], dimensions=3, d=1, L=20):
+        return simulation_factory(
+            two_particle_snapshot_factory(particle_types, dimensions, d, L))
+
+    return sim_factory
+
+
+@pytest.fixture
+def integrator_elements():
+    nlist = md.nlist.Cell()
+    lj = md.pair.LJ(nlist=nlist, default_r_cut=2.5)
+    gauss = md.pair.Gauss(nlist, default_r_cut=3.0)
+    lj.params[("A", "A")] = {"epsilon": 1.0, "sigma": 1.0}
+    gauss.params[("A", "A")] = {"epsilon": 1.0, "sigma": 1.0}
+    return {
+        "methods": [md.methods.NVE(hoomd.filter.All())],
+        "forces": [lj, gauss],
+        "constraints": [md.constrain.Distance()]
+    }
+
+
+def test_attaching(make_simulation, integrator_elements):
+    sim = make_simulation()
+    integrator = hoomd.md.Integrator(0.005, **integrator_elements)
+    sim.operations.integrator = integrator
+    sim.run(0)
+    assert integrator._attached
+    assert integrator._forces._synced
+    assert integrator._methods._synced
+    assert integrator._contraints._synced
+
+
+def test_detaching(make_simulation, methods, forces):
+    sim = make_simulation()
+    integrator = hoomd.md.Integrator(0.005, **integrator_elements)
+    sim.operations.integrator = integrator
+    sim.run(0)
+    sim.operations._unschedule()
+    assert not integrator._attached
+    assert not integrator._forces._synced
+    assert not integrator._methods._synced
+    assert not integrator._contraints._synced

--- a/hoomd/md/pytest/test_nlist.py
+++ b/hoomd/md/pytest/test_nlist.py
@@ -98,19 +98,20 @@ def test_simple_simulation(nlist_params, simulation_factory,
     sim.run(2)
 
 
-def test_auto_detach_simulation(simulation_factory, lattice_snapshot_factory):
+def test_auto_detach_simulation(simulation_factory,
+                                two_particle_snapshot_factory):
     nlist = Cell()
     lj = hoomd.md.pair.LJ(nlist, default_r_cut=1.1)
     lj.params[('A', 'A')] = dict(epsilon=1, sigma=1)
     lj.params[('A', 'B')] = dict(epsilon=1, sigma=1)
     lj.params[('B', 'B')] = dict(epsilon=1, sigma=1)
-    lj_2 = cp.copy(lj)
+    lj_2 = cp.deepcopy(lj)
     lj_2.nlist = nlist
     integrator = hoomd.md.Integrator(0.005, forces=[lj, lj_2])
     integrator.methods.append(
         hoomd.md.methods.Langevin(hoomd.filter.All(), kT=1))
 
-    sim = simulation_factory(lattice_snapshot_factory(n=10))
+    sim = simulation_factory(two_particle_snapshot_factory(d=2.0))
     sim.operations.integrator = integrator
     sim.run(0)
     del integrator.forces[1]
@@ -118,4 +119,4 @@ def test_auto_detach_simulation(simulation_factory, lattice_snapshot_factory):
     assert hasattr(nlist, "_cpp_obj")
     del integrator.forces[0]
     assert not nlist._attached
-    assert not hasattr(nlist, "_cpp_obj")
+    assert nlist._cpp_obj is None

--- a/hoomd/md/pytest/test_nlist.py
+++ b/hoomd/md/pytest/test_nlist.py
@@ -96,3 +96,26 @@ def test_simple_simulation(nlist_params, simulation_factory,
     sim = simulation_factory(lattice_snapshot_factory(n=10))
     sim.operations.integrator = integrator
     sim.run(2)
+
+
+def test_auto_detach_simulation(simulation_factory, lattice_snapshot_factory):
+    nlist = Cell()
+    lj = hoomd.md.pair.LJ(nlist, default_r_cut=1.1)
+    lj.params[('A', 'A')] = dict(epsilon=1, sigma=1)
+    lj.params[('A', 'B')] = dict(epsilon=1, sigma=1)
+    lj.params[('B', 'B')] = dict(epsilon=1, sigma=1)
+    lj_2 = cp.copy(lj)
+    lj_2.nlist = nlist
+    integrator = hoomd.md.Integrator(0.005, forces=[lj, lj_2])
+    integrator.methods.append(
+        hoomd.md.methods.Langevin(hoomd.filter.All(), kT=1))
+
+    sim = simulation_factory(lattice_snapshot_factory(n=10))
+    sim.operations.integrator = integrator
+    sim.run(0)
+    del integrator.forces[1]
+    assert nlist._attached
+    assert hasattr(nlist, "_cpp_obj")
+    del integrator.forces[0]
+    assert not nlist._attached
+    assert not hasattr(nlist, "_cpp_obj")

--- a/hoomd/operation.py
+++ b/hoomd/operation.py
@@ -226,12 +226,10 @@ class _HOOMDBaseObject(_HOOMDGetSetAttrBase,
             self._update_param_dict()
             if hasattr(self._cpp_obj, "notifyDetach"):
                 self._cpp_obj.notifyDetach()
-
-            self._cpp_obj = None
-            # _detach should always be followed by _remove or at the vary least
-            # removed from the simulation, meaning all dependencies within the
-            # simulation need to be resolved here and not `_remove`.
+            # In case the C++ object is necessary for proper disconnect
+            # notification we call _notify_disconnect here as well.
             self._notify_disconnect()
+            self._cpp_obj = None
             return self
 
     def _attach(self):
@@ -250,9 +248,10 @@ class _HOOMDBaseObject(_HOOMDGetSetAttrBase,
         self._simulation = simulation
 
     def _remove(self):
-        # _remove should always be follow _detach if attached meaning
-        # dependencies handled here will handle both detaching and adding
-        # dependencies.
+        # Since objects can be added without being attached, we need to call
+        # _notify_disconnect on both _remove and _detach. The method should be
+        # do nothing after being called onces so being called twice is not a
+        # concern.
         self._notify_disconnect()
         self._simulation = None
 

--- a/hoomd/operation.py
+++ b/hoomd/operation.py
@@ -188,6 +188,7 @@ class _HOOMDBaseObject(_HOOMDGetSetAttrBase,
     """
     _reserved_default_attrs = {
         **_HOOMDGetSetAttrBase._reserved_default_attrs, '_cpp_obj': None,
+        '_simulation': None,
         '_dependents': list,
         '_dependencies': list
     }
@@ -249,11 +250,15 @@ class _HOOMDBaseObject(_HOOMDGetSetAttrBase,
         self._simulation = simulation
 
     def _remove(self):
-        del self._simulation
+        # _remove should always be follow _detach if attached meaning
+        # dependencies handled here will handle both detaching and adding
+        # dependencies.
+        self._notify_disconnect()
+        self._simulation = None
 
     @property
     def _added(self):
-        return hasattr(self, '_simulation')
+        return self._simulation is not None
 
     def _apply_param_dict(self):
         for attr, value in self._param_dict.items():

--- a/hoomd/operation.py
+++ b/hoomd/operation.py
@@ -251,7 +251,9 @@ class _HOOMDBaseObject(_HOOMDGetSetAttrBase,
         # Since objects can be added without being attached, we need to call
         # _notify_disconnect on both _remove and _detach. The method should be
         # do nothing after being called onces so being called twice is not a
-        # concern.
+        # concern. I should note that if
+        # `hoomd.operations.Operations._unschedule` is called this is
+        # invalidated, but as that is not public facing this should be fine.
         self._notify_disconnect()
         self._simulation = None
 

--- a/hoomd/operations.py
+++ b/hoomd/operations.py
@@ -266,7 +266,6 @@ class Operations(Collection):
             if op is not None:
                 op._attach()
         if old_ref is not None:
-            old_ref._notify_disconnect(self._simulation)
             old_ref._detach()
             old_ref._remove()
 

--- a/hoomd/pytest/test_filter_updater.py
+++ b/hoomd/pytest/test_filter_updater.py
@@ -53,7 +53,7 @@ def test_attaching(simulation, filter_updater):
     simulation.run(0)
     assert trigger == filter_updater.trigger
     assert filters == filter_updater.filters
-    assert hasattr(filter_updater, "_cpp_obj")
+    assert filter_updater._cpp_obj is not None
     assert filter_updater._attached
 
 

--- a/hoomd/pytest/test_operation.py
+++ b/hoomd/pytest/test_operation.py
@@ -88,11 +88,12 @@ def test_setattr(full_op):
 
 def test_adding(full_op):
     assert not full_op._added
-    full_op._add(None)
+    # need a non-None dummy simulation 1 works
+    full_op._add(1)
     assert full_op._added
-    assert full_op._simulation is None
+    assert full_op._simulation == 1
     full_op._remove()
-    assert not hasattr(full_op, '_simulation')
+    assert full_op._simulation is None
 
 
 def test_apply_typeparam_dict(full_op):
@@ -121,7 +122,7 @@ def test_apply_param_dict(full_op):
 def attached(full_op):
     cp = deepcopy(full_op)
     op = test_apply_param_dict(test_apply_typeparam_dict(cp))
-    op._add(None)
+    op._add(1)
     return op
 
 

--- a/hoomd/pytest/test_syncedlist.py
+++ b/hoomd/pytest/test_syncedlist.py
@@ -165,7 +165,8 @@ def test_setitem(synced_list, op_list):
 
     # Check when attached
     sync_list = []
-    synced_list._sync(None, sync_list)
+    # need a non-None dummy simulation 1 works
+    synced_list._sync(1, sync_list)
     new_op = DummyOperation()
     old_op = synced_list[1]
     synced_list[1] = new_op


### PR DESCRIPTION

<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should based on *maint*. -->
<!-- New features should based on *master*. -->

## Description

Fixes `hoomd.md._DynamicIntegrator` and `hoomd.md.nlist.NList` detaching. Currently MD integrator objects do not detach any of the forces, methods, or constraints or the rigid parameter. The neighbor list is not detached by the composing potentials either. This is fixed as well through using the `_DependencyRelation` interface. This interface is cleaned up and fixed in this PR as well.

This PR cherry-picks a commit from #1099, so either a rebase and force push here or there will be needed after the other is merged.

This is also dependent on #1053 like #1099.
<!-- Describe your changes in detail. -->

## Motivation and context

This fixes multiple existing bugs with detaching properly which is done when operations or other objects are removed from a simulation that is attached.

## How has this been tested?

Currently, neighbor list detaching is tested, but no tests for the md integrator currently exist. I can add the test for detaching, but I don't think all the tests should go in this PR.
<!--- Please describe in detail how you tested your changes. -->

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
Fixes: Removing an integrator from a simulation after running.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
