### PR TITLE
Improve object introspection and autocomplete support

### DIFF
--- a/hoomd/custom/custom_operation.py
+++ b/hoomd/custom/custom_operation.py
@@ -5,6 +5,7 @@
 """Implement CustomOperation."""
 
 from abc import abstractmethod
+import itertools
 
 from hoomd.operation import _TriggeredOperation
 from hoomd.data.parameterdicts import ParameterDict
@@ -166,3 +167,18 @@ class _InternalCustomOperation(CustomOperation,
     @property
     def action(self):
         raise AttributeError(f"Object {self} has no attribute 'action'.")
+
+    def __dir__(self):
+        """Expose all attributes for dynamic querying in notebooks and IDEs."""
+        list_ = super().__dir__()
+        act = self._action
+        action_list = [
+            k for k in itertools.chain(act._param_dict, act._typeparam_dict)
+        ]
+        list_.remove("action")
+        list_.remove("act")
+        return list_ + action_list
+
+    @property
+    def act(self):
+        raise AttributeError(f"Object {self} has no attribute 'act'.")

--- a/hoomd/custom/custom_operation.py
+++ b/hoomd/custom/custom_operation.py
@@ -159,10 +159,14 @@ class _InternalCustomOperation(CustomOperation,
 
     def __init__(self, trigger, *args, **kwargs):
         super().__init__(self._internal_class(*args, **kwargs), trigger)
+        # handle pass through logging
         self._export_dict = {
             key: value.update_cls(self.__class__)
             for key, value in self._export_dict.items()
         }
+        # Wrap action act method with operation appropriate one.
+        wrapping_method = getattr(self, self._operation_func).__func__
+        setattr(wrapping_method, "__doc__", self._action.act.__doc__)
 
     @property
     def action(self):

--- a/hoomd/operation.py
+++ b/hoomd/operation.py
@@ -8,6 +8,7 @@
 # Triggered objects should inherit from _TriggeredOperation.
 
 from copy import copy
+import itertools
 
 from hoomd.trigger import Trigger
 from hoomd.logging import Loggable
@@ -98,6 +99,12 @@ class _HOOMDGetSetAttrBase:
         except TypeError:
             raise ValueError("To set {}, you must use a dictionary "
                              "with types as keys.".format(attr))
+
+    def __dir__(self):
+        """Expose all attributes for dynamic querying in notebooks and IDEs."""
+        return super().__dir__() + [
+            k for k in itertools.chain(self._param_dict, self._typeparam_dict)
+        ]
 
 
 class _DependencyRelation:

--- a/hoomd/tune/custom_tuner.py
+++ b/hoomd/tune/custom_tuner.py
@@ -57,7 +57,7 @@ class CustomTuner(CustomOperation, _TunerProperty, Tuner):
         Operation._attach(self)
 
 
-class _InternalCustomTuner(_InternalCustomOperation, _TunerProperty, Tuner):
+class _InternalCustomTuner(_InternalCustomOperation, Tuner):
     _cpp_list_name = 'tuners'
     _cpp_class_name = 'PythonTuner'
 

--- a/hoomd/tune/custom_tuner.py
+++ b/hoomd/tune/custom_tuner.py
@@ -60,9 +60,13 @@ class CustomTuner(CustomOperation, _TunerProperty, Tuner):
 class _InternalCustomTuner(_InternalCustomOperation, Tuner):
     _cpp_list_name = 'tuners'
     _cpp_class_name = 'PythonTuner'
+    _operation_func = "tune"
 
     def _attach(self):
         self._cpp_obj = getattr(_hoomd, self._cpp_class_name)(
             self._simulation.state._cpp_sys_def, self.trigger, self._action)
         self._action.attach(self._simulation)
         Operation._attach(self)
+
+    def tune(self, timestep):
+        return self._action.act(timestep)

--- a/hoomd/update/custom_updater.py
+++ b/hoomd/update/custom_updater.py
@@ -48,7 +48,6 @@ class CustomUpdater(CustomOperation, _UpdaterProperty, Updater):
     _cpp_class_name = 'PythonUpdater'
 
 
-class _InternalCustomUpdater(_InternalCustomOperation, _UpdaterProperty,
-                             Updater):
+class _InternalCustomUpdater(_InternalCustomOperation, Updater):
     _cpp_list_name = 'updaters'
     _cpp_class_name = 'PythonUpdater'

--- a/hoomd/update/custom_updater.py
+++ b/hoomd/update/custom_updater.py
@@ -51,3 +51,7 @@ class CustomUpdater(CustomOperation, _UpdaterProperty, Updater):
 class _InternalCustomUpdater(_InternalCustomOperation, Updater):
     _cpp_list_name = 'updaters'
     _cpp_class_name = 'PythonUpdater'
+    _operation_func = "update"
+
+    def update(self, timestep):
+        return self._action.act(timestep)

--- a/hoomd/write/custom_writer.py
+++ b/hoomd/write/custom_writer.py
@@ -11,11 +11,11 @@ from hoomd.operation import Writer
 class _WriterProperty:
 
     @property
-    def analyzer(self):
+    def writer(self):
         return self._action
 
-    @analyzer.setter
-    def analyzer(self, analyzer):
+    @writer.setter
+    def writer(self, analyzer):
         if isinstance(analyzer, Action):
             self._action = analyzer
         else:

--- a/hoomd/write/custom_writer.py
+++ b/hoomd/write/custom_writer.py
@@ -49,6 +49,6 @@ class CustomWriter(CustomOperation, _WriterProperty, Writer):
     _cpp_class_name = 'PythonAnalyzer'
 
 
-class _InternalCustomWriter(_InternalCustomOperation, _WriterProperty, Writer):
+class _InternalCustomWriter(_InternalCustomOperation, Writer):
     _cpp_list_name = 'analyzers'
     _cpp_class_name = 'PythonAnalyzer'

--- a/hoomd/write/custom_writer.py
+++ b/hoomd/write/custom_writer.py
@@ -52,3 +52,7 @@ class CustomWriter(CustomOperation, _WriterProperty, Writer):
 class _InternalCustomWriter(_InternalCustomOperation, Writer):
     _cpp_list_name = 'analyzers'
     _cpp_class_name = 'PythonAnalyzer'
+    _operation_func = "write"
+
+    def write(self, timestep):
+        return self._action.act(timestep)


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should based on *maint*. -->
<!-- New features should based on *master*. -->

## Description

Adds autocomplete support to interactive notebooks, and improves internal
custom action passthrough as well.
<!-- Describe your changes in detail. -->

## Motivation and context

This was requested at one point by @bdice and is a generally useful feature when developing
scripts or workflows through notebooks or potentially IDE's (I am not sure how
good their autocomplete is generally).
<!--- Why is this change required? What problem does it solve? -->

## How has this been tested?

Locally tested in jupyter lab. We could test that `_param_dict` and
`_typeparam_dict` keys are in `__dir__` if desired.
<!--- Please describe in detail how you tested your changes. -->

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
- Added autocomplete support for interactive notebooks.
- Changed ``hoomd.write.CustomWriter`` now exposes action through the ``writer`` attribute.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
