### PR TITLE
Add linker options for GNU only on non-Apple systems

### DIFF
--- a/hoomd/md/test/CMakeLists.txt
+++ b/hoomd/md/test/CMakeLists.txt
@@ -54,7 +54,7 @@ foreach (CUR_TEST ${TEST_LIST} ${MPI_TEST_LIST})
 
     add_dependencies(test_all ${CUR_TEST})
 
-    if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+    if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" AND NOT APPLE)
         # these options are needed to avoid linker errors with GCC
         set(additional_link_options "-Wl,--allow-shlib-undefined -Wl,--no-as-needed")
     endif()


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should based on *maint*. -->
<!-- New features should based on *master*. -->
Following instruction that during beta release cycle all work should be based on master.

## Description
Fix issue #1191 

## Motivation and context
Using gcc on Apple systems gave linker errors because the MacOS linker does not recognize some options that are necessary when using gcc on systems with the GNU linker. See issue #1191 for details.

<!--- Why is this change required? What problem does it solve? -->

<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves #1191 

## How has this been tested?
Identified problem on two different Mac systems and tested that compiling works when the offending linker options are removed from CMakeLists.txt.

Tested the fix with CMake 3.22 on an M1 Mac with MacOS 12.1 and gcc 11: The offending options are no longer generated and compilation now succeeds. The resulting code passes both ctest and pytest.

## Change log

<!-- Propose a change log entry. -->
```
Removed invalid linker options when using gcc on Apple systems.
```

## Checklist:

- [X] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [X] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [X] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
