### PR TITLE
OverdampedViscous method

### DIFF
--- a/hoomd/md/TwoStepBD.cc
+++ b/hoomd/md/TwoStepBD.cc
@@ -23,8 +23,10 @@ using namespace std;
 */
 TwoStepBD::TwoStepBD(std::shared_ptr<SystemDefinition> sysdef,
                      std::shared_ptr<ParticleGroup> group,
-                     std::shared_ptr<Variant> T)
-    : TwoStepLangevinBase(sysdef, group, T), m_noiseless_t(false), m_noiseless_r(false)
+                     std::shared_ptr<Variant> T,
+                     bool noiseless_t,
+                     bool noiseless_r)
+    : TwoStepLangevinBase(sysdef, group, T), m_noiseless_t(noiseless_t), m_noiseless_r(noiseless_r)
     {
     m_exec_conf->msg->notice(5) << "Constructing TwoStepBD" << endl;
     }
@@ -241,5 +243,7 @@ void export_TwoStepBD(py::module& m)
     py::class_<TwoStepBD, TwoStepLangevinBase, std::shared_ptr<TwoStepBD>>(m, "TwoStepBD")
         .def(py::init<std::shared_ptr<SystemDefinition>,
                       std::shared_ptr<ParticleGroup>,
-                      std::shared_ptr<Variant>>());
+                      std::shared_ptr<Variant>,
+                      bool,
+                      bool>());
     }

--- a/hoomd/md/TwoStepBD.cc
+++ b/hoomd/md/TwoStepBD.cc
@@ -137,16 +137,28 @@ void TwoStepBD::integrateStepOne(uint64_t timestep)
         // into place
         box.wrap(h_pos.data[j], h_image.data[j]);
 
-        // draw a new random velocity for particle j
-        Scalar mass = h_vel.data[j].w;
-        Scalar sigma = fast::sqrt(currentTemp / mass);
-        NormalDistribution<Scalar> normal(sigma);
-        h_vel.data[j].x = normal(rng);
-        h_vel.data[j].y = normal(rng);
-        if (D > 2)
-            h_vel.data[j].z = normal(rng);
+        if (m_noiseless_t)
+            {
+            h_vel.data[j].x = h_net_force.data[j].x / gamma;
+            h_vel.data[j].y = h_net_force.data[j].y / gamma;
+            if (D > 2)
+                h_vel.data[j].z = h_net_force.data[j].z / gamma;
+            else
+                h_vel.data[j].z = 0;
+            }
         else
-            h_vel.data[j].z = 0;
+            {
+            // draw a new random velocity for particle j
+            Scalar mass = h_vel.data[j].w;
+            Scalar sigma = fast::sqrt(currentTemp / mass);
+            NormalDistribution<Scalar> normal(sigma);
+            h_vel.data[j].x = normal(rng);
+            h_vel.data[j].y = normal(rng);
+            if (D > 2)
+                h_vel.data[j].z = normal(rng);
+            else
+                h_vel.data[j].z = 0;
+            }
 
         // rotational random force and orientation quaternion updates
         if (m_aniso)
@@ -205,10 +217,20 @@ void TwoStepBD::integrateStepOne(uint64_t timestep)
                 q = q * (Scalar(1.0) / slow::sqrt(norm2(q)));
                 h_orientation.data[j] = quat_to_scalar4(q);
 
-                // draw a new random ang_mom for particle j in body frame
-                p_vec.x = NormalDistribution<Scalar>(fast::sqrt(currentTemp * I.x))(rng);
-                p_vec.y = NormalDistribution<Scalar>(fast::sqrt(currentTemp * I.y))(rng);
-                p_vec.z = NormalDistribution<Scalar>(fast::sqrt(currentTemp * I.z))(rng);
+                if (m_noiseless_r)
+                    {
+                    p_vec.x = t.x / gamma_r.x;
+                    p_vec.y = t.y / gamma_r.y;
+                    p_vec.z = t.z / gamma_r.z;
+                    }
+                else
+                    {
+                    // draw a new random ang_mom for particle j in body frame
+                    p_vec.x = NormalDistribution<Scalar>(fast::sqrt(currentTemp * I.x))(rng);
+                    p_vec.y = NormalDistribution<Scalar>(fast::sqrt(currentTemp * I.y))(rng);
+                    p_vec.z = NormalDistribution<Scalar>(fast::sqrt(currentTemp * I.z))(rng);
+                    }
+
                 if (x_zero)
                     p_vec.x = 0;
                 if (y_zero)

--- a/hoomd/md/TwoStepBD.h
+++ b/hoomd/md/TwoStepBD.h
@@ -22,7 +22,9 @@ class PYBIND11_EXPORT TwoStepBD : public TwoStepLangevinBase
     /// Constructs the integration method and associates it with the system
     TwoStepBD(std::shared_ptr<SystemDefinition> sysdef,
               std::shared_ptr<ParticleGroup> group,
-              std::shared_ptr<Variant> T);
+              std::shared_ptr<Variant> T,
+              bool noiseless_t,
+              bool noiseless_r);
 
     virtual ~TwoStepBD();
 

--- a/hoomd/md/TwoStepBDGPU.cc
+++ b/hoomd/md/TwoStepBDGPU.cc
@@ -20,8 +20,10 @@ using namespace std;
 */
 TwoStepBDGPU::TwoStepBDGPU(std::shared_ptr<SystemDefinition> sysdef,
                            std::shared_ptr<ParticleGroup> group,
-                           std::shared_ptr<Variant> T)
-    : TwoStepBD(sysdef, group, T)
+                           std::shared_ptr<Variant> T,
+                           bool noiseless_t,
+                           bool noiseless_r)
+    : TwoStepBD(sysdef, group, T, noiseless_t, noiseless_r)
     {
     if (!m_exec_conf->isCUDAEnabled())
         {
@@ -166,5 +168,7 @@ void export_TwoStepBDGPU(py::module& m)
     py::class_<TwoStepBDGPU, TwoStepBD, std::shared_ptr<TwoStepBDGPU>>(m, "TwoStepBDGPU")
         .def(py::init<std::shared_ptr<SystemDefinition>,
                       std::shared_ptr<ParticleGroup>,
-                      std::shared_ptr<Variant>>());
+                      std::shared_ptr<Variant>,
+                      bool,
+                      bool>());
     }

--- a/hoomd/md/TwoStepBDGPU.cu
+++ b/hoomd/md/TwoStepBDGPU.cu
@@ -162,16 +162,28 @@ extern "C" __global__ void gpu_brownian_step_one_kernel(Scalar4* d_pos,
         // into place
         box.wrap(postype, image);
 
-        // draw a new random velocity for particle j
-        Scalar mass = vel.w;
-        Scalar sigma = fast::sqrt(T / mass);
-        NormalDistribution<Scalar> normal(sigma);
-        vel.x = normal(rng);
-        vel.y = normal(rng);
-        if (D > 2)
-            vel.z = normal(rng);
+        if (d_noiseless_t)
+            {
+            vel.x = net_force.x / gamma;
+            vel.y = net_force.y / gamma;
+            if (D > 2)
+                vel.z = net_force.z / gamma;
+            else
+                vel.z = 0;
+            }
         else
-            vel.z = 0;
+            {
+            // draw a new random velocity for particle j
+            Scalar mass = vel.w;
+            Scalar sigma = fast::sqrt(T / mass);
+            NormalDistribution<Scalar> normal(sigma);
+            vel.x = normal(rng);
+            vel.y = normal(rng);
+            if (D > 2)
+                vel.z = normal(rng);
+            else
+                vel.z = 0;
+            }
 
         // write out data
         d_pos[idx] = postype;
@@ -234,10 +246,20 @@ extern "C" __global__ void gpu_brownian_step_one_kernel(Scalar4* d_pos,
                 q = q * (Scalar(1.0) / slow::sqrt(norm2(q)));
                 d_orientation[idx] = quat_to_scalar4(q);
 
-                // draw a new random ang_mom for particle j in body frame
-                p_vec.x = NormalDistribution<Scalar>(fast::sqrt(T * I.x))(rng);
-                p_vec.y = NormalDistribution<Scalar>(fast::sqrt(T * I.y))(rng);
-                p_vec.z = NormalDistribution<Scalar>(fast::sqrt(T * I.z))(rng);
+                if (d_noiseless_r)
+                    {
+                    p_vec.x = t.x / gamma_r.x;
+                    p_vec.y = t.y / gamma_r.y;
+                    p_vec.z = t.z / gamma_r.z;
+                    }
+                else
+                    {
+                    // draw a new random ang_mom for particle j in body frame
+                    p_vec.x = NormalDistribution<Scalar>(fast::sqrt(T * I.x))(rng);
+                    p_vec.y = NormalDistribution<Scalar>(fast::sqrt(T * I.y))(rng);
+                    p_vec.z = NormalDistribution<Scalar>(fast::sqrt(T * I.z))(rng);
+                    }
+
                 if (x_zero)
                     p_vec.x = 0;
                 if (y_zero)

--- a/hoomd/md/TwoStepBDGPU.h
+++ b/hoomd/md/TwoStepBDGPU.h
@@ -22,7 +22,9 @@ class PYBIND11_EXPORT TwoStepBDGPU : public TwoStepBD
     //! Constructs the integration method and associates it with the system
     TwoStepBDGPU(std::shared_ptr<SystemDefinition> sysdef,
                  std::shared_ptr<ParticleGroup> group,
-                 std::shared_ptr<Variant> T);
+                 std::shared_ptr<Variant> T,
+                 bool noiseless_t,
+                 bool noiseless_r);
 
     virtual ~TwoStepBDGPU() {};
 

--- a/hoomd/md/TwoStepRATTLEBD.h
+++ b/hoomd/md/TwoStepRATTLEBD.h
@@ -42,6 +42,8 @@ template<class Manifold> class PYBIND11_EXPORT TwoStepRATTLEBD : public TwoStepL
                     std::shared_ptr<ParticleGroup> group,
                     Manifold manifold,
                     std::shared_ptr<Variant> T,
+                    bool noiseless_t,
+                    bool noiseless_r,
                     Scalar tolerance = 0.000001);
 
     virtual ~TwoStepRATTLEBD();
@@ -111,9 +113,11 @@ TwoStepRATTLEBD<Manifold>::TwoStepRATTLEBD(std::shared_ptr<SystemDefinition> sys
                                            std::shared_ptr<ParticleGroup> group,
                                            Manifold manifold,
                                            std::shared_ptr<Variant> T,
+                                           bool noiseless_t,
+                                           bool noiseless_r,
                                            Scalar tolerance)
-    : TwoStepLangevinBase(sysdef, group, T), m_manifold(manifold), m_noiseless_t(false),
-      m_noiseless_r(false), m_tolerance(tolerance), m_box_changed(false)
+    : TwoStepLangevinBase(sysdef, group, T), m_manifold(manifold), m_noiseless_t(noiseless_t),
+      m_noiseless_r(noiseless_r), m_tolerance(tolerance), m_box_changed(false)
     {
     m_exec_conf->msg->notice(5) << "Constructing TwoStepRATTLEBD" << endl;
 
@@ -538,6 +542,8 @@ template<class Manifold> void export_TwoStepRATTLEBD(py::module& m, const std::s
                       std::shared_ptr<ParticleGroup>,
                       Manifold,
                       std::shared_ptr<Variant>,
+                      bool,
+                      bool,
                       Scalar>())
         .def_property("tolerance",
                       &TwoStepRATTLEBD<Manifold>::getTolerance,

--- a/hoomd/md/TwoStepRATTLEBDGPU.h
+++ b/hoomd/md/TwoStepRATTLEBDGPU.h
@@ -37,6 +37,8 @@ template<class Manifold> class PYBIND11_EXPORT TwoStepRATTLEBDGPU : public TwoSt
                        std::shared_ptr<ParticleGroup> group,
                        Manifold manifold,
                        std::shared_ptr<Variant> T,
+                       bool noiseless_t,
+                       bool noiseless_r,
                        Scalar tolerance);
 
     virtual ~TwoStepRATTLEBDGPU() {};
@@ -64,8 +66,10 @@ TwoStepRATTLEBDGPU<Manifold>::TwoStepRATTLEBDGPU(std::shared_ptr<SystemDefinitio
                                                  std::shared_ptr<ParticleGroup> group,
                                                  Manifold manifold,
                                                  std::shared_ptr<Variant> T,
+                                                 bool noiseless_t,
+                                                 bool noiseless_r,
                                                  Scalar tolerance)
-    : TwoStepRATTLEBD<Manifold>(sysdef, group, manifold, T, tolerance)
+    : TwoStepRATTLEBD<Manifold>(sysdef, group, manifold, T, noiseless_t, noiseless_r, tolerance)
     {
     if (!this->m_exec_conf->isCUDAEnabled())
         {
@@ -288,6 +292,8 @@ template<class Manifold> void export_TwoStepRATTLEBDGPU(py::module& m, const std
                       std::shared_ptr<ParticleGroup>,
                       Manifold,
                       std::shared_ptr<Variant>,
+                      bool,
+                      bool,
                       Scalar>());
     }
 #endif // ENABLE_HIP

--- a/hoomd/md/methods/__init__.py
+++ b/hoomd/md/methods/__init__.py
@@ -8,4 +8,4 @@ For methods that constrain motion to a manifold see `hoomd.md.methods.rattle`
 """
 
 from . import rattle
-from .methods import (Method, NVT, NPT, NPH, NVE, Langevin, Brownian, Berendsen)
+from .methods import (Method, NVT, NPT, NPH, NVE, Langevin, Brownian, Berendsen, OverdampedViscous)

--- a/hoomd/md/methods/methods.py
+++ b/hoomd/md/methods/methods.py
@@ -1151,10 +1151,6 @@ class OverdampedViscous(Method):
 
     Examples::
 
-        odv = hoomd.md.methods.Brownian(filter=hoomd.filter.All(), alpha=1.0)
-
-    Examples of using ``gamma`` or ``gamma_r`` on drag coefficient::
-
         odv = hoomd.md.methods.Brownian(filter=hoomd.filter.All())
         odv.gamma.default = 2.0
         odv.gamma_r.default = [1.0, 2.0, 3.0]

--- a/hoomd/md/methods/methods.py
+++ b/hoomd/md/methods/methods.py
@@ -1022,11 +1022,15 @@ class Brownian(Method):
         if isinstance(sim.device, hoomd.device.CPU):
             self._cpp_obj = _md.TwoStepBD(sim.state._cpp_sys_def,
                                           sim.state._get_group(self.filter),
-                                          self.kT)
+                                          self.kT,
+                                          False,
+                                          False)
         else:
             self._cpp_obj = _md.TwoStepBDGPU(sim.state._cpp_sys_def,
                                              sim.state._get_group(self.filter),
-                                             self.kT)
+                                             self.kT,
+                                             False,
+                                             False)
 
         # Attach param_dict and typeparam_dict
         super()._attach()

--- a/hoomd/md/methods/methods.py
+++ b/hoomd/md/methods/methods.py
@@ -1232,13 +1232,13 @@ class OverdampedViscous(Method):
         if isinstance(sim.device, hoomd.device.CPU):
             self._cpp_obj = _md.TwoStepBD(sim.state._cpp_sys_def,
                                           sim.state._get_group(self.filter),
-                                          1.0,
+                                          hoomd.variant.Constant(1.0),
                                           True,
                                           True)
         else:
             self._cpp_obj = _md.TwoStepBDGPU(sim.state._cpp_sys_def,
                                              sim.state._get_group(self.filter),
-                                             1.0,
+                                             hoomd.variant.Constant(1.0),
                                              True,
                                              True)
 

--- a/hoomd/md/methods/methods.py
+++ b/hoomd/md/methods/methods.py
@@ -1164,7 +1164,7 @@ class OverdampedViscous(Method):
         integrator = hoomd.md.Integrator(dt=0.001, methods=[odv],
         forces=[lj])
 
-    Examples of using ``gamma`` pr ``gamma_r`` on drag coefficient::
+    Examples of using ``gamma`` or ``gamma_r`` on drag coefficient::
 
         odv = hoomd.md.methods.Brownian(filter=hoomd.filter.All())
         odv.gamma.default = 2.0
@@ -1233,14 +1233,14 @@ class OverdampedViscous(Method):
             self._cpp_obj = _md.TwoStepBD(sim.state._cpp_sys_def,
                                           sim.state._get_group(self.filter),
                                           1.0,
-                                          False,
-                                          False)
+                                          True,
+                                          True)
         else:
             self._cpp_obj = _md.TwoStepBDGPU(sim.state._cpp_sys_def,
                                              sim.state._get_group(self.filter),
                                              1.0,
-                                             False,
-                                             False)
+                                             True,
+                                             True)
 
         # Attach param_dict and typeparam_dict
         super()._attach()

--- a/hoomd/md/methods/methods.py
+++ b/hoomd/md/methods/methods.py
@@ -1111,3 +1111,136 @@ class Berendsen(Method):
                                    thermo_cls(sim.state._cpp_sys_def, group),
                                    self.tau, self.kT)
         super()._attach()
+
+
+class OverdampedViscous(Method):
+    r"""Overdamped viscous dynamics.
+
+    Args:
+        filter (`hoomd.filter.ParticleFilter`): Subset of particles to
+            apply this method to.
+
+        alpha (`float`): When set, use :math:`\alpha d_i` for the
+            drag coefficient where :math:`d_i` is particle diameter.
+            Defaults to None
+            :math:`[\mathrm{mass} \cdot \mathrm{length}^{-1}
+            \cdot \mathrm{time}^{-1}]`.
+
+    `OverdampedViscous` integrates particles forward in time on the Brownian,
+    or diffusive, timescale with a drag force but no random force.
+
+    .. math::
+
+        \frac{d\vec{x}}{dt} = \frac{\vec{F}_\mathrm{C}}{\gamma}
+
+        \langle \vec{v}(t) \rangle = 0
+
+        \langle |\vec{v}(t)|^2 \rangle = d k T / m
+
+
+    where :math:`\vec{F}_\mathrm{C}` is the force on the particle from all
+    potentials and constraint forces, :math:`\gamma` is the drag coefficient,
+    :math:`\vec{v}` is the particle's velocity, and :math:`d` is the dimensionality
+    of the system.
+
+    `OverdampedViscous` uses the same internal integrator as `Brownian`, except the random
+    force is turned off
+
+    Overdamped viscous dynamics neglects the acceleration term in the equation of motion.
+
+    You can specify :math:`\gamma` in two ways:
+
+    1. Specify :math:`\alpha` which scales the particle diameter to
+       :math:`\gamma = \alpha d_i`. The units of :math:`\alpha` are mass /
+       distance / time.
+    2. After the method object is created, specify the attribute ``gamma``
+       and ``gamma_r`` for rotational damping or random torque to assign them
+       directly, with independent values for each particle type in the
+       system.
+
+    Examples::
+
+        odv = hoomd.md.methods.Brownian(filter=hoomd.filter.All(), alpha=1.0)
+        integrator = hoomd.md.Integrator(dt=0.001, methods=[odv],
+        forces=[lj])
+
+    Examples of using ``gamma`` pr ``gamma_r`` on drag coefficient::
+
+        odv = hoomd.md.methods.Brownian(filter=hoomd.filter.All())
+        odv.gamma.default = 2.0
+        odv.gamma_r.default = [1.0, 2.0, 3.0]
+
+
+    Attributes:
+        filter (hoomd.filter.ParticleFilter): Subset of particles to
+            apply this method to.
+
+        alpha (float): When set, use :math:`\alpha d_i` for the drag
+            coefficient where :math:`d_i` is particle diameter
+            :math:`[\mathrm{mass} \cdot \mathrm{length}^{-1}
+            \cdot \mathrm{time}^{-1}]`. Defaults to None.
+
+        gamma (TypeParameter[ ``particle type``, `float` ]): The drag
+            coefficient can be directly set instead of the ratio of particle
+            diameter (:math:`\gamma = \alpha d_i`). The type of ``gamma``
+            parameter is either positive float or zero
+            :math:`[\mathrm{mass} \cdot \mathrm{time}^{-1}]`.
+
+        gamma_r (TypeParameter[``particle type``, [`float`, `float`, `float`]]):
+            The rotational drag coefficient can be set. The type of ``gamma_r``
+            parameter is a tuple of three float. The type of each element of
+            tuple is either positive float or zero
+            :math:`[\mathrm{force} \cdot \mathrm{length} \cdot
+            \mathrm{radian}^{-1} \cdot \mathrm{time}^{-1}]`.
+    """
+
+    def __init__(self, filter, alpha=None):
+
+        # store metadata
+        param_dict = ParameterDict(
+            filter=ParticleFilter,
+            alpha=OnlyTypes(float, allow_none=True),
+        )
+        param_dict.update(dict(alpha=alpha, filter=filter))
+
+        # set defaults
+        self._param_dict.update(param_dict)
+
+        gamma = TypeParameter('gamma',
+                              type_kind='particle_types',
+                              param_dict=TypeParameterDict(1., len_keys=1))
+
+        gamma_r = TypeParameter('gamma_r',
+                                type_kind='particle_types',
+                                param_dict=TypeParameterDict((1., 1., 1.),
+                                                             len_keys=1))
+        self._extend_typeparam([gamma, gamma_r])
+
+    def _add(self, simulation):
+        """Add the operation to a simulation.
+
+        OverdampedViscous uses RNGs. Warn the user if they did not set the seed.
+        """
+        if simulation is not None:
+            simulation._warn_if_seed_unset()
+
+        super()._add(simulation)
+
+    def _attach(self):
+
+        sim = self._simulation
+        if isinstance(sim.device, hoomd.device.CPU):
+            self._cpp_obj = _md.TwoStepBD(sim.state._cpp_sys_def,
+                                          sim.state._get_group(self.filter),
+                                          1.0,
+                                          False,
+                                          False)
+        else:
+            self._cpp_obj = _md.TwoStepBDGPU(sim.state._cpp_sys_def,
+                                             sim.state._get_group(self.filter),
+                                             1.0,
+                                             False,
+                                             False)
+
+        # Attach param_dict and typeparam_dict
+        super()._attach()

--- a/hoomd/md/methods/methods.py
+++ b/hoomd/md/methods/methods.py
@@ -1136,14 +1136,15 @@ class OverdampedViscous(Method):
 
     where :math:`\vec{F}_\mathrm{C}` is the force on the particle from all
     potentials, :math:`\gamma` is the drag coefficient,
-    :math:`\vec{v}` is the particle's velocity, and :math:`d` is the dimensionality
-    of the system.
+    :math:`\vec{v}` is the particle's velocity, and :math:`d` is the
+    dimensionality of the system.
 
     You can specify :math:`\gamma` in two ways:
 
     1. Specify :math:`\alpha` which scales the particle diameter to
-       :math:`\gamma = \alpha d_i`. The units of :math:`\alpha` are mass /
-       distance / time.
+       :math:`\gamma = \alpha d_i`. The units of :math:`\alpha` are
+       :math:`[\mathrm{mass} \cdot \mathrm{length}^{-1}
+       \cdot \mathrm{time}^{-1}]`.
     2. After the method object is created, specify the attribute ``gamma``
        and ``gamma_r`` for rotational damping or random torque to assign them
        directly, with independent values for each particle type in the

--- a/hoomd/md/methods/methods.py
+++ b/hoomd/md/methods/methods.py
@@ -1150,6 +1150,10 @@ class OverdampedViscous(Method):
        directly, with independent values for each particle type in the
        system.
 
+    Tip:
+        `OverdampedViscous` can be used to simulate systems of athermal active
+        matter, such as athermal Active Brownian Particles.
+
     Examples::
 
         odv = hoomd.md.methods.Brownian(filter=hoomd.filter.All())

--- a/hoomd/md/methods/rattle.py
+++ b/hoomd/md/methods/rattle.py
@@ -487,10 +487,10 @@ class OverdampedViscous(MethodRATTLE):
 
         sphere = hoomd.md.manifold.Sphere(r=10)
         odv_rattle = hoomd.md.methods.rattle.OverdampedViscous(
-        filter=hoomd.filter.All(), manifold_constraint=sphere,
-        seed=1, alpha=1.0)
-        integrator = hoomd.md.Integrator(dt=0.001, methods=[odv_rattle],
-        forces=[lj])
+            filter=hoomd.filter.All(), manifold_constraint=sphere, seed=1,
+            alpha=1.0)
+        integrator = hoomd.md.Integrator(
+            dt=0.001, methods=[odv_rattle], forces=[lj])
 
 
     Attributes:

--- a/hoomd/md/methods/rattle.py
+++ b/hoomd/md/methods/rattle.py
@@ -454,3 +454,132 @@ class Brownian(MethodRATTLE):
 
         # Attach param_dict and typeparam_dict
         super()._attach()
+
+
+class OverdampedViscous(Method):
+    r"""Overdamped viscous dynamics with RATTLE constraint.
+
+    Args:
+        filter (`hoomd.filter.ParticleFilter`): Subset of particles to
+            apply this method to.
+
+        manifold_constraint (:py:mod:`hoomd.md.manifold.Manifold`): Manifold
+            constraint.
+
+        alpha (`float`): When set, use :math:`\alpha d_i` for the
+            drag coefficient where :math:`d_i` is particle diameter.
+            Defaults to None
+            :math:`[\mathrm{mass} \cdot \mathrm{length}^{-1}
+            \cdot \mathrm{time}^{-1}]`.
+
+        tolerance (`float`): Defines the tolerated error particles are allowed
+            to deviate from the manifold in terms of the implicit function.
+            The units of tolerance match that of the selected manifold's
+            implicit function. Defaults to 1e-6
+
+    `OverdampedViscous` uses the same integrator as `hoomd.md.methods.OverdampedViscous`, which
+    follows the overdamped Langevin equations of motion with the additional
+    force term :math:`- \lambda \vec{F}_\mathrm{M}`. The force
+    :math:`\vec{F}_\mathrm{M}` keeps the particles on the manifold constraint,
+    where the Lagrange multiplier :math:`\lambda` is calculated via the RATTLE
+    algorithm. For more details about overdamped viscous dynamics see
+    `hoomd.md.methods.OverdampedViscous`.
+
+    Examples of using ``manifold_constraint``::
+
+        sphere = hoomd.md.manifold.Sphere(r=10)
+        odv_rattle = hoomd.md.methods.rattle.OverdampedViscous(
+        filter=hoomd.filter.All(), manifold_constraint=sphere,
+        seed=1, alpha=1.0)
+        integrator = hoomd.md.Integrator(dt=0.001, methods=[odv_rattle],
+        forces=[lj])
+
+
+    Attributes:
+        filter (hoomd.filter.ParticleFilter): Subset of particles to
+            apply this method to.
+
+        manifold_constraint (hoomd.md.manifold.Manifold): Manifold constraint
+            which is used by and as a trigger for the RATTLE algorithm of this
+            method.
+
+        alpha (float): When set, use :math:`\alpha d_i` for the drag
+            coefficient where :math:`d_i` is particle diameter
+            :math:`[\mathrm{mass} \cdot \mathrm{length}^{-1}
+            \cdot \mathrm{time}^{-1}]`. Defaults to None.
+
+        tolerance (float): Defines the tolerated error particles are allowed to
+            deviate from the manifold in terms of the implicit function.
+            The units of tolerance match that of the selected manifold's
+            implicit function. Defaults to 1e-6
+
+        gamma (TypeParameter[ ``particle type``, `float` ]): The drag
+            coefficient can be directly set instead of the ratio of particle
+            diameter (:math:`\gamma = \alpha d_i`). The type of ``gamma``
+            parameter is either positive float or zero
+            :math:`[\mathrm{mass} \cdot \mathrm{time}^{-1}]`.
+
+        gamma_r (TypeParameter[``particle type``, [`float`, `float`, `float`]]):
+            The rotational drag coefficient can be set. The type of ``gamma_r``
+            parameter is a tuple of three float. The type of each element of
+            tuple is either positive float or zero
+            :math:`[\mathrm{force} \cdot \mathrm{length} \cdot
+            \mathrm{radian}^{-1} \cdot \mathrm{time}^{-1}]`.
+    """
+
+# store metadata
+        param_dict = ParameterDict(
+            filter=ParticleFilter,
+            alpha=OnlyTypes(float, allow_none=True),
+        )
+        param_dict.update(dict(alpha=alpha, filter=filter))
+
+        # set defaults
+        self._param_dict.update(param_dict)
+
+        gamma = TypeParameter('gamma',
+                              type_kind='particle_types',
+                              param_dict=TypeParameterDict(1., len_keys=1))
+
+        gamma_r = TypeParameter('gamma_r',
+                                type_kind='particle_types',
+                                param_dict=TypeParameterDict((1., 1., 1.),
+                                                             len_keys=1))
+        self._extend_typeparam([gamma, gamma_r])
+
+        super().__init__(manifold_constraint, tolerance)
+
+    def _add(self, simulation):
+        """Add the operation to a simulation.
+
+        OverdampedViscous uses RNGs. Warn the user if they did not set the seed.
+        """
+        if simulation is not None:
+            simulation._warn_if_seed_unset()
+
+        super()._add(simulation)
+
+    def _attach(self):
+
+        sim = self._simulation
+        self._attach_constraint(sim)
+
+        if isinstance(sim.device, hoomd.device.CPU):
+            my_class = getattr(
+                _md,
+                'TwoStepRATTLEBD' + self.manifold_constraint.__class__.__name__)
+        else:
+            my_class = getattr(
+                _md, 'TwoStepRATTLEBD'
+                + self.manifold_constraint.__class__.__name__ + 'GPU')
+
+        self._cpp_obj = my_class(sim.state._cpp_sys_def,
+                                 sim.state._get_group(self.filter),
+                                 self.manifold_constraint._cpp_obj,
+                                 1.0,
+                                 True,
+                                 True,
+                                 self.tolerance)
+
+        # Attach param_dict and typeparam_dict
+        super()._attach()

--- a/hoomd/md/methods/rattle.py
+++ b/hoomd/md/methods/rattle.py
@@ -448,6 +448,8 @@ class Brownian(MethodRATTLE):
         self._cpp_obj = my_class(sim.state._cpp_sys_def,
                                  sim.state._get_group(self.filter),
                                  self.manifold_constraint._cpp_obj, self.kT,
+                                 False,
+                                 False,
                                  self.tolerance)
 
         # Attach param_dict and typeparam_dict

--- a/hoomd/md/methods/rattle.py
+++ b/hoomd/md/methods/rattle.py
@@ -456,7 +456,7 @@ class Brownian(MethodRATTLE):
         super()._attach()
 
 
-class OverdampedViscous(Method):
+class OverdampedViscous(MethodRATTLE):
     r"""Overdamped viscous dynamics with RATTLE constraint.
 
     Args:
@@ -526,8 +526,12 @@ class OverdampedViscous(Method):
             :math:`[\mathrm{force} \cdot \mathrm{length} \cdot
             \mathrm{radian}^{-1} \cdot \mathrm{time}^{-1}]`.
     """
-
-# store metadata
+    def __init__(self,
+                 filter,
+                 manifold_constraint,
+                 tolerance=0.000001,
+                 alpha=None):
+        # store metadata
         param_dict = ParameterDict(
             filter=ParticleFilter,
             alpha=OnlyTypes(float, allow_none=True),
@@ -576,7 +580,7 @@ class OverdampedViscous(Method):
         self._cpp_obj = my_class(sim.state._cpp_sys_def,
                                  sim.state._get_group(self.filter),
                                  self.manifold_constraint._cpp_obj,
-                                 1.0,
+                                 hoomd.variant.Constant(1.0),
                                  True,
                                  True,
                                  self.tolerance)

--- a/hoomd/md/methods/rattle.py
+++ b/hoomd/md/methods/rattle.py
@@ -578,7 +578,7 @@ class OverdampedViscous(MethodRATTLE):
         self._cpp_obj = my_class(sim.state._cpp_sys_def,
                                  sim.state._get_group(self.filter),
                                  self.manifold_constraint._cpp_obj,
-                                 hoomd.variant.Constant(1.0), True, True,
+                                 hoomd.variant.Constant(0.0), True, True,
                                  self.tolerance)
 
         # Attach param_dict and typeparam_dict

--- a/hoomd/md/methods/rattle.py
+++ b/hoomd/md/methods/rattle.py
@@ -475,8 +475,9 @@ class OverdampedViscous(MethodRATTLE):
             The units of tolerance match that of the selected manifold's
             implicit function. Defaults to 1e-6
 
-    `OverdampedViscous` uses the same integrator as `hoomd.md.methods.OverdampedViscous`,
-    with the additional force term :math:`- \lambda \vec{F}_\mathrm{M}`. The force
+    `OverdampedViscous` uses the same integrator as
+    `hoomd.md.methods.OverdampedViscous`, with the additional force term
+    :math:`- \lambda \vec{F}_\mathrm{M}`. The force
     :math:`\vec{F}_\mathrm{M}` keeps the particles on the manifold constraint,
     where the Lagrange multiplier :math:`\lambda` is calculated via the RATTLE
     algorithm. For more details about overdamped viscous dynamics see

--- a/hoomd/md/methods/rattle.py
+++ b/hoomd/md/methods/rattle.py
@@ -477,9 +477,8 @@ class OverdampedViscous(MethodRATTLE):
             The units of tolerance match that of the selected manifold's
             implicit function. Defaults to 1e-6
 
-    `OverdampedViscous` uses the same integrator as `hoomd.md.methods.OverdampedViscous`, which
-    follows the overdamped Langevin equations of motion with the additional
-    force term :math:`- \lambda \vec{F}_\mathrm{M}`. The force
+    `OverdampedViscous` uses the same integrator as `hoomd.md.methods.OverdampedViscous`,
+    with the additional force term :math:`- \lambda \vec{F}_\mathrm{M}`. The force
     :math:`\vec{F}_\mathrm{M}` keeps the particles on the manifold constraint,
     where the Lagrange multiplier :math:`\lambda` is calculated via the RATTLE
     algorithm. For more details about overdamped viscous dynamics see

--- a/hoomd/md/pytest/test_methods.py
+++ b/hoomd/md/pytest/test_methods.py
@@ -40,6 +40,17 @@ def _method_base_params():
                    hoomd.md.methods.Brownian)
     ])
 
+    overdamped_viscous_setup_params = {}
+    overdamped_viscous_extra_params = {'alpha': None}
+    overdamped_viscous_changed_params = {'alpha': 0.125}
+
+    method_base_params_list.extend([
+        paramtuple(overdamped_viscous_setup_params, overdamped_viscous_extra_params,
+                   overdamped_viscous_changed_params, hoomd.md.methods.rattle.OverdampedViscous,
+                   hoomd.md.methods.OverdampedViscous)
+    ])
+
+
     constant_s = [
         hoomd.variant.Constant(1.0),
         hoomd.variant.Constant(2.0),

--- a/sphinx-doc/module-md-methods-rattle.rst
+++ b/sphinx-doc/module-md-methods-rattle.rst
@@ -12,6 +12,7 @@ md.methods.rattle
     Brownian
     Langevin
     NVE
+    OverdampedViscous
 
 .. rubric:: Details
 
@@ -20,4 +21,5 @@ md.methods.rattle
     :members: MethodRATTLE,
         Brownian,
         Langevin,
-        NVE
+        NVE,
+        OverdampedViscous

--- a/sphinx-doc/module-md-methods.rst
+++ b/sphinx-doc/module-md-methods.rst
@@ -15,6 +15,7 @@ md.methods
     NPT
     NVE
     NVT
+    OverdampedViscous
 
 
 .. rubric:: Details
@@ -27,7 +28,8 @@ md.methods
               NPH,
               NPT,
               NVE,
-              NVT
+              NVT,
+              OverdampedViscous
 
 .. rubric:: Modules
 


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should based on *maint*. -->
<!-- New features should based on *master*. -->

## Description

This implements a new MD method in python, `OverdampedViscous`, that is an overdamped integrator with a drag force but no random force. This class uses the C++ `Brownian` integrator with `noiseless_t` and `noiseless_r` set to `True`.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
In the version 2 API, `noiseless_t` and `noiseless_r` were arguments to the Python `Brownian` integrator. These arguments were removed in version 3, so this `OverdampedViscous` class re-enables simulations that are on the Brownian time scale with a drag force but have no Brownian force or torque.

<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves #1100 

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
I added the `OverdampedViscous` method to `test_methods.py`
<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
Added: Overdamped integrator with a drag force but no random force ``hoomd.md.methods.OverdampedViscous``
```

## Checklist:

- [X] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [X] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [X] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
