### PR TITLE
Support systems with arbitrary scale.

### DIFF
--- a/hoomd/HOOMDMath.h
+++ b/hoomd/HOOMDMath.h
@@ -203,9 +203,6 @@ void export_hoomd_math_functions(pybind11::module& m);
 #endif
 #endif
 
-//! Small epsilon value
-const Scalar EPSILON = 1.0e-6;
-
 //! Fastmath routines
 /*! Routines in the fast namespace map to fast math routines on the CPU and GPU. Where possible,
    these use the less accurate intrinsics on the GPU (i.e. __sinf). The routines are provide

--- a/hoomd/hpmc/ShapeFacetedEllipsoid.h
+++ b/hoomd/hpmc/ShapeFacetedEllipsoid.h
@@ -168,6 +168,7 @@ struct FacetedEllipsoidParams : ShapeParams
     /// Generate the intersections points of polyhedron edges with the sphere
     DEVICE void initializeVertices(bool managed = false)
         {
+        const Scalar tolerance = 1e-5;
         additional_verts = detail::PolyhedronVertices(2 * N * N, managed);
         additional_verts.diameter = OverlapReal(2.0); // for unit sphere
         additional_verts.N = 0;
@@ -242,7 +243,7 @@ struct FacetedEllipsoidParams : ShapeParams
                         }
                     }
 
-                if (allowed && dot(v1, v1) <= OverlapReal(1.0 + SMALL))
+                if (allowed && dot(v1, v1) <= OverlapReal(1.0 + tolerance))
                     {
                     additional_verts.x[additional_verts.N] = v1.x;
                     additional_verts.y[additional_verts.N] = v1.y;
@@ -273,7 +274,7 @@ struct FacetedEllipsoidParams : ShapeParams
                         }
                     }
 
-                if (allowed && dot(v2, v2) <= (OverlapReal(1.0 + SMALL)))
+                if (allowed && dot(v2, v2) <= (OverlapReal(1.0 + tolerance)))
                     {
                     additional_verts.x[additional_verts.N] = v2.x;
                     additional_verts.y[additional_verts.N] = v2.y;
@@ -381,6 +382,8 @@ class SupportFuncFacetedEllipsoid
     */
     DEVICE vec3<OverlapReal> operator()(const vec3<OverlapReal>& n_in) const
         {
+        const Scalar tolerance = 1e-5;
+
         // transform support direction into coordinate system of the unit sphere
         vec3<OverlapReal> n(n_in);
         n.x *= params.a;
@@ -420,7 +423,7 @@ class SupportFuncFacetedEllipsoid
             OverlapReal alpha = dot(n_sphere, n_p);
             OverlapReal arg = (OverlapReal(1.0) - alpha * alpha / np_sq);
             vec3<OverlapReal> v;
-            if (arg >= OverlapReal(SMALL))
+            if (arg >= OverlapReal(tolerance))
                 {
                 OverlapReal arg2 = OverlapReal(1.0) - b * b / np_sq;
                 OverlapReal invgamma = fast::sqrt(arg2 / arg);

--- a/hoomd/hpmc/ShapeSphere.h
+++ b/hoomd/hpmc/ShapeSphere.h
@@ -27,8 +27,6 @@
 #include <pybind11/pybind11.h>
 #endif
 
-#define SMALL 1e-5
-
 namespace hoomd
     {
 namespace hpmc

--- a/hoomd/hpmc/XenoCollide3D.h
+++ b/hoomd/hpmc/XenoCollide3D.h
@@ -118,7 +118,8 @@ DEVICE inline bool xenocollide_3d(const SupportFuncA& sa,
     // within v1 support plane. If origin is on a line between v1 and v0, particles overlap.
     // if (dot(n, n) < tol)
     // cross product has units of length**2, multiply tolerance by R**2 to put in the same units
-    if (fabs(n.x) < precision_tol * R * R && fabs(n.y) < precision_tol * R * R && fabs(n.z) < precision_tol * R * R)
+    if (fabs(n.x) < precision_tol * R * R && fabs(n.y) < precision_tol * R * R
+        && fabs(n.z) < precision_tol * R * R)
         return true;
 
     v2 = S(n); // Convexity should guarantee ||v2|| > 0, but v2 == v1 may be possible in edge cases

--- a/hoomd/hpmc/XenoCollide3D.h
+++ b/hoomd/hpmc/XenoCollide3D.h
@@ -86,7 +86,9 @@ DEVICE inline bool xenocollide_3d(const SupportFuncA& sa,
     OverlapReal d;
     const OverlapReal precision_tol
         = OverlapReal(1e-7); // precision tolerance for single-precision floats near 1.0
-    const OverlapReal root_tol = OverlapReal(3e-4); // square root of precision tolerance
+
+    // square root of precision tolerance, in distance units
+    const OverlapReal root_tol = OverlapReal(3e-4) * R;
 
     if (fabs(ab_t.x) < root_tol && fabs(ab_t.y) < root_tol && fabs(ab_t.z) < root_tol)
         {
@@ -115,7 +117,8 @@ DEVICE inline bool xenocollide_3d(const SupportFuncA& sa,
     // cross product is zero if v0,v1 colinear with origin, but we have already determined origin is
     // within v1 support plane. If origin is on a line between v1 and v0, particles overlap.
     // if (dot(n, n) < tol)
-    if (fabs(n.x) < precision_tol && fabs(n.y) < precision_tol && fabs(n.z) < precision_tol)
+    // cross product has units of length**2, multiply tolerance by R**2 to put in the same units
+    if (fabs(n.x) < precision_tol * R * R && fabs(n.y) < precision_tol * R * R && fabs(n.z) < precision_tol * R * R)
         return true;
 
     v2 = S(n); // Convexity should guarantee ||v2|| > 0, but v2 == v1 may be possible in edge cases
@@ -211,7 +214,8 @@ DEVICE inline bool xenocollide_3d(const SupportFuncA& sa,
         const OverlapReal tol_multiplier = 10000;
         n = cross(v2 - v1, v3 - v1);
         d = dot((v4 - v1) * tol_multiplier, n);
-        OverlapReal tol = precision_tol * tol_multiplier * R * fast::sqrt(dot(n, n));
+        // d is in units of length**3, multiply by R**2 * |n| to put in the same units
+        OverlapReal tol = precision_tol * tol_multiplier * R * R * fast::sqrt(dot(n, n));
 
         // First, check if v4 is on plane (v2,v1,v3)
         if (fabs(d) < tol)

--- a/hoomd/hpmc/pytest/CMakeLists.txt
+++ b/hoomd/hpmc/pytest/CMakeLists.txt
@@ -11,6 +11,7 @@ set(files __init__.py
           test_pair_user.py
           test_pair_union_user.py
           test_quick_compress.py
+          test_scale.py
           test_small_box_2d.py
           test_small_box_3d.py
           conftest.py

--- a/hoomd/hpmc/pytest/test_scale.py
+++ b/hoomd/hpmc/pytest/test_scale.py
@@ -1,0 +1,70 @@
+# Copyright (c) 2009-2021 The Regents of the University of Michigan
+# This file is part of the HOOMD-blue project, released under the BSD 3-Clause
+# License.
+
+"""Test HPMC with scaled shapes."""
+
+import hoomd
+import pytest
+import math
+
+@pytest.mark.parametrize("scale", [1e-9, 1, 1000, 1e9])
+@pytest.mark.parametrize("shape", ['ConvexPolygon', 'SimplePolygon'])
+@pytest.mark.parametrize("offset", [-100, -10, -1, 1, 10, 100])
+@pytest.mark.serial
+@pytest.mark.cpu
+def test_polygon(scale, shape, offset, simulation_factory, two_particle_snapshot_factory):
+    """Test polygons at a variety of scales."""
+    # make a many sided polygon to ensure that the overlap check is non-trivial
+    a = 0.5 * scale
+    vertices = []
+    n_points = 12
+    for i in range(12):
+        theta = 2 * math.pi / n_points * i
+        vertices.append([math.cos(theta) * a, math.sin(theta) * a])
+
+    epsilon = 1e-5
+    initial_snap = two_particle_snapshot_factory(dimensions=2, d=scale * (1 + offset*epsilon), L=scale*3)
+    initial_snap.particles.position[:,1] = 0
+    sim = simulation_factory(initial_snap)
+
+    mc = getattr(hoomd.hpmc.integrate, shape)(default_d=0)
+    mc.shape['A'] = dict(vertices=vertices)
+    sim.operations.integrator = mc
+    sim.run(0)
+
+    if offset < 0:
+        assert mc.overlaps == 1
+    else:
+        assert mc.overlaps == 0
+
+
+@pytest.mark.parametrize("scale", [1e-9, 1, 1000, 1e9])
+@pytest.mark.parametrize("offset", [-100, -10, -1, 1, 10, 100])
+@pytest.mark.serial
+@pytest.mark.cpu
+def test_convex_polyhedron(scale, offset, simulation_factory, two_particle_snapshot_factory):
+    """Test convex polyhedrons at a variety of scales."""
+    # make a many sized prism to ensure that the overlap check is non-trivial
+    a = 0.5 * scale
+    vertices = []
+    n_points = 12
+    for i in range(12):
+        theta = 2 * math.pi / n_points * i
+        vertices.append([math.cos(theta) * a, math.sin(theta) * a, -a])
+        vertices.append([math.cos(theta) * a, math.sin(theta) * a, a])
+
+    epsilon = 1e-5
+    initial_snap = two_particle_snapshot_factory(dimensions=3, d=scale * (1 + offset*epsilon), L=scale*3)
+    initial_snap.particles.position[:,2] = 0
+    sim = simulation_factory(initial_snap)
+
+    mc = hoomd.hpmc.integrate.ConvexPolyhedron(default_d=0)
+    mc.shape['A'] = dict(vertices=vertices)
+    sim.operations.integrator = mc
+    sim.run(0)
+
+    if offset < 0:
+        assert mc.overlaps == 1
+    else:
+        assert mc.overlaps == 0

--- a/hoomd/hpmc/pytest/test_scale.py
+++ b/hoomd/hpmc/pytest/test_scale.py
@@ -8,12 +8,14 @@ import hoomd
 import pytest
 import math
 
+
 @pytest.mark.parametrize("scale", [1e-9, 1, 1000, 1e9])
 @pytest.mark.parametrize("shape", ['ConvexPolygon', 'SimplePolygon'])
 @pytest.mark.parametrize("offset", [-100, -10, -1, 1, 10, 100])
 @pytest.mark.serial
 @pytest.mark.cpu
-def test_polygon(scale, shape, offset, simulation_factory, two_particle_snapshot_factory):
+def test_polygon(scale, shape, offset, simulation_factory,
+                 two_particle_snapshot_factory):
     """Test polygons at a variety of scales."""
     # make a many sided polygon to ensure that the overlap check is non-trivial
     a = 0.5 * scale
@@ -24,8 +26,9 @@ def test_polygon(scale, shape, offset, simulation_factory, two_particle_snapshot
         vertices.append([math.cos(theta) * a, math.sin(theta) * a])
 
     epsilon = 1e-5
-    initial_snap = two_particle_snapshot_factory(dimensions=2, d=scale * (1 + offset*epsilon), L=scale*3)
-    initial_snap.particles.position[:,1] = 0
+    d = scale * (1 + offset * epsilon)
+    initial_snap = two_particle_snapshot_factory(dimensions=2, d=d, L=scale * 3)
+    initial_snap.particles.position[:, 1] = 0
     sim = simulation_factory(initial_snap)
 
     mc = getattr(hoomd.hpmc.integrate, shape)(default_d=0)
@@ -43,7 +46,8 @@ def test_polygon(scale, shape, offset, simulation_factory, two_particle_snapshot
 @pytest.mark.parametrize("offset", [-100, -10, -1, 1, 10, 100])
 @pytest.mark.serial
 @pytest.mark.cpu
-def test_convex_polyhedron(scale, offset, simulation_factory, two_particle_snapshot_factory):
+def test_convex_polyhedron(scale, offset, simulation_factory,
+                           two_particle_snapshot_factory):
     """Test convex polyhedrons at a variety of scales."""
     # make a many sized prism to ensure that the overlap check is non-trivial
     a = 0.5 * scale
@@ -55,8 +59,9 @@ def test_convex_polyhedron(scale, offset, simulation_factory, two_particle_snaps
         vertices.append([math.cos(theta) * a, math.sin(theta) * a, a])
 
     epsilon = 1e-5
-    initial_snap = two_particle_snapshot_factory(dimensions=3, d=scale * (1 + offset*epsilon), L=scale*3)
-    initial_snap.particles.position[:,2] = 0
+    d = scale * (1 + offset * epsilon)
+    initial_snap = two_particle_snapshot_factory(dimensions=3, d=d, L=scale * 3)
+    initial_snap.particles.position[:, 2] = 0
     sim = simulation_factory(initial_snap)
 
     mc = hoomd.hpmc.integrate.ConvexPolyhedron(default_d=0)

--- a/hoomd/md/ComputeThermo.cc
+++ b/hoomd/md/ComputeThermo.cc
@@ -183,15 +183,15 @@ void ComputeThermo::computeProperties()
 
                 // only if the moment of inertia along one principal axis is non-zero, that axis
                 // carries angular momentum
-                if (I.x >= EPSILON)
+                if (I.x > 0)
                     {
                     ke_rot_total += s.v.x * s.v.x / I.x;
                     }
-                if (I.y >= EPSILON)
+                if (I.y > 0)
                     {
                     ke_rot_total += s.v.y * s.v.y / I.y;
                     }
-                if (I.z >= EPSILON)
+                if (I.z > 0)
                     {
                     ke_rot_total += s.v.z * s.v.z / I.z;
                     }

--- a/hoomd/md/ComputeThermoGPU.cu
+++ b/hoomd/md/ComputeThermoGPU.cu
@@ -266,15 +266,15 @@ __global__ void gpu_compute_rotational_ke_partial_sums(Scalar* d_scratch,
 
             Scalar ke_rot(0.0);
 
-            if (I.x >= EPSILON)
+            if (I.x > 0)
                 {
                 ke_rot += s.v.x * s.v.x / I.x;
                 }
-            if (I.y >= EPSILON)
+            if (I.y > 0)
                 {
                 ke_rot += s.v.y * s.v.y / I.y;
                 }
-            if (I.z >= EPSILON)
+            if (I.z > 0)
                 {
                 ke_rot += s.v.z * s.v.z / I.z;
                 }

--- a/hoomd/md/CosineSqAngleForceCompute.cc
+++ b/hoomd/md/CosineSqAngleForceCompute.cc
@@ -10,9 +10,6 @@
 
 using namespace std;
 
-// SMALL a relatively small number
-#define SMALL Scalar(0.001)
-
 /*! \file CosineSqAngleForceCompute.cc
     \brief Contains code for the CosineSqAngleForceCompute class
 */

--- a/hoomd/md/CosineSqAngleForceGPU.cu
+++ b/hoomd/md/CosineSqAngleForceGPU.cu
@@ -7,9 +7,6 @@
 
 #include <assert.h>
 
-// SMALL a relatively small number
-#define SMALL Scalar(0.001)
-
 /*! \file CosineSqAngleForceGPU.cu
     \brief Defines GPU kernel code for calculating the cosine squared angle forces. Used by
     CosineSqAngleForceComputeGPU.

--- a/hoomd/md/FIREEnergyMinimizer.cc
+++ b/hoomd/md/FIREEnergyMinimizer.cc
@@ -262,9 +262,9 @@ void FIREEnergyMinimizer::update(uint64_t timestep)
 
                 // check for zero moment of inertia
                 bool x_zero, y_zero, z_zero;
-                x_zero = (I.x < EPSILON);
-                y_zero = (I.y < EPSILON);
-                z_zero = (I.z < EPSILON);
+                x_zero = (I.x == 0);
+                y_zero = (I.y == 0);
+                z_zero = (I.z == 0);
 
                 // ignore torque component along an axis for which the moment of inertia zero
                 if (x_zero)
@@ -353,14 +353,14 @@ void FIREEnergyMinimizer::update(uint64_t timestep)
         }
 
     Scalar factor_t;
-    if (fabs(fnorm) > EPSILON)
+    if (fabs(fnorm) > 0)
         factor_t = m_alpha * vnorm / fnorm;
     else
         factor_t = 1.0;
 
     Scalar factor_r = 0.0;
 
-    if (fabs(tnorm) > EPSILON)
+    if (fabs(tnorm) > 0)
         factor_r = m_alpha * wnorm / tnorm;
     else
         factor_r = 1.0;
@@ -405,9 +405,9 @@ void FIREEnergyMinimizer::update(uint64_t timestep)
 
                 // check for zero moment of inertia
                 bool x_zero, y_zero, z_zero;
-                x_zero = (I.x < EPSILON);
-                y_zero = (I.y < EPSILON);
-                z_zero = (I.z < EPSILON);
+                x_zero = (I.x == 0);
+                y_zero = (I.y == 0);
+                z_zero = (I.z == 0);
 
                 // ignore torque component along an axis for which the moment of inertia zero
                 if (x_zero)

--- a/hoomd/md/FIREEnergyMinimizerGPU.cc
+++ b/hoomd/md/FIREEnergyMinimizerGPU.cc
@@ -355,14 +355,14 @@ void FIREEnergyMinimizerGPU::update(uint64_t timestep)
         m_prof->push(m_exec_conf, "FIRE update velocities");
 
     Scalar factor_t;
-    if (fabs(fnorm) > EPSILON)
+    if (fabs(fnorm) > 0)
         factor_t = m_alpha * vnorm / fnorm;
     else
         factor_t = 1.0;
 
     Scalar factor_r = 0.0;
 
-    if (fabs(tnorm) > EPSILON)
+    if (fabs(tnorm) > 0)
         factor_r = m_alpha * wnorm / tnorm;
     else
         factor_r = 1.0;

--- a/hoomd/md/FIREEnergyMinimizerGPU.cu
+++ b/hoomd/md/FIREEnergyMinimizerGPU.cu
@@ -328,9 +328,9 @@ __global__ void gpu_fire_reduce_Pr_partial_kernel(const Scalar4* d_angmom,
 
         // check for zero moment of inertia
         bool x_zero, y_zero, z_zero;
-        x_zero = (I.x < EPSILON);
-        y_zero = (I.y < EPSILON);
-        z_zero = (I.z < EPSILON);
+        x_zero = (I.x == 0);
+        y_zero = (I.y == 0);
+        z_zero = (I.z == 0);
 
         // ignore torque component along an axis for which the moment of inertia zero
         if (x_zero)
@@ -523,9 +523,9 @@ __global__ void gpu_fire_reduce_tsq_partial_kernel(const Scalar4* d_net_torque,
 
         // check for zero moment of inertia
         bool x_zero, y_zero, z_zero;
-        x_zero = (I.x < EPSILON);
-        y_zero = (I.y < EPSILON);
-        z_zero = (I.z < EPSILON);
+        x_zero = (I.x == 0);
+        y_zero = (I.y == 0);
+        z_zero = (I.z == 0);
 
         // ignore torque component along an axis for which the moment of inertia zero
         if (x_zero)
@@ -836,9 +836,9 @@ __global__ void gpu_fire_update_angmom_kernel(const Scalar4* d_net_torque,
 
         // check for zero moment of inertia
         bool x_zero, y_zero, z_zero;
-        x_zero = (I.x < EPSILON);
-        y_zero = (I.y < EPSILON);
-        z_zero = (I.z < EPSILON);
+        x_zero = (I.x == 0);
+        y_zero = (I.y == 0);
+        z_zero = (I.z == 0);
 
         // ignore torque component along an axis for which the moment of inertia zero
         if (x_zero)

--- a/hoomd/md/HarmonicDihedralForceCompute.cc
+++ b/hoomd/md/HarmonicDihedralForceCompute.cc
@@ -12,9 +12,6 @@
 
 using namespace std;
 
-// SMALL a relatively small number
-#define SMALL Scalar(0.001)
-
 /*! \file HarmonicDihedralForceCompute.cc
     \brief Contains code for the HarmonicDihedralForceCompute class
 */

--- a/hoomd/md/HarmonicDihedralForceGPU.cu
+++ b/hoomd/md/HarmonicDihedralForceGPU.cu
@@ -14,9 +14,6 @@
 #define __scalar2int_rn __double2int_rn
 #endif
 
-// SMALL a relatively small number
-#define SMALL Scalar(0.001)
-
 /*! \file HarmonicDihedralForceGPU.cu
     \brief Defines GPU kernel code for calculating the harmonic dihedral forces. Used by
    HarmonicDihedralForceComputeGPU.

--- a/hoomd/md/IntegrationMethodTwoStep.cc
+++ b/hoomd/md/IntegrationMethodTwoStep.cc
@@ -130,18 +130,18 @@ Scalar IntegrationMethodTwoStep::getRotationalDOF(std::shared_ptr<ParticleGroup>
             {
             if (dimension == 3)
                 {
-                if (fabs(h_moment_inertia.data[j].x) >= EPSILON)
+                if (fabs(h_moment_inertia.data[j].x) > 0)
                     query_group_dof++;
 
-                if (fabs(h_moment_inertia.data[j].y) >= EPSILON)
+                if (fabs(h_moment_inertia.data[j].y) > 0)
                     query_group_dof++;
 
-                if (fabs(h_moment_inertia.data[j].z) >= EPSILON)
+                if (fabs(h_moment_inertia.data[j].z) > 0)
                     query_group_dof++;
                 }
             else
                 {
-                if (fabs(h_moment_inertia.data[j].z) >= EPSILON)
+                if (fabs(h_moment_inertia.data[j].z) > 0)
                     query_group_dof++;
                 }
             }

--- a/hoomd/md/QuaternionMath.h
+++ b/hoomd/md/QuaternionMath.h
@@ -111,7 +111,7 @@ no_squish_rotate(unsigned int k, Scalar4& p, Scalar4& q, Scalar4& inertia, Scala
         inertia_t = inertia.z;
     else
         inertia_t = Scalar(0.0);
-    if (fabs(inertia_t) < EPSILON)
+    if (fabs(inertia_t) == 0)
         phi *= Scalar(0.0);
     else
         phi /= (Scalar(4.0) * inertia_t);
@@ -187,19 +187,19 @@ DEVICE inline void computeAngularVelocity(Scalar4& angmom,
     Scalar angbody[3];
 
     // angbody = angmom_body / moment_inertia = transpose(rotation_matrix) * angmom / moment_inertia
-    if (moment_inertia.x < EPSILON)
+    if (moment_inertia.x == 0)
         angbody[0] = Scalar(0.0);
     else
         angbody[0] = (ex_space.x * angmom.x + ex_space.y * angmom.y + ex_space.z * angmom.z)
                      / moment_inertia.x;
 
-    if (moment_inertia.y < EPSILON)
+    if (moment_inertia.y == 0)
         angbody[1] = Scalar(0.0);
     else
         angbody[1] = (ey_space.x * angmom.x + ey_space.y * angmom.y + ey_space.z * angmom.z)
                      / moment_inertia.y;
 
-    if (moment_inertia.z < EPSILON)
+    if (moment_inertia.z == 0)
         angbody[2] = Scalar(0.0);
     else
         angbody[2] = (ez_space.x * angmom.x + ez_space.y * angmom.y + ez_space.z * angmom.z)

--- a/hoomd/md/TwoStepBD.cc
+++ b/hoomd/md/TwoStepBD.cc
@@ -176,9 +176,9 @@ void TwoStepBD::integrateStepOne(uint64_t timestep)
                 vec3<Scalar> I(h_inertia.data[j]);
 
                 bool x_zero, y_zero, z_zero;
-                x_zero = (I.x < EPSILON);
-                y_zero = (I.y < EPSILON);
-                z_zero = (I.z < EPSILON);
+                x_zero = (I.x == 0);
+                y_zero = (I.y == 0);
+                z_zero = (I.z == 0);
 
                 Scalar3 sigma_r
                     = make_scalar3(fast::sqrt(Scalar(2.0) * gamma_r.x * currentTemp / m_deltaT),

--- a/hoomd/md/TwoStepBDGPU.cu
+++ b/hoomd/md/TwoStepBDGPU.cu
@@ -212,9 +212,9 @@ __global__ void gpu_brownian_step_one_kernel(Scalar4* d_pos,
 
                 // check if the shape is degenerate
                 bool x_zero, y_zero, z_zero;
-                x_zero = (I.x < EPSILON);
-                y_zero = (I.y < EPSILON);
-                z_zero = (I.z < EPSILON);
+                x_zero = (I.x == 0);
+                y_zero = (I.y == 0);
+                z_zero = (I.z == 0);
 
                 Scalar3 sigma_r = make_scalar3(fast::sqrt(Scalar(2.0) * gamma_r.x * T / deltaT),
                                                fast::sqrt(Scalar(2.0) * gamma_r.y * T / deltaT),

--- a/hoomd/md/TwoStepLangevin.cc
+++ b/hoomd/md/TwoStepLangevin.cc
@@ -113,9 +113,9 @@ void TwoStepLangevin::integrateStepOne(uint64_t timestep)
 
             // check for zero moment of inertia
             bool x_zero, y_zero, z_zero;
-            x_zero = (I.x < EPSILON);
-            y_zero = (I.y < EPSILON);
-            z_zero = (I.z < EPSILON);
+            x_zero = (I.x == 0);
+            y_zero = (I.y == 0);
+            z_zero = (I.z == 0);
 
             // ignore torque component along an axis for which the moment of inertia zero
             if (x_zero)
@@ -347,9 +347,9 @@ void TwoStepLangevin::integrateStepTwo(uint64_t timestep)
 
                 // check for degenerate moment of inertia
                 bool x_zero, y_zero, z_zero;
-                x_zero = (I.x < EPSILON);
-                y_zero = (I.y < EPSILON);
-                z_zero = (I.z < EPSILON);
+                x_zero = (I.x == 0);
+                y_zero = (I.y == 0);
+                z_zero = (I.z == 0);
 
                 bf_torque.x = rand_x - gamma_r.x * (s.x / I.x);
                 bf_torque.y = rand_y - gamma_r.y * (s.y / I.y);
@@ -395,9 +395,9 @@ void TwoStepLangevin::integrateStepTwo(uint64_t timestep)
 
             // check for zero moment of inertia
             bool x_zero, y_zero, z_zero;
-            x_zero = (I.x < EPSILON);
-            y_zero = (I.y < EPSILON);
-            z_zero = (I.z < EPSILON);
+            x_zero = (I.x == 0);
+            y_zero = (I.y == 0);
+            z_zero = (I.z == 0);
 
             // ignore torque component along an axis for which the moment of inertia zero
             if (x_zero)

--- a/hoomd/md/TwoStepLangevinGPU.cu
+++ b/hoomd/md/TwoStepLangevinGPU.cu
@@ -317,9 +317,9 @@ __global__ void gpu_langevin_angular_step_two_kernel(const Scalar4* d_pos,
 
             // check for zero moment of inertia
             bool x_zero, y_zero, z_zero;
-            x_zero = (I.x < Scalar(EPSILON));
-            y_zero = (I.y < Scalar(EPSILON));
-            z_zero = (I.z < Scalar(EPSILON));
+            x_zero = (I.x == 0);
+            y_zero = (I.y == 0);
+            z_zero = (I.z == 0);
 
             bf_torque.x = rand_x - gamma_r.x * (s.x / I.x);
             bf_torque.y = rand_y - gamma_r.y * (s.y / I.y);
@@ -358,9 +358,9 @@ __global__ void gpu_langevin_angular_step_two_kernel(const Scalar4* d_pos,
 
         // check for zero moment of inertia
         bool x_zero, y_zero, z_zero;
-        x_zero = (I.x < Scalar(EPSILON));
-        y_zero = (I.y < Scalar(EPSILON));
-        z_zero = (I.z < Scalar(EPSILON));
+        x_zero = (I.x == 0);
+        y_zero = (I.y == 0);
+        z_zero = (I.z == 0);
 
         // ignore torque component along an axis for which the moment of inertia zero
         if (x_zero)

--- a/hoomd/md/TwoStepNPTMTK.cc
+++ b/hoomd/md/TwoStepNPTMTK.cc
@@ -305,9 +305,9 @@ void TwoStepNPTMTK::integrateStepOne(uint64_t timestep)
 
             // check for zero moment of inertia
             bool x_zero, y_zero, z_zero;
-            x_zero = (I.x < EPSILON);
-            y_zero = (I.y < EPSILON);
-            z_zero = (I.z < EPSILON);
+            x_zero = (I.x == 0);
+            y_zero = (I.y == 0);
+            z_zero = (I.z == 0);
 
             // ignore torque component along an axis for which the moment of inertia zero
             if (x_zero)
@@ -519,9 +519,9 @@ void TwoStepNPTMTK::integrateStepTwo(uint64_t timestep)
 
                 // check for zero moment of inertia
                 bool x_zero, y_zero, z_zero;
-                x_zero = (I.x < EPSILON);
-                y_zero = (I.y < EPSILON);
-                z_zero = (I.z < EPSILON);
+                x_zero = (I.x == 0);
+                y_zero = (I.y == 0);
+                z_zero = (I.z == 0);
 
                 // ignore torque component along an axis for which the moment of inertia zero
                 if (x_zero)

--- a/hoomd/md/TwoStepNVE.cc
+++ b/hoomd/md/TwoStepNVE.cc
@@ -195,9 +195,9 @@ void TwoStepNVE::integrateStepOne(uint64_t timestep)
 
             // check for zero moment of inertia
             bool x_zero, y_zero, z_zero;
-            x_zero = (I.x < EPSILON);
-            y_zero = (I.y < EPSILON);
-            z_zero = (I.z < EPSILON);
+            x_zero = (I.x == 0);
+            y_zero = (I.y == 0);
+            z_zero = (I.z == 0);
 
             // ignore torque component along an axis for which the moment of inertia zero
             if (x_zero)
@@ -379,9 +379,9 @@ void TwoStepNVE::integrateStepTwo(uint64_t timestep)
 
             // check for zero moment of inertia
             bool x_zero, y_zero, z_zero;
-            x_zero = (I.x < EPSILON);
-            y_zero = (I.y < EPSILON);
-            z_zero = (I.z < EPSILON);
+            x_zero = (I.x == 0);
+            y_zero = (I.y == 0);
+            z_zero = (I.z == 0);
 
             // ignore torque component along an axis for which the moment of inertia zero
             if (x_zero)

--- a/hoomd/md/TwoStepNVEGPU.cu
+++ b/hoomd/md/TwoStepNVEGPU.cu
@@ -216,9 +216,9 @@ __global__ void gpu_nve_angular_step_one_kernel(Scalar4* d_orientation,
 
         // check for zero moment of inertia
         bool x_zero, y_zero, z_zero;
-        x_zero = (I.x < Scalar(EPSILON));
-        y_zero = (I.y < Scalar(EPSILON));
-        z_zero = (I.z < Scalar(EPSILON));
+        x_zero = (I.x == 0);
+        y_zero = (I.y == 0);
+        z_zero = (I.z == 0);
 
         // ignore torque component along an axis for which the moment of inertia zero
         if (x_zero)
@@ -540,9 +540,9 @@ __global__ void gpu_nve_angular_step_two_kernel(const Scalar4* d_orientation,
 
         // check for zero moment of inertia
         bool x_zero, y_zero, z_zero;
-        x_zero = (I.x < Scalar(EPSILON));
-        y_zero = (I.y < Scalar(EPSILON));
-        z_zero = (I.z < Scalar(EPSILON));
+        x_zero = (I.x == 0);
+        y_zero = (I.y == 0);
+        z_zero = (I.z == 0);
 
         // ignore torque component along an axis for which the moment of inertia zero
         if (x_zero)

--- a/hoomd/md/TwoStepNVTMTK.cc
+++ b/hoomd/md/TwoStepNVTMTK.cc
@@ -169,9 +169,9 @@ void TwoStepNVTMTK::integrateStepOne(uint64_t timestep)
 
             // check for zero moment of inertia
             bool x_zero, y_zero, z_zero;
-            x_zero = (I.x < EPSILON);
-            y_zero = (I.y < EPSILON);
-            z_zero = (I.z < EPSILON);
+            x_zero = (I.x == 0);
+            y_zero = (I.y == 0);
+            z_zero = (I.z == 0);
 
             // ignore torque component along an axis for which the moment of inertia zero
             if (x_zero)
@@ -358,9 +358,9 @@ void TwoStepNVTMTK::integrateStepTwo(uint64_t timestep)
 
             // check for zero moment of inertia
             bool x_zero, y_zero, z_zero;
-            x_zero = (I.x < EPSILON);
-            y_zero = (I.y < EPSILON);
-            z_zero = (I.z < EPSILON);
+            x_zero = (I.x == 0);
+            y_zero = (I.y == 0);
+            z_zero = (I.z == 0);
 
             // ignore torque component along an axis for which the moment of inertia zero
             if (x_zero)

--- a/hoomd/md/TwoStepRATTLEBD.h
+++ b/hoomd/md/TwoStepRATTLEBD.h
@@ -328,9 +328,9 @@ template<class Manifold> void TwoStepRATTLEBD<Manifold>::integrateStepOne(uint64
                 vec3<Scalar> I(h_inertia.data[j]);
 
                 bool x_zero, y_zero, z_zero;
-                x_zero = (I.x < EPSILON);
-                y_zero = (I.y < EPSILON);
-                z_zero = (I.z < EPSILON);
+                x_zero = (I.x == 0);
+                y_zero = (I.y == 0);
+                z_zero = (I.z == 0);
 
                 Scalar3 sigma_r
                     = make_scalar3(fast::sqrt(Scalar(2.0) * gamma_r.x * currentTemp / m_deltaT),

--- a/hoomd/md/TwoStepRATTLEBDGPU.cuh
+++ b/hoomd/md/TwoStepRATTLEBDGPU.cuh
@@ -276,9 +276,9 @@ __global__ void gpu_rattle_brownian_step_one_kernel(Scalar4* d_pos,
 
                 // check if the shape is degenerate
                 bool x_zero, y_zero, z_zero;
-                x_zero = (I.x < EPSILON);
-                y_zero = (I.y < EPSILON);
-                z_zero = (I.z < EPSILON);
+                x_zero = (I.x == 0);
+                y_zero = (I.y == 0);
+                z_zero = (I.z == 0);
 
                 Scalar3 sigma_r = make_scalar3(fast::sqrt(Scalar(2.0) * gamma_r.x * T / deltaT),
                                                fast::sqrt(Scalar(2.0) * gamma_r.y * T / deltaT),

--- a/hoomd/md/TwoStepRATTLELangevin.h
+++ b/hoomd/md/TwoStepRATTLELangevin.h
@@ -250,9 +250,9 @@ template<class Manifold> void TwoStepRATTLELangevin<Manifold>::integrateStepOne(
 
             // check for zero moment of inertia
             bool x_zero, y_zero, z_zero;
-            x_zero = (I.x < EPSILON);
-            y_zero = (I.y < EPSILON);
-            z_zero = (I.z < EPSILON);
+            x_zero = (I.x == 0);
+            y_zero = (I.y == 0);
+            z_zero = (I.z == 0);
 
             // ignore torque component along an axis for which the moment of inertia zero
             if (x_zero)
@@ -557,9 +557,9 @@ template<class Manifold> void TwoStepRATTLELangevin<Manifold>::integrateStepTwo(
 
                 // check for degenerate moment of inertia
                 bool x_zero, y_zero, z_zero;
-                x_zero = (I.x < EPSILON);
-                y_zero = (I.y < EPSILON);
-                z_zero = (I.z < EPSILON);
+                x_zero = (I.x == 0);
+                y_zero = (I.y == 0);
+                z_zero = (I.z == 0);
 
                 bf_torque.x = rand_x - gamma_r.x * (s.x / I.x);
                 bf_torque.y = rand_y - gamma_r.y * (s.y / I.y);
@@ -600,9 +600,9 @@ template<class Manifold> void TwoStepRATTLELangevin<Manifold>::integrateStepTwo(
 
             // check for zero moment of inertia
             bool x_zero, y_zero, z_zero;
-            x_zero = (I.x < EPSILON);
-            y_zero = (I.y < EPSILON);
-            z_zero = (I.z < EPSILON);
+            x_zero = (I.x == 0);
+            y_zero = (I.y == 0);
+            z_zero = (I.z == 0);
 
             // ignore torque component along an axis for which the moment of inertia zero
             if (x_zero)

--- a/hoomd/md/TwoStepRATTLELangevinGPU.cu
+++ b/hoomd/md/TwoStepRATTLELangevinGPU.cu
@@ -105,9 +105,9 @@ __global__ void gpu_rattle_langevin_angular_step_two_kernel(const Scalar4* d_pos
 
             // check for zero moment of inertia
             bool x_zero, y_zero, z_zero;
-            x_zero = (I.x < Scalar(EPSILON));
-            y_zero = (I.y < Scalar(EPSILON));
-            z_zero = (I.z < Scalar(EPSILON));
+            x_zero = (I.x == 0);
+            y_zero = (I.y == 0);
+            z_zero = (I.z == 0);
 
             // first calculate in the body frame random and damping torque imposed by the dynamics
             vec3<Scalar> bf_torque;
@@ -147,9 +147,9 @@ __global__ void gpu_rattle_langevin_angular_step_two_kernel(const Scalar4* d_pos
         t = rotate(conj(q), t);
 
         // check for zero moment of inertia
-        bool x_zero = (I.x < Scalar(EPSILON));
-        bool y_zero = (I.y < Scalar(EPSILON));
-        bool z_zero = (I.z < Scalar(EPSILON));
+        bool x_zero = (I.x == 0);
+        bool y_zero = (I.y == 0);
+        bool z_zero = (I.z == 0);
 
         // ignore torque component along an axis for which the moment of inertia zero
         if (x_zero)

--- a/hoomd/md/TwoStepRATTLENVE.h
+++ b/hoomd/md/TwoStepRATTLENVE.h
@@ -307,9 +307,9 @@ template<class Manifold> void TwoStepRATTLENVE<Manifold>::integrateStepOne(uint6
 
             // check for zero moment of inertia
             bool x_zero, y_zero, z_zero;
-            x_zero = (I.x < EPSILON);
-            y_zero = (I.y < EPSILON);
-            z_zero = (I.z < EPSILON);
+            x_zero = (I.x == 0);
+            y_zero = (I.y == 0);
+            z_zero = (I.z == 0);
 
             // ignore torque component along an axis for which the moment of inertia zero
             if (x_zero)
@@ -547,9 +547,9 @@ template<class Manifold> void TwoStepRATTLENVE<Manifold>::integrateStepTwo(uint6
 
             // check for zero moment of inertia
             bool x_zero, y_zero, z_zero;
-            x_zero = (I.x < EPSILON);
-            y_zero = (I.y < EPSILON);
-            z_zero = (I.z < EPSILON);
+            x_zero = (I.x == 0);
+            y_zero = (I.y == 0);
+            z_zero = (I.z == 0);
 
             // ignore torque component along an axis for which the moment of inertia zero
             if (x_zero)

--- a/hoomd/md/TwoStepRATTLENVEGPU.cu
+++ b/hoomd/md/TwoStepRATTLENVEGPU.cu
@@ -210,9 +210,9 @@ __global__ void gpu_rattle_nve_angular_step_one_kernel(Scalar4* d_orientation,
 
         // check for zero moment of inertia
         bool x_zero, y_zero, z_zero;
-        x_zero = (I.x < Scalar(EPSILON));
-        y_zero = (I.y < Scalar(EPSILON));
-        z_zero = (I.z < Scalar(EPSILON));
+        x_zero = (I.x == 0);
+        y_zero = (I.y == 0);
+        z_zero = (I.z == 0);
 
         // ignore torque component along an axis for which the moment of inertia zero
         if (x_zero)
@@ -396,9 +396,9 @@ __global__ void gpu_rattle_nve_angular_step_two_kernel(const Scalar4* d_orientat
 
         // check for zero moment of inertia
         bool x_zero, y_zero, z_zero;
-        x_zero = (I.x < Scalar(EPSILON));
-        y_zero = (I.y < Scalar(EPSILON));
-        z_zero = (I.z < Scalar(EPSILON));
+        x_zero = (I.x == 0);
+        y_zero = (I.y == 0);
+        z_zero = (I.z == 0);
 
         // ignore torque component along an axis for which the moment of inertia zero
         if (x_zero)

--- a/hoomd/md/minimize/fire.py
+++ b/hoomd/md/minimize/fire.py
@@ -116,9 +116,10 @@ class FIRE(_DynamicIntegrator):
 
     Examples::
 
-        fire = md.minimize.FIRE(dt=0.05)
-        fire.force_tol = 1e-2
-        fire.energy_tol = 1e-7
+        fire = md.minimize.FIRE(dt=0.05,
+                                force_tol=1e-2,
+                                angmom_tol=1e-2,
+                                energy_tol=1e-7)
         fire.methods.append(md.methods.NVE(hoomd.filter.All()))
         sim.operations.integrator = fire
         while not(fire.converged):
@@ -154,6 +155,14 @@ class FIRE(_DynamicIntegrator):
             This is the maximum step size the minimizer is permitted to use
             :math:`[\\mathrm{time}]`. Consider the stability of the system when
             setting.
+        force_tol (float):
+            Force convergence criteria
+            :math:`[\\mathrm{force} / \\mathrm{mass}]`.
+        angmom_tol (float):
+            Angular momentum convergence criteria
+            :math:`[\\mathrm{energy} * \\mathrm{time}]`.
+        energy_tol (float):
+            Energy convergence criteria :math:`[\\mathrm{energy}]`.
         integrate_rotational_dof (bool): When True, integrate rotational degrees
             of freedom.
         forces (Sequence[hoomd.md.force.Force]):
@@ -186,14 +195,6 @@ class FIRE(_DynamicIntegrator):
         fdec_alpha (float):
             Factor to decrease :math:`\\alpha t` by
             :math:`[\\mathrm{dimensionless}]`.
-        force_tol (float):
-            Force convergence criteria
-            :math:`[\\mathrm{force} / \\mathrm{mass}]`.
-        angmom_tol (float):
-            Angular momentum convergence criteria
-            :math:`[\\mathrm{energy} * \\mathrm{time}]`.
-        energy_tol (float):
-            Energy convergence criteria :math:`[\\mathrm{energy}]`.
         min_steps_conv (int):
             A minimum number of attempts before convergence criteria are
             considered.
@@ -203,6 +204,9 @@ class FIRE(_DynamicIntegrator):
 
     def __init__(self,
                  dt,
+                 force_tol,
+                 angmom_tol,
+                 energy_tol,
                  integrate_rotational_dof=False,
                  forces=None,
                  constraints=None,
@@ -213,9 +217,6 @@ class FIRE(_DynamicIntegrator):
                  fdec_dt=0.5,
                  alpha_start=0.1,
                  fdec_alpha=0.99,
-                 force_tol=0.1,
-                 angmom_tol=0.1,
-                 energy_tol=1e-5,
                  min_steps_conv=10):
 
         super().__init__(forces, constraints, methods, rigid)

--- a/hoomd/md/nlist.py
+++ b/hoomd/md/nlist.py
@@ -154,7 +154,7 @@ class Cell(NList):
     """
 
     def __init__(self,
-                 buffer=0.4,
+                 buffer,
                  exclusions=('bond',),
                  rebuild_check_delay=1,
                  diameter_shift=False,
@@ -233,7 +233,7 @@ class Stencil(NList):
 
     def __init__(self,
                  cell_width,
-                 buffer=0.4,
+                 buffer,
                  exclusions=('bond',),
                  rebuild_check_delay=1,
                  diameter_shift=False,
@@ -296,7 +296,7 @@ class Tree(NList):
     """
 
     def __init__(self,
-                 buffer=0.4,
+                 buffer,
                  exclusions=('bond',),
                  rebuild_check_delay=1,
                  diameter_shift=False,

--- a/hoomd/md/pytest/test_aniso_pair.py
+++ b/hoomd/md/pytest/test_aniso_pair.py
@@ -70,7 +70,7 @@ def make_two_particle_simulation(two_particle_snapshot_factory,
 @pytest.mark.parametrize("mode", [('none', 'shift'), ('shift', 'none')])
 def test_mode(make_two_particle_simulation, mode):
     """Test that all modes are correctly set on construction."""
-    cell = md.nlist.Cell()
+    cell = md.nlist.Cell(buffer=0.4)
     # Test setting on construction
     gay_berne = md.pair.aniso.GayBerne(nlist=cell,
                                        default_r_cut=2.5,
@@ -93,10 +93,10 @@ def test_mode_invalid(mode):
     """Test mode validation on construction and setting."""
     # Test errors on construction
     with pytest.raises(TypeConversionError):
-        gay_berne = md.pair.aniso.GayBerne(nlist=md.nlist.Cell(),
+        gay_berne = md.pair.aniso.GayBerne(nlist=md.nlist.Cell(buffer=0.4),
                                            default_r_cut=2.5,
                                            mode=mode)
-    gay_berne = md.pair.aniso.GayBerne(nlist=md.nlist.Cell(), default_r_cut=2.5)
+    gay_berne = md.pair.aniso.GayBerne(nlist=md.nlist.Cell(buffer=0.4), default_r_cut=2.5)
     gay_berne.params[('A', 'A')] = {'epsilon': 1, 'lpar': 0.5, 'lperp': 1.0}
     # Test errors on setting
     with pytest.raises(TypeConversionError):
@@ -106,7 +106,7 @@ def test_mode_invalid(mode):
 @pytest.mark.parametrize("r_cut", [2.5, 4.0, 1.0, 0.01])
 def test_rcut(make_two_particle_simulation, r_cut):
     """Test that r_cut is correctly set and settable."""
-    cell = md.nlist.Cell()
+    cell = md.nlist.Cell(buffer=0.4)
     # Test construction
     gay_berne = md.pair.aniso.GayBerne(nlist=cell, default_r_cut=r_cut)
     assert gay_berne.r_cut.default == r_cut
@@ -132,7 +132,7 @@ def test_rcut(make_two_particle_simulation, r_cut):
 @pytest.mark.parametrize("r_cut", [-1., 'foo', None])
 def test_rcut_invalid(r_cut):
     """Test r_cut validation logic."""
-    cell = md.nlist.Cell()
+    cell = md.nlist.Cell(buffer=0.4)
     # Test construction error
     if r_cut is not None:
         with pytest.raises(TypeConversionError):
@@ -247,7 +247,7 @@ def _valid_params(particle_types=['A', 'B']):
 @pytest.mark.parametrize('pair_potential_spec', _valid_params())
 def test_setting_params_and_shape(make_two_particle_simulation,
                                   pair_potential_spec):
-    pair_potential = pair_potential_spec.cls(nlist=md.nlist.Cell(),
+    pair_potential = pair_potential_spec.cls(nlist=md.nlist.Cell(buffer=0.4),
                                              default_r_cut=2.5)
     for key, value in pair_potential_spec.type_parameters.items():
         setattr(pair_potential, key, value)
@@ -299,7 +299,7 @@ def _aniso_forces_and_energies():
 @pytest.fixture(scope="function", params=_valid_params())
 def pair_potential(request):
     spec = request.param
-    pair_potential = spec.cls(nlist=md.nlist.Cell(), default_r_cut=2.5)
+    pair_potential = spec.cls(nlist=md.nlist.Cell(buffer=0.4), default_r_cut=2.5)
     for key, value in spec.type_parameters.items():
         setattr(pair_potential, key, value)
     return pair_potential
@@ -347,7 +347,7 @@ def test_aniso_force_computes(make_two_particle_simulation,
         \theta_1 = (1, 0, 0, 0) \ \theta_2 = (0.70738827, 0, 0, 0.70682518) \\
 
     """
-    pot = aniso_forces_and_energies.pair_potential(nlist=md.nlist.Cell(),
+    pot = aniso_forces_and_energies.pair_potential(nlist=md.nlist.Cell(buffer=0.4),
                                                    default_r_cut=2.5,
                                                    mode='none')
     for param, value in aniso_forces_and_energies.pair_potential_params.items():
@@ -382,7 +382,7 @@ def test_aniso_force_computes(make_two_particle_simulation,
 
 @pytest.mark.parametrize('pair_potential_spec', _valid_params())
 def test_pickling(make_two_particle_simulation, pair_potential_spec):
-    pair_potential = pair_potential_spec.cls(nlist=md.nlist.Cell(),
+    pair_potential = pair_potential_spec.cls(nlist=md.nlist.Cell(buffer=0.4),
                                              default_r_cut=2.5)
     for key, value in pair_potential_spec.type_parameters.items():
         setattr(pair_potential, key, value)

--- a/hoomd/md/pytest/test_aniso_pair.py
+++ b/hoomd/md/pytest/test_aniso_pair.py
@@ -96,7 +96,8 @@ def test_mode_invalid(mode):
         gay_berne = md.pair.aniso.GayBerne(nlist=md.nlist.Cell(buffer=0.4),
                                            default_r_cut=2.5,
                                            mode=mode)
-    gay_berne = md.pair.aniso.GayBerne(nlist=md.nlist.Cell(buffer=0.4), default_r_cut=2.5)
+    gay_berne = md.pair.aniso.GayBerne(nlist=md.nlist.Cell(buffer=0.4),
+                                       default_r_cut=2.5)
     gay_berne.params[('A', 'A')] = {'epsilon': 1, 'lpar': 0.5, 'lperp': 1.0}
     # Test errors on setting
     with pytest.raises(TypeConversionError):
@@ -299,7 +300,8 @@ def _aniso_forces_and_energies():
 @pytest.fixture(scope="function", params=_valid_params())
 def pair_potential(request):
     spec = request.param
-    pair_potential = spec.cls(nlist=md.nlist.Cell(buffer=0.4), default_r_cut=2.5)
+    pair_potential = spec.cls(nlist=md.nlist.Cell(buffer=0.4),
+                              default_r_cut=2.5)
     for key, value in spec.type_parameters.items():
         setattr(pair_potential, key, value)
     return pair_potential
@@ -347,9 +349,8 @@ def test_aniso_force_computes(make_two_particle_simulation,
         \theta_1 = (1, 0, 0, 0) \ \theta_2 = (0.70738827, 0, 0, 0.70682518) \\
 
     """
-    pot = aniso_forces_and_energies.pair_potential(nlist=md.nlist.Cell(buffer=0.4),
-                                                   default_r_cut=2.5,
-                                                   mode='none')
+    pot = aniso_forces_and_energies.pair_potential(
+        nlist=md.nlist.Cell(buffer=0.4), default_r_cut=2.5, mode='none')
     for param, value in aniso_forces_and_energies.pair_potential_params.items():
         getattr(pot, param)[('A', 'A')] = value
     sim = make_two_particle_simulation(types=['A'], d=0.75, force=pot)

--- a/hoomd/md/pytest/test_constrain_distance.py
+++ b/hoomd/md/pytest/test_constrain_distance.py
@@ -116,7 +116,7 @@ def test_basic_simulation(simulation_factory, polymer_snapshot_factory):
     integrator.methods.append(nve)
     integrator.constraints.append(d)
 
-    cell = hoomd.md.nlist.Cell()
+    cell = hoomd.md.nlist.Cell(buffer=0.4)
     lj = hoomd.md.pair.LJ(nlist=cell)
     lj.params[('A', 'A')] = dict(epsilon=1, sigma=1)
     lj.r_cut[('A', 'A')] = 2**(1 / 6)

--- a/hoomd/md/pytest/test_flags.py
+++ b/hoomd/md/pytest/test_flags.py
@@ -3,7 +3,7 @@ import numpy
 
 
 def test_per_particle_virial(simulation_factory, lattice_snapshot_factory):
-    cell = hoomd.md.nlist.Cell()
+    cell = hoomd.md.nlist.Cell(buffer=0.4)
     lj = hoomd.md.pair.LJ(nlist=cell)
     lj.params[('A', 'A')] = dict(sigma=1.0, epsilon=1.0)
     lj.r_cut[('A', 'A')] = 2.5

--- a/hoomd/md/pytest/test_gsd.py
+++ b/hoomd/md/pytest/test_gsd.py
@@ -68,7 +68,7 @@ def hoomd_snapshot(lattice_snapshot_factory):
 
 def lj_integrator():
     integrator = hoomd.md.Integrator(dt=0.005)
-    lj = hoomd.md.pair.LJ(nlist=hoomd.md.nlist.Cell(), default_r_cut=2.5)
+    lj = hoomd.md.pair.LJ(nlist=hoomd.md.nlist.Cell(buffer=0.4), default_r_cut=2.5)
     lj.params.default = {'sigma': 1, 'epsilon': 1}
     integrator.forces.append(lj)
     langevin = hoomd.md.methods.Langevin(hoomd.filter.All(), kT=1)

--- a/hoomd/md/pytest/test_gsd.py
+++ b/hoomd/md/pytest/test_gsd.py
@@ -68,7 +68,8 @@ def hoomd_snapshot(lattice_snapshot_factory):
 
 def lj_integrator():
     integrator = hoomd.md.Integrator(dt=0.005)
-    lj = hoomd.md.pair.LJ(nlist=hoomd.md.nlist.Cell(buffer=0.4), default_r_cut=2.5)
+    lj = hoomd.md.pair.LJ(nlist=hoomd.md.nlist.Cell(buffer=0.4),
+                          default_r_cut=2.5)
     lj.params.default = {'sigma': 1, 'epsilon': 1}
     integrator.forces.append(lj)
     langevin = hoomd.md.methods.Langevin(hoomd.filter.All(), kT=1)

--- a/hoomd/md/pytest/test_integrate.py
+++ b/hoomd/md/pytest/test_integrate.py
@@ -15,7 +15,7 @@ def make_simulation(simulation_factory, two_particle_snapshot_factory):
 
 @pytest.fixture
 def integrator_elements():
-    nlist = md.nlist.Cell()
+    nlist = md.nlist.Cell(buffer=0.4)
     lj = md.pair.LJ(nlist=nlist, default_r_cut=2.5)
     gauss = md.pair.Gauss(nlist, default_r_cut=3.0)
     lj.params[("A", "A")] = {"epsilon": 1.0, "sigma": 1.0}

--- a/hoomd/md/pytest/test_lj_equation_of_state.py
+++ b/hoomd/md/pytest/test_lj_equation_of_state.py
@@ -50,7 +50,7 @@ def test_lj_equation_of_state(
 
     # set the simulation parameters
     integrator = hoomd.md.Integrator(dt=0.005)
-    lj = hoomd.md.pair.LJ(nlist=hoomd.md.nlist.Cell(),
+    lj = hoomd.md.pair.LJ(nlist=hoomd.md.nlist.Cell(buffer=0.4),
                           default_r_cut=r_cut,
                           mode='shift')
     lj.params.default = {'sigma': 1, 'epsilon': 1}

--- a/hoomd/md/pytest/test_minimize_fire.py
+++ b/hoomd/md/pytest/test_minimize_fire.py
@@ -101,7 +101,7 @@ def test_run_minimization(lattice_snapshot_factory, simulation_factory):
     snap = lattice_snapshot_factory(a=1.5, n=8)
     sim = simulation_factory(snap)
 
-    lj = md.pair.LJ(default_r_cut=2.5, nlist=md.nlist.Cell())
+    lj = md.pair.LJ(default_r_cut=2.5, nlist=md.nlist.Cell(buffer=0.4))
     lj.params[('A', 'A')] = dict(sigma=1.0, epsilon=1.0)
     nve = md.methods.NVE(hoomd.filter.All())
 

--- a/hoomd/md/pytest/test_minimize_fire.py
+++ b/hoomd/md/pytest/test_minimize_fire.py
@@ -55,14 +55,25 @@ def _assert_error_if_nonpositive(fire):
 def test_constructor_validation():
     """Make sure constructor validates arguments."""
     with pytest.raises(ValueError):
-        md.minimize.FIRE(dt=0.01, min_steps_conv=-5)
+        md.minimize.FIRE(dt=0.01,
+                         force_tol=1e-1,
+                         angmom_tol=1e-1,
+                         energy_tol=1e-5,
+                         min_steps_conv=-5)
     with pytest.raises(ValueError):
-        md.minimize.FIRE(dt=0.01, min_steps_adapt=0)
+        md.minimize.FIRE(dt=0.01,
+                         force_tol=1e-1,
+                         angmom_tol=1e-1,
+                         energy_tol=1e-5,
+                         min_steps_adapt=0)
 
 
 def test_get_set_params(simulation_factory, two_particle_snapshot_factory):
     """Assert we can get/set params when not attached and when attached."""
-    fire = md.minimize.FIRE(dt=0.01)
+    fire = md.minimize.FIRE(dt=0.01,
+                            force_tol=1e-1,
+                            angmom_tol=1e-1,
+                            energy_tol=1e-5)
     default_params = {
         'dt': 0.01,
         'integrate_rotational_dof': False,
@@ -106,6 +117,9 @@ def test_run_minimization(lattice_snapshot_factory, simulation_factory):
     nve = md.methods.NVE(hoomd.filter.All())
 
     fire = md.minimize.FIRE(dt=0.0025,
+                            force_tol=1e-1,
+                            angmom_tol=1e-1,
+                            energy_tol=1e-5,
                             methods=[nve],
                             forces=[lj],
                             min_steps_conv=3)
@@ -132,14 +146,21 @@ def test_pickling(lattice_snapshot_factory, simulation_factory):
 
     nve = md.methods.NVE(hoomd.filter.All())
 
-    fire = md.minimize.FIRE(dt=0.0025, methods=[nve])
+    fire = md.minimize.FIRE(dt=0.0025,
+                            force_tol=1e-1,
+                            angmom_tol=1e-1,
+                            energy_tol=1e-5,
+                            methods=[nve])
 
     operation_pickling_check(fire, sim)
 
 
 def _try_add_to_fire(sim, method, should_error=False):
     """Try adding method to FIRE's method list."""
-    fire = md.minimize.FIRE(dt=0.0025)
+    fire = md.minimize.FIRE(dt=0.0025,
+                            force_tol=1e-1,
+                            angmom_tol=1e-1,
+                            energy_tol=1e-5)
     sim.operations.integrator = fire
     if should_error:
         with pytest.raises(ValueError):

--- a/hoomd/md/pytest/test_nlist.py
+++ b/hoomd/md/pytest/test_nlist.py
@@ -30,7 +30,7 @@ def _assert_nlist_params(nlist, param_dict):
 
 def test_common_params(nlist_params):
     nlist_cls, required_args = nlist_params
-    nlist = nlist_cls(**required_args)
+    nlist = nlist_cls(**required_args, buffer=0.4)
     default_params_dict = {
         "buffer": 0.4,
         "exclusions": ('bond',),
@@ -63,7 +63,7 @@ def test_common_params(nlist_params):
 
 
 def test_cell_specific_params():
-    nlist = Cell()
+    nlist = Cell(buffer=0.4)
     _assert_nlist_params(nlist, dict(deterministic=False))
     nlist.deterministic = True
     _assert_nlist_params(nlist, dict(deterministic=True))
@@ -71,7 +71,7 @@ def test_cell_specific_params():
 
 def test_stencil_specific_params():
     cell_width = np.random.uniform(12.1)
-    nlist = Stencil(cell_width)
+    nlist = Stencil(cell_width=cell_width,buffer=0.4)
     _assert_nlist_params(nlist, dict(deterministic=False,
                                      cell_width=cell_width))
     nlist.deterministic = True
@@ -83,7 +83,7 @@ def test_stencil_specific_params():
 def test_simple_simulation(nlist_params, simulation_factory,
                            lattice_snapshot_factory):
     nlist_cls, required_args = nlist_params
-    nlist = nlist_cls(**required_args)
+    nlist = nlist_cls(**required_args, buffer=0.4)
     lj = hoomd.md.pair.LJ(nlist, default_r_cut=1.1)
     lj.params[('A', 'A')] = dict(epsilon=1, sigma=1)
     lj.params[('A', 'B')] = dict(epsilon=1, sigma=1)
@@ -100,7 +100,7 @@ def test_simple_simulation(nlist_params, simulation_factory,
 
 def test_auto_detach_simulation(simulation_factory,
                                 two_particle_snapshot_factory):
-    nlist = Cell()
+    nlist = Cell(buffer=0.4)
     lj = hoomd.md.pair.LJ(nlist, default_r_cut=1.1)
     lj.params[('A', 'A')] = dict(epsilon=1, sigma=1)
     lj.params[('A', 'B')] = dict(epsilon=1, sigma=1)

--- a/hoomd/md/pytest/test_nlist.py
+++ b/hoomd/md/pytest/test_nlist.py
@@ -71,7 +71,7 @@ def test_cell_specific_params():
 
 def test_stencil_specific_params():
     cell_width = np.random.uniform(12.1)
-    nlist = Stencil(cell_width=cell_width,buffer=0.4)
+    nlist = Stencil(cell_width=cell_width, buffer=0.4)
     _assert_nlist_params(nlist, dict(deterministic=False,
                                      cell_width=cell_width))
     nlist.deterministic = True

--- a/hoomd/md/pytest/test_potential.py
+++ b/hoomd/md/pytest/test_potential.py
@@ -98,7 +98,9 @@ def test_mode(simulation_factory, two_particle_snapshot_factory, mode):
 
 
 def test_ron(simulation_factory, two_particle_snapshot_factory):
-    lj = md.pair.LJ(nlist=md.nlist.Cell(buffer=0.4), mode='xplor', default_r_cut=2.5)
+    lj = md.pair.LJ(nlist=md.nlist.Cell(buffer=0.4),
+                    mode='xplor',
+                    default_r_cut=2.5)
     lj.params[('A', 'A')] = {'sigma': 1, 'epsilon': 0.5}
     with pytest.raises(TypeConversionError):
         lj.r_on[('A', 'A')] = 'str'

--- a/hoomd/md/pytest/test_potential.py
+++ b/hoomd/md/pytest/test_potential.py
@@ -50,7 +50,7 @@ def _assert_equivalent_parameter_dicts(param_dict1, param_dict2):
 
 
 def test_rcut(simulation_factory, two_particle_snapshot_factory):
-    lj = md.pair.LJ(nlist=md.nlist.Cell(), default_r_cut=2.5)
+    lj = md.pair.LJ(nlist=md.nlist.Cell(buffer=0.4), default_r_cut=2.5)
     assert lj.r_cut.default == 2.5
     # ensure 0 is a valid value for r_cut
     lj.r_cut[("A", "A")] = 0.0
@@ -76,7 +76,7 @@ def test_rcut(simulation_factory, two_particle_snapshot_factory):
 
 
 def test_invalid_mode():
-    cell = md.nlist.Cell()
+    cell = md.nlist.Cell(buffer=0.4)
     for invalid_mode in [1, 'str', [1, 2, 3]]:
         with pytest.raises(TypeConversionError):
             md.pair.LJ(nlist=cell, default_r_cut=2.5, mode=invalid_mode)
@@ -84,7 +84,7 @@ def test_invalid_mode():
 
 @pytest.mark.parametrize("mode", ['none', 'shift', 'xplor'])
 def test_mode(simulation_factory, two_particle_snapshot_factory, mode):
-    cell = md.nlist.Cell()
+    cell = md.nlist.Cell(buffer=0.4)
     lj = md.pair.LJ(nlist=cell, default_r_cut=2.5, mode=mode)
     lj.params[('A', 'A')] = {'sigma': 1, 'epsilon': 0.5}
     snap = two_particle_snapshot_factory(dimensions=3, d=.5)
@@ -98,7 +98,7 @@ def test_mode(simulation_factory, two_particle_snapshot_factory, mode):
 
 
 def test_ron(simulation_factory, two_particle_snapshot_factory):
-    lj = md.pair.LJ(nlist=md.nlist.Cell(), mode='xplor', default_r_cut=2.5)
+    lj = md.pair.LJ(nlist=md.nlist.Cell(buffer=0.4), mode='xplor', default_r_cut=2.5)
     lj.params[('A', 'A')] = {'sigma': 1, 'epsilon': 0.5}
     with pytest.raises(TypeConversionError):
         lj.r_on[('A', 'A')] = 'str'
@@ -353,7 +353,7 @@ def invalid_params(request):
 
 def test_invalid_params(invalid_params):
     pot = invalid_params.pair_potential(**invalid_params.extra_args,
-                                        nlist=md.nlist.Cell())
+                                        nlist=md.nlist.Cell(buffer=0.4))
     for pair in invalid_params.pair_potential_params:
         if isinstance(pair, tuple):
             with pytest.raises(TypeConversionError):
@@ -361,7 +361,7 @@ def test_invalid_params(invalid_params):
 
 
 def test_invalid_pair_key():
-    pot = md.pair.LJ(nlist=md.nlist.Cell())
+    pot = md.pair.LJ(nlist=md.nlist.Cell(buffer=0.4))
     for invalid_key in [3, [1, 2], 'str']:
         with pytest.raises(KeyError):
             pot.r_cut[invalid_key] = 2.5
@@ -633,7 +633,7 @@ def valid_params(request):
 
 def test_valid_params(valid_params):
     pot = valid_params.pair_potential(**valid_params.extra_args,
-                                      nlist=md.nlist.Cell(),
+                                      nlist=md.nlist.Cell(buffer=0.4),
                                       default_r_cut=2.5)
     for pair in valid_params.pair_potential_params:
         pot.params[pair] = valid_params.pair_potential_params[pair]
@@ -666,7 +666,7 @@ def test_attached_params(simulation_factory, lattice_snapshot_factory,
     pair_keys = valid_params.pair_potential_params.keys()
     particle_types = list(set(itertools.chain.from_iterable(pair_keys)))
     pot = valid_params.pair_potential(**valid_params.extra_args,
-                                      nlist=md.nlist.Cell(),
+                                      nlist=md.nlist.Cell(buffer=0.4),
                                       default_r_cut=2.5)
     pot.params = valid_params.pair_potential_params
 
@@ -693,7 +693,7 @@ def test_run(simulation_factory, lattice_snapshot_factory, valid_params):
     pair_keys = valid_params.pair_potential_params.keys()
     particle_types = list(set(itertools.chain.from_iterable(pair_keys)))
     pot = valid_params.pair_potential(**valid_params.extra_args,
-                                      nlist=md.nlist.Cell(),
+                                      nlist=md.nlist.Cell(buffer=0.4),
                                       default_r_cut=2.5)
     pot.params = valid_params.pair_potential_params
 
@@ -741,7 +741,7 @@ def test_energy_shifting(simulation_factory, two_particle_snapshot_factory):
     r_on = 0.5
     r = 1.0
 
-    lj = md.pair.LJ(nlist=md.nlist.Cell(), default_r_cut=r_cut)
+    lj = md.pair.LJ(nlist=md.nlist.Cell(buffer=0.4), default_r_cut=r_cut)
     lj.params[('A', 'A')] = {'sigma': 1, 'epsilon': 0.5}
 
     sim = simulation_factory(two_particle_snapshot_factory(dimensions=3, d=r))
@@ -766,7 +766,7 @@ def test_energy_shifting(simulation_factory, two_particle_snapshot_factory):
     if energies is not None:
         E_rcut = sum(energies)
 
-    lj_shift = md.pair.LJ(nlist=md.nlist.Cell(),
+    lj_shift = md.pair.LJ(nlist=md.nlist.Cell(buffer=0.4),
                           mode='shift',
                           default_r_cut=r_cut)
     lj_shift.params[('A', 'A')] = {'sigma': 1, 'epsilon': 0.5}
@@ -787,7 +787,7 @@ def test_energy_shifting(simulation_factory, two_particle_snapshot_factory):
     if energies is not None:
         assert sum(energies) == E_r - E_rcut
 
-    lj_xplor = md.pair.LJ(nlist=md.nlist.Cell(),
+    lj_xplor = md.pair.LJ(nlist=md.nlist.Cell(buffer=0.4),
                           mode='xplor',
                           default_r_cut=r_cut)
     lj_xplor.params[('A', 'A')] = {'sigma': 1, 'epsilon': 0.5}
@@ -863,7 +863,7 @@ def test_force_energy_relationship(simulation_factory,
     pair_keys = valid_params.pair_potential_params.keys()
     particle_types = list(set(itertools.chain.from_iterable(pair_keys)))
     pot = valid_params.pair_potential(**valid_params.extra_args,
-                                      nlist=md.nlist.Cell(),
+                                      nlist=md.nlist.Cell(buffer=0.4),
                                       default_r_cut=2.5)
     for pair in valid_params.pair_potential_params:
         pot.params[pair] = valid_params.pair_potential_params[pair]
@@ -968,7 +968,7 @@ def test_force_energy_accuracy(simulation_factory,
                     + " pair force")
 
     pot = forces_and_energies.pair_potential(**forces_and_energies.extra_args,
-                                             nlist=md.nlist.Cell(),
+                                             nlist=md.nlist.Cell(buffer=0.4),
                                              default_r_cut=2.5)
     pot.params[('A', 'A')] = forces_and_energies.pair_potential_params
     snap = two_particle_snapshot_factory(particle_types=['A'], d=0.75)
@@ -1009,7 +1009,7 @@ def test_setting_to_new_sim(simulation_factory, two_particle_snapshot_factory):
     sim1 = populate_sim(simulation_factory(two_particle_snapshot_factory()))
     sim2 = populate_sim(simulation_factory(two_particle_snapshot_factory()))
 
-    nlist = md.nlist.Cell()
+    nlist = md.nlist.Cell(buffer=0.4)
     lj = md.pair.LJ(nlist, default_r_cut=1.1)
     lj.params[("A", "A")] = {"sigma": 0.5, "epsilon": 1.0}
     sim1.operations.integrator.forces.append(lj)
@@ -1041,7 +1041,7 @@ def test_setting_nlist(simulation_factory, two_particle_snapshot_factory):
     sim1 = populate_sim(simulation_factory(two_particle_snapshot_factory()))
     sim2 = populate_sim(simulation_factory(two_particle_snapshot_factory()))
 
-    nlist = md.nlist.Cell()
+    nlist = md.nlist.Cell(buffer=0.4)
     lj = md.pair.LJ(nlist, default_r_cut=1.1)
     lj.params[("A", "A")] = {"sigma": 0.5, "epsilon": 1.0}
     lj2 = deepcopy(lj)
@@ -1091,7 +1091,7 @@ def test_pickling(simulation_factory, two_particle_snapshot_factory,
     sim = simulation_factory(two_particle_snapshot_factory())
     _skip_if_triplet_gpu_mpi(sim, valid_params.pair_potential)
     pot = valid_params.pair_potential(**valid_params.extra_args,
-                                      nlist=md.nlist.Cell(),
+                                      nlist=md.nlist.Cell(buffer=0.4),
                                       default_r_cut=2.5)
     for pair in valid_params.pair_potential_params:
         pot.params[pair] = valid_params.pair_potential_params[pair]

--- a/hoomd/md/pytest/test_pppm_coulomb.py
+++ b/hoomd/md/pytest/test_pppm_coulomb.py
@@ -38,7 +38,7 @@ def test_attach_detach(simulation_factory,
     Also test that parameters can be set.
     """
     # detached
-    nlist = hoomd.md.nlist.Cell()
+    nlist = hoomd.md.nlist.Cell(buffer=0.4)
     ewald, coulomb = hoomd.md.long_range.pppm.make_pppm_coulomb_forces(
         nlist=nlist, resolution=(64, 64, 64), order=6, r_cut=3.0, alpha=0)
 
@@ -49,7 +49,7 @@ def test_attach_detach(simulation_factory,
     assert coulomb.r_cut == 3.0
     assert coulomb.alpha == 0
 
-    nlist2 = hoomd.md.nlist.Tree()
+    nlist2 = hoomd.md.nlist.Tree(buffer=0.4)
     coulomb.nlist = nlist2
     assert coulomb.nlist is nlist2
     assert ewald.nlist is nlist2
@@ -99,7 +99,7 @@ def test_attach_detach(simulation_factory,
 def test_pickling(simulation_factory, two_charged_particle_snapshot_factory):
     """Test that md.long_range.pppm.Coulomb can be pickled and unpickled."""
     # detached
-    nlist = hoomd.md.nlist.Cell()
+    nlist = hoomd.md.nlist.Cell(buffer=0.4)
     ewald, coulomb = hoomd.md.long_range.pppm.make_pppm_coulomb_forces(
         nlist=nlist, resolution=(64, 64, 64), order=6, r_cut=3.0, alpha=0)
     pickling_check(coulomb)
@@ -122,7 +122,7 @@ def test_pickling(simulation_factory, two_charged_particle_snapshot_factory):
 
 def test_pppm_energy(simulation_factory, two_charged_particle_snapshot_factory):
     """Test that md.long_range.pppm.Coulomb computes the correct energy."""
-    nlist = hoomd.md.nlist.Cell()
+    nlist = hoomd.md.nlist.Cell(buffer=0.4)
     ewald, coulomb = hoomd.md.long_range.pppm.make_pppm_coulomb_forces(
         nlist=nlist, resolution=(64, 64, 64), order=6, r_cut=3.0, alpha=0)
 

--- a/hoomd/md/pytest/test_rigid.py
+++ b/hoomd/md/pytest/test_rigid.py
@@ -227,7 +227,7 @@ def test_running_simulation(simulation_factory, two_particle_snapshot_factory,
     rigid = md.constrain.Rigid()
     rigid.body["A"] = valid_body_definition
     langevin = md.methods.Langevin(kT=2.0, filter=hoomd.filter.Rigid())
-    lj = hoomd.md.pair.LJ(nlist=md.nlist.Cell(), mode="shift")
+    lj = hoomd.md.pair.LJ(nlist=md.nlist.Cell(buffer=0.4), mode="shift")
     lj.params.default = {"epsilon": 0.0, "sigma": 1}
     lj.params[("A", "A")] = {"epsilon": 1.0}
     lj.params[("B", "B")] = {"epsilon": 1.0}
@@ -253,7 +253,7 @@ def test_running_without_body_definition(simulation_factory,
                                          two_particle_snapshot_factory):
     rigid = md.constrain.Rigid()
     langevin = md.methods.Langevin(kT=2.0, filter=hoomd.filter.Rigid())
-    lj = hoomd.md.pair.LJ(nlist=md.nlist.Cell(), mode="shift")
+    lj = hoomd.md.pair.LJ(nlist=md.nlist.Cell(buffer=0.4), mode="shift")
     lj.params.default = {"epsilon": 0.0, "sigma": 1}
     lj.params[("A", "A")] = {"epsilon": 1.0}
     lj.params[("B", "B")] = {"epsilon": 1.0}
@@ -277,7 +277,7 @@ def test_setting_body_after_attaching(simulation_factory,
                                       valid_body_definition):
     rigid = md.constrain.Rigid()
     langevin = md.methods.Langevin(kT=2.0, filter=hoomd.filter.Rigid())
-    lj = hoomd.md.pair.LJ(nlist=md.nlist.Cell(), mode="shift")
+    lj = hoomd.md.pair.LJ(nlist=md.nlist.Cell(buffer=0.4), mode="shift")
     lj.params.default = {"epsilon": 0.0, "sigma": 1}
     lj.params[("A", "A")] = {"epsilon": 1.0}
     lj.params[("B", "B")] = {"epsilon": 1.0}


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should based on *maint*. -->
<!-- New features should based on *master*. -->

## Description

<!-- Describe your changes in detail. -->
Remove default values for parameters that have units and use relative tolerances.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Allow users to use arbitrary systems of units, even when the scale is very large (e.g. SI units for nanoscale systems).

<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves #1147

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
* Existing unit tests pass.
* Added unit tests for HPMC shapes with scales ranging from 1e-9 to 1e9.
* Offline test of a LJ fluid at 3 scales.

The MD test simulation used 
```
units = [dict(energy=1, length=1, mass=1, time=1),
         dict(energy=1e-9, length=1e-3, mass=1e-3, time=1),
         dict(energy=1e9, length=1e3, mass=1e3, time=1)]
```
And the resulting normalized PE vs time plot collapses as expected:
![download](https://user-images.githubusercontent.com/2197568/145212992-533792af-6b94-4a9c-842e-06ffdd6a4540.png)

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
Added:

* Support simulations with arbitrarily large or small scales (within the limits of the floating point representation).

Changed:

* [breaking]: ``buffer`` is now a required argument when constructing a neighbor list.
* [breaking]:  ``force_tol``, ``angmom_tol``, and ``energy_tol`` are now required arguments to ``md.minimize.FIRE``
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.

## TODO:

- [ ] Update tutorials after https://github.com/glotzerlab/hoomd-examples/pull/53 is merged.