### PR TITLE
Fix errors compiling with single precision

### DIFF
--- a/hoomd/UpdaterRemoveDrift.h
+++ b/hoomd/UpdaterRemoveDrift.h
@@ -61,7 +61,7 @@ class UpdaterRemoveDrift : public Updater
         }
 
     //! Get reference positions as a (N_particles, 3) numpy array
-    pybind11::array_t<double> getReferencePositions() const
+    pybind11::array_t<Scalar> getReferencePositions() const
         {
         std::vector<size_t> dims(2);
         dims[0] = this->m_ref_positions.size();
@@ -69,7 +69,7 @@ class UpdaterRemoveDrift : public Updater
         // the cast from vec3<Scalar>* to Scalar* is safe since vec3 is tightly packed without any
         // padding. This also makes a copy so, modifications of this array do not effect the
         // original reference positions.
-        const auto reference_array = pybind11::array_t<double>(
+        const auto reference_array = pybind11::array_t<Scalar>(
             dims,
             reinterpret_cast<const Scalar*>(this->m_ref_positions.data()));
         // This is necessary to expose the array in a read only fashion through C++

--- a/hoomd/md/EvaluatorPairLJ0804.h
+++ b/hoomd/md/EvaluatorPairLJ0804.h
@@ -69,8 +69,8 @@ class EvaluatorPairLJ0804
             {
             auto sigma(v["sigma"].cast<Scalar>());
             auto epsilon(v["epsilon"].cast<Scalar>());
-            lj1 = 4.0 * epsilon * fast::pow(sigma, 8.0);
-            lj2 = 4.0 * epsilon * fast::pow(sigma, 4.0);
+            lj1 = 4.0 * epsilon * fast::pow(sigma, static_cast<Scalar>(8.0));
+            lj2 = 4.0 * epsilon * fast::pow(sigma, static_cast<Scalar>(4.0));
             }
 
         pybind11::dict asDict()

--- a/hoomd/md/EvaluatorPairLJ0804.h
+++ b/hoomd/md/EvaluatorPairLJ0804.h
@@ -69,8 +69,8 @@ class EvaluatorPairLJ0804
             {
             auto sigma(v["sigma"].cast<Scalar>());
             auto epsilon(v["epsilon"].cast<Scalar>());
-            lj1 = 4.0 * epsilon * fast::pow(sigma, static_cast<Scalar>(8.0));
-            lj2 = 4.0 * epsilon * fast::pow(sigma, static_cast<Scalar>(4.0));
+            lj1 = 4.0 * epsilon * fast::pow(sigma, Scalar(8.0));
+            lj2 = 4.0 * epsilon * fast::pow(sigma, Scalar(4.0));
             }
 
         pybind11::dict asDict()

--- a/hoomd/md/EvaluatorPairLJ1208.h
+++ b/hoomd/md/EvaluatorPairLJ1208.h
@@ -81,16 +81,16 @@ class EvaluatorPairLJ1208
             {
             auto sigma(v["sigma"].cast<Scalar>());
             auto epsilon(v["epsilon"].cast<Scalar>());
-            lj1 = 4.0 * epsilon * pow(sigma, 12.0);
-            lj2 = 4.0 * epsilon * pow(sigma, 8.0);
+            lj1 = 4.0 * epsilon * pow(sigma, static_cast<Scalar>(12.0));
+            lj2 = 4.0 * epsilon * pow(sigma, static_cast<Scalar>(8.0));
             }
 
         pybind11::dict asDict()
             {
             pybind11::dict v;
             auto sigma4 = lj1 / lj2;
-            v["sigma"] = pow(sigma4, 1. / 4.);
-            v["epsilon"] = lj2 / (4 * pow(sigma4, 2.0));
+            v["sigma"] = pow(sigma4, static_cast<Scalar>(1. / 4.));
+            v["epsilon"] = lj2 / (4 * pow(sigma4, static_cast<Scalar>(2.0)));
             return v;
             }
 #endif

--- a/hoomd/md/EvaluatorPairLJ1208.h
+++ b/hoomd/md/EvaluatorPairLJ1208.h
@@ -81,16 +81,16 @@ class EvaluatorPairLJ1208
             {
             auto sigma(v["sigma"].cast<Scalar>());
             auto epsilon(v["epsilon"].cast<Scalar>());
-            lj1 = 4.0 * epsilon * pow(sigma, static_cast<Scalar>(12.0));
-            lj2 = 4.0 * epsilon * pow(sigma, static_cast<Scalar>(8.0));
+            lj1 = 4.0 * epsilon * pow(sigma, Scalar(12.0));
+            lj2 = 4.0 * epsilon * pow(sigma, Scalar(8.0));
             }
 
         pybind11::dict asDict()
             {
             pybind11::dict v;
             auto sigma4 = lj1 / lj2;
-            v["sigma"] = pow(sigma4, static_cast<Scalar>(1. / 4.));
-            v["epsilon"] = lj2 / (4 * pow(sigma4, static_cast<Scalar>(2.0)));
+            v["sigma"] = pow(sigma4, Scalar(1. / 4.));
+            v["epsilon"] = lj2 / (4 * pow(sigma4, Scalar(2.0)));
             return v;
             }
 #endif


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should based on *maint*. -->
<!-- New features should based on *master*. -->

## Description

This PR allows HOOMD to be compiled in single precision without errors. I changed the _hoomd/UpdaterRemoveDrift.h_ file to use the `Scalar` data type instead of explicitly using `double` and cast numbers to `Scalar` in the _hoomd/md/EvaluatorPairLJ1208.h_ and _hoomd/md/EvaluatorPairLJ0804.h_ files.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Currently, the _hoomd/UpdaterRemoveDrift.h_, _hoomd/md/EvaluatorPairLJ1208.h_, and _hoomd/md/EvaluatorPairLJ0804.h_ files give errors when compiling in single precision.

<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves #1120 

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
HOOMD now compiles in single precision without errors.
<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```

```

## Checklist:

- [X] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [X] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [X] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
