### PR TITLE
Rename pivot_move_ratio in the Cluster updater

### DIFF
--- a/hoomd/hpmc/UpdaterClusters.h
+++ b/hoomd/hpmc/UpdaterClusters.h
@@ -1778,7 +1778,7 @@ template < class Shape> void export_UpdaterClusters(pybind11::module& m, const s
           .def( pybind11::init< std::shared_ptr<SystemDefinition>,
                          std::shared_ptr< IntegratorHPMCMono<Shape> > >())
         .def("getCounters", &UpdaterClusters<Shape>::getCounters)
-        .def_property("pivot_move_ratio", &UpdaterClusters<Shape>::getMoveRatio, &UpdaterClusters<Shape>::setMoveRatio)
+        .def_property("pivot_move_probability", &UpdaterClusters<Shape>::getMoveRatio, &UpdaterClusters<Shape>::setMoveRatio)
         .def_property("flip_probability", &UpdaterClusters<Shape>::getFlipProbability, &UpdaterClusters<Shape>::setFlipProbability)
     ;
     }

--- a/hoomd/hpmc/pytest/test_clusters.py
+++ b/hoomd/hpmc/pytest/test_clusters.py
@@ -13,16 +13,16 @@ import hoomd.hpmc.pytest.conftest
 # here that require preprocessing
 valid_constructor_args = [
     dict(trigger=hoomd.trigger.Periodic(10),
-         pivot_move_ratio=0.1,
+         pivot_move_probability=0.1,
          flip_probability=0.8),
     dict(trigger=hoomd.trigger.After(100),
-         pivot_move_ratio=0.7,
+         pivot_move_probability=0.7,
          flip_probability=1),
     dict(trigger=hoomd.trigger.Before(100),
-         pivot_move_ratio=0.7,
+         pivot_move_probability=0.7,
          flip_probability=1),
     dict(trigger=hoomd.trigger.Periodic(1000),
-         pivot_move_ratio=0.7,
+         pivot_move_probability=0.7,
          flip_probability=1),
 ]
 
@@ -30,8 +30,8 @@ valid_attrs = [('trigger', hoomd.trigger.Periodic(10000)),
                ('trigger', hoomd.trigger.After(100)),
                ('trigger', hoomd.trigger.Before(12345)),
                ('flip_probability', 0.2), ('flip_probability', 0.5),
-               ('flip_probability', 0.8), ('pivot_move_ratio', 0.2),
-               ('pivot_move_ratio', 0.5), ('pivot_move_ratio', 0.8)]
+               ('flip_probability', 0.8), ('pivot_move_probability', 0.2),
+               ('pivot_move_probability', 0.5), ('pivot_move_probability', 0.8)]
 
 
 @pytest.mark.serial
@@ -145,7 +145,7 @@ def test_pivot_moves(device, simulation_factory, lattice_snapshot_factory):
     sim.operations.integrator = mc
 
     cl = hoomd.hpmc.update.Clusters(trigger=hoomd.trigger.Periodic(5),
-                                    pivot_move_ratio=0.5)
+                                    pivot_move_probability=0.5)
     sim.operations.updaters.append(cl)
 
     sim.run(100)
@@ -163,5 +163,5 @@ def test_pickling(simulation_factory, two_particle_snapshot_factory):
     sim.operations.integrator = mc
 
     cl = hoomd.hpmc.update.Clusters(trigger=hoomd.trigger.Periodic(5),
-                                    pivot_move_ratio=0.1)
+                                    pivot_move_probability=0.1)
     operation_pickling_check(cl, sim)

--- a/hoomd/hpmc/update.py
+++ b/hoomd/hpmc/update.py
@@ -472,8 +472,8 @@ class Clusters(Updater):
     """Apply geometric cluster algorithm (GCA) moves.
 
     Args:
-        pivot_move_ratio (float): Set the ratio between pivot and reflection
-          moves.
+        pivot_move_probability (float): Set the probability for attempting a
+                                        pivot move.
         flip_probability (float): Set the probability for transforming an
                                  individual cluster.
         trigger (Trigger): Select the timesteps on which to perform cluster
@@ -503,8 +503,8 @@ class Clusters(Updater):
     The `Clusters` updater support threaded execution on multiple CPU cores.
 
     Attributes:
-        pivot_move_ratio (float): Set the ratio between pivot and reflection
-          moves.
+        pivot_move_probability (float): Set the probability for attempting a
+                                        pivot move.
         flip_probability (float): Set the probability for transforming an
                                  individual cluster.
         trigger (Trigger): Select the timesteps on which to perform cluster
@@ -513,11 +513,15 @@ class Clusters(Updater):
     _remove_for_pickling = Updater._remove_for_pickling + ('_cpp_cell',)
     _skip_for_equality = Updater._skip_for_equality | {'_cpp_cell'}
 
-    def __init__(self, pivot_move_ratio=0.5, flip_probability=0.5, trigger=1):
+    def __init__(self,
+                 pivot_move_probability=0.5,
+                 flip_probability=0.5,
+                 trigger=1):
         super().__init__(trigger)
 
-        param_dict = ParameterDict(pivot_move_ratio=float(pivot_move_ratio),
-                                   flip_probability=float(flip_probability))
+        param_dict = ParameterDict(
+            pivot_move_probability=float(pivot_move_probability),
+            flip_probability=float(flip_probability))
 
         self._param_dict.update(param_dict)
         self.instance = 0


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should based on *maint*. -->
<!-- New features should based on *master*. -->

## Motivation and context

The `pivot_move_ratio` in `hpmc.update.clusters` is actually the fraction of pivot moves. See issue #777 for more details on the motivation.

Currently this PR only fixes the names in the cluster updater in the python file. The names in the wall updater and the muvt updater are not changed since they haven't been implemented for version 3.

<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves #777

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
