### PR TITLE
Fix pair.Table on the GPU

### DIFF
--- a/hoomd/md/EvaluatorPairTable.h
+++ b/hoomd/md/EvaluatorPairTable.h
@@ -77,7 +77,12 @@ class EvaluatorPairTable
 
             if (V_py.size() != F_py.size())
                 {
-                throw std::runtime_error("The length of V and F arrays must be equal");
+                throw std::runtime_error("The length of V and F arrays must be equal.");
+                }
+
+            if (V_py.size() == 0)
+                {
+                throw std::runtime_error("The length of V and F must not be zero.");
                 }
 
             size_t width = V_py.size();

--- a/hoomd/md/PotentialPairGPU.cuh
+++ b/hoomd/md/PotentialPairGPU.cuh
@@ -189,6 +189,8 @@ gpu_compute_pair_forces_shared_kernel(Scalar4* d_force,
     // initialize extra shared mem
     auto s_extra = reinterpret_cast<char*>(s_ronsq + num_typ_parameters);
 
+    __syncthreads();
+
     unsigned int available_bytes = max_extra_bytes;
     for (unsigned int cur_pair = 0; cur_pair < num_typ_parameters; ++cur_pair)
         s_params[cur_pair].load_shared(s_extra, available_bytes);

--- a/hoomd/md/pair/pair.py
+++ b/hoomd/md/pair/pair.py
@@ -591,8 +591,8 @@ class Table(Pair):
         \\begin{eqnarray*}
         \\vec{F}(\\vec{r}) = & 0; & r < r_{\\mathrm{min}} \\\\
                            = & F(r)\\hat{r};
-                             & r_{\\mathrm{min}} \\le r < r_{\\mathrm{max}} \\\\
-                           = & 0; & r \\ge r_{\\mathrm{max}} \\\\
+                             & r_{\\mathrm{min}} \\le r < r_{\\mathrm{cut}} \\\\
+                           = & 0; & r \\ge r_{\\mathrm{cut}} \\\\
         \\end{eqnarray*}
 
     and the potential :math:`V(r)` is:
@@ -603,12 +603,13 @@ class Table(Pair):
         \\begin{eqnarray*}
         V(r) = & 0; & r < r_{\\mathrm{min}} \\\\
              = & V(r);
-               & r_{\\mathrm{min}} \\le r < r_{\\mathrm{max}} \\\\
-             = & 0; & r \\ge r_{\\mathrm{max}} \\\\
+               & r_{\\mathrm{min}} \\le r < r_{\\mathrm{cut}} \\\\
+             = & 0; & r \\ge r_{\\mathrm{cut}} \\\\
         \\end{eqnarray*}
 
     where :math:`\\vec{r}` is the vector pointing from one particle to the other
-    in the pair.
+    in the pair, ``r_min`` is defined in `params`, and ``r_cut`` is defined in
+    `Pair.r_cut`.
 
     Provide :math:`F(r)` and :math:`V(r)` on an evenly space set of grid points
     points between :math:`r_{\\mathrm{min}}` and :math:`r_{\\mathrm{cut}}`.

--- a/hoomd/md/pair/pair.py
+++ b/hoomd/md/pair/pair.py
@@ -100,16 +100,18 @@ class Pair(force.Force):
 
     .. py:attribute:: r_cut
 
-        *r_cut* :math:`[\mathrm{length}]`, *optional*: defaults to the
-            value ``default_r_cut`` specified on construction.
+        Cuttoff radius beyond which the energy and force are 0
+        :math:`[\mathrm{length}]`. *Optional*: defaults to the value
+        ``default_r_cut`` specified on construction.
 
         Type: `TypeParameter` [`tuple` [``particle_type``, ``particle_type``],
         `float`])
 
     .. py:attribute:: r_on
 
-        *r_on* :math:`[\mathrm{length}]`,  *optional*: defaults to the
-         value ``default_r_on`` specified on construction.
+        Radius at which the smoothing modification to the potential starts
+        :math:`[\mathrm{length}]`.  *Optional*: defaults to the value
+        ``default_r_on`` specified on construction.
 
         Type: `TypeParameter` [`tuple` [``particle_type``, ``particle_type``],
         `float`])

--- a/hoomd/md/pair/pair.py
+++ b/hoomd/md/pair/pair.py
@@ -637,9 +637,17 @@ class Table(Pair):
             same length as ``V``.
 
     Note:
-
         The implicitly defined :math:`r` values are those that would be returned
         by ``numpy.linspace(r_min, r_cut, len(V), endpoint=False)``.
+
+    Tip:
+        Define non-interacting potentials with::
+
+            table.params[(type1, type2)] = dict(r_min=0, V=[0], F=[0])
+            table.r_cut[(type1, type2)] = 0
+
+        There must be at least one element in V and F, but the ``r_cut`` value
+        of 0 disables the interaction entirely.
     """
     _cpp_class_name = "PotentialPairTable"
     _accepted_modes = ("none",)


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should based on *maint*. -->
<!-- New features should based on *master*. -->

## Description

<!-- Describe your changes in detail. -->
* Fix a race condition in PotentialPairGPU.
* Check for invalid user input in pair.Table that could lead to invalid memory accesses.
* Inform users how to define non-interacting terms in pair.Table.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
The race condition caused random errors when using pair.Table - even when the tables were populated with 0's (#1105). The other changes proactively fix issues that could lead to invalid memory accesses when users provide invalid input to the table.

<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves #1105 

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
I tested the changes locally with the scripts provided in #1105. The automated unit tests for pair.Table should be affected by this bug, but for some reason they don't trigger it.

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
Fixed:

* Race condition that lead to incorrect simulations with ``md.pair.Table``.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
