### PR TITLE
Remove obselete state logging category

### DIFF
--- a/hoomd/logging.py
+++ b/hoomd/logging.py
@@ -487,8 +487,6 @@ class _LoggerEntry:
         except DataAccessError:
             attr = None
 
-        if self.category is LoggerCategories.state:
-            return attr
         if callable(attr):
             return (attr(), self.category.name)
         else:

--- a/hoomd/logging.py
+++ b/hoomd/logging.py
@@ -48,8 +48,6 @@ class LoggerCategories(Flag):
 
         particle: per-particle quantity
 
-        state: internal category for specifying object's internal state
-
         ALL: a combination of all other categories
 
         NONE: represents no category
@@ -67,7 +65,6 @@ class LoggerCategories(Flag):
     improper = auto()
     pair = auto()
     particle = auto()
-    state = auto()
 
     @classmethod
     def any(cls, categories=None):


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should based on *maint*. -->
<!-- New features should based on *master*. -->

## Description

Removes a left over logging category.
<!-- Describe your changes in detail. -->

## Motivation and context

Having this in the documentation and API was incorrect.
<!--- Why is this change required? What problem does it solve? -->

<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves #???

## How has this been tested?

NA
<!--- Please describe in detail how you tested your changes. -->

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
Removed leftover ``state`` logging category.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
