### PR TITLE
Fix setting of ptr for zero sized ManagedArrays.

### DIFF
--- a/hoomd/ManagedArray.h
+++ b/hoomd/ManagedArray.h
@@ -300,6 +300,7 @@ template<class T> class ManagedArray
             {
             managed_allocator<T>::deallocate_destroy_aligned(ptr, N, managed, allocation_ptr);
             }
+        ptr = nullptr;
         }
 #endif
 


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should based on *maint*. -->
<!-- New features should based on *master*. -->

## Description

This prevents empty ManagedArrays from leading to invalid memory access
on the GPU.

<!-- Describe your changes in detail. -->

## Motivation and context

This resolves an issue, I found in #992 with zero sized `ManagedArrays` leading
to a CUDA error for calling `cudaMemAdvise` on a zero sized pointer.
<!--- Why is this change required? What problem does it solve? -->

<!-- Replace ??? with the issue number that this pull request resolves. -->
This may resolve #1105, but I am not sure currently.

## How has this been tested?

The error on #992 no longer triggers, and existing tests pass.
<!--- Please describe in detail how you tested your changes. -->

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
Fixed: Bug in setting zero sized ``ManagedArrays``.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
