### PR TITLE
Fix RATTLE methods on the GPU

### DIFF
--- a/hoomd/GPUPartition.cuh
+++ b/hoomd/GPUPartition.cuh
@@ -149,7 +149,6 @@ class __attribute__((visibility("default"))) GPUPartition
     private:
     unsigned int m_n_gpu;
     unsigned int* m_gpu_map;
-    unsigned int m_offset;
 
     std::pair<unsigned int, unsigned int>* m_gpu_range;
     };

--- a/hoomd/md/TwoStepRATTLELangevinGPU.h
+++ b/hoomd/md/TwoStepRATTLELangevinGPU.h
@@ -40,13 +40,13 @@ class PYBIND11_EXPORT TwoStepRATTLELangevinGPU : public TwoStepRATTLELangevin<Ma
     virtual ~TwoStepRATTLELangevinGPU() {};
 
     //! Performs the first step of the integration
-    virtual void integrateStepOne(unsigned int timestep);
+    virtual void integrateStepOne(uint64_t timestep);
 
     //! Performs the second step of the integration
-    virtual void integrateStepTwo(unsigned int timestep);
+    virtual void integrateStepTwo(uint64_t timestep);
 
     //! Includes the RATTLE forces to the virial/net force
-    virtual void includeRATTLEForce(unsigned int timestep);
+    virtual void includeRATTLEForce(uint64_t timestep);
 
     //! Set autotuner parameters
     /*! \param enable Enable/disable autotuning
@@ -124,7 +124,7 @@ TwoStepRATTLELangevinGPU<Manifold>::TwoStepRATTLELangevinGPU(
                                             this->m_exec_conf));
     }
 template<class Manifold>
-void TwoStepRATTLELangevinGPU<Manifold>::integrateStepOne(unsigned int timestep)
+void TwoStepRATTLELangevinGPU<Manifold>::integrateStepOne(uint64_t timestep)
     {
     // profile this step
     if (this->m_prof)
@@ -222,7 +222,7 @@ void TwoStepRATTLELangevinGPU<Manifold>::integrateStepOne(unsigned int timestep)
     \post particle velocities are moved forward to timestep+1 on the GPU
 */
 template<class Manifold>
-void TwoStepRATTLELangevinGPU<Manifold>::integrateStepTwo(unsigned int timestep)
+void TwoStepRATTLELangevinGPU<Manifold>::integrateStepTwo(uint64_t timestep)
     {
     const GlobalArray<Scalar4>& net_force = this->m_pdata->getNetForce();
 
@@ -357,7 +357,7 @@ void TwoStepRATTLELangevinGPU<Manifold>::integrateStepTwo(unsigned int timestep)
     }
 
 template<class Manifold>
-void TwoStepRATTLELangevinGPU<Manifold>::includeRATTLEForce(unsigned int timestep)
+void TwoStepRATTLELangevinGPU<Manifold>::includeRATTLEForce(uint64_t timestep)
     {
     // access all the needed data
     const GlobalArray<Scalar4>& net_force = this->m_pdata->getNetForce();

--- a/hoomd/md/TwoStepRATTLENVEGPU.h
+++ b/hoomd/md/TwoStepRATTLENVEGPU.h
@@ -43,13 +43,13 @@ class PYBIND11_EXPORT TwoStepRATTLENVEGPU : public TwoStepRATTLENVE<Manifold>
     virtual ~TwoStepRATTLENVEGPU() {};
 
     //! Performs the first step of the integration
-    virtual void integrateStepOne(unsigned int timestep);
+    virtual void integrateStepOne(uint64_t timestep);
 
     //! Performs the second step of the integration
-    virtual void integrateStepTwo(unsigned int timestep);
+    virtual void integrateStepTwo(uint64_t timestep);
 
     //! Includes the RATTLE forces to the virial/net force
-    virtual void includeRATTLEForce(unsigned int timestep);
+    virtual void includeRATTLEForce(uint64_t timestep);
 
     //! Set autotuner parameters
     /*! \param enable Enable/disable autotuning
@@ -117,7 +117,7 @@ TwoStepRATTLENVEGPU<Manifold>::TwoStepRATTLENVEGPU(std::shared_ptr<SystemDefinit
     \post Particle positions are moved forward to timestep+1 and velocities to timestep+1/2 per the
    velocity verlet method.
 */
-template<class Manifold> void TwoStepRATTLENVEGPU<Manifold>::integrateStepOne(unsigned int timestep)
+template<class Manifold> void TwoStepRATTLENVEGPU<Manifold>::integrateStepOne(uint64_t timestep)
     {
     // profile this step
     if (this->m_prof)
@@ -215,7 +215,7 @@ template<class Manifold> void TwoStepRATTLENVEGPU<Manifold>::integrateStepOne(un
 /*! \param timestep Current time step
     \post particle velocities are moved forward to timestep+1 on the GPU
 */
-template<class Manifold> void TwoStepRATTLENVEGPU<Manifold>::integrateStepTwo(unsigned int timestep)
+template<class Manifold> void TwoStepRATTLENVEGPU<Manifold>::integrateStepTwo(uint64_t timestep)
     {
     const GlobalArray<Scalar4>& net_force = this->m_pdata->getNetForce();
 
@@ -304,7 +304,7 @@ template<class Manifold> void TwoStepRATTLENVEGPU<Manifold>::integrateStepTwo(un
     }
 
 template<class Manifold>
-void TwoStepRATTLENVEGPU<Manifold>::includeRATTLEForce(unsigned int timestep)
+void TwoStepRATTLENVEGPU<Manifold>::includeRATTLEForce(uint64_t timestep)
     {
     // access all the needed data
     const GlobalArray<Scalar4>& net_force = this->m_pdata->getNetForce();

--- a/hoomd/md/TwoStepRATTLENVEGPU.h
+++ b/hoomd/md/TwoStepRATTLENVEGPU.h
@@ -303,8 +303,7 @@ template<class Manifold> void TwoStepRATTLENVEGPU<Manifold>::integrateStepTwo(ui
         this->m_prof->pop(this->m_exec_conf);
     }
 
-template<class Manifold>
-void TwoStepRATTLENVEGPU<Manifold>::includeRATTLEForce(uint64_t timestep)
+template<class Manifold> void TwoStepRATTLENVEGPU<Manifold>::includeRATTLEForce(uint64_t timestep)
     {
     // access all the needed data
     const GlobalArray<Scalar4>& net_force = this->m_pdata->getNetForce();

--- a/hoomd/mpcd/CellThermoComputeGPU.cc
+++ b/hoomd/mpcd/CellThermoComputeGPU.cc
@@ -245,8 +245,11 @@ void mpcd::CellThermoComputeGPU::calcInnerCellProperties()
 void mpcd::CellThermoComputeGPU::computeNetProperties()
     {
     if (m_prof)
+        {
         m_prof->push(m_exec_conf, "MPCD thermo");
-    // first reduce the properties on the rank
+        }
+
+        // first reduce the properties on the rank
         {
         const Index3D& ci = m_cl->getCellIndexer();
         uint3 upper = make_uint3(ci.getW(), ci.getH(), ci.getD());

--- a/hoomd/mpcd/CellThermoComputeGPU.cc
+++ b/hoomd/mpcd/CellThermoComputeGPU.cc
@@ -249,7 +249,7 @@ void mpcd::CellThermoComputeGPU::computeNetProperties()
         m_prof->push(m_exec_conf, "MPCD thermo");
         }
 
-        // first reduce the properties on the rank
+    // first reduce the properties on the rank
         {
         const Index3D& ci = m_cl->getCellIndexer();
         uint3 upper = make_uint3(ci.getW(), ci.getH(), ci.getD());

--- a/hoomd/mpcd/SorterGPU.cc
+++ b/hoomd/mpcd/SorterGPU.cc
@@ -35,11 +35,16 @@ mpcd::SorterGPU::SorterGPU(std::shared_ptr<mpcd::SystemData> sysdata,
 void mpcd::SorterGPU::computeOrder(uint64_t timestep)
     {
     if (m_prof)
+        {
         m_prof->pop(m_exec_conf);
+        }
+
     // compute the cell list at current timestep, guarantees owned particles are on rank
     m_cl->compute(timestep);
     if (m_prof)
+        {
         m_prof->push(m_exec_conf, "MPCD sort");
+        }
 
     // fill the empty cell list entries with a sentinel larger than number of MPCD particles
         {


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should based on *maint*. -->
<!-- New features should based on *master*. -->

## Description

<!-- Describe your changes in detail. -->
The RATTLE integration methods were not running on the GPU due to typos in the function argument lists.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

I discovered this when building with clang 12 which issued a warning. In C++, functions with different arguments are different functions, so the virtual functions in the CPU methods were not being overridden. Thus, simulations using the RATTLE methods on the GPU were executing the method on the CPU.

I also made some miscellaneous changes that squash other compiler warnings issued by clang 12.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
Unit tests pass. @SchoeniPhlippsn can you please run some production tests on this and ensure that the GPU methods work correctly and produce higher performance than the CPU methods?

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
Fixed:

- RATTLE integration methods execute on the GPU.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
