### PR TITLE
Fix hoomd.Operations.__len__

### DIFF
--- a/hoomd/operations.py
+++ b/hoomd/operations.py
@@ -235,7 +235,8 @@ class Operations(Collection):
 
     def __len__(self):
         """Return the number of operations contained in this collection."""
-        return len(list(self))
+        base_len = len(self._writers) + len(self._updaters) + len(self._tuners)
+        return base_len + (1 if self._integrator is not None else 0)
 
     @property
     def integrator(self):

--- a/hoomd/pytest/CMakeLists.txt
+++ b/hoomd/pytest/CMakeLists.txt
@@ -25,6 +25,7 @@ set(files __init__.py
           test_table.py
           test_variant.py
           test_sorter.py
+          test_operations.py
     )
 
 install(FILES ${files}

--- a/hoomd/pytest/test_operations.py
+++ b/hoomd/pytest/test_operations.py
@@ -1,0 +1,38 @@
+import hoomd
+
+
+class FakeIntegrator(hoomd.integrate.BaseIntegrator):
+    pass
+
+
+def test_len():
+    operations = hoomd.Operations()
+    # ParticleSorter automatically added
+    assert len(operations) == 1
+    operations.tuners.clear()
+    assert len(operations) == 0
+
+    operations.integrator = FakeIntegrator()
+    operations.updaters.append(
+        hoomd.update.FilterUpdater(1, [hoomd.filter.Type(["A"])]))
+    operations.writers.append(hoomd.write.GSD(1, "filename.gsd"))
+
+    assert len(operations) == 3
+
+
+def test_iter():
+    operations = hoomd.Operations()
+    # ParticleSorter automatically added
+    assert len(list(operations)) == 1
+
+    operations.updaters.append(
+        hoomd.update.FilterUpdater(1, [hoomd.filter.Type(["A"])]))
+    operations.writers.append(hoomd.write.GSD(1, "filename.gsd"))
+
+    expected_list = (operations._tuners[:] + operations._updaters[:]
+                     + operations._writers[:])
+    assert list(operations) == expected_list
+
+    operations.integrator = FakeIntegrator()
+    expected_list.insert(2, operations.integrator)
+    assert list(operations) == expected_list


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should based on *maint*. -->
<!-- New features should based on *master*. -->

## Description

Fixes the behavior of `hoomd.Operations.__len__`.

<!-- Describe your changes in detail. -->

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves #1128

## How has this been tested?

Tests have been added for `__len__` and `__iter__`.
<!--- Please describe in detail how you tested your changes. -->

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
Fixed: Calling `hoomd.Operations.__len__` no longer raises a `RecursionError`.
```

## Checklist:

- [ ] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [ ] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [ ] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
