### PR TITLE
Evaluator pair dlvo bug fix

### DIFF
--- a/hoomd/md/CMakeLists.txt
+++ b/hoomd/md/CMakeLists.txt
@@ -86,6 +86,7 @@ set(_md_headers ActiveForceComputeGPU.h
                 EvaluatorExternalPeriodic.h
                 EvaluatorPairBuckingham.h
                 EvaluatorPairDipole.h
+                EvaluatorPairDLVO.h
                 EvaluatorPairDPDLJThermo.h
                 EvaluatorPairDPDThermo.h
                 EvaluatorPairEwald.h

--- a/sphinx-doc/credits.rst
+++ b/sphinx-doc/credits.rst
@@ -102,3 +102,4 @@ The following people have contributed to the to HOOMD-blue:
 * Wouter Ellenbroek, Eindhoven University of Technology
 * Yuan Zhou, University of Michigan
 * Åsmund Ervik, SINTEF
+* Nathan Barrett, Pritzker School of Molecular Engineering


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should based on *maint*. -->
<!-- New features should based on *master*. -->

## Description

<!-- Describe your changes in detail. -->

There appears to be a missing file in the _md_headers portion of the hoomd/md/CMakeLists.txt file.
I propose that the file "EvaluatorPairDLVO.h" be added so that it can be included externally from hoomd (i.e. in a plugin)

This is because EvaluatorPairDLVO.h is not referenced in hoomd/md/CMakeLists.txt

I just added it in the appropriate place.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

When trying to include the file hoomd/md/EvaluatorPairDLVO.h from an external plugin, the compiler throws an error since the file is not copied into the python module's "include" folder.

Adding a reference to the file allows for the file to be copied over to the python module at compile time and therefore enables it to be included by an external plugin.

<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves #1142

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->

1. I added a reference to EvaluatorPairDLVO.h in the _md_headers section of hoomd/md/CMakeLists.txt
2. I compiled and install hoomd with this change.
3. I checked to make sure EvaluatorPairDLVO.h is in python3.9/site-packages/hoomd/include/hoomd/md (which it is, after the change)

## Change log

<!-- Propose a change log entry. -->
```
2021-09-21  Nathan Barrett  <ndb.nathan.barrett@gmail.com>

    * hoomd/md/CMakeLists.txt (_md_headers): added "EvaluatorPairDLVO.h"
    
    * sphinx-doc/credits.rst: added "Nathan Barrett, Pritzker School of Molecular Engineering"
```

## Checklist:

- [ x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x ] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x ] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
