### PR TITLE
Jit llvm one library

### DIFF
--- a/hoomd/hpmc/CMakeLists.txt
+++ b/hoomd/hpmc/CMakeLists.txt
@@ -238,44 +238,44 @@ if (ENABLE_LLVM)
                                  ClangCompiler.h
        )
 
-    pybind11_add_module(_${PACKAGE_NAME} SHARED ${_${PACKAGE_NAME}_sources} ${_${PACKAGE_NAME}_cu_sources} NO_EXTRAS)
+    pybind11_add_module(_${PACKAGE_NAME} SHARED ${_${PACKAGE_NAME}_sources} ${_${PACKAGE_NAME}_cu_sources} ${_${PACKAGE_NAME}_llvm_sources} NO_EXTRAS)
     # alias into the HOOMD namespace so that plugins and symlinked components both work
     add_library(HOOMD::_${PACKAGE_NAME} ALIAS _${PACKAGE_NAME})
 
-    add_library (_${PACKAGE_NAME}_llvm SHARED ${_${PACKAGE_NAME}_llvm_sources})
+    # add_library (_${PACKAGE_NAME}_llvm SHARED ${_${PACKAGE_NAME}_llvm_sources})
 
     if (ENABLE_HIP AND HIP_PLATFORM STREQUAL "nvcc")
         target_link_libraries(_${PACKAGE_NAME} PUBLIC CUDA::cuda CUDA::nvrtc)
     endif ()
 
-    target_include_directories(_${PACKAGE_NAME}_llvm PUBLIC ${LLVM_INCLUDE_DIRS})
-    target_compile_definitions(_${PACKAGE_NAME}_llvm PUBLIC ${LLVM_DEFINITIONS})
-    target_compile_definitions(_${PACKAGE_NAME}_llvm PUBLIC HOOMD_LLVM_INSTALL_PREFIX=\"${LLVM_INSTALL_PREFIX}\")
+    target_include_directories(_${PACKAGE_NAME} PUBLIC ${LLVM_INCLUDE_DIRS})
+    target_compile_definitions(_${PACKAGE_NAME} PUBLIC ${LLVM_DEFINITIONS})
+    target_compile_definitions(_${PACKAGE_NAME} PUBLIC HOOMD_LLVM_INSTALL_PREFIX=\"${LLVM_INSTALL_PREFIX}\")
 
-    target_include_directories(_${PACKAGE_NAME}_llvm PUBLIC
+    target_include_directories(_${PACKAGE_NAME} PUBLIC
                                $<BUILD_INTERFACE:${HOOMD_SOURCE_DIR}>
                                $<INSTALL_INTERFACE:${PYTHON_SITE_INSTALL_DIR}/include>)
 
     # set the appropriate compiler flags on the _llvm target
-    list(APPEND CMAKE_MODULE_PATH "${LLVM_CMAKE_DIR}")
-    include(AddLLVM)
-    llvm_update_compile_flags(_${PACKAGE_NAME}_llvm)
+    # list(APPEND CMAKE_MODULE_PATH "${LLVM_CMAKE_DIR}")
+    # include(AddLLVM)
+    # llvm_update_compile_flags(_${PACKAGE_NAME}_llvm)
 
     # work around missing LLVM link information
-    if(LLVM_ENABLE_TERMINFO)
-        find_library(TERMINFO NAMES tinfo ncurses)
-        if (${TERMINFO} STREQUAL TERMINFO-NOTFOUND)
-            message(FATAL_ERROR "no libtinfo or libncurses is found in system")
-        else (${TERMINFO} STREQUAL TERMINFO-NOTFOUND)
-            target_link_libraries(_${PACKAGE_NAME}_llvm ${TERMINFO})
-        endif (${TERMINFO} STREQUAL TERMINFO-NOTFOUND)
-    endif()
+    # if(LLVM_ENABLE_TERMINFO)
+    #     find_library(TERMINFO NAMES tinfo ncurses)
+    #     if (${TERMINFO} STREQUAL TERMINFO-NOTFOUND)
+    #         message(FATAL_ERROR "no libtinfo or libncurses is found in system")
+    #     else (${TERMINFO} STREQUAL TERMINFO-NOTFOUND)
+    #         target_link_libraries(_${PACKAGE_NAME}_llvm PRIVATE ${TERMINFO})
+    #     endif (${TERMINFO} STREQUAL TERMINFO-NOTFOUND)
+    # endif()
 
     # link the libraries to their dependencies
-    target_link_libraries(_${PACKAGE_NAME}_llvm ${llvm_library} ${clang_library})
+    # target_link_libraries(_${PACKAGE_NAME}_llvm PUBLIC ${llvm_library} ${clang_library} _hoomd)
 
-    # need to link the LLVM library here, too, otherwise module import fails
-    target_link_libraries(_${PACKAGE_NAME} PUBLIC _hoomd PRIVATE _${PACKAGE_NAME}_llvm ${llvm_library} ${clang_library})
+    # # need to link the LLVM library here, too, otherwise module import fails
+    target_link_libraries(_${PACKAGE_NAME} PUBLIC ${llvm_library} ${clang_library} _hoomd )
 
     # set installation RPATH
     if(APPLE)
@@ -285,10 +285,10 @@ if (ENABLE_LLVM)
     endif()
 
     fix_cudart_rpath(_${PACKAGE_NAME})
-    fix_cudart_rpath(_${PACKAGE_NAME}_llvm)
+    # fix_cudart_rpath(_${PACKAGE_NAME}_llvm)
 
     # install the library
-    install(TARGETS _${PACKAGE_NAME} _${PACKAGE_NAME}_llvm
+    install(TARGETS _${PACKAGE_NAME}
             LIBRARY DESTINATION ${PYTHON_SITE_INSTALL_DIR}/hpmc
             )
 

--- a/hoomd/hpmc/CMakeLists.txt
+++ b/hoomd/hpmc/CMakeLists.txt
@@ -220,8 +220,6 @@ if (ENABLE_LLVM)
          PatchEnergyJITUnionGPU.cc
        )
 
-    # we compile a separate package just for the LLVM-interfacing part,
-    # so that can be compiled with and without RTTI
     set(_${PACKAGE_NAME}_llvm_sources EvalFactory.cc ExternalFieldEvalFactory.cc ClangCompiler.cc)
 
     set(_${PACKAGE_NAME}_headers PatchEnergyJIT.h
@@ -242,8 +240,6 @@ if (ENABLE_LLVM)
     # alias into the HOOMD namespace so that plugins and symlinked components both work
     add_library(HOOMD::_${PACKAGE_NAME} ALIAS _${PACKAGE_NAME})
 
-    # add_library (_${PACKAGE_NAME}_llvm SHARED ${_${PACKAGE_NAME}_llvm_sources})
-
     if (ENABLE_HIP AND HIP_PLATFORM STREQUAL "nvcc")
         target_link_libraries(_${PACKAGE_NAME} PUBLIC CUDA::cuda CUDA::nvrtc)
     endif ()
@@ -256,25 +252,6 @@ if (ENABLE_LLVM)
                                $<BUILD_INTERFACE:${HOOMD_SOURCE_DIR}>
                                $<INSTALL_INTERFACE:${PYTHON_SITE_INSTALL_DIR}/include>)
 
-    # set the appropriate compiler flags on the _llvm target
-    # list(APPEND CMAKE_MODULE_PATH "${LLVM_CMAKE_DIR}")
-    # include(AddLLVM)
-    # llvm_update_compile_flags(_${PACKAGE_NAME}_llvm)
-
-    # work around missing LLVM link information
-    # if(LLVM_ENABLE_TERMINFO)
-    #     find_library(TERMINFO NAMES tinfo ncurses)
-    #     if (${TERMINFO} STREQUAL TERMINFO-NOTFOUND)
-    #         message(FATAL_ERROR "no libtinfo or libncurses is found in system")
-    #     else (${TERMINFO} STREQUAL TERMINFO-NOTFOUND)
-    #         target_link_libraries(_${PACKAGE_NAME}_llvm PRIVATE ${TERMINFO})
-    #     endif (${TERMINFO} STREQUAL TERMINFO-NOTFOUND)
-    # endif()
-
-    # link the libraries to their dependencies
-    # target_link_libraries(_${PACKAGE_NAME}_llvm PUBLIC ${llvm_library} ${clang_library} _hoomd)
-
-    # # need to link the LLVM library here, too, otherwise module import fails
     target_link_libraries(_${PACKAGE_NAME} PUBLIC ${llvm_library} ${clang_library} _hoomd )
 
     # set installation RPATH
@@ -285,7 +262,6 @@ if (ENABLE_LLVM)
     endif()
 
     fix_cudart_rpath(_${PACKAGE_NAME})
-    # fix_cudart_rpath(_${PACKAGE_NAME}_llvm)
 
     # install the library
     install(TARGETS _${PACKAGE_NAME}

--- a/hoomd/hpmc/EvalFactory.cc
+++ b/hoomd/hpmc/EvalFactory.cc
@@ -37,7 +37,6 @@ EvalFactory::EvalFactory(const std::string& cpp_code,
         }
 
     llvm::LLVMContext Context;
-    llvm::SMDiagnostic Err;
 
     // compile the module
     auto module = clang_compiler->compileCode(cpp_code, compiler_args, Context, sstream);

--- a/hoomd/hpmc/KaleidoscopeJIT.h
+++ b/hoomd/hpmc/KaleidoscopeJIT.h
@@ -55,9 +55,15 @@ class KaleidoscopeJIT
     MangleAndInterner Mangle;
     ThreadSafeContext Ctx;
     JITDylib& mainJD;
+    SectionMemoryManager *memory_manager;
 
     KaleidoscopeJIT(JITTargetMachineBuilder JTMB, DataLayout DL)
-        : ObjectLayer(ES, []() { return std::make_unique<SectionMemoryManager>(); }),
+      : ObjectLayer(ES,
+                     [&]() {
+                       auto smgr = std::make_unique<SectionMemoryManager>();
+                       memory_manager = smgr.get();
+                       return smgr;
+                     }),
           CompileLayer(
               ES,
               ObjectLayer,
@@ -72,6 +78,16 @@ class KaleidoscopeJIT
         mainJD.addGenerator(
             cantFail(DynamicLibrarySearchGenerator::GetForCurrentProcess(DL.getGlobalPrefix())));
         }
+
+    ~KaleidoscopeJIT()
+        {
+        // avoid seg fault when an exception is thrown later
+        // https://github.com/taichi-dev/taichi/issues/655#issuecomment-620344230
+        // https://github.com/taichi-dev/taichi/pull/885/files#
+        if (memory_manager)
+        memory_manager->deregisterEHFrames();
+        }
+
     const DataLayout& getDataLayout() const
         {
         return DL;


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should based on *maint*. -->
<!-- New features should based on *master*. -->

## Description

<!-- Describe your changes in detail. -->
Fix a bug that caused seg faults when exceptions where thrown after a KaleidoscopeJIT class was destroyed.
Also testing whether the EvalFactory classes really need to be in a separate library.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
* HOOMD relies on exceptions to report errors to the user.
* One fewer library simplifies the cmake setup

<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves #970

## How has this been tested?

- Tested manually on vance:
- [x] Test on Summit
- [x] Test on a Mac

<!--- Please describe in detail how you tested your changes. -->

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
