### PR TITLE
Use non-static variables to define max block sizes

### DIFF
--- a/hoomd/CellListGPU.cu
+++ b/hoomd/CellListGPU.cu
@@ -195,13 +195,10 @@ void gpu_compute_cell_list(unsigned int* d_cell_size,
                            const unsigned int block_size,
                            const GPUPartition& gpu_partition)
     {
-    static unsigned int max_block_size = UINT_MAX;
-    if (max_block_size == UINT_MAX)
-        {
-        hipFuncAttributes attr;
-        hipFuncGetAttributes(&attr, reinterpret_cast<const void*>(&gpu_compute_cell_list_kernel));
-        max_block_size = attr.maxThreadsPerBlock;
-        }
+    unsigned int max_block_size;
+    hipFuncAttributes attr;
+    hipFuncGetAttributes(&attr, reinterpret_cast<const void*>(&gpu_compute_cell_list_kernel));
+    max_block_size = attr.maxThreadsPerBlock;
 
     // iterate over active GPUs in reverse, to end up on first GPU when returning from this function
     for (int idev = gpu_partition.getNumActiveGPUs() - 1; idev >= 0; --idev)

--- a/hoomd/LoadBalancerGPU.cu
+++ b/hoomd/LoadBalancerGPU.cu
@@ -107,13 +107,11 @@ void gpu_load_balance_mark_rank(unsigned int* d_ranks,
                                 const unsigned int N,
                                 const unsigned int block_size)
     {
-    static unsigned int max_block_size = UINT_MAX;
-    if (max_block_size == UINT_MAX)
-        {
-        hipFuncAttributes attr;
-        hipFuncGetAttributes(&attr, (const void*)gpu_load_balance_mark_rank_kernel);
-        max_block_size = attr.maxThreadsPerBlock;
-        }
+    unsigned int max_block_size;
+    hipFuncAttributes attr;
+    hipFuncGetAttributes(&attr, (const void*)gpu_load_balance_mark_rank_kernel);
+    max_block_size = attr.maxThreadsPerBlock;
+
     unsigned int run_block_size = min(block_size, max_block_size);
     unsigned int n_blocks = N / run_block_size + 1;
 

--- a/hoomd/hpmc/ComputeFreeVolumeGPU.cuh
+++ b/hoomd/hpmc/ComputeFreeVolumeGPU.cuh
@@ -378,8 +378,7 @@ hipError_t gpu_hpmc_free_volume(const hpmc_free_volume_args_t& args,
     // determine the maximum block size and clamp the input block size down
     int max_block_size;
     hipFuncAttributes attr;
-    hipFuncGetAttributes(&attr,
-                            reinterpret_cast<const void*>(gpu_hpmc_free_volume_kernel<Shape>));
+    hipFuncGetAttributes(&attr, reinterpret_cast<const void*>(gpu_hpmc_free_volume_kernel<Shape>));
     max_block_size = attr.maxThreadsPerBlock;
 
     // setup the grid to run the kernel

--- a/hoomd/hpmc/ComputeFreeVolumeGPU.cuh
+++ b/hoomd/hpmc/ComputeFreeVolumeGPU.cuh
@@ -376,14 +376,11 @@ hipError_t gpu_hpmc_free_volume(const hpmc_free_volume_args_t& args,
     hipMemsetAsync(args.d_n_overlap_all, 0, sizeof(unsigned int));
 
     // determine the maximum block size and clamp the input block size down
-    static int max_block_size = -1;
-    static hipFuncAttributes attr;
-    if (max_block_size == -1)
-        {
-        hipFuncGetAttributes(&attr,
-                             reinterpret_cast<const void*>(gpu_hpmc_free_volume_kernel<Shape>));
-        max_block_size = attr.maxThreadsPerBlock;
-        }
+    int max_block_size;
+    hipFuncAttributes attr;
+    hipFuncGetAttributes(&attr,
+                            reinterpret_cast<const void*>(gpu_hpmc_free_volume_kernel<Shape>));
+    max_block_size = attr.maxThreadsPerBlock;
 
     // setup the grid to run the kernel
     unsigned int n_groups

--- a/hoomd/hpmc/IntegratorHPMCMonoGPU.cu
+++ b/hoomd/hpmc/IntegratorHPMCMonoGPU.cu
@@ -166,13 +166,10 @@ void hpmc_excell(unsigned int* d_excell_idx,
     assert(d_cell_adj);
 
     // determine the maximum block size and clamp the input block size down
-    static int max_block_size = -1;
-    if (max_block_size == -1)
-        {
-        hipFuncAttributes attr;
-        hipFuncGetAttributes(&attr, reinterpret_cast<const void*>(kernel::hpmc_excell));
-        max_block_size = attr.maxThreadsPerBlock;
-        }
+    int max_block_size;
+    hipFuncAttributes attr;
+    hipFuncGetAttributes(&attr, reinterpret_cast<const void*>(kernel::hpmc_excell));
+    max_block_size = attr.maxThreadsPerBlock;
 
     // setup the grid to run the kernel
     unsigned int run_block_size = min(block_size, (unsigned int)max_block_size);
@@ -235,13 +232,10 @@ void hpmc_check_convergence(const unsigned int* d_trial_move_type,
                             const unsigned int block_size)
     {
     // determine the maximum block size and clamp the input block size down
-    static int max_block_size = -1;
-    if (max_block_size == -1)
-        {
-        hipFuncAttributes attr;
-        hipFuncGetAttributes(&attr, reinterpret_cast<const void*>(kernel::hpmc_check_convergence));
-        max_block_size = attr.maxThreadsPerBlock;
-        }
+    int max_block_size;
+    hipFuncAttributes attr;
+    hipFuncGetAttributes(&attr, reinterpret_cast<const void*>(kernel::hpmc_check_convergence));
+    max_block_size = attr.maxThreadsPerBlock;
 
     // setup the grid to run the kernel
     unsigned int run_block_size = min(block_size, (unsigned int)max_block_size);

--- a/hoomd/hpmc/IntegratorHPMCMonoGPU.cuh
+++ b/hoomd/hpmc/IntegratorHPMCMonoGPU.cuh
@@ -378,18 +378,15 @@ void narrow_phase_launcher(const hpmc_args_t& args,
     if (max_threads == cur_launch_bounds * MIN_BLOCK_SIZE)
         {
         // determine the maximum block size and clamp the input block size down
-        static int max_block_size = -1;
-        static hipFuncAttributes attr;
+        int max_block_size;
+        hipFuncAttributes attr;
         constexpr unsigned int launch_bounds_nonzero
             = cur_launch_bounds > 0 ? cur_launch_bounds : 1;
-        if (max_block_size == -1)
-            {
-            hipFuncGetAttributes(
-                &attr,
-                reinterpret_cast<const void*>(
-                    kernel::hpmc_narrow_phase<Shape, launch_bounds_nonzero * MIN_BLOCK_SIZE>));
-            max_block_size = attr.maxThreadsPerBlock;
-            }
+        hipFuncGetAttributes(
+            &attr,
+            reinterpret_cast<const void*>(
+                kernel::hpmc_narrow_phase<Shape, launch_bounds_nonzero * MIN_BLOCK_SIZE>));
+        max_block_size = attr.maxThreadsPerBlock;
 
         // choose a block size based on the max block size by regs (max_block_size) and include
         // dynamic shared memory usage

--- a/hoomd/hpmc/IntegratorHPMCMonoGPUDepletants.cu
+++ b/hoomd/hpmc/IntegratorHPMCMonoGPUDepletants.cu
@@ -181,13 +181,10 @@ void generate_num_depletants(const uint16_t seed,
                              const GPUPartition& gpu_partition)
     {
     // determine the maximum block size and clamp the input block size down
-    static unsigned int max_block_size = UINT_MAX;
-    if (max_block_size == UINT_MAX)
-        {
-        hipFuncAttributes attr;
-        hipFuncGetAttributes(&attr, reinterpret_cast<const void*>(kernel::generate_num_depletants));
-        max_block_size = attr.maxThreadsPerBlock;
-        }
+    unsigned int max_block_size;
+    hipFuncAttributes attr;
+    hipFuncGetAttributes(&attr, reinterpret_cast<const void*>(kernel::generate_num_depletants));
+    max_block_size = attr.maxThreadsPerBlock;
 
     unsigned int run_block_size = min(block_size, max_block_size);
 
@@ -233,14 +230,11 @@ void generate_num_depletants_ntrial(const Scalar4* d_vel,
                                     const hipStream_t* streams)
     {
     // determine the maximum block size and clamp the input block size down
-    static unsigned int max_block_size = UINT_MAX;
-    if (max_block_size == UINT_MAX)
-        {
-        hipFuncAttributes attr;
-        hipFuncGetAttributes(&attr,
-                             reinterpret_cast<const void*>(kernel::generate_num_depletants_ntrial));
-        max_block_size = attr.maxThreadsPerBlock;
-        }
+    unsigned int max_block_size;
+    hipFuncAttributes attr;
+    hipFuncGetAttributes(&attr,
+                            reinterpret_cast<const void*>(kernel::generate_num_depletants_ntrial));
+    max_block_size = attr.maxThreadsPerBlock;
 
     unsigned int run_block_size = min(block_size, max_block_size);
 
@@ -376,13 +370,10 @@ void hpmc_depletants_accept(const uint16_t seed,
                             const unsigned int block_size)
     {
     // determine the maximum block size and clamp the input block size down
-    static unsigned int max_block_size = UINT_MAX;
-    if (max_block_size == UINT_MAX)
-        {
-        hipFuncAttributes attr;
-        hipFuncGetAttributes(&attr, reinterpret_cast<const void*>(kernel::hpmc_depletants_accept));
-        max_block_size = attr.maxThreadsPerBlock;
-        }
+    unsigned int max_block_size;
+    hipFuncAttributes attr;
+    hipFuncGetAttributes(&attr, reinterpret_cast<const void*>(kernel::hpmc_depletants_accept));
+    max_block_size = attr.maxThreadsPerBlock;
 
     unsigned int run_block_size = min(block_size, max_block_size);
 

--- a/hoomd/hpmc/IntegratorHPMCMonoGPUDepletants.cu
+++ b/hoomd/hpmc/IntegratorHPMCMonoGPUDepletants.cu
@@ -233,7 +233,7 @@ void generate_num_depletants_ntrial(const Scalar4* d_vel,
     unsigned int max_block_size;
     hipFuncAttributes attr;
     hipFuncGetAttributes(&attr,
-                            reinterpret_cast<const void*>(kernel::generate_num_depletants_ntrial));
+                         reinterpret_cast<const void*>(kernel::generate_num_depletants_ntrial));
     max_block_size = attr.maxThreadsPerBlock;
 
     unsigned int run_block_size = min(block_size, max_block_size);

--- a/hoomd/hpmc/IntegratorHPMCMonoGPUDepletants.cuh
+++ b/hoomd/hpmc/IntegratorHPMCMonoGPUDepletants.cuh
@@ -674,20 +674,17 @@ void depletants_launcher(const hpmc_args_t& args,
     if (max_threads == cur_launch_bounds * MIN_BLOCK_SIZE)
         {
         // determine the maximum block size and clamp the input block size down
-        static int max_block_size = -1;
-        static hipFuncAttributes attr;
+        int max_block_size;
+        hipFuncAttributes attr;
         constexpr unsigned int launch_bounds_nonzero
             = cur_launch_bounds > 0 ? cur_launch_bounds : 1;
-        if (max_block_size == -1)
-            {
-            hipFuncGetAttributes(
-                &attr,
-                reinterpret_cast<const void*>(
-                    &kernel::hpmc_insert_depletants<Shape,
-                                                    launch_bounds_nonzero * MIN_BLOCK_SIZE,
-                                                    pairwise>));
-            max_block_size = attr.maxThreadsPerBlock;
-            }
+        hipFuncGetAttributes(
+            &attr,
+            reinterpret_cast<const void*>(
+                &kernel::hpmc_insert_depletants<Shape,
+                                                launch_bounds_nonzero * MIN_BLOCK_SIZE,
+                                                pairwise>));
+        max_block_size = attr.maxThreadsPerBlock;
 
         // choose a block size based on the max block size by regs (max_block_size) and include
         // dynamic shared memory usage

--- a/hoomd/hpmc/IntegratorHPMCMonoGPUDepletantsAuxilliaryPhase1.cuh
+++ b/hoomd/hpmc/IntegratorHPMCMonoGPUDepletantsAuxilliaryPhase1.cuh
@@ -678,8 +678,8 @@ void depletants_launcher_phase1(const hpmc_args_t& args,
             &attr,
             reinterpret_cast<const void*>(
                 &kernel::hpmc_insert_depletants_phase1<Shape,
-                                                    launch_bounds_nonzero * MIN_BLOCK_SIZE,
-                                                    pairwise>));
+                                                       launch_bounds_nonzero * MIN_BLOCK_SIZE,
+                                                       pairwise>));
         max_block_size = attr.maxThreadsPerBlock;
 
         // choose a block size based on the max block size by regs (max_block_size) and include

--- a/hoomd/hpmc/IntegratorHPMCMonoGPUDepletantsAuxilliaryPhase1.cuh
+++ b/hoomd/hpmc/IntegratorHPMCMonoGPUDepletantsAuxilliaryPhase1.cuh
@@ -670,20 +670,17 @@ void depletants_launcher_phase1(const hpmc_args_t& args,
     if (max_threads == cur_launch_bounds * MIN_BLOCK_SIZE)
         {
         // determine the maximum block size and clamp the input block size down
-        static int max_block_size = -1;
-        static hipFuncAttributes attr;
+        int max_block_size;
+        hipFuncAttributes attr;
         constexpr unsigned int launch_bounds_nonzero
             = cur_launch_bounds > 0 ? cur_launch_bounds : 1;
-        if (max_block_size == -1)
-            {
-            hipFuncGetAttributes(
-                &attr,
-                reinterpret_cast<const void*>(
-                    &kernel::hpmc_insert_depletants_phase1<Shape,
-                                                           launch_bounds_nonzero * MIN_BLOCK_SIZE,
-                                                           pairwise>));
-            max_block_size = attr.maxThreadsPerBlock;
-            }
+        hipFuncGetAttributes(
+            &attr,
+            reinterpret_cast<const void*>(
+                &kernel::hpmc_insert_depletants_phase1<Shape,
+                                                    launch_bounds_nonzero * MIN_BLOCK_SIZE,
+                                                    pairwise>));
+        max_block_size = attr.maxThreadsPerBlock;
 
         // choose a block size based on the max block size by regs (max_block_size) and include
         // dynamic shared memory usage

--- a/hoomd/hpmc/IntegratorHPMCMonoGPUDepletantsAuxilliaryPhase2.cuh
+++ b/hoomd/hpmc/IntegratorHPMCMonoGPUDepletantsAuxilliaryPhase2.cuh
@@ -715,8 +715,8 @@ void depletants_launcher_phase2(const hpmc_args_t& args,
             &attr,
             reinterpret_cast<const void*>(
                 &kernel::hpmc_insert_depletants_phase2<Shape,
-                                                        launch_bounds_nonzero * MIN_BLOCK_SIZE,
-                                                        pairwise>));
+                                                       launch_bounds_nonzero * MIN_BLOCK_SIZE,
+                                                       pairwise>));
         max_block_size = attr.maxThreadsPerBlock;
 
         // choose a block size based on the max block size by regs (max_block_size) and include

--- a/hoomd/hpmc/IntegratorHPMCMonoGPUDepletantsAuxilliaryPhase2.cuh
+++ b/hoomd/hpmc/IntegratorHPMCMonoGPUDepletantsAuxilliaryPhase2.cuh
@@ -707,20 +707,17 @@ void depletants_launcher_phase2(const hpmc_args_t& args,
     if (max_threads == cur_launch_bounds * MIN_BLOCK_SIZE)
         {
         // determine the maximum block size and clamp the input block size down
-        static int max_block_size = -1;
-        static hipFuncAttributes attr;
+        int max_block_size;
+        hipFuncAttributes attr;
         constexpr unsigned int launch_bounds_nonzero
             = cur_launch_bounds > 0 ? cur_launch_bounds : 1;
-        if (max_block_size == -1)
-            {
-            hipFuncGetAttributes(
-                &attr,
-                reinterpret_cast<const void*>(
-                    &kernel::hpmc_insert_depletants_phase2<Shape,
-                                                           launch_bounds_nonzero * MIN_BLOCK_SIZE,
-                                                           pairwise>));
-            max_block_size = attr.maxThreadsPerBlock;
-            }
+        hipFuncGetAttributes(
+            &attr,
+            reinterpret_cast<const void*>(
+                &kernel::hpmc_insert_depletants_phase2<Shape,
+                                                        launch_bounds_nonzero * MIN_BLOCK_SIZE,
+                                                        pairwise>));
+        max_block_size = attr.maxThreadsPerBlock;
 
         // choose a block size based on the max block size by regs (max_block_size) and include
         // dynamic shared memory usage

--- a/hoomd/hpmc/IntegratorHPMCMonoGPUMoves.cuh
+++ b/hoomd/hpmc/IntegratorHPMCMonoGPUMoves.cuh
@@ -286,7 +286,7 @@ void hpmc_gen_moves(const hpmc_args_t& args, const typename Shape::param_type* p
         int max_block_size;
         hipFuncAttributes attr;
         hipFuncGetAttributes(&attr,
-                                reinterpret_cast<const void*>(kernel::hpmc_gen_moves<Shape, 2>));
+                             reinterpret_cast<const void*>(kernel::hpmc_gen_moves<Shape, 2>));
         max_block_size = attr.maxThreadsPerBlock;
 
         // choose a block size based on the max block size by regs (max_block_size) and include
@@ -339,7 +339,7 @@ void hpmc_gen_moves(const hpmc_args_t& args, const typename Shape::param_type* p
         int max_block_size;
         hipFuncAttributes attr;
         hipFuncGetAttributes(&attr,
-                                reinterpret_cast<const void*>(kernel::hpmc_gen_moves<Shape, 3>));
+                             reinterpret_cast<const void*>(kernel::hpmc_gen_moves<Shape, 3>));
         max_block_size = attr.maxThreadsPerBlock;
 
         // choose a block size based on the max block size by regs (max_block_size) and include
@@ -395,8 +395,7 @@ void hpmc_update_pdata(const hpmc_update_args_t& args, const typename Shape::par
     // determine the maximum block size and clamp the input block size down
     int max_block_size;
     hipFuncAttributes attr;
-    hipFuncGetAttributes(&attr,
-                            reinterpret_cast<const void*>(kernel::hpmc_update_pdata<Shape>));
+    hipFuncGetAttributes(&attr, reinterpret_cast<const void*>(kernel::hpmc_update_pdata<Shape>));
     max_block_size = attr.maxThreadsPerBlock;
 
     unsigned int block_size = min(args.block_size, (unsigned int)max_block_size);

--- a/hoomd/hpmc/IntegratorHPMCMonoGPUMoves.cuh
+++ b/hoomd/hpmc/IntegratorHPMCMonoGPUMoves.cuh
@@ -283,14 +283,11 @@ void hpmc_gen_moves(const hpmc_args_t& args, const typename Shape::param_type* p
     if (args.dim == 2)
         {
         // determine the maximum block size and clamp the input block size down
-        static int max_block_size = -1;
-        static hipFuncAttributes attr;
-        if (max_block_size == -1)
-            {
-            hipFuncGetAttributes(&attr,
-                                 reinterpret_cast<const void*>(kernel::hpmc_gen_moves<Shape, 2>));
-            max_block_size = attr.maxThreadsPerBlock;
-            }
+        int max_block_size;
+        hipFuncAttributes attr;
+        hipFuncGetAttributes(&attr,
+                                reinterpret_cast<const void*>(kernel::hpmc_gen_moves<Shape, 2>));
+        max_block_size = attr.maxThreadsPerBlock;
 
         // choose a block size based on the max block size by regs (max_block_size) and include
         // dynamic shared memory usage
@@ -339,14 +336,11 @@ void hpmc_gen_moves(const hpmc_args_t& args, const typename Shape::param_type* p
     else
         {
         // determine the maximum block size and clamp the input block size down
-        static int max_block_size = -1;
-        static hipFuncAttributes attr;
-        if (max_block_size == -1)
-            {
-            hipFuncGetAttributes(&attr,
-                                 reinterpret_cast<const void*>(kernel::hpmc_gen_moves<Shape, 3>));
-            max_block_size = attr.maxThreadsPerBlock;
-            }
+        int max_block_size;
+        hipFuncAttributes attr;
+        hipFuncGetAttributes(&attr,
+                                reinterpret_cast<const void*>(kernel::hpmc_gen_moves<Shape, 3>));
+        max_block_size = attr.maxThreadsPerBlock;
 
         // choose a block size based on the max block size by regs (max_block_size) and include
         // dynamic shared memory usage
@@ -399,14 +393,11 @@ template<class Shape>
 void hpmc_update_pdata(const hpmc_update_args_t& args, const typename Shape::param_type* params)
     {
     // determine the maximum block size and clamp the input block size down
-    static int max_block_size = -1;
-    static hipFuncAttributes attr;
-    if (max_block_size == -1)
-        {
-        hipFuncGetAttributes(&attr,
-                             reinterpret_cast<const void*>(kernel::hpmc_update_pdata<Shape>));
-        max_block_size = attr.maxThreadsPerBlock;
-        }
+    int max_block_size;
+    hipFuncAttributes attr;
+    hipFuncGetAttributes(&attr,
+                            reinterpret_cast<const void*>(kernel::hpmc_update_pdata<Shape>));
+    max_block_size = attr.maxThreadsPerBlock;
 
     unsigned int block_size = min(args.block_size, (unsigned int)max_block_size);
     for (int idev = args.gpu_partition.getNumActiveGPUs() - 1; idev >= 0; --idev)

--- a/hoomd/hpmc/UpdaterClustersGPU.cu
+++ b/hoomd/hpmc/UpdaterClustersGPU.cu
@@ -187,14 +187,11 @@ void concatenate_adjacency_list(const unsigned int* d_adjacency,
                                 const unsigned int group_size)
     {
     // determine the maximum block size and clamp the input block size down
-    static int max_block_size = -1;
-    if (max_block_size == -1)
-        {
-        hipFuncAttributes attr;
-        hipFuncGetAttributes(&attr,
-                             reinterpret_cast<const void*>(kernel::concatenate_adjacency_list));
-        max_block_size = attr.maxThreadsPerBlock;
-        }
+    int max_block_size;
+    hipFuncAttributes attr;
+    hipFuncGetAttributes(&attr,
+                            reinterpret_cast<const void*>(kernel::concatenate_adjacency_list));
+    max_block_size = attr.maxThreadsPerBlock;
 
     // setup the grid to run the kernel
     unsigned int run_block_size = min(block_size, (unsigned int)max_block_size);
@@ -244,13 +241,10 @@ void flip_clusters(Scalar4* d_postype,
                    const unsigned int block_size)
     {
     // determine the maximum block size and clamp the input block size down
-    static int max_block_size = -1;
-    if (max_block_size == -1)
-        {
-        hipFuncAttributes attr;
-        hipFuncGetAttributes(&attr, reinterpret_cast<const void*>(kernel::flip_clusters));
-        max_block_size = attr.maxThreadsPerBlock;
-        }
+    int max_block_size;
+    hipFuncAttributes attr;
+    hipFuncGetAttributes(&attr, reinterpret_cast<const void*>(kernel::flip_clusters));
+    max_block_size = attr.maxThreadsPerBlock;
 
     // setup the grid to run the kernel
     unsigned int run_block_size = min(block_size, (unsigned int)max_block_size);

--- a/hoomd/hpmc/UpdaterClustersGPU.cu
+++ b/hoomd/hpmc/UpdaterClustersGPU.cu
@@ -189,8 +189,7 @@ void concatenate_adjacency_list(const unsigned int* d_adjacency,
     // determine the maximum block size and clamp the input block size down
     int max_block_size;
     hipFuncAttributes attr;
-    hipFuncGetAttributes(&attr,
-                            reinterpret_cast<const void*>(kernel::concatenate_adjacency_list));
+    hipFuncGetAttributes(&attr, reinterpret_cast<const void*>(kernel::concatenate_adjacency_list));
     max_block_size = attr.maxThreadsPerBlock;
 
     // setup the grid to run the kernel

--- a/hoomd/hpmc/UpdaterClustersGPU.cuh
+++ b/hoomd/hpmc/UpdaterClustersGPU.cuh
@@ -495,8 +495,7 @@ void cluster_overlaps_launcher(const cluster_args_t& args,
         max_block_size = attr.maxThreadsPerBlock;
         if (max_block_size % args.devprop.warpSize)
             // handle non-sensical return values from hipFuncGetAttributes
-            max_block_size
-                = (max_block_size / args.devprop.warpSize - 1) * args.devprop.warpSize;
+            max_block_size = (max_block_size / args.devprop.warpSize - 1) * args.devprop.warpSize;
 
         // choose a block size based on the max block size by regs (max_block_size) and include
         // dynamic shared memory usage
@@ -705,8 +704,7 @@ void transform_particles(const clusters_transform_args_t& args,
     // determine the maximum block size and clamp the input block size down
     int max_block_size;
     hipFuncAttributes attr;
-    hipFuncGetAttributes(&attr,
-                            reinterpret_cast<const void*>(&kernel::transform_particles<Shape>));
+    hipFuncGetAttributes(&attr, reinterpret_cast<const void*>(&kernel::transform_particles<Shape>));
     max_block_size = attr.maxThreadsPerBlock;
 
     // setup the grid to run the kernel

--- a/hoomd/hpmc/UpdaterClustersGPU.cuh
+++ b/hoomd/hpmc/UpdaterClustersGPU.cuh
@@ -484,22 +484,19 @@ void cluster_overlaps_launcher(const cluster_args_t& args,
     if (max_threads == cur_launch_bounds * MIN_BLOCK_SIZE)
         {
         // determine the maximum block size and clamp the input block size down
-        static int max_block_size = -1;
-        static hipFuncAttributes attr;
+        int max_block_size;
+        hipFuncAttributes attr;
         constexpr unsigned int launch_bounds_nonzero
             = cur_launch_bounds > 0 ? cur_launch_bounds : 1;
-        if (max_block_size == -1)
-            {
-            hipFuncGetAttributes(
-                &attr,
-                reinterpret_cast<const void*>(
-                    kernel::hpmc_cluster_overlaps<Shape, launch_bounds_nonzero * MIN_BLOCK_SIZE>));
-            max_block_size = attr.maxThreadsPerBlock;
-            if (max_block_size % args.devprop.warpSize)
-                // handle non-sensical return values from hipFuncGetAttributes
-                max_block_size
-                    = (max_block_size / args.devprop.warpSize - 1) * args.devprop.warpSize;
-            }
+        hipFuncGetAttributes(
+            &attr,
+            reinterpret_cast<const void*>(
+                kernel::hpmc_cluster_overlaps<Shape, launch_bounds_nonzero * MIN_BLOCK_SIZE>));
+        max_block_size = attr.maxThreadsPerBlock;
+        if (max_block_size % args.devprop.warpSize)
+            // handle non-sensical return values from hipFuncGetAttributes
+            max_block_size
+                = (max_block_size / args.devprop.warpSize - 1) * args.devprop.warpSize;
 
         // choose a block size based on the max block size by regs (max_block_size) and include
         // dynamic shared memory usage
@@ -552,24 +549,20 @@ void cluster_overlaps_launcher(const cluster_args_t& args,
             }
 
         // determine dynamically allocated shared memory size
-        static unsigned int base_shared_bytes = UINT_MAX;
-        bool shared_bytes_changed = base_shared_bytes != shared_bytes + attr.sharedSizeBytes;
+        unsigned int base_shared_bytes;
         base_shared_bytes = static_cast<unsigned int>(shared_bytes + attr.sharedSizeBytes);
 
         unsigned int max_extra_bytes
             = static_cast<unsigned int>(args.devprop.sharedMemPerBlock - base_shared_bytes);
-        static unsigned int extra_bytes = UINT_MAX;
-        if (extra_bytes == UINT_MAX || args.update_shape_param || shared_bytes_changed)
+        unsigned int extra_bytes;
+        // determine dynamically requested shared memory
+        char* ptr = (char*)nullptr;
+        unsigned int available_bytes = max_extra_bytes;
+        for (unsigned int i = 0; i < args.num_types; ++i)
             {
-            // determine dynamically requested shared memory
-            char* ptr = (char*)nullptr;
-            unsigned int available_bytes = max_extra_bytes;
-            for (unsigned int i = 0; i < args.num_types; ++i)
-                {
-                params[i].allocate_shared(ptr, available_bytes);
-                }
-            extra_bytes = max_extra_bytes - available_bytes;
+            params[i].allocate_shared(ptr, available_bytes);
             }
+        extra_bytes = max_extra_bytes - available_bytes;
 
         shared_bytes += extra_bytes;
         dim3 thread(overlap_threads, n_groups, tpp);
@@ -710,14 +703,11 @@ void transform_particles(const clusters_transform_args_t& args,
                          const typename Shape::param_type* d_params)
     {
     // determine the maximum block size and clamp the input block size down
-    static int max_block_size = -1;
-    if (max_block_size == -1)
-        {
-        hipFuncAttributes attr;
-        hipFuncGetAttributes(&attr,
-                             reinterpret_cast<const void*>(&kernel::transform_particles<Shape>));
-        max_block_size = attr.maxThreadsPerBlock;
-        }
+    int max_block_size;
+    hipFuncAttributes attr;
+    hipFuncGetAttributes(&attr,
+                            reinterpret_cast<const void*>(&kernel::transform_particles<Shape>));
+    max_block_size = attr.maxThreadsPerBlock;
 
     // setup the grid to run the kernel
     unsigned int run_block_size = min(args.block_size, (unsigned int)max_block_size);

--- a/hoomd/hpmc/UpdaterClustersGPUDepletants.cuh
+++ b/hoomd/hpmc/UpdaterClustersGPUDepletants.cuh
@@ -814,8 +814,7 @@ void clusters_depletants_launcher(const cluster_args_t& args,
         max_block_size = attr.maxThreadsPerBlock;
         if (max_block_size % args.devprop.warpSize)
             // handle non-sensical return values from hipFuncGetAttributes
-            max_block_size
-                = (max_block_size / args.devprop.warpSize - 1) * args.devprop.warpSize;
+            max_block_size = (max_block_size / args.devprop.warpSize - 1) * args.devprop.warpSize;
 
         // choose a block size based on the max block size by regs (max_block_size) and include
         // dynamic shared memory usage

--- a/hoomd/hpmc/UpdaterClustersGPUDepletants.cuh
+++ b/hoomd/hpmc/UpdaterClustersGPUDepletants.cuh
@@ -802,23 +802,20 @@ void clusters_depletants_launcher(const cluster_args_t& args,
     if (max_threads == cur_launch_bounds * MIN_BLOCK_SIZE)
         {
         // determine the maximum block size and clamp the input block size down
-        static int max_block_size = -1;
-        static hipFuncAttributes attr;
+        int max_block_size;
+        hipFuncAttributes attr;
         constexpr unsigned int launch_bounds_nonzero
             = cur_launch_bounds > 0 ? cur_launch_bounds : 1;
-        if (max_block_size == -1)
-            {
-            hipFuncGetAttributes(
-                &attr,
-                reinterpret_cast<const void*>(
-                    &kernel::clusters_insert_depletants<Shape,
-                                                        launch_bounds_nonzero * MIN_BLOCK_SIZE>));
-            max_block_size = attr.maxThreadsPerBlock;
-            if (max_block_size % args.devprop.warpSize)
-                // handle non-sensical return values from hipFuncGetAttributes
-                max_block_size
-                    = (max_block_size / args.devprop.warpSize - 1) * args.devprop.warpSize;
-            }
+        hipFuncGetAttributes(
+            &attr,
+            reinterpret_cast<const void*>(
+                &kernel::clusters_insert_depletants<Shape,
+                                                    launch_bounds_nonzero * MIN_BLOCK_SIZE>));
+        max_block_size = attr.maxThreadsPerBlock;
+        if (max_block_size % args.devprop.warpSize)
+            // handle non-sensical return values from hipFuncGetAttributes
+            max_block_size
+                = (max_block_size / args.devprop.warpSize - 1) * args.devprop.warpSize;
 
         // choose a block size based on the max block size by regs (max_block_size) and include
         // dynamic shared memory usage
@@ -859,24 +856,20 @@ void clusters_depletants_launcher(const cluster_args_t& args,
                 + max_depletant_queue_size * sizeof(unsigned int) + min_shared_bytes);
             }
 
-        static unsigned int base_shared_bytes = UINT_MAX;
-        bool shared_bytes_changed = base_shared_bytes != shared_bytes + attr.sharedSizeBytes;
+        unsigned int base_shared_bytes;
         base_shared_bytes = static_cast<unsigned int>(shared_bytes + attr.sharedSizeBytes);
 
         unsigned int max_extra_bytes
             = static_cast<unsigned int>(args.devprop.sharedMemPerBlock - base_shared_bytes);
-        static unsigned int extra_bytes = UINT_MAX;
-        if (extra_bytes == UINT_MAX || args.update_shape_param || shared_bytes_changed)
+        unsigned int extra_bytes;
+        // determine dynamically requested shared memory
+        char* ptr = (char*)nullptr;
+        unsigned int available_bytes = max_extra_bytes;
+        for (unsigned int i = 0; i < args.num_types; ++i)
             {
-            // determine dynamically requested shared memory
-            char* ptr = (char*)nullptr;
-            unsigned int available_bytes = max_extra_bytes;
-            for (unsigned int i = 0; i < args.num_types; ++i)
-                {
-                params[i].allocate_shared(ptr, available_bytes);
-                }
-            extra_bytes = max_extra_bytes - available_bytes;
+            params[i].allocate_shared(ptr, available_bytes);
             }
+        extra_bytes = max_extra_bytes - available_bytes;
 
         shared_bytes += extra_bytes;
 

--- a/hoomd/md/AnisoPotentialPairGPU.cuh
+++ b/hoomd/md/AnisoPotentialPairGPU.cuh
@@ -434,12 +434,12 @@ struct AnisoPairForceComputeKernel
 
             unsigned int max_block_size;
             hipFuncAttributes attr;
-            hipFuncGetAttributes(&attr,
-                                    reinterpret_cast<const void*>(
-                                        &gpu_compute_pair_aniso_forces_kernel<evaluator,
-                                                                            shift_mode,
-                                                                            compute_virial,
-                                                                            tpp>));
+            hipFuncGetAttributes(
+                &attr,
+                reinterpret_cast<const void*>(&gpu_compute_pair_aniso_forces_kernel<evaluator,
+                                                                                    shift_mode,
+                                                                                    compute_virial,
+                                                                                    tpp>));
             int max_threads = attr.maxThreadsPerBlock;
             // number of threads has to be multiple of warp size
             max_block_size = max_threads - max_threads % gpu_aniso_pair_force_max_tpp;

--- a/hoomd/md/AnisoPotentialPairGPU.cuh
+++ b/hoomd/md/AnisoPotentialPairGPU.cuh
@@ -432,46 +432,36 @@ struct AnisoPairForceComputeKernel
                                       * typpair_idx.getNumElements()
                                   + sizeof(typename evaluator::shape_type) * pair_args.ntypes;
 
-            static unsigned int max_block_size = UINT_MAX;
+            unsigned int max_block_size;
             hipFuncAttributes attr;
-            if (max_block_size == UINT_MAX)
-                {
-                hipFuncGetAttributes(&attr,
-                                     reinterpret_cast<const void*>(
-                                         &gpu_compute_pair_aniso_forces_kernel<evaluator,
-                                                                               shift_mode,
-                                                                               compute_virial,
-                                                                               tpp>));
-                int max_threads = attr.maxThreadsPerBlock;
-                // number of threads has to be multiple of warp size
-                max_block_size = max_threads - max_threads % gpu_aniso_pair_force_max_tpp;
-                }
+            hipFuncGetAttributes(&attr,
+                                    reinterpret_cast<const void*>(
+                                        &gpu_compute_pair_aniso_forces_kernel<evaluator,
+                                                                            shift_mode,
+                                                                            compute_virial,
+                                                                            tpp>));
+            int max_threads = attr.maxThreadsPerBlock;
+            // number of threads has to be multiple of warp size
+            max_block_size = max_threads - max_threads % gpu_aniso_pair_force_max_tpp;
 
-            static unsigned int base_shared_bytes = UINT_MAX;
-            bool shared_bytes_changed = base_shared_bytes != shared_bytes + attr.sharedSizeBytes;
+            unsigned int base_shared_bytes;
             base_shared_bytes = (unsigned int)(shared_bytes + attr.sharedSizeBytes);
 
             unsigned int max_extra_bytes
                 = (unsigned int)(pair_args.devprop.sharedMemPerBlock - base_shared_bytes);
-            static unsigned int extra_bytes = UINT_MAX;
-            if (extra_bytes == UINT_MAX || pair_args.update_shape_param || shared_bytes_changed)
+            unsigned int extra_bytes;
+            // determine dynamically requested shared memory
+            char* ptr = (char*)nullptr;
+            unsigned int available_bytes = max_extra_bytes;
+            for (unsigned int i = 0; i < typpair_idx.getNumElements(); ++i)
                 {
-                // required for memory coherency
-                hipDeviceSynchronize();
-
-                // determine dynamically requested shared memory
-                char* ptr = (char*)nullptr;
-                unsigned int available_bytes = max_extra_bytes;
-                for (unsigned int i = 0; i < typpair_idx.getNumElements(); ++i)
-                    {
-                    params[i].load_shared(ptr, available_bytes);
-                    }
-                for (unsigned int i = 0; i < pair_args.ntypes; ++i)
-                    {
-                    shape_params[i].load_shared(ptr, available_bytes);
-                    }
-                extra_bytes = max_extra_bytes - available_bytes;
+                params[i].load_shared(ptr, available_bytes);
                 }
+            for (unsigned int i = 0; i < pair_args.ntypes; ++i)
+                {
+                shape_params[i].load_shared(ptr, available_bytes);
+                }
+            extra_bytes = max_extra_bytes - available_bytes;
 
             shared_bytes += extra_bytes;
 

--- a/hoomd/md/BondTablePotentialGPU.cu
+++ b/hoomd/md/BondTablePotentialGPU.cu
@@ -204,13 +204,10 @@ hipError_t gpu_compute_bondtable_forces(Scalar4* d_force,
     assert(n_bond_type > 0);
     assert(table_width > 1);
 
-    static unsigned int max_block_size = UINT_MAX;
-    if (max_block_size == UINT_MAX)
-        {
-        hipFuncAttributes attr;
-        hipFuncGetAttributes(&attr, (const void*)gpu_compute_bondtable_forces_kernel);
-        max_block_size = attr.maxThreadsPerBlock;
-        }
+    unsigned int max_block_size;
+    hipFuncAttributes attr;
+    hipFuncGetAttributes(&attr, (const void*)gpu_compute_bondtable_forces_kernel);
+    max_block_size = attr.maxThreadsPerBlock;
 
     unsigned int run_block_size = min(block_size, max_block_size);
 

--- a/hoomd/md/CosineSqAngleForceGPU.cu
+++ b/hoomd/md/CosineSqAngleForceGPU.cu
@@ -226,13 +226,10 @@ hipError_t gpu_compute_cosinesq_angle_forces(Scalar4* d_force,
     {
     assert(d_params);
 
-    static unsigned int max_block_size = UINT_MAX;
-    if (max_block_size == UINT_MAX)
-        {
-        hipFuncAttributes attr;
-        hipFuncGetAttributes(&attr, (const void*)gpu_compute_cosinesq_angle_forces_kernel);
-        max_block_size = attr.maxThreadsPerBlock;
-        }
+    unsigned int max_block_size;
+    hipFuncAttributes attr;
+    hipFuncGetAttributes(&attr, (const void*)gpu_compute_cosinesq_angle_forces_kernel);
+    max_block_size = attr.maxThreadsPerBlock;
 
     unsigned int run_block_size = min(block_size, max_block_size);
 

--- a/hoomd/md/ForceCompositeGPU.cu
+++ b/hoomd/md/ForceCompositeGPU.cu
@@ -472,13 +472,10 @@ hipError_t gpu_rigid_force(Scalar4* d_force,
 
         dim3 force_grid(nwork / n_bodies_per_block + 1, 1, 1);
 
-        static unsigned int max_block_size = UINT_MAX;
-        static hipFuncAttributes attr;
-        if (max_block_size == UINT_MAX)
-            {
-            hipFuncGetAttributes(&attr, (const void*)gpu_rigid_force_sliding_kernel);
-            max_block_size = attr.maxThreadsPerBlock;
-            }
+        unsigned int max_block_size;
+        hipFuncAttributes attr;
+        hipFuncGetAttributes(&attr, (const void*)gpu_rigid_force_sliding_kernel);
+        max_block_size = attr.maxThreadsPerBlock;
 
         unsigned int run_block_size = max_block_size < block_size ? max_block_size : block_size;
 
@@ -575,13 +572,10 @@ hipError_t gpu_rigid_virial(Scalar* d_virial,
 
         dim3 force_grid(nwork / n_bodies_per_block + 1, 1, 1);
 
-        static unsigned int max_block_size = UINT_MAX;
-        static hipFuncAttributes attr;
-        if (max_block_size == UINT_MAX)
-            {
-            hipFuncGetAttributes(&attr, (const void*)gpu_rigid_virial_sliding_kernel);
-            max_block_size = attr.maxThreadsPerBlock;
-            }
+        unsigned int max_block_size;
+        hipFuncAttributes attr;
+        hipFuncGetAttributes(&attr, (const void*)gpu_rigid_virial_sliding_kernel);
+        max_block_size = attr.maxThreadsPerBlock;
 
         unsigned int run_block_size = max_block_size < block_size ? max_block_size : block_size;
 
@@ -760,13 +754,10 @@ void gpu_update_composite(unsigned int N,
     {
     unsigned int run_block_size = block_size;
 
-    static unsigned int max_block_size = UINT_MAX;
-    static hipFuncAttributes attr;
-    if (max_block_size == UINT_MAX)
-        {
-        hipFuncGetAttributes(&attr, (const void*)gpu_update_composite_kernel);
-        max_block_size = attr.maxThreadsPerBlock;
-        }
+    unsigned int max_block_size;
+    hipFuncAttributes attr;
+    hipFuncGetAttributes(&attr, (const void*)gpu_update_composite_kernel);
+    max_block_size = attr.maxThreadsPerBlock;
 
     if (max_block_size <= run_block_size)
         {

--- a/hoomd/md/ForceDistanceConstraintGPU.cu
+++ b/hoomd/md/ForceDistanceConstraintGPU.cu
@@ -189,13 +189,10 @@ hipError_t gpu_fill_matrix_vector(unsigned int n_constraint,
                                   const BoxDim box,
                                   unsigned int block_size)
     {
-    static unsigned int max_block_size = UINT_MAX;
-    if (max_block_size == UINT_MAX)
-        {
-        hipFuncAttributes attr;
-        hipFuncGetAttributes(&attr, (const void*)gpu_fill_matrix_vector_kernel);
-        max_block_size = attr.maxThreadsPerBlock;
-        }
+    unsigned int max_block_size;
+    hipFuncAttributes attr;
+    hipFuncGetAttributes(&attr, (const void*)gpu_fill_matrix_vector_kernel);
+    max_block_size = attr.maxThreadsPerBlock;
 
     // run configuration
     unsigned int run_block_size = min(block_size, max_block_size);
@@ -392,13 +389,10 @@ hipError_t gpu_compute_constraint_forces(const Scalar4* d_pos,
     // d_lagrange contains the Lagrange multipliers
 
     // fill out force array
-    static unsigned int max_block_size = UINT_MAX;
-    if (max_block_size == UINT_MAX)
-        {
-        hipFuncAttributes attr;
-        hipFuncGetAttributes(&attr, (const void*)gpu_fill_constraint_forces_kernel);
-        max_block_size = attr.maxThreadsPerBlock;
-        }
+    unsigned int max_block_size;
+    hipFuncAttributes attr;
+    hipFuncGetAttributes(&attr, (const void*)gpu_fill_constraint_forces_kernel);
+    max_block_size = attr.maxThreadsPerBlock;
 
     // run configuration
     unsigned int run_block_size = min(block_size, max_block_size);

--- a/hoomd/md/HarmonicAngleForceGPU.cu
+++ b/hoomd/md/HarmonicAngleForceGPU.cu
@@ -232,13 +232,10 @@ hipError_t gpu_compute_harmonic_angle_forces(Scalar4* d_force,
     {
     assert(d_params);
 
-    static unsigned int max_block_size = UINT_MAX;
-    if (max_block_size == UINT_MAX)
-        {
-        hipFuncAttributes attr;
-        hipFuncGetAttributes(&attr, (const void*)gpu_compute_harmonic_angle_forces_kernel);
-        max_block_size = attr.maxThreadsPerBlock;
-        }
+    unsigned int max_block_size;
+    hipFuncAttributes attr;
+    hipFuncGetAttributes(&attr, (const void*)gpu_compute_harmonic_angle_forces_kernel);
+    max_block_size = attr.maxThreadsPerBlock;
 
     unsigned int run_block_size = min(block_size, max_block_size);
 

--- a/hoomd/md/HarmonicDihedralForceGPU.cu
+++ b/hoomd/md/HarmonicDihedralForceGPU.cu
@@ -340,16 +340,13 @@ hipError_t gpu_compute_harmonic_dihedral_forces(Scalar4* d_force,
     {
     assert(d_params);
 
-    static unsigned int max_block_size = UINT_MAX;
-    if (max_block_size == UINT_MAX)
-        {
-        hipFuncAttributes attr;
-        hipFuncGetAttributes(&attr, (const void*)gpu_compute_harmonic_dihedral_forces_kernel);
-        max_block_size = attr.maxThreadsPerBlock;
-        if (max_block_size % warp_size)
-            // handle non-sensical return values from hipFuncGetAttributes
-            max_block_size = (max_block_size / warp_size - 1) * warp_size;
-        }
+    unsigned int max_block_size;
+    hipFuncAttributes attr;
+    hipFuncGetAttributes(&attr, (const void*)gpu_compute_harmonic_dihedral_forces_kernel);
+    max_block_size = attr.maxThreadsPerBlock;
+    if (max_block_size % warp_size)
+        // handle non-sensical return values from hipFuncGetAttributes
+        max_block_size = (max_block_size / warp_size - 1) * warp_size;
 
     unsigned int run_block_size = min(block_size, max_block_size);
 

--- a/hoomd/md/HarmonicImproperForceGPU.cu
+++ b/hoomd/md/HarmonicImproperForceGPU.cu
@@ -299,16 +299,13 @@ hipError_t gpu_compute_harmonic_improper_forces(Scalar4* d_force,
     if (N == 0)
         return hipSuccess;
 
-    static unsigned int max_block_size = UINT_MAX;
-    if (max_block_size == UINT_MAX)
-        {
-        hipFuncAttributes attr;
-        hipFuncGetAttributes(&attr, (const void*)gpu_compute_harmonic_improper_forces_kernel);
-        max_block_size = attr.maxThreadsPerBlock;
-        if (max_block_size % warp_size)
-            // handle non-sensical return values from hipFuncGetAttributes
-            max_block_size = (max_block_size / warp_size - 1) * warp_size;
-        }
+    unsigned int max_block_size;
+    hipFuncAttributes attr;
+    hipFuncGetAttributes(&attr, (const void*)gpu_compute_harmonic_improper_forces_kernel);
+    max_block_size = attr.maxThreadsPerBlock;
+    if (max_block_size % warp_size)
+        // handle non-sensical return values from hipFuncGetAttributes
+        max_block_size = (max_block_size / warp_size - 1) * warp_size;
 
     unsigned int run_block_size = min(block_size, max_block_size);
 

--- a/hoomd/md/NeighborListGPU.cu
+++ b/hoomd/md/NeighborListGPU.cu
@@ -241,13 +241,10 @@ hipError_t gpu_nlist_filter(unsigned int* d_n_neigh,
                             const unsigned int N,
                             const unsigned int block_size)
     {
-    static unsigned int max_block_size = UINT_MAX;
-    if (max_block_size == UINT_MAX)
-        {
-        hipFuncAttributes attr;
-        hipFuncGetAttributes(&attr, (const void*)gpu_nlist_filter_kernel);
-        max_block_size = attr.maxThreadsPerBlock;
-        }
+    unsigned int max_block_size;
+    hipFuncAttributes attr;
+    hipFuncGetAttributes(&attr, (const void*)gpu_nlist_filter_kernel);
+    max_block_size = attr.maxThreadsPerBlock;
 
     unsigned int run_block_size = min(block_size, max_block_size);
 
@@ -445,13 +442,10 @@ hipError_t gpu_nlist_build_head_list(unsigned int* d_head_list,
                                      const unsigned int ntypes,
                                      const unsigned int block_size)
     {
-    static unsigned int max_block_size = UINT_MAX;
-    if (max_block_size == UINT_MAX)
-        {
-        hipFuncAttributes attr;
-        hipFuncGetAttributes(&attr, (const void*)gpu_nlist_init_head_list_kernel);
-        max_block_size = attr.maxThreadsPerBlock;
-        }
+    unsigned int max_block_size;
+    hipFuncAttributes attr;
+    hipFuncGetAttributes(&attr, (const void*)gpu_nlist_init_head_list_kernel);
+    max_block_size = attr.maxThreadsPerBlock;
 
     unsigned int run_block_size = min(block_size, max_block_size);
     const size_t shared_bytes = ntypes * sizeof(unsigned int);

--- a/hoomd/md/NeighborListGPUBinned.cu
+++ b/hoomd/md/NeighborListGPUBinned.cu
@@ -350,8 +350,7 @@ inline void launcher(unsigned int* d_nlist,
             if (!diameter_shift && !filter_body)
                 {
                 unsigned int max_block_size;
-                max_block_size
-                    = get_max_block_size(gpu_compute_nlist_binned_kernel<0, 0, cur_tpp>);
+                max_block_size = get_max_block_size(gpu_compute_nlist_binned_kernel<0, 0, cur_tpp>);
 
                 block_size = block_size < max_block_size ? block_size : max_block_size;
                 dim3 grid(nwork / (block_size / tpp) + 1);
@@ -391,8 +390,7 @@ inline void launcher(unsigned int* d_nlist,
             else if (!diameter_shift && filter_body)
                 {
                 unsigned int max_block_size;
-                max_block_size
-                    = get_max_block_size(gpu_compute_nlist_binned_kernel<1, 0, cur_tpp>);
+                max_block_size = get_max_block_size(gpu_compute_nlist_binned_kernel<1, 0, cur_tpp>);
 
                 block_size = block_size < max_block_size ? block_size : max_block_size;
                 dim3 grid(nwork / (block_size / tpp) + 1);
@@ -432,8 +430,7 @@ inline void launcher(unsigned int* d_nlist,
             else if (diameter_shift && !filter_body)
                 {
                 unsigned int max_block_size;
-                max_block_size
-                    = get_max_block_size(gpu_compute_nlist_binned_kernel<2, 0, cur_tpp>);
+                max_block_size = get_max_block_size(gpu_compute_nlist_binned_kernel<2, 0, cur_tpp>);
 
                 block_size = block_size < max_block_size ? block_size : max_block_size;
                 dim3 grid(nwork / (block_size / tpp) + 1);
@@ -473,8 +470,7 @@ inline void launcher(unsigned int* d_nlist,
             else if (diameter_shift && filter_body)
                 {
                 unsigned int max_block_size;
-                max_block_size
-                    = get_max_block_size(gpu_compute_nlist_binned_kernel<3, 0, cur_tpp>);
+                max_block_size = get_max_block_size(gpu_compute_nlist_binned_kernel<3, 0, cur_tpp>);
 
                 block_size = block_size < max_block_size ? block_size : max_block_size;
                 dim3 grid(nwork / (block_size / tpp) + 1);
@@ -517,8 +513,7 @@ inline void launcher(unsigned int* d_nlist,
             if (!diameter_shift && !filter_body)
                 {
                 unsigned int max_block_size;
-                max_block_size
-                    = get_max_block_size(gpu_compute_nlist_binned_kernel<0, 1, cur_tpp>);
+                max_block_size = get_max_block_size(gpu_compute_nlist_binned_kernel<0, 1, cur_tpp>);
 
                 block_size = block_size < max_block_size ? block_size : max_block_size;
                 dim3 grid(nwork / (block_size / tpp) + 1);
@@ -558,8 +553,7 @@ inline void launcher(unsigned int* d_nlist,
             else if (!diameter_shift && filter_body)
                 {
                 unsigned int max_block_size;
-                max_block_size
-                    = get_max_block_size(gpu_compute_nlist_binned_kernel<1, 1, cur_tpp>);
+                max_block_size = get_max_block_size(gpu_compute_nlist_binned_kernel<1, 1, cur_tpp>);
 
                 block_size = block_size < max_block_size ? block_size : max_block_size;
                 dim3 grid(nwork / (block_size / tpp) + 1);
@@ -599,8 +593,7 @@ inline void launcher(unsigned int* d_nlist,
             else if (diameter_shift && !filter_body)
                 {
                 unsigned int max_block_size;
-                max_block_size
-                    = get_max_block_size(gpu_compute_nlist_binned_kernel<2, 1, cur_tpp>);
+                max_block_size = get_max_block_size(gpu_compute_nlist_binned_kernel<2, 1, cur_tpp>);
 
                 block_size = block_size < max_block_size ? block_size : max_block_size;
                 dim3 grid(nwork / (block_size / tpp) + 1);
@@ -640,8 +633,7 @@ inline void launcher(unsigned int* d_nlist,
             else if (diameter_shift && filter_body)
                 {
                 unsigned int max_block_size;
-                max_block_size
-                    = get_max_block_size(gpu_compute_nlist_binned_kernel<3, 1, cur_tpp>);
+                max_block_size = get_max_block_size(gpu_compute_nlist_binned_kernel<3, 1, cur_tpp>);
 
                 block_size = block_size < max_block_size ? block_size : max_block_size;
                 dim3 grid(nwork / (block_size / tpp) + 1);

--- a/hoomd/md/NeighborListGPUBinned.cu
+++ b/hoomd/md/NeighborListGPUBinned.cu
@@ -349,10 +349,9 @@ inline void launcher(unsigned int* d_nlist,
             {
             if (!diameter_shift && !filter_body)
                 {
-                static unsigned int max_block_size = UINT_MAX;
-                if (max_block_size == UINT_MAX)
-                    max_block_size
-                        = get_max_block_size(gpu_compute_nlist_binned_kernel<0, 0, cur_tpp>);
+                unsigned int max_block_size;
+                max_block_size
+                    = get_max_block_size(gpu_compute_nlist_binned_kernel<0, 0, cur_tpp>);
 
                 block_size = block_size < max_block_size ? block_size : max_block_size;
                 dim3 grid(nwork / (block_size / tpp) + 1);
@@ -391,10 +390,9 @@ inline void launcher(unsigned int* d_nlist,
                 }
             else if (!diameter_shift && filter_body)
                 {
-                static unsigned int max_block_size = UINT_MAX;
-                if (max_block_size == UINT_MAX)
-                    max_block_size
-                        = get_max_block_size(gpu_compute_nlist_binned_kernel<1, 0, cur_tpp>);
+                unsigned int max_block_size;
+                max_block_size
+                    = get_max_block_size(gpu_compute_nlist_binned_kernel<1, 0, cur_tpp>);
 
                 block_size = block_size < max_block_size ? block_size : max_block_size;
                 dim3 grid(nwork / (block_size / tpp) + 1);
@@ -433,10 +431,9 @@ inline void launcher(unsigned int* d_nlist,
                 }
             else if (diameter_shift && !filter_body)
                 {
-                static unsigned int max_block_size = UINT_MAX;
-                if (max_block_size == UINT_MAX)
-                    max_block_size
-                        = get_max_block_size(gpu_compute_nlist_binned_kernel<2, 0, cur_tpp>);
+                unsigned int max_block_size;
+                max_block_size
+                    = get_max_block_size(gpu_compute_nlist_binned_kernel<2, 0, cur_tpp>);
 
                 block_size = block_size < max_block_size ? block_size : max_block_size;
                 dim3 grid(nwork / (block_size / tpp) + 1);
@@ -475,10 +472,9 @@ inline void launcher(unsigned int* d_nlist,
                 }
             else if (diameter_shift && filter_body)
                 {
-                static unsigned int max_block_size = UINT_MAX;
-                if (max_block_size == UINT_MAX)
-                    max_block_size
-                        = get_max_block_size(gpu_compute_nlist_binned_kernel<3, 0, cur_tpp>);
+                unsigned int max_block_size;
+                max_block_size
+                    = get_max_block_size(gpu_compute_nlist_binned_kernel<3, 0, cur_tpp>);
 
                 block_size = block_size < max_block_size ? block_size : max_block_size;
                 dim3 grid(nwork / (block_size / tpp) + 1);
@@ -520,10 +516,9 @@ inline void launcher(unsigned int* d_nlist,
             {
             if (!diameter_shift && !filter_body)
                 {
-                static unsigned int max_block_size = UINT_MAX;
-                if (max_block_size == UINT_MAX)
-                    max_block_size
-                        = get_max_block_size(gpu_compute_nlist_binned_kernel<0, 1, cur_tpp>);
+                unsigned int max_block_size;
+                max_block_size
+                    = get_max_block_size(gpu_compute_nlist_binned_kernel<0, 1, cur_tpp>);
 
                 block_size = block_size < max_block_size ? block_size : max_block_size;
                 dim3 grid(nwork / (block_size / tpp) + 1);
@@ -562,10 +557,9 @@ inline void launcher(unsigned int* d_nlist,
                 }
             else if (!diameter_shift && filter_body)
                 {
-                static unsigned int max_block_size = UINT_MAX;
-                if (max_block_size == UINT_MAX)
-                    max_block_size
-                        = get_max_block_size(gpu_compute_nlist_binned_kernel<1, 1, cur_tpp>);
+                unsigned int max_block_size;
+                max_block_size
+                    = get_max_block_size(gpu_compute_nlist_binned_kernel<1, 1, cur_tpp>);
 
                 block_size = block_size < max_block_size ? block_size : max_block_size;
                 dim3 grid(nwork / (block_size / tpp) + 1);
@@ -604,10 +598,9 @@ inline void launcher(unsigned int* d_nlist,
                 }
             else if (diameter_shift && !filter_body)
                 {
-                static unsigned int max_block_size = UINT_MAX;
-                if (max_block_size == UINT_MAX)
-                    max_block_size
-                        = get_max_block_size(gpu_compute_nlist_binned_kernel<2, 1, cur_tpp>);
+                unsigned int max_block_size;
+                max_block_size
+                    = get_max_block_size(gpu_compute_nlist_binned_kernel<2, 1, cur_tpp>);
 
                 block_size = block_size < max_block_size ? block_size : max_block_size;
                 dim3 grid(nwork / (block_size / tpp) + 1);
@@ -646,10 +639,9 @@ inline void launcher(unsigned int* d_nlist,
                 }
             else if (diameter_shift && filter_body)
                 {
-                static unsigned int max_block_size = UINT_MAX;
-                if (max_block_size == UINT_MAX)
-                    max_block_size
-                        = get_max_block_size(gpu_compute_nlist_binned_kernel<3, 1, cur_tpp>);
+                unsigned int max_block_size;
+                max_block_size
+                    = get_max_block_size(gpu_compute_nlist_binned_kernel<3, 1, cur_tpp>);
 
                 block_size = block_size < max_block_size ? block_size : max_block_size;
                 dim3 grid(nwork / (block_size / tpp) + 1);

--- a/hoomd/md/NeighborListGPUStencil.cu
+++ b/hoomd/md/NeighborListGPUStencil.cu
@@ -353,10 +353,9 @@ inline void stencil_launcher(unsigned int* d_nlist,
         {
         if (!diameter_shift && !filter_body)
             {
-            static unsigned int max_block_size = UINT_MAX;
-            if (max_block_size == UINT_MAX)
-                max_block_size
-                    = get_max_block_size_stencil(gpu_compute_nlist_stencil_kernel<0, cur_tpp>);
+            unsigned int max_block_size;
+            max_block_size
+                = get_max_block_size_stencil(gpu_compute_nlist_stencil_kernel<0, cur_tpp>);
 
             unsigned int run_block_size
                 = (block_size < max_block_size) ? block_size : max_block_size;
@@ -393,10 +392,9 @@ inline void stencil_launcher(unsigned int* d_nlist,
             }
         else if (!diameter_shift && filter_body)
             {
-            static unsigned int max_block_size = UINT_MAX;
-            if (max_block_size == UINT_MAX)
-                max_block_size
-                    = get_max_block_size_stencil(gpu_compute_nlist_stencil_kernel<1, cur_tpp>);
+            unsigned int max_block_size;
+            max_block_size
+                = get_max_block_size_stencil(gpu_compute_nlist_stencil_kernel<1, cur_tpp>);
 
             unsigned int run_block_size
                 = (block_size < max_block_size) ? block_size : max_block_size;
@@ -433,10 +431,9 @@ inline void stencil_launcher(unsigned int* d_nlist,
             }
         else if (diameter_shift && !filter_body)
             {
-            static unsigned int max_block_size = UINT_MAX;
-            if (max_block_size == UINT_MAX)
-                max_block_size
-                    = get_max_block_size_stencil(gpu_compute_nlist_stencil_kernel<2, cur_tpp>);
+            unsigned int max_block_size;
+            max_block_size
+                = get_max_block_size_stencil(gpu_compute_nlist_stencil_kernel<2, cur_tpp>);
 
             unsigned int run_block_size
                 = (block_size < max_block_size) ? block_size : max_block_size;
@@ -473,10 +470,9 @@ inline void stencil_launcher(unsigned int* d_nlist,
             }
         else if (diameter_shift && filter_body)
             {
-            static unsigned int max_block_size = UINT_MAX;
-            if (max_block_size == UINT_MAX)
-                max_block_size
-                    = get_max_block_size_stencil(gpu_compute_nlist_stencil_kernel<3, cur_tpp>);
+            unsigned int max_block_size;
+            max_block_size
+                = get_max_block_size_stencil(gpu_compute_nlist_stencil_kernel<3, cur_tpp>);
 
             unsigned int run_block_size
                 = (block_size < max_block_size) ? block_size : max_block_size;

--- a/hoomd/md/NeighborListGPUTree.cu
+++ b/hoomd/md/NeighborListGPUTree.cu
@@ -317,8 +317,7 @@ hipError_t gpu_nlist_copy_primitives(unsigned int* d_traverse_order,
     {
     unsigned int max_block_size;
     hipFuncAttributes attr;
-    hipFuncGetAttributes(&attr,
-                            reinterpret_cast<const void*>(gpu_nlist_copy_primitives_kernel));
+    hipFuncGetAttributes(&attr, reinterpret_cast<const void*>(gpu_nlist_copy_primitives_kernel));
     max_block_size = attr.maxThreadsPerBlock;
 
     int run_block_size = min(block_size, max_block_size);

--- a/hoomd/md/NeighborListGPUTree.cu
+++ b/hoomd/md/NeighborListGPUTree.cu
@@ -118,13 +118,10 @@ hipError_t gpu_nlist_mark_types(unsigned int* d_types,
                                 const Scalar3 ghost_width,
                                 const unsigned int block_size)
     {
-    static unsigned int max_block_size = UINT_MAX;
-    if (max_block_size == UINT_MAX)
-        {
-        hipFuncAttributes attr;
-        hipFuncGetAttributes(&attr, reinterpret_cast<const void*>(gpu_nlist_mark_types_kernel));
-        max_block_size = attr.maxThreadsPerBlock;
-        }
+    unsigned int max_block_size;
+    hipFuncAttributes attr;
+    hipFuncGetAttributes(&attr, reinterpret_cast<const void*>(gpu_nlist_mark_types_kernel));
+    max_block_size = attr.maxThreadsPerBlock;
 
     const unsigned int run_block_size = min(block_size, max_block_size);
     const unsigned int num_blocks = ((N + nghosts) + run_block_size - 1) / run_block_size;
@@ -260,13 +257,10 @@ hipError_t gpu_nlist_count_types(unsigned int* d_first,
     thrust::fill(thrust::device, d_first, d_first + ntypes, NeighborListTypeSentinel);
     hipMemset(d_last, 0, sizeof(unsigned int) * ntypes);
 
-    static unsigned int max_block_size = UINT_MAX;
-    if (max_block_size == UINT_MAX)
-        {
-        hipFuncAttributes attr;
-        hipFuncGetAttributes(&attr, reinterpret_cast<const void*>(gpu_nlist_count_types_kernel));
-        max_block_size = attr.maxThreadsPerBlock;
-        }
+    unsigned int max_block_size;
+    hipFuncAttributes attr;
+    hipFuncGetAttributes(&attr, reinterpret_cast<const void*>(gpu_nlist_count_types_kernel));
+    max_block_size = attr.maxThreadsPerBlock;
 
     int run_block_size = min(block_size, max_block_size);
     hipLaunchKernelGGL(gpu_nlist_count_types_kernel,
@@ -321,14 +315,11 @@ hipError_t gpu_nlist_copy_primitives(unsigned int* d_traverse_order,
                                      const unsigned int N,
                                      const unsigned int block_size)
     {
-    static unsigned int max_block_size = UINT_MAX;
-    if (max_block_size == UINT_MAX)
-        {
-        hipFuncAttributes attr;
-        hipFuncGetAttributes(&attr,
-                             reinterpret_cast<const void*>(gpu_nlist_copy_primitives_kernel));
-        max_block_size = attr.maxThreadsPerBlock;
-        }
+    unsigned int max_block_size;
+    hipFuncAttributes attr;
+    hipFuncGetAttributes(&attr,
+                            reinterpret_cast<const void*>(gpu_nlist_copy_primitives_kernel));
+    max_block_size = attr.maxThreadsPerBlock;
 
     int run_block_size = min(block_size, max_block_size);
     hipLaunchKernelGGL(gpu_nlist_copy_primitives_kernel,

--- a/hoomd/md/OPLSDihedralForceGPU.cu
+++ b/hoomd/md/OPLSDihedralForceGPU.cu
@@ -330,16 +330,13 @@ hipError_t gpu_compute_opls_dihedral_forces(Scalar4* d_force,
     {
     assert(d_params);
 
-    static unsigned int max_block_size = UINT_MAX;
-    if (max_block_size == UINT_MAX)
-        {
-        hipFuncAttributes attr;
-        hipFuncGetAttributes(&attr, (const void*)gpu_compute_opls_dihedral_forces_kernel);
-        max_block_size = attr.maxThreadsPerBlock;
-        if (max_block_size % warp_size)
-            // handle non-sensical return values from hipFuncGetAttributes
-            max_block_size = (max_block_size / warp_size - 1) * warp_size;
-        }
+    unsigned int max_block_size;
+    hipFuncAttributes attr;
+    hipFuncGetAttributes(&attr, (const void*)gpu_compute_opls_dihedral_forces_kernel);
+    max_block_size = attr.maxThreadsPerBlock;
+    if (max_block_size % warp_size)
+        // handle non-sensical return values from hipFuncGetAttributes
+        max_block_size = (max_block_size / warp_size - 1) * warp_size;
 
     unsigned int run_block_size = min(block_size, max_block_size);
 

--- a/hoomd/md/PPPMForceComputeGPU.cu
+++ b/hoomd/md/PPPMForceComputeGPU.cu
@@ -329,13 +329,10 @@ void gpu_assign_particles(const uint3 mesh_dim,
     hipMemsetAsync(d_mesh, 0, sizeof(hipfftComplex) * grid_dim.x * grid_dim.y * grid_dim.z);
     Scalar V_cell = box.getVolume() / (Scalar)(mesh_dim.x * mesh_dim.y * mesh_dim.z);
 
-    static unsigned int max_block_size = UINT_MAX;
-    static hipFuncAttributes attr;
-    if (max_block_size == UINT_MAX)
-        {
-        hipFuncGetAttributes(&attr, (const void*)gpu_assign_particles_kernel);
-        max_block_size = attr.maxThreadsPerBlock;
-        }
+    unsigned int max_block_size;
+    hipFuncAttributes attr;
+    hipFuncGetAttributes(&attr, (const void*)gpu_assign_particles_kernel);
+    max_block_size = attr.maxThreadsPerBlock;
 
     unsigned int run_block_size = min(max_block_size, block_size);
 
@@ -523,13 +520,10 @@ void gpu_update_meshes(const unsigned int n_wave_vectors,
                        unsigned int block_size)
 
     {
-    static unsigned int max_block_size = UINT_MAX;
-    if (max_block_size == UINT_MAX)
-        {
-        hipFuncAttributes attr;
-        hipFuncGetAttributes(&attr, (const void*)gpu_update_meshes_kernel);
-        max_block_size = attr.maxThreadsPerBlock;
-        }
+    unsigned int max_block_size;
+    hipFuncAttributes attr;
+    hipFuncGetAttributes(&attr, (const void*)gpu_update_meshes_kernel);
+    max_block_size = attr.maxThreadsPerBlock;
 
     unsigned int run_block_size = min(max_block_size, block_size);
     dim3 grid(n_wave_vectors / run_block_size + 1, 1, 1);
@@ -710,13 +704,10 @@ void gpu_compute_forces(const unsigned int N,
                         bool local_fft,
                         unsigned int inv_mesh_elements)
     {
-    static unsigned int max_block_size = UINT_MAX;
-    if (max_block_size == UINT_MAX)
-        {
-        hipFuncAttributes attr;
-        hipFuncGetAttributes(&attr, (const void*)gpu_compute_forces_kernel);
-        max_block_size = attr.maxThreadsPerBlock;
-        }
+    unsigned int max_block_size;
+    hipFuncAttributes attr;
+    hipFuncGetAttributes(&attr, (const void*)gpu_compute_forces_kernel);
+    max_block_size = attr.maxThreadsPerBlock;
 
     unsigned int run_block_size = min(max_block_size, block_size);
 
@@ -1260,13 +1251,10 @@ void gpu_compute_influence_function(const uint3 mesh_dim,
 
     if (local_fft)
         {
-        static unsigned int max_block_size = UINT_MAX;
-        if (max_block_size == UINT_MAX)
-            {
-            hipFuncAttributes attr;
-            hipFuncGetAttributes(&attr, (const void*)gpu_compute_influence_function_kernel<true>);
-            max_block_size = attr.maxThreadsPerBlock;
-            }
+        unsigned int max_block_size;
+        hipFuncAttributes attr;
+        hipFuncGetAttributes(&attr, (const void*)gpu_compute_influence_function_kernel<true>);
+        max_block_size = attr.maxThreadsPerBlock;
 
         unsigned int run_block_size = min(max_block_size, block_size);
 
@@ -1302,13 +1290,10 @@ void gpu_compute_influence_function(const uint3 mesh_dim,
 #ifdef ENABLE_MPI
     else
         {
-        static unsigned int max_block_size = UINT_MAX;
-        if (max_block_size == UINT_MAX)
-            {
-            hipFuncAttributes attr;
-            hipFuncGetAttributes(&attr, (const void*)gpu_compute_influence_function_kernel<false>);
-            max_block_size = attr.maxThreadsPerBlock;
-            }
+        unsigned int max_block_size;
+        hipFuncAttributes attr;
+        hipFuncGetAttributes(&attr, (const void*)gpu_compute_influence_function_kernel<false>);
+        max_block_size = attr.maxThreadsPerBlock;
 
         unsigned int run_block_size = min(max_block_size, block_size);
 

--- a/hoomd/md/PotentialBondGPU.cuh
+++ b/hoomd/md/PotentialBondGPU.cuh
@@ -251,9 +251,8 @@ hipError_t gpu_compute_bond_forces(const bond_args_t& bond_args,
 
     unsigned int max_block_size;
     hipFuncAttributes attr;
-    hipFuncGetAttributes(
-        &attr,
-        reinterpret_cast<const void*>(&gpu_compute_bond_forces_kernel<evaluator>));
+    hipFuncGetAttributes(&attr,
+                         reinterpret_cast<const void*>(&gpu_compute_bond_forces_kernel<evaluator>));
     max_block_size = attr.maxThreadsPerBlock;
 
     unsigned int run_block_size = min(bond_args.block_size, max_block_size);

--- a/hoomd/md/PotentialBondGPU.cuh
+++ b/hoomd/md/PotentialBondGPU.cuh
@@ -249,15 +249,12 @@ hipError_t gpu_compute_bond_forces(const bond_args_t& bond_args,
     // check that block_size is valid
     assert(bond_args.block_size != 0);
 
-    static unsigned int max_block_size = UINT_MAX;
-    if (max_block_size == UINT_MAX)
-        {
-        hipFuncAttributes attr;
-        hipFuncGetAttributes(
-            &attr,
-            reinterpret_cast<const void*>(&gpu_compute_bond_forces_kernel<evaluator>));
-        max_block_size = attr.maxThreadsPerBlock;
-        }
+    unsigned int max_block_size;
+    hipFuncAttributes attr;
+    hipFuncGetAttributes(
+        &attr,
+        reinterpret_cast<const void*>(&gpu_compute_bond_forces_kernel<evaluator>));
+    max_block_size = attr.maxThreadsPerBlock;
 
     unsigned int run_block_size = min(bond_args.block_size, max_block_size);
 

--- a/hoomd/md/PotentialExternalGPU.cuh
+++ b/hoomd/md/PotentialExternalGPU.cuh
@@ -161,15 +161,12 @@ hipError_t gpu_cpef(const external_potential_args_t& external_potential_args,
                     const typename evaluator::param_type* d_params,
                     const typename evaluator::field_type* d_field)
     {
-    static unsigned int max_block_size = UINT_MAX;
-    if (max_block_size == UINT_MAX)
-        {
-        hipFuncAttributes attr;
-        hipFuncGetAttributes(
-            &attr,
-            reinterpret_cast<const void*>(&gpu_compute_external_forces_kernel<evaluator>));
-        max_block_size = attr.maxThreadsPerBlock;
-        }
+    unsigned int max_block_size;
+    hipFuncAttributes attr;
+    hipFuncGetAttributes(
+        &attr,
+        reinterpret_cast<const void*>(&gpu_compute_external_forces_kernel<evaluator>));
+    max_block_size = attr.maxThreadsPerBlock;
 
     unsigned int run_block_size = min(external_potential_args.block_size, max_block_size);
 

--- a/hoomd/md/PotentialPairDPDThermoGPU.cuh
+++ b/hoomd/md/PotentialPairDPDThermoGPU.cuh
@@ -373,12 +373,11 @@ struct DPDForceComputeKernel
                                         * typpair_idx.getNumElements();
 
             unsigned int max_block_size;
-            max_block_size
-                = dpd_get_max_block_size(gpu_compute_dpd_forces_kernel<evaluator,
-                                                                        shift_mode,
-                                                                        compute_virial,
-                                                                        use_gmem_nlist,
-                                                                        tpp>);
+            max_block_size = dpd_get_max_block_size(gpu_compute_dpd_forces_kernel<evaluator,
+                                                                                  shift_mode,
+                                                                                  compute_virial,
+                                                                                  use_gmem_nlist,
+                                                                                  tpp>);
 
             block_size = block_size < max_block_size ? block_size : max_block_size;
             dim3 grid(args.N / (block_size / tpp) + 1, 1, 1);

--- a/hoomd/md/PotentialPairDPDThermoGPU.cuh
+++ b/hoomd/md/PotentialPairDPDThermoGPU.cuh
@@ -372,14 +372,13 @@ struct DPDForceComputeKernel
             const size_t shared_bytes = (sizeof(Scalar) + sizeof(typename evaluator::param_type))
                                         * typpair_idx.getNumElements();
 
-            static unsigned int max_block_size = UINT_MAX;
-            if (max_block_size == UINT_MAX)
-                max_block_size
-                    = dpd_get_max_block_size(gpu_compute_dpd_forces_kernel<evaluator,
-                                                                           shift_mode,
-                                                                           compute_virial,
-                                                                           use_gmem_nlist,
-                                                                           tpp>);
+            unsigned int max_block_size;
+            max_block_size
+                = dpd_get_max_block_size(gpu_compute_dpd_forces_kernel<evaluator,
+                                                                        shift_mode,
+                                                                        compute_virial,
+                                                                        use_gmem_nlist,
+                                                                        tpp>);
 
             block_size = block_size < max_block_size ? block_size : max_block_size;
             dim3 grid(args.N / (block_size / tpp) + 1, 1, 1);

--- a/hoomd/md/PotentialPairGPU.cuh
+++ b/hoomd/md/PotentialPairGPU.cuh
@@ -434,13 +434,12 @@ struct PairForceComputeKernel
                 = (2 * sizeof(Scalar) + sizeof(typename evaluator::param_type))
                   * typpair_idx.getNumElements();
 
-            static unsigned int max_block_size = UINT_MAX;
-            if (max_block_size == UINT_MAX)
-                max_block_size
-                    = get_max_block_size(gpu_compute_pair_forces_shared_kernel<evaluator,
-                                                                               shift_mode,
-                                                                               compute_virial,
-                                                                               tpp>);
+            unsigned int max_block_size;
+            max_block_size
+                = get_max_block_size(gpu_compute_pair_forces_shared_kernel<evaluator,
+                                                                            shift_mode,
+                                                                            compute_virial,
+                                                                            tpp>);
 
             hipFuncAttributes attr;
             hipFuncGetAttributes(

--- a/hoomd/md/PotentialPairGPU.cuh
+++ b/hoomd/md/PotentialPairGPU.cuh
@@ -435,11 +435,8 @@ struct PairForceComputeKernel
                   * typpair_idx.getNumElements();
 
             unsigned int max_block_size;
-            max_block_size
-                = get_max_block_size(gpu_compute_pair_forces_shared_kernel<evaluator,
-                                                                            shift_mode,
-                                                                            compute_virial,
-                                                                            tpp>);
+            max_block_size = get_max_block_size(
+                gpu_compute_pair_forces_shared_kernel<evaluator, shift_mode, compute_virial, tpp>);
 
             hipFuncAttributes attr;
             hipFuncGetAttributes(

--- a/hoomd/md/PotentialTersoffGPU.cuh
+++ b/hoomd/md/PotentialTersoffGPU.cuh
@@ -927,11 +927,10 @@ template<class evaluator, unsigned int compute_virial, int tpp> struct TersoffCo
             {
             unsigned int max_block_size;
             unsigned int kernel_shared_bytes;
-            get_max_block_size(
-                gpu_compute_triplet_forces_kernel<evaluator, compute_virial, tpp>,
-                pair_args,
-                max_block_size,
-                kernel_shared_bytes);
+            get_max_block_size(gpu_compute_triplet_forces_kernel<evaluator, compute_virial, tpp>,
+                               pair_args,
+                               max_block_size,
+                               kernel_shared_bytes);
             int run_block_size = min(pair_args.block_size, max_block_size);
 
             // size shared bytes

--- a/hoomd/md/PotentialTersoffGPU.cuh
+++ b/hoomd/md/PotentialTersoffGPU.cuh
@@ -925,14 +925,13 @@ template<class evaluator, unsigned int compute_virial, int tpp> struct TersoffCo
         {
         if (tpp == pair_args.tpp)
             {
-            static unsigned int max_block_size = UINT_MAX;
-            static unsigned int kernel_shared_bytes = 0;
-            if (max_block_size == UINT_MAX)
-                get_max_block_size(
-                    gpu_compute_triplet_forces_kernel<evaluator, compute_virial, tpp>,
-                    pair_args,
-                    max_block_size,
-                    kernel_shared_bytes);
+            unsigned int max_block_size;
+            unsigned int kernel_shared_bytes;
+            get_max_block_size(
+                gpu_compute_triplet_forces_kernel<evaluator, compute_virial, tpp>,
+                pair_args,
+                max_block_size,
+                kernel_shared_bytes);
             int run_block_size = min(pair_args.block_size, max_block_size);
 
             // size shared bytes

--- a/hoomd/md/TableAngleForceGPU.cu
+++ b/hoomd/md/TableAngleForceGPU.cu
@@ -256,13 +256,10 @@ hipError_t gpu_compute_table_angle_forces(Scalar4* d_force,
     if (N == 0)
         return hipSuccess;
 
-    static unsigned int max_block_size = UINT_MAX;
-    if (max_block_size == UINT_MAX)
-        {
-        hipFuncAttributes attr;
-        hipFuncGetAttributes(&attr, (const void*)gpu_compute_table_angle_forces_kernel);
-        max_block_size = attr.maxThreadsPerBlock;
-        }
+    unsigned int max_block_size;
+    hipFuncAttributes attr;
+    hipFuncGetAttributes(&attr, (const void*)gpu_compute_table_angle_forces_kernel);
+    max_block_size = attr.maxThreadsPerBlock;
 
     unsigned int run_block_size = min(block_size, max_block_size);
 

--- a/hoomd/md/TableDihedralForceGPU.cu
+++ b/hoomd/md/TableDihedralForceGPU.cu
@@ -329,13 +329,10 @@ hipError_t gpu_compute_table_dihedral_forces(Scalar4* d_force,
     if (N == 0)
         return hipSuccess;
 
-    static unsigned int max_block_size = UINT_MAX;
-    if (max_block_size == UINT_MAX)
-        {
-        hipFuncAttributes attr;
-        hipFuncGetAttributes(&attr, (const void*)gpu_compute_table_dihedral_forces_kernel);
-        max_block_size = attr.maxThreadsPerBlock;
-        }
+    unsigned int max_block_size;
+    hipFuncAttributes attr;
+    hipFuncGetAttributes(&attr, (const void*)gpu_compute_table_dihedral_forces_kernel);
+    max_block_size = attr.maxThreadsPerBlock;
 
     unsigned int run_block_size = min(block_size, max_block_size);
 

--- a/hoomd/md/TwoStepNPTMTKGPU.cu
+++ b/hoomd/md/TwoStepNPTMTKGPU.cu
@@ -120,13 +120,10 @@ hipError_t gpu_npt_mtk_step_one(Scalar4* d_pos,
                                 bool rescale_all,
                                 const unsigned int block_size)
     {
-    static unsigned int max_block_size = UINT_MAX;
-    if (max_block_size == UINT_MAX)
-        {
-        hipFuncAttributes attr;
-        hipFuncGetAttributes(&attr, (const void*)gpu_npt_mtk_step_one_kernel);
-        max_block_size = attr.maxThreadsPerBlock;
-        }
+    unsigned int max_block_size;
+    hipFuncAttributes attr;
+    hipFuncGetAttributes(&attr, (const void*)gpu_npt_mtk_step_one_kernel);
+    max_block_size = attr.maxThreadsPerBlock;
 
     unsigned int run_block_size = min(block_size, max_block_size);
 
@@ -229,13 +226,10 @@ hipError_t gpu_npt_mtk_wrap(const GPUPartition& gpu_partition,
                             const BoxDim& box,
                             const unsigned int block_size)
     {
-    static unsigned int max_block_size = UINT_MAX;
-    if (max_block_size == UINT_MAX)
-        {
-        hipFuncAttributes attr;
-        hipFuncGetAttributes(&attr, (const void*)gpu_npt_mtk_wrap_kernel);
-        max_block_size = attr.maxThreadsPerBlock;
-        }
+    unsigned int max_block_size;
+    hipFuncAttributes attr;
+    hipFuncGetAttributes(&attr, (const void*)gpu_npt_mtk_wrap_kernel);
+    max_block_size = attr.maxThreadsPerBlock;
 
     unsigned int run_block_size = min(block_size, max_block_size);
 
@@ -341,13 +335,10 @@ hipError_t gpu_npt_mtk_step_two(Scalar4* d_vel,
                                 Scalar exp_thermo_fac,
                                 const unsigned int block_size)
     {
-    static unsigned int max_block_size = UINT_MAX;
-    if (max_block_size == UINT_MAX)
-        {
-        hipFuncAttributes attr;
-        hipFuncGetAttributes(&attr, (const void*)gpu_npt_mtk_step_two_kernel);
-        max_block_size = attr.maxThreadsPerBlock;
-        }
+    unsigned int max_block_size;
+    hipFuncAttributes attr;
+    hipFuncGetAttributes(&attr, (const void*)gpu_npt_mtk_step_two_kernel);
+    max_block_size = attr.maxThreadsPerBlock;
 
     unsigned int run_block_size = min(block_size, max_block_size);
 
@@ -424,13 +415,10 @@ void gpu_npt_mtk_rescale(const GPUPartition& gpu_partition,
                          Scalar mat_exp_r_zz,
                          const unsigned int block_size)
     {
-    static unsigned int max_block_size = UINT_MAX;
-    if (max_block_size == UINT_MAX)
-        {
-        hipFuncAttributes attr;
-        hipFuncGetAttributes(&attr, (const void*)gpu_npt_mtk_rescale_kernel);
-        max_block_size = attr.maxThreadsPerBlock;
-        }
+    unsigned int max_block_size;
+    hipFuncAttributes attr;
+    hipFuncGetAttributes(&attr, (const void*)gpu_npt_mtk_rescale_kernel);
+    max_block_size = attr.maxThreadsPerBlock;
 
     unsigned int run_block_size = min(block_size, max_block_size);
 

--- a/hoomd/md/TwoStepNVEGPU.cu
+++ b/hoomd/md/TwoStepNVEGPU.cu
@@ -132,13 +132,10 @@ hipError_t gpu_nve_step_one(Scalar4* d_pos,
                             bool zero_force,
                             unsigned int block_size)
     {
-    static unsigned int max_block_size = UINT_MAX;
-    if (max_block_size == UINT_MAX)
-        {
-        hipFuncAttributes attr;
-        hipFuncGetAttributes(&attr, (const void*)gpu_nve_step_one_kernel);
-        max_block_size = attr.maxThreadsPerBlock;
-        }
+    unsigned int max_block_size;
+    hipFuncAttributes attr;
+    hipFuncGetAttributes(&attr, (const void*)gpu_nve_step_one_kernel);
+    max_block_size = attr.maxThreadsPerBlock;
 
     unsigned int run_block_size = min(block_size, max_block_size);
 
@@ -323,13 +320,10 @@ hipError_t gpu_nve_angular_step_one(Scalar4* d_orientation,
                                     Scalar scale,
                                     const unsigned int block_size)
     {
-    static unsigned int max_block_size = UINT_MAX;
-    if (max_block_size == UINT_MAX)
-        {
-        hipFuncAttributes attr;
-        hipFuncGetAttributes(&attr, (const void*)gpu_nve_angular_step_one_kernel);
-        max_block_size = attr.maxThreadsPerBlock;
-        }
+    unsigned int max_block_size;
+    hipFuncAttributes attr;
+    hipFuncGetAttributes(&attr, (const void*)gpu_nve_angular_step_one_kernel);
+    max_block_size = attr.maxThreadsPerBlock;
 
     unsigned int run_block_size = min(block_size, max_block_size);
 
@@ -465,13 +459,10 @@ hipError_t gpu_nve_step_two(Scalar4* d_vel,
                             bool zero_force,
                             unsigned int block_size)
     {
-    static unsigned int max_block_size = UINT_MAX;
-    if (max_block_size == UINT_MAX)
-        {
-        hipFuncAttributes attr;
-        hipFuncGetAttributes(&attr, (const void*)gpu_nve_step_two_kernel);
-        max_block_size = attr.maxThreadsPerBlock;
-        }
+    unsigned int max_block_size;
+    hipFuncAttributes attr;
+    hipFuncGetAttributes(&attr, (const void*)gpu_nve_step_two_kernel);
+    max_block_size = attr.maxThreadsPerBlock;
 
     unsigned int run_block_size = min(block_size, max_block_size);
 
@@ -584,13 +575,10 @@ hipError_t gpu_nve_angular_step_two(const Scalar4* d_orientation,
                                     Scalar scale,
                                     const unsigned int block_size)
     {
-    static unsigned int max_block_size = UINT_MAX;
-    if (max_block_size == UINT_MAX)
-        {
-        hipFuncAttributes attr;
-        hipFuncGetAttributes(&attr, (const void*)gpu_nve_angular_step_two_kernel);
-        max_block_size = attr.maxThreadsPerBlock;
-        }
+    unsigned int max_block_size;
+    hipFuncAttributes attr;
+    hipFuncGetAttributes(&attr, (const void*)gpu_nve_angular_step_two_kernel);
+    max_block_size = attr.maxThreadsPerBlock;
 
     unsigned int run_block_size = min(block_size, max_block_size);
 

--- a/hoomd/md/TwoStepNVTMTKGPU.cu
+++ b/hoomd/md/TwoStepNVTMTKGPU.cu
@@ -99,13 +99,10 @@ hipError_t gpu_nvt_mtk_step_one(Scalar4* d_pos,
                                 Scalar deltaT,
                                 const GPUPartition& gpu_partition)
     {
-    static unsigned int max_block_size = UINT_MAX;
-    if (max_block_size == UINT_MAX)
-        {
-        hipFuncAttributes attr;
-        hipFuncGetAttributes(&attr, (const void*)gpu_nvt_mtk_step_one_kernel);
-        max_block_size = attr.maxThreadsPerBlock;
-        }
+    unsigned int max_block_size;
+    hipFuncAttributes attr;
+    hipFuncGetAttributes(&attr, (const void*)gpu_nvt_mtk_step_one_kernel);
+    max_block_size = attr.maxThreadsPerBlock;
 
     unsigned int run_block_size = min(block_size, max_block_size);
 
@@ -209,13 +206,10 @@ hipError_t gpu_nvt_mtk_step_two(Scalar4* d_vel,
                                 Scalar exp_v_fac_thermo,
                                 const GPUPartition& gpu_partition)
     {
-    static unsigned int max_block_size = UINT_MAX;
-    if (max_block_size == UINT_MAX)
-        {
-        hipFuncAttributes attr;
-        hipFuncGetAttributes(&attr, (const void*)gpu_nvt_mtk_step_two_kernel);
-        max_block_size = attr.maxThreadsPerBlock;
-        }
+    unsigned int max_block_size;
+    hipFuncAttributes attr;
+    hipFuncGetAttributes(&attr, (const void*)gpu_nvt_mtk_step_two_kernel);
+    max_block_size = attr.maxThreadsPerBlock;
 
     unsigned int run_block_size = min(block_size, max_block_size);
 

--- a/hoomd/md/TwoStepRATTLENVEGPU.cu
+++ b/hoomd/md/TwoStepRATTLENVEGPU.cu
@@ -126,13 +126,10 @@ hipError_t gpu_rattle_nve_step_one(Scalar4* d_pos,
                                    Scalar limit_val,
                                    unsigned int block_size)
     {
-    static unsigned int max_block_size = UINT_MAX;
-    if (max_block_size == UINT_MAX)
-        {
-        cudaFuncAttributes attr;
-        cudaFuncGetAttributes(&attr, (const void*)gpu_rattle_nve_step_one_kernel);
-        max_block_size = attr.maxThreadsPerBlock;
-        }
+    unsigned int max_block_size;
+    cudaFuncAttributes attr;
+    cudaFuncGetAttributes(&attr, (const void*)gpu_rattle_nve_step_one_kernel);
+    max_block_size = attr.maxThreadsPerBlock;
 
     unsigned int run_block_size = min(block_size, max_block_size);
 
@@ -317,13 +314,10 @@ hipError_t gpu_rattle_nve_angular_step_one(Scalar4* d_orientation,
                                            Scalar scale,
                                            const unsigned int block_size)
     {
-    static unsigned int max_block_size = UINT_MAX;
-    if (max_block_size == UINT_MAX)
-        {
-        hipFuncAttributes attr;
-        hipFuncGetAttributes(&attr, (const void*)gpu_rattle_nve_angular_step_one_kernel);
-        max_block_size = attr.maxThreadsPerBlock;
-        }
+    unsigned int max_block_size;
+    hipFuncAttributes attr;
+    hipFuncGetAttributes(&attr, (const void*)gpu_rattle_nve_angular_step_one_kernel);
+    max_block_size = attr.maxThreadsPerBlock;
 
     unsigned int run_block_size = min(block_size, max_block_size);
 
@@ -437,13 +431,10 @@ hipError_t gpu_rattle_nve_angular_step_two(const Scalar4* d_orientation,
                                            Scalar scale,
                                            const unsigned int block_size)
     {
-    static unsigned int max_block_size = UINT_MAX;
-    if (max_block_size == UINT_MAX)
-        {
-        hipFuncAttributes attr;
-        hipFuncGetAttributes(&attr, (const void*)gpu_rattle_nve_angular_step_two_kernel);
-        max_block_size = attr.maxThreadsPerBlock;
-        }
+    unsigned int max_block_size;
+    hipFuncAttributes attr;
+    hipFuncGetAttributes(&attr, (const void*)gpu_rattle_nve_angular_step_two_kernel);
+    max_block_size = attr.maxThreadsPerBlock;
 
     unsigned int run_block_size = min(block_size, max_block_size);
 

--- a/hoomd/md/TwoStepRATTLENVEGPU.cuh
+++ b/hoomd/md/TwoStepRATTLENVEGPU.cuh
@@ -249,13 +249,10 @@ hipError_t gpu_rattle_nve_step_two(Scalar4* d_pos,
                                    bool zero_force,
                                    unsigned int block_size)
     {
-    static unsigned int max_block_size = UINT_MAX;
-    if (max_block_size == UINT_MAX)
-        {
-        hipFuncAttributes attr;
-        hipFuncGetAttributes(&attr, (const void*)gpu_rattle_nve_step_two_kernel<Manifold>);
-        max_block_size = attr.maxThreadsPerBlock;
-        }
+    unsigned int max_block_size;
+    hipFuncAttributes attr;
+    hipFuncGetAttributes(&attr, (const void*)gpu_rattle_nve_step_two_kernel<Manifold>);
+    max_block_size = attr.maxThreadsPerBlock;
 
     unsigned int run_block_size = min(block_size, max_block_size);
 
@@ -419,13 +416,10 @@ hipError_t gpu_include_rattle_force_nve(const Scalar4* d_pos,
                                         bool zero_force,
                                         unsigned int block_size)
     {
-    static unsigned int max_block_size = UINT_MAX;
-    if (max_block_size == UINT_MAX)
-        {
-        hipFuncAttributes attr;
-        hipFuncGetAttributes(&attr, (const void*)gpu_include_rattle_force_nve_kernel<Manifold>);
-        max_block_size = attr.maxThreadsPerBlock;
-        }
+    unsigned int max_block_size;
+    hipFuncAttributes attr;
+    hipFuncGetAttributes(&attr, (const void*)gpu_include_rattle_force_nve_kernel<Manifold>);
+    max_block_size = attr.maxThreadsPerBlock;
 
     unsigned int run_block_size = min(block_size, max_block_size);
 

--- a/hoomd/metal/EAMForceGPU.cu
+++ b/hoomd/metal/EAMForceGPU.cu
@@ -324,8 +324,8 @@ hipError_t gpu_compute_eam_tex_inter_forces(Scalar4* d_force,
                                             const Scalar4* d_drphi,
                                             const unsigned int block_size)
     {
-    static unsigned int max_block_size_1 = UINT_MAX;
-    static unsigned int max_block_size_2 = UINT_MAX;
+    unsigned int max_block_size_1;
+    unsigned int max_block_size_2;
 
     hipFuncAttributes attr1;
     hipFuncGetAttributes(&attr1, reinterpret_cast<const void*>(gpu_kernel_1));

--- a/hoomd/mpcd/ATCollisionMethodGPU.cu
+++ b/hoomd/mpcd/ATCollisionMethodGPU.cu
@@ -139,13 +139,10 @@ cudaError_t at_draw_velocity(Scalar4* d_alt_vel,
                              const unsigned int N_tot,
                              const unsigned int block_size)
     {
-    static unsigned int max_block_size = UINT_MAX;
-    if (max_block_size == UINT_MAX)
-        {
-        cudaFuncAttributes attr;
-        cudaFuncGetAttributes(&attr, (const void*)mpcd::gpu::kernel::at_draw_velocity);
-        max_block_size = attr.maxThreadsPerBlock;
-        }
+    unsigned int max_block_size;
+    cudaFuncAttributes attr;
+    cudaFuncGetAttributes(&attr, (const void*)mpcd::gpu::kernel::at_draw_velocity);
+    max_block_size = attr.maxThreadsPerBlock;
 
     unsigned int run_block_size = min(block_size, max_block_size);
 
@@ -178,13 +175,10 @@ cudaError_t at_apply_velocity(Scalar4* d_vel,
                               const unsigned int N_tot,
                               const unsigned int block_size)
     {
-    static unsigned int max_block_size = UINT_MAX;
-    if (max_block_size == UINT_MAX)
-        {
-        cudaFuncAttributes attr;
-        cudaFuncGetAttributes(&attr, (const void*)mpcd::gpu::kernel::at_apply_velocity);
-        max_block_size = attr.maxThreadsPerBlock;
-        }
+    unsigned int max_block_size;
+    cudaFuncAttributes attr;
+    cudaFuncGetAttributes(&attr, (const void*)mpcd::gpu::kernel::at_apply_velocity);
+    max_block_size = attr.maxThreadsPerBlock;
 
     unsigned int run_block_size = min(block_size, max_block_size);
 

--- a/hoomd/mpcd/BounceBackNVEGPU.cu
+++ b/hoomd/mpcd/BounceBackNVEGPU.cu
@@ -91,13 +91,10 @@ cudaError_t nve_bounce_step_two(Scalar4* d_vel,
                                 const unsigned int N,
                                 const unsigned int block_size)
     {
-    static unsigned int max_block_size = UINT_MAX;
-    if (max_block_size == UINT_MAX)
-        {
-        cudaFuncAttributes attr;
-        cudaFuncGetAttributes(&attr, (const void*)kernel::nve_bounce_step_two);
-        max_block_size = attr.maxThreadsPerBlock;
-        }
+    unsigned int max_block_size;
+    cudaFuncAttributes attr;
+    cudaFuncGetAttributes(&attr, (const void*)kernel::nve_bounce_step_two);
+    max_block_size = attr.maxThreadsPerBlock;
 
     unsigned int run_block_size = min(block_size, max_block_size);
     dim3 grid(N / run_block_size + 1);

--- a/hoomd/mpcd/BounceBackNVEGPU.cuh
+++ b/hoomd/mpcd/BounceBackNVEGPU.cuh
@@ -150,13 +150,10 @@ __global__ void nve_bounce_step_one(Scalar4* d_pos,
 template<class Geometry>
 cudaError_t nve_bounce_step_one(const bounce_args_t& args, const Geometry& geom)
     {
-    static unsigned int max_block_size = UINT_MAX;
-    if (max_block_size == UINT_MAX)
-        {
-        cudaFuncAttributes attr;
-        cudaFuncGetAttributes(&attr, (const void*)kernel::nve_bounce_step_one<Geometry>);
-        max_block_size = attr.maxThreadsPerBlock;
-        }
+    unsigned int max_block_size;
+    cudaFuncAttributes attr;
+    cudaFuncGetAttributes(&attr, (const void*)kernel::nve_bounce_step_one<Geometry>);
+    max_block_size = attr.maxThreadsPerBlock;
 
     unsigned int run_block_size = min(args.block_size, max_block_size);
     dim3 grid(args.N / run_block_size + 1);

--- a/hoomd/mpcd/CellCommunicator.cuh
+++ b/hoomd/mpcd/CellCommunicator.cuh
@@ -153,13 +153,11 @@ cudaError_t pack_cell_buffer(typename PackOpT::element* d_send_buf,
                              unsigned int block_size)
     {
     // determine runtime block size
-    static unsigned int max_block_size = UINT_MAX;
-    if (max_block_size == UINT_MAX)
-        {
-        cudaFuncAttributes attr;
-        cudaFuncGetAttributes(&attr, (const void*)mpcd::gpu::kernel::pack_cell_buffer<T, PackOpT>);
-        max_block_size = attr.maxThreadsPerBlock;
-        }
+    unsigned int max_block_size;
+    cudaFuncAttributes attr;
+    cudaFuncGetAttributes(&attr, (const void*)mpcd::gpu::kernel::pack_cell_buffer<T, PackOpT>);
+    max_block_size = attr.maxThreadsPerBlock;
+
     const unsigned int run_block_size = min(block_size, max_block_size);
 
     dim3 grid(num_send / run_block_size + 1);
@@ -201,14 +199,12 @@ cudaError_t unpack_cell_buffer(T* d_props,
                                const unsigned int block_size)
     {
     // determine runtime block size
-    static unsigned int max_block_size = UINT_MAX;
-    if (max_block_size == UINT_MAX)
-        {
-        cudaFuncAttributes attr;
-        cudaFuncGetAttributes(&attr,
-                              (const void*)mpcd::gpu::kernel::unpack_cell_buffer<T, PackOpT>);
-        max_block_size = attr.maxThreadsPerBlock;
-        }
+    unsigned int max_block_size;
+    cudaFuncAttributes attr;
+    cudaFuncGetAttributes(&attr,
+                            (const void*)mpcd::gpu::kernel::unpack_cell_buffer<T, PackOpT>);
+    max_block_size = attr.maxThreadsPerBlock;
+
     const unsigned int run_block_size = min(block_size, max_block_size);
 
     dim3 grid(num_cells / run_block_size + 1);

--- a/hoomd/mpcd/CellCommunicator.cuh
+++ b/hoomd/mpcd/CellCommunicator.cuh
@@ -201,8 +201,7 @@ cudaError_t unpack_cell_buffer(T* d_props,
     // determine runtime block size
     unsigned int max_block_size;
     cudaFuncAttributes attr;
-    cudaFuncGetAttributes(&attr,
-                            (const void*)mpcd::gpu::kernel::unpack_cell_buffer<T, PackOpT>);
+    cudaFuncGetAttributes(&attr, (const void*)mpcd::gpu::kernel::unpack_cell_buffer<T, PackOpT>);
     max_block_size = attr.maxThreadsPerBlock;
 
     const unsigned int run_block_size = min(block_size, max_block_size);

--- a/hoomd/mpcd/CellListGPU.cu
+++ b/hoomd/mpcd/CellListGPU.cu
@@ -281,13 +281,10 @@ cudaError_t mpcd::gpu::compute_cell_list(unsigned int* d_cell_np,
     if (error != cudaSuccess)
         return error;
 
-    static unsigned int max_block_size = UINT_MAX;
-    if (max_block_size == UINT_MAX)
-        {
-        cudaFuncAttributes attr;
-        cudaFuncGetAttributes(&attr, (const void*)mpcd::gpu::kernel::compute_cell_list);
-        max_block_size = attr.maxThreadsPerBlock;
-        }
+    unsigned int max_block_size;
+    cudaFuncAttributes attr;
+    cudaFuncGetAttributes(&attr, (const void*)mpcd::gpu::kernel::compute_cell_list);
+    max_block_size = attr.maxThreadsPerBlock;
 
     unsigned int run_block_size = min(block_size, max_block_size);
     dim3 grid(N_tot / run_block_size + 1);
@@ -335,13 +332,10 @@ cudaError_t mpcd::gpu::cell_check_migrate_embed(unsigned int* d_migrate_flag,
     // ensure that the flag is always zeroed even if the caller forgets
     cudaMemset(d_migrate_flag, 0, sizeof(unsigned int));
 
-    static unsigned int max_block_size = UINT_MAX;
-    if (max_block_size == UINT_MAX)
-        {
-        cudaFuncAttributes attr;
-        cudaFuncGetAttributes(&attr, (const void*)mpcd::gpu::kernel::cell_check_migrate_embed);
-        max_block_size = attr.maxThreadsPerBlock;
-        }
+    unsigned int max_block_size;
+    cudaFuncAttributes attr;
+    cudaFuncGetAttributes(&attr, (const void*)mpcd::gpu::kernel::cell_check_migrate_embed);
+    max_block_size = attr.maxThreadsPerBlock;
 
     unsigned int run_block_size = min(block_size, max_block_size);
     dim3 grid(N / run_block_size + 1);
@@ -362,13 +356,10 @@ cudaError_t mpcd::gpu::cell_apply_sort(unsigned int* d_cell_list,
                                        const unsigned int N_mpcd,
                                        const unsigned int block_size)
     {
-    static unsigned int max_block_size = UINT_MAX;
-    if (max_block_size == UINT_MAX)
-        {
-        cudaFuncAttributes attr;
-        cudaFuncGetAttributes(&attr, (const void*)mpcd::gpu::kernel::cell_apply_sort);
-        max_block_size = attr.maxThreadsPerBlock;
-        }
+    unsigned int max_block_size;
+    cudaFuncAttributes attr;
+    cudaFuncGetAttributes(&attr, (const void*)mpcd::gpu::kernel::cell_apply_sort);
+    max_block_size = attr.maxThreadsPerBlock;
 
     const unsigned int N_cli = cli.getNumElements();
 

--- a/hoomd/mpcd/CellThermoComputeGPU.cu
+++ b/hoomd/mpcd/CellThermoComputeGPU.cu
@@ -411,9 +411,8 @@ inline void launch_begin_cell_thermo(const mpcd::detail::thermo_args_t& args,
             {
             unsigned int max_block_size_energy;
             cudaFuncAttributes attr;
-            cudaFuncGetAttributes(
-                &attr,
-                (const void*)mpcd::gpu::kernel::begin_cell_thermo<true, cur_tpp>);
+            cudaFuncGetAttributes(&attr,
+                                  (const void*)mpcd::gpu::kernel::begin_cell_thermo<true, cur_tpp>);
             max_block_size_energy = attr.maxThreadsPerBlock;
 
             unsigned int run_block_size = min(block_size, max_block_size_energy);
@@ -583,9 +582,8 @@ inline void launch_inner_cell_thermo(const mpcd::detail::thermo_args_t& args,
             {
             unsigned int max_block_size_energy;
             cudaFuncAttributes attr;
-            cudaFuncGetAttributes(
-                &attr,
-                (const void*)mpcd::gpu::kernel::inner_cell_thermo<true, cur_tpp>);
+            cudaFuncGetAttributes(&attr,
+                                  (const void*)mpcd::gpu::kernel::inner_cell_thermo<true, cur_tpp>);
             max_block_size_energy = attr.maxThreadsPerBlock;
 
             unsigned int run_block_size = min(block_size, max_block_size_energy);
@@ -712,8 +710,7 @@ cudaError_t stage_net_cell_thermo(mpcd::detail::cell_thermo_element* d_tmp_therm
         {
         unsigned int max_block_size_energy;
         cudaFuncAttributes attr;
-        cudaFuncGetAttributes(&attr,
-                                (const void*)mpcd::gpu::kernel::stage_net_cell_thermo<true>);
+        cudaFuncGetAttributes(&attr, (const void*)mpcd::gpu::kernel::stage_net_cell_thermo<true>);
         max_block_size_energy = attr.maxThreadsPerBlock;
 
         unsigned int run_block_size = min(block_size, max_block_size_energy);
@@ -725,8 +722,7 @@ cudaError_t stage_net_cell_thermo(mpcd::detail::cell_thermo_element* d_tmp_therm
         {
         unsigned int max_block_size_noenergy;
         cudaFuncAttributes attr;
-        cudaFuncGetAttributes(&attr,
-                                (const void*)mpcd::gpu::kernel::stage_net_cell_thermo<false>);
+        cudaFuncGetAttributes(&attr, (const void*)mpcd::gpu::kernel::stage_net_cell_thermo<false>);
         max_block_size_noenergy = attr.maxThreadsPerBlock;
 
         unsigned int run_block_size = min(block_size, max_block_size_noenergy);

--- a/hoomd/mpcd/CellThermoComputeGPU.cu
+++ b/hoomd/mpcd/CellThermoComputeGPU.cu
@@ -409,15 +409,12 @@ inline void launch_begin_cell_thermo(const mpcd::detail::thermo_args_t& args,
         {
         if (args.need_energy)
             {
-            static unsigned int max_block_size_energy = UINT_MAX;
-            if (max_block_size_energy == UINT_MAX)
-                {
-                cudaFuncAttributes attr;
-                cudaFuncGetAttributes(
-                    &attr,
-                    (const void*)mpcd::gpu::kernel::begin_cell_thermo<true, cur_tpp>);
-                max_block_size_energy = attr.maxThreadsPerBlock;
-                }
+            unsigned int max_block_size_energy;
+            cudaFuncAttributes attr;
+            cudaFuncGetAttributes(
+                &attr,
+                (const void*)mpcd::gpu::kernel::begin_cell_thermo<true, cur_tpp>);
+            max_block_size_energy = attr.maxThreadsPerBlock;
 
             unsigned int run_block_size = min(block_size, max_block_size_energy);
             dim3 grid(cur_tpp * num_cells / run_block_size + 1);
@@ -437,15 +434,12 @@ inline void launch_begin_cell_thermo(const mpcd::detail::thermo_args_t& args,
             }
         else
             {
-            static unsigned int max_block_size_noenergy = UINT_MAX;
-            if (max_block_size_noenergy == UINT_MAX)
-                {
-                cudaFuncAttributes attr;
-                cudaFuncGetAttributes(
-                    &attr,
-                    (const void*)mpcd::gpu::kernel::begin_cell_thermo<false, cur_tpp>);
-                max_block_size_noenergy = attr.maxThreadsPerBlock;
-                }
+            unsigned int max_block_size_noenergy;
+            cudaFuncAttributes attr;
+            cudaFuncGetAttributes(
+                &attr,
+                (const void*)mpcd::gpu::kernel::begin_cell_thermo<false, cur_tpp>);
+            max_block_size_noenergy = attr.maxThreadsPerBlock;
 
             unsigned int run_block_size = min(block_size, max_block_size_noenergy);
             dim3 grid(cur_tpp * num_cells / run_block_size + 1);
@@ -529,13 +523,10 @@ cudaError_t end_cell_thermo(double4* d_cell_vel,
 
     if (need_energy)
         {
-        static unsigned int max_block_size_energy = UINT_MAX;
-        if (max_block_size_energy == UINT_MAX)
-            {
-            cudaFuncAttributes attr;
-            cudaFuncGetAttributes(&attr, (const void*)mpcd::gpu::kernel::end_cell_thermo<true>);
-            max_block_size_energy = attr.maxThreadsPerBlock;
-            }
+        unsigned int max_block_size_energy;
+        cudaFuncAttributes attr;
+        cudaFuncGetAttributes(&attr, (const void*)mpcd::gpu::kernel::end_cell_thermo<true>);
+        max_block_size_energy = attr.maxThreadsPerBlock;
 
         unsigned int run_block_size = min(block_size, max_block_size_energy);
         dim3 grid(Ncell / run_block_size + 1);
@@ -544,13 +535,10 @@ cudaError_t end_cell_thermo(double4* d_cell_vel,
         }
     else
         {
-        static unsigned int max_block_size_noenergy = UINT_MAX;
-        if (max_block_size_noenergy == UINT_MAX)
-            {
-            cudaFuncAttributes attr;
-            cudaFuncGetAttributes(&attr, (const void*)mpcd::gpu::kernel::end_cell_thermo<true>);
-            max_block_size_noenergy = attr.maxThreadsPerBlock;
-            }
+        unsigned int max_block_size_noenergy;
+        cudaFuncAttributes attr;
+        cudaFuncGetAttributes(&attr, (const void*)mpcd::gpu::kernel::end_cell_thermo<true>);
+        max_block_size_noenergy = attr.maxThreadsPerBlock;
 
         unsigned int run_block_size = min(block_size, max_block_size_noenergy);
         dim3 grid(Ncell / run_block_size + 1);
@@ -593,15 +581,12 @@ inline void launch_inner_cell_thermo(const mpcd::detail::thermo_args_t& args,
         {
         if (args.need_energy)
             {
-            static unsigned int max_block_size_energy = UINT_MAX;
-            if (max_block_size_energy == UINT_MAX)
-                {
-                cudaFuncAttributes attr;
-                cudaFuncGetAttributes(
-                    &attr,
-                    (const void*)mpcd::gpu::kernel::inner_cell_thermo<true, cur_tpp>);
-                max_block_size_energy = attr.maxThreadsPerBlock;
-                }
+            unsigned int max_block_size_energy;
+            cudaFuncAttributes attr;
+            cudaFuncGetAttributes(
+                &attr,
+                (const void*)mpcd::gpu::kernel::inner_cell_thermo<true, cur_tpp>);
+            max_block_size_energy = attr.maxThreadsPerBlock;
 
             unsigned int run_block_size = min(block_size, max_block_size_energy);
             dim3 grid(cur_tpp * ci.getNumElements() / run_block_size + 1);
@@ -623,15 +608,12 @@ inline void launch_inner_cell_thermo(const mpcd::detail::thermo_args_t& args,
             }
         else
             {
-            static unsigned int max_block_size_noenergy = UINT_MAX;
-            if (max_block_size_noenergy == UINT_MAX)
-                {
-                cudaFuncAttributes attr;
-                cudaFuncGetAttributes(
-                    &attr,
-                    (const void*)mpcd::gpu::kernel::inner_cell_thermo<false, cur_tpp>);
-                max_block_size_noenergy = attr.maxThreadsPerBlock;
-                }
+            unsigned int max_block_size_noenergy;
+            cudaFuncAttributes attr;
+            cudaFuncGetAttributes(
+                &attr,
+                (const void*)mpcd::gpu::kernel::inner_cell_thermo<false, cur_tpp>);
+            max_block_size_noenergy = attr.maxThreadsPerBlock;
 
             unsigned int run_block_size = min(block_size, max_block_size_noenergy);
             dim3 grid(cur_tpp * ci.getNumElements() / run_block_size + 1);
@@ -728,14 +710,11 @@ cudaError_t stage_net_cell_thermo(mpcd::detail::cell_thermo_element* d_tmp_therm
     {
     if (need_energy)
         {
-        static unsigned int max_block_size_energy = UINT_MAX;
-        if (max_block_size_energy == UINT_MAX)
-            {
-            cudaFuncAttributes attr;
-            cudaFuncGetAttributes(&attr,
-                                  (const void*)mpcd::gpu::kernel::stage_net_cell_thermo<true>);
-            max_block_size_energy = attr.maxThreadsPerBlock;
-            }
+        unsigned int max_block_size_energy;
+        cudaFuncAttributes attr;
+        cudaFuncGetAttributes(&attr,
+                                (const void*)mpcd::gpu::kernel::stage_net_cell_thermo<true>);
+        max_block_size_energy = attr.maxThreadsPerBlock;
 
         unsigned int run_block_size = min(block_size, max_block_size_energy);
         dim3 grid(tmp_ci.getNumElements() / run_block_size + 1);
@@ -744,14 +723,11 @@ cudaError_t stage_net_cell_thermo(mpcd::detail::cell_thermo_element* d_tmp_therm
         }
     else
         {
-        static unsigned int max_block_size_noenergy = UINT_MAX;
-        if (max_block_size_noenergy == UINT_MAX)
-            {
-            cudaFuncAttributes attr;
-            cudaFuncGetAttributes(&attr,
-                                  (const void*)mpcd::gpu::kernel::stage_net_cell_thermo<false>);
-            max_block_size_noenergy = attr.maxThreadsPerBlock;
-            }
+        unsigned int max_block_size_noenergy;
+        cudaFuncAttributes attr;
+        cudaFuncGetAttributes(&attr,
+                                (const void*)mpcd::gpu::kernel::stage_net_cell_thermo<false>);
+        max_block_size_noenergy = attr.maxThreadsPerBlock;
 
         unsigned int run_block_size = min(block_size, max_block_size_noenergy);
         dim3 grid(tmp_ci.getNumElements() / run_block_size + 1);

--- a/hoomd/mpcd/CommunicatorGPU.cu
+++ b/hoomd/mpcd/CommunicatorGPU.cu
@@ -170,13 +170,11 @@ cudaError_t mpcd::gpu::stage_particles(unsigned int* d_comm_flag,
                                        const BoxDim& box,
                                        const unsigned int block_size)
     {
-    static unsigned int max_block_size = UINT_MAX;
-    if (max_block_size == UINT_MAX)
-        {
-        cudaFuncAttributes attr;
-        cudaFuncGetAttributes(&attr, (const void*)mpcd::gpu::kernel::stage_particles);
-        max_block_size = attr.maxThreadsPerBlock;
-        }
+    unsigned int max_block_size;
+    cudaFuncAttributes attr;
+    cudaFuncGetAttributes(&attr, (const void*)mpcd::gpu::kernel::stage_particles);
+    max_block_size = attr.maxThreadsPerBlock;
+
     unsigned int run_block_size = min(block_size, max_block_size);
     dim3 grid(N / run_block_size + 1);
     mpcd::gpu::kernel::stage_particles<<<grid, run_block_size>>>(d_comm_flag, d_pos, N, box);

--- a/hoomd/mpcd/ConfinedStreamingMethodGPU.cuh
+++ b/hoomd/mpcd/ConfinedStreamingMethodGPU.cuh
@@ -141,13 +141,10 @@ __global__ void confined_stream(Scalar4* d_pos,
 template<class Geometry>
 cudaError_t confined_stream(const stream_args_t& args, const Geometry& geom)
     {
-    static unsigned int max_block_size = UINT_MAX;
-    if (max_block_size == UINT_MAX)
-        {
-        cudaFuncAttributes attr;
-        cudaFuncGetAttributes(&attr, (const void*)mpcd::gpu::kernel::confined_stream<Geometry>);
-        max_block_size = attr.maxThreadsPerBlock;
-        }
+    unsigned int max_block_size;
+    cudaFuncAttributes attr;
+    cudaFuncGetAttributes(&attr, (const void*)mpcd::gpu::kernel::confined_stream<Geometry>);
+    max_block_size = attr.maxThreadsPerBlock;
 
     unsigned int run_block_size = min(args.block_size, max_block_size);
     dim3 grid(args.N / run_block_size + 1);

--- a/hoomd/mpcd/ParticleData.cu
+++ b/hoomd/mpcd/ParticleData.cu
@@ -119,13 +119,10 @@ cudaError_t mpcd::gpu::mark_removed_particles(unsigned char* d_remove_flags,
                                               const unsigned int N,
                                               const unsigned int block_size)
     {
-    static unsigned int max_block_size = UINT_MAX;
-    if (max_block_size == UINT_MAX)
-        {
-        cudaFuncAttributes attr;
-        cudaFuncGetAttributes(&attr, (const void*)mpcd::gpu::kernel::mark_removed_particles);
-        max_block_size = attr.maxThreadsPerBlock;
-        }
+    unsigned int max_block_size;
+    cudaFuncAttributes attr;
+    cudaFuncGetAttributes(&attr, (const void*)mpcd::gpu::kernel::mark_removed_particles);
+    max_block_size = attr.maxThreadsPerBlock;
 
     unsigned int run_block_size = min(block_size, max_block_size);
     dim3 grid(N / run_block_size + 1);
@@ -203,13 +200,10 @@ cudaError_t mpcd::gpu::remove_particles(mpcd::detail::pdata_element* d_out,
                                         const unsigned int N,
                                         const unsigned int block_size)
     {
-    static unsigned int max_block_size = UINT_MAX;
-    if (max_block_size == UINT_MAX)
-        {
-        cudaFuncAttributes attr;
-        cudaFuncGetAttributes(&attr, (const void*)mpcd::gpu::kernel::remove_particles);
-        max_block_size = attr.maxThreadsPerBlock;
-        }
+    unsigned int max_block_size;
+    cudaFuncAttributes attr;
+    cudaFuncGetAttributes(&attr, (const void*)mpcd::gpu::kernel::remove_particles);
+    max_block_size = attr.maxThreadsPerBlock;
 
     unsigned int run_block_size = min(block_size, max_block_size);
     dim3 grid(n_remove / run_block_size + 1);
@@ -294,13 +288,10 @@ void mpcd::gpu::add_particles(unsigned int old_nparticles,
                               const unsigned int mask,
                               const unsigned int block_size)
     {
-    static unsigned int max_block_size = UINT_MAX;
-    if (max_block_size == UINT_MAX)
-        {
-        cudaFuncAttributes attr;
-        cudaFuncGetAttributes(&attr, (const void*)mpcd::gpu::kernel::add_particles);
-        max_block_size = attr.maxThreadsPerBlock;
-        }
+    unsigned int max_block_size;
+    cudaFuncAttributes attr;
+    cudaFuncGetAttributes(&attr, (const void*)mpcd::gpu::kernel::add_particles);
+    max_block_size = attr.maxThreadsPerBlock;
 
     unsigned int run_block_size = min(block_size, max_block_size);
     dim3 grid(num_add_ptls / run_block_size + 1);

--- a/hoomd/mpcd/SRDCollisionMethodGPU.cu
+++ b/hoomd/mpcd/SRDCollisionMethodGPU.cu
@@ -197,13 +197,10 @@ cudaError_t srd_draw_vectors(double3* d_rotvec,
     {
     if (d_factors != NULL)
         {
-        static unsigned int max_block_thermostat = UINT_MAX;
-        if (max_block_thermostat == UINT_MAX)
-            {
-            cudaFuncAttributes attr;
-            cudaFuncGetAttributes(&attr, (const void*)mpcd::gpu::kernel::srd_draw_vectors<true>);
-            max_block_thermostat = attr.maxThreadsPerBlock;
-            }
+        unsigned int max_block_thermostat;
+        cudaFuncAttributes attr;
+        cudaFuncGetAttributes(&attr, (const void*)mpcd::gpu::kernel::srd_draw_vectors<true>);
+        max_block_thermostat = attr.maxThreadsPerBlock;
 
         unsigned int run_block_size = min(block_size, max_block_thermostat);
 
@@ -224,13 +221,10 @@ cudaError_t srd_draw_vectors(double3* d_rotvec,
         }
     else
         {
-        static unsigned int max_block_nothermostat = UINT_MAX;
-        if (max_block_nothermostat == UINT_MAX)
-            {
-            cudaFuncAttributes attr;
-            cudaFuncGetAttributes(&attr, (const void*)mpcd::gpu::kernel::srd_draw_vectors<false>);
-            max_block_nothermostat = attr.maxThreadsPerBlock;
-            }
+        unsigned int max_block_nothermostat;
+        cudaFuncAttributes attr;
+        cudaFuncGetAttributes(&attr, (const void*)mpcd::gpu::kernel::srd_draw_vectors<false>);
+        max_block_nothermostat = attr.maxThreadsPerBlock;
 
         unsigned int run_block_size = min(block_size, max_block_nothermostat);
 
@@ -265,13 +259,10 @@ cudaError_t srd_rotate(Scalar4* d_vel,
                        const unsigned int N_tot,
                        const unsigned int block_size)
     {
-    static unsigned int max_block_size = UINT_MAX;
-    if (max_block_size == UINT_MAX)
-        {
-        cudaFuncAttributes attr;
-        cudaFuncGetAttributes(&attr, (const void*)mpcd::gpu::kernel::srd_rotate);
-        max_block_size = attr.maxThreadsPerBlock;
-        }
+    unsigned int max_block_size;
+    cudaFuncAttributes attr;
+    cudaFuncGetAttributes(&attr, (const void*)mpcd::gpu::kernel::srd_rotate);
+    max_block_size = attr.maxThreadsPerBlock;
 
     // precompute angles for rotation
     const double cos_a = slow::cos(angle);

--- a/hoomd/mpcd/SlitGeometryFillerGPU.cu
+++ b/hoomd/mpcd/SlitGeometryFillerGPU.cu
@@ -148,13 +148,10 @@ cudaError_t slit_draw_particles(Scalar4* d_pos,
     if (N_tot == 0)
         return cudaSuccess;
 
-    static unsigned int max_block_size = UINT_MAX;
-    if (max_block_size == UINT_MAX)
-        {
-        cudaFuncAttributes attr;
-        cudaFuncGetAttributes(&attr, (const void*)kernel::slit_draw_particles);
-        max_block_size = attr.maxThreadsPerBlock;
-        }
+    unsigned int max_block_size;
+    cudaFuncAttributes attr;
+    cudaFuncGetAttributes(&attr, (const void*)kernel::slit_draw_particles);
+    max_block_size = attr.maxThreadsPerBlock;
 
     // precompute factor for rescaling the velocities since it is the same for all particles
     const Scalar vel_factor = fast::sqrt(kT / mass);

--- a/hoomd/mpcd/SlitPoreGeometryFillerGPU.cu
+++ b/hoomd/mpcd/SlitPoreGeometryFillerGPU.cu
@@ -157,13 +157,10 @@ cudaError_t slit_pore_draw_particles(Scalar4* d_pos,
     if (N_tot == 0)
         return cudaSuccess;
 
-    static unsigned int max_block_size = UINT_MAX;
-    if (max_block_size == UINT_MAX)
-        {
-        cudaFuncAttributes attr;
-        cudaFuncGetAttributes(&attr, (const void*)kernel::slit_pore_draw_particles);
-        max_block_size = attr.maxThreadsPerBlock;
-        }
+    unsigned int max_block_size;
+    cudaFuncAttributes attr;
+    cudaFuncGetAttributes(&attr, (const void*)kernel::slit_pore_draw_particles);
+    max_block_size = attr.maxThreadsPerBlock;
 
     // precompute factor for rescaling the velocities since it is the same for all particles
     const Scalar vel_factor = fast::sqrt(kT / mass);

--- a/hoomd/mpcd/SorterGPU.cu
+++ b/hoomd/mpcd/SorterGPU.cu
@@ -148,13 +148,10 @@ cudaError_t sort_apply(Scalar4* d_pos_alt,
     if (N == 0)
         return cudaSuccess;
 
-    static unsigned int max_block_size = UINT_MAX;
-    if (max_block_size == UINT_MAX)
-        {
-        cudaFuncAttributes attr;
-        cudaFuncGetAttributes(&attr, (const void*)mpcd::gpu::kernel::sort_apply);
-        max_block_size = attr.maxThreadsPerBlock;
-        }
+    unsigned int max_block_size;
+    cudaFuncAttributes attr;
+    cudaFuncGetAttributes(&attr, (const void*)mpcd::gpu::kernel::sort_apply);
+    max_block_size = attr.maxThreadsPerBlock;
 
     unsigned int run_block_size = min(block_size, max_block_size);
     dim3 grid(N / run_block_size + 1);
@@ -188,13 +185,10 @@ cudaError_t sort_set_sentinel(unsigned int* d_cell_list,
                               const unsigned int sentinel,
                               const unsigned int block_size)
     {
-    static unsigned int max_block_size = UINT_MAX;
-    if (max_block_size == UINT_MAX)
-        {
-        cudaFuncAttributes attr;
-        cudaFuncGetAttributes(&attr, (const void*)mpcd::gpu::kernel::sort_set_sentinel);
-        max_block_size = attr.maxThreadsPerBlock;
-        }
+    unsigned int max_block_size;
+    cudaFuncAttributes attr;
+    cudaFuncGetAttributes(&attr, (const void*)mpcd::gpu::kernel::sort_set_sentinel);
+    max_block_size = attr.maxThreadsPerBlock;
 
     const unsigned int N_cli = cli.getNumElements();
 
@@ -282,13 +276,10 @@ cudaError_t sort_gen_reverse(unsigned int* d_rorder,
     if (N == 0)
         return cudaSuccess;
 
-    static unsigned int max_block_size = UINT_MAX;
-    if (max_block_size == UINT_MAX)
-        {
-        cudaFuncAttributes attr;
-        cudaFuncGetAttributes(&attr, (const void*)mpcd::gpu::kernel::sort_gen_reverse);
-        max_block_size = attr.maxThreadsPerBlock;
-        }
+    unsigned int max_block_size;
+    cudaFuncAttributes attr;
+    cudaFuncGetAttributes(&attr, (const void*)mpcd::gpu::kernel::sort_gen_reverse);
+    max_block_size = attr.maxThreadsPerBlock;
 
     unsigned int run_block_size = min(block_size, max_block_size);
     dim3 grid(N / run_block_size + 1);


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should based on *maint*. -->
<!-- New features should based on *master*. -->

## Description

<!-- Describe your changes in detail. -->
Remove static integers and cached maximum block sizes.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
When one process uses two HOOMD devices on different GPUs, the cached static variables will be incorrect.

<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves #532

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
All unit tests pass. The branch compiles without warnings.

I also tested this with [hoomd-benchmarks](https://github.com/glotzerlab/hoomd-benchmarks) and found no performance degradation.

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
Fixed:

- Kernel launch errors when one process uses different GPU devices.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
