### PR TITLE
Add Communicator.walltime

### DIFF
--- a/hoomd/ExecutionConfiguration.h
+++ b/hoomd/ExecutionConfiguration.h
@@ -4,7 +4,7 @@
 #ifndef __EXECUTION_CONFIGURATION__
 #define __EXECUTION_CONFIGURATION__
 
-// ensure that HOOMDMath.h is the first thing included
+// ensure that HOOMDMath.h is the first header included to work around broken mpi headers
 #include "HOOMDMath.h"
 
 #ifdef ENABLE_MPI

--- a/hoomd/MPIConfiguration.cc
+++ b/hoomd/MPIConfiguration.cc
@@ -98,6 +98,7 @@ void export_MPIConfiguration(pybind11::module& m)
         .def("barrier", &MPIConfiguration::barrier)
         .def("getNRanksGlobal", &MPIConfiguration::getNRanksGlobal)
         .def("getRankGlobal", &MPIConfiguration::getRankGlobal)
+        .def("getWalltime", &MPIConfiguration::getWalltime)
 #ifdef ENABLE_MPI
         .def_static("_make_mpi_conf_mpi_comm",
                     [](pybind11::object mpi_comm) -> std::shared_ptr<MPIConfiguration>

--- a/hoomd/MPIConfiguration.h
+++ b/hoomd/MPIConfiguration.h
@@ -4,8 +4,8 @@
 #pragma once
 
 // ensure that HOOMDMath.h is the first thing included
-#include "HOOMDMath.h"
 #include "ClockSource.h"
+#include "HOOMDMath.h"
 
 #ifdef ENABLE_MPI
 #include <mpi.h>

--- a/hoomd/MPIConfiguration.h
+++ b/hoomd/MPIConfiguration.h
@@ -3,13 +3,14 @@
 
 #pragma once
 
-// ensure that HOOMDMath.h is the first thing included
-#include "ClockSource.h"
+// ensure that HOOMDMath.h is the first header included to work around broken mpi headers
 #include "HOOMDMath.h"
 
 #ifdef ENABLE_MPI
 #include <mpi.h>
 #endif
+
+#include "ClockSource.h"
 
 /*! \file MPIConfiguration.h
     \brief Declares MPIConfiguration, which initializes the MPI environment

--- a/hoomd/MPIConfiguration.h
+++ b/hoomd/MPIConfiguration.h
@@ -5,6 +5,7 @@
 
 // ensure that HOOMDMath.h is the first thing included
 #include "HOOMDMath.h"
+#include "ClockSource.h"
 
 #ifdef ENABLE_MPI
 #include <mpi.h>
@@ -128,6 +129,15 @@ class PYBIND11_EXPORT MPIConfiguration
 #endif
         }
 
+    double getWalltime()
+        {
+        double walltime = static_cast<double>(m_clock.getTime()) / 1e9;
+#ifdef ENABLE_MPI
+        MPI_Bcast(&walltime, 1, MPI_DOUBLE, 0, m_mpi_comm);
+#endif
+        return walltime;
+        }
+
     protected:
 #ifdef ENABLE_MPI
     MPI_Comm m_mpi_comm;    //!< The MPI communicator
@@ -135,6 +145,9 @@ class PYBIND11_EXPORT MPIConfiguration
 #endif
     unsigned int m_rank;   //!< Rank of this processor (0 if running in single-processor mode)
     unsigned int m_n_rank; //!< Ranks per partition
+
+    /// Clock to provide rank synchronized walltime.
+    ClockSource m_clock;
     };
 
 namespace detail

--- a/hoomd/communicator.py
+++ b/hoomd/communicator.py
@@ -181,6 +181,14 @@ class Communicator(object):
         yield None
         _current_communicator = prev
 
+    @property
+    def walltime(self):
+        """Wall clock time since creating the `Communicator` [seconds].
+
+        `walltime` returns the same value on each rank in the current partition.
+        """
+        return self.cpp_mpi_conf.getWalltime()
+
 
 # store the "current" communicator to be used for MPI_Abort calls. This defaults
 # to the world communicator, but users can opt in to a more specific

--- a/hoomd/pytest/test_communicator.py
+++ b/hoomd/pytest/test_communicator.py
@@ -3,6 +3,8 @@
 
 import hoomd
 import pytest
+import time
+import numpy
 try:
     from mpi4py import MPI
     mpi4py_available = True
@@ -56,6 +58,15 @@ def test_communicator_partition():
             mpi_communicator = MPI.COMM_WORLD
             assert communicator.partition == mpi_communicator.Get_rank()
 
+
+def test_commuicator_walltime():
+    """Check that Communicator.walltime functions."""
+    ref_time = 1/16
+    c = hoomd.communicator.Communicator()
+    time.sleep(ref_time)
+    t = c.walltime
+
+    numpy.testing.assert_allclose(t, ref_time, rtol=1e-01)
 
 @skip_mpi4py
 @pytest.mark.skipif(not hoomd.version.mpi_enabled,

--- a/hoomd/pytest/test_communicator.py
+++ b/hoomd/pytest/test_communicator.py
@@ -61,12 +61,13 @@ def test_communicator_partition():
 
 def test_commuicator_walltime():
     """Check that Communicator.walltime functions."""
-    ref_time = 1/16
+    ref_time = 1 / 16
     c = hoomd.communicator.Communicator()
     time.sleep(ref_time)
     t = c.walltime
 
     numpy.testing.assert_allclose(t, ref_time, rtol=1e-01)
+
 
 @skip_mpi4py
 @pytest.mark.skipif(not hoomd.version.mpi_enabled,


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should based on *maint*. -->
<!-- New features should based on *master*. -->

## Description

<!-- Describe your changes in detail. -->
Add the `walltime` property to `Communicator`.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
One feature from v2 missing in v3 is the ability to stop the simulation run when a time limit has passed. I don't plan to add this explicitly, but the v3 API is designed to make this possible for the user to implement Python code. 

However, the user's code could deadlock when using `time.time()` in an MPI simulation and the node clocks were not *exactly* synchronized. To prevent this, I'm adding `Communicator.walltime` which returns the elapsed time since the communicator's creation, broadcasted to all ranks. With this, a user can implement a robust wall time limit with code like this (to appear in a tutorial on workflows soon).
```
while sim.timestep < end_step:
    sim.run(min(100_000, end_step - sim.timestep))
    
    if sim.device.communicator.walltime + sim.walltime >= WALLTIME_LIMIT:
        break
```

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
I have tested the method locally.

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
Added:

* ``Communicator.walltime`` - the wall clock time since creating the ``Communicator``.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
