### PR TITLE
Add note about pandoc

### DIFF
--- a/BUILDING.rst
+++ b/BUILDING.rst
@@ -29,6 +29,10 @@ To build the documentation from source (optional):
 
    $ <package-manager> install sphinx sphinx_rtd_theme nbsphinx ipython
 
+.. note::
+
+   `nbsphinx` requires `pandoc>=1.12.1`, which you may need to install separately.
+
 2. `Build the documentation`_::
 
    $ sphinx-build -b html hoomd-blue/sphinx-doc build/hoomd-documentation


### PR DESCRIPTION
## Description

Added note that while building the docs, `pandoc` may need to be installed separately from other dependencies.

## Motivation and context

I was building the docs trying to follow the instructions, and a new enough version of `pandoc` was not installed when installing the other dependencies from pip.

## How has this been tested?

I have built and rendered the documentation on how to build the documentation.

## Change log

```
Added note on dependencies for building the documentation.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
