### PR TITLE
Fix/custom force aniso

### DIFF
--- a/hoomd/md/CustomForceCompute.cc
+++ b/hoomd/md/CustomForceCompute.cc
@@ -48,7 +48,10 @@ void export_CustomForceCompute(py::module& m)
     py::class_<CustomForceCompute, ForceCompute, std::shared_ptr<CustomForceCompute>>(
         m,
         "CustomForceCompute")
-        .def(py::init<std::shared_ptr<SystemDefinition>, pybind11::object>());
+        .def(py::init<std::shared_ptr<SystemDefinition>, pybind11::object>())
+        .def_property("aniso",
+                     &CustomForceCompute::isAnisotropic,
+                     &CustomForceCompute::setAnisotropic);
     }
 
     } // end namespace detail

--- a/hoomd/md/CustomForceCompute.cc
+++ b/hoomd/md/CustomForceCompute.cc
@@ -19,8 +19,9 @@ namespace md
 /*! \param sysdef SystemDefinition containing the ParticleData to compute forces on
  */
 CustomForceCompute::CustomForceCompute(std::shared_ptr<SystemDefinition> sysdef,
-                                       pybind11::object py_setForces)
-    : ForceCompute(sysdef)
+                                       pybind11::object py_setForces,
+                                       bool aniso)
+    : ForceCompute(sysdef), m_aniso(aniso)
     {
     m_exec_conf->msg->notice(5) << "Constructing ConstForceCompute" << endl;
     m_setForces = py_setForces;
@@ -48,10 +49,7 @@ void export_CustomForceCompute(py::module& m)
     py::class_<CustomForceCompute, ForceCompute, std::shared_ptr<CustomForceCompute>>(
         m,
         "CustomForceCompute")
-        .def(py::init<std::shared_ptr<SystemDefinition>, pybind11::object>())
-        .def_property("aniso",
-                      &CustomForceCompute::isAnisotropic,
-                      &CustomForceCompute::setAnisotropic);
+        .def(py::init<std::shared_ptr<SystemDefinition>, pybind11::object, bool>());
     }
 
     } // end namespace detail

--- a/hoomd/md/CustomForceCompute.cc
+++ b/hoomd/md/CustomForceCompute.cc
@@ -50,8 +50,8 @@ void export_CustomForceCompute(py::module& m)
         "CustomForceCompute")
         .def(py::init<std::shared_ptr<SystemDefinition>, pybind11::object>())
         .def_property("aniso",
-                     &CustomForceCompute::isAnisotropic,
-                     &CustomForceCompute::setAnisotropic);
+                      &CustomForceCompute::isAnisotropic,
+                      &CustomForceCompute::setAnisotropic);
     }
 
     } // end namespace detail

--- a/hoomd/md/CustomForceCompute.h
+++ b/hoomd/md/CustomForceCompute.h
@@ -31,7 +31,8 @@ class PYBIND11_EXPORT CustomForceCompute : public ForceCompute
     public:
     //! Constructs the compute
     CustomForceCompute(std::shared_ptr<hoomd::SystemDefinition> sysdef,
-                       pybind11::object py_setForces);
+                       pybind11::object py_setForces,
+                       bool aniso);
 
     //! Destructor
     ~CustomForceCompute();
@@ -39,11 +40,6 @@ class PYBIND11_EXPORT CustomForceCompute : public ForceCompute
     bool isAnisotropic()
         {
         return m_aniso;
-        }
-
-    void setAnisotropic(bool aniso)
-        {
-        m_aniso = aniso;
         }
 
     protected:
@@ -55,7 +51,7 @@ class PYBIND11_EXPORT CustomForceCompute : public ForceCompute
     pybind11::object m_setForces;
 
     //! flag for anisotropic python custom forces
-    bool m_aniso = false;
+    bool m_aniso;
     };
 
 namespace detail

--- a/hoomd/md/CustomForceCompute.h
+++ b/hoomd/md/CustomForceCompute.h
@@ -36,6 +36,16 @@ class PYBIND11_EXPORT CustomForceCompute : public ForceCompute
     //! Destructor
     ~CustomForceCompute();
 
+    bool isAnisotropic()
+        {
+        return m_aniso;
+        }
+
+    void setAnisotropic(bool aniso)
+        {
+        m_aniso = aniso;
+        }
+
     protected:
     //! Actually compute the forces
     virtual void computeForces(uint64_t timestep);
@@ -43,6 +53,9 @@ class PYBIND11_EXPORT CustomForceCompute : public ForceCompute
     private:
     //! A python callback when the force is updated
     pybind11::object m_setForces;
+
+    //! flag for anisotropic python custom forces
+    bool m_aniso = false;
     };
 
 namespace detail

--- a/hoomd/md/force.py
+++ b/hoomd/md/force.py
@@ -211,7 +211,7 @@ class Custom(Force):
     ``_with_ghost``.
 
     Note:
-        Pass `aniso=True` to the `md.force.Custom` constructor if your custom
+        Pass ``aniso=True`` to the `md.force.Custom` constructor if your custom
         force produces non-zero torques on particles.
 
     Examples::

--- a/hoomd/md/force.py
+++ b/hoomd/md/force.py
@@ -181,8 +181,8 @@ class Custom(Force):
     """Custom forces implemented in python.
 
     Derive a custom force class from `Custom`, and override the `set_forces`
-    method to  compute forces on particles. Use have direct, zero-copy access to
-    the C++ managed buffers via either the `cpu_local_force_arrays` or
+    method to compute forces on particles. Users have direct, zero-copy access
+    to the C++ managed buffers via either the `cpu_local_force_arrays` or
     `gpu_local_force_arrays` property. Choose the property that corresponds to
     the device you wish to alter the data on. In addition to zero-copy access to
     force buffers, custom forces have access to the local snapshot API via the
@@ -197,6 +197,7 @@ class Custom(Force):
         class MyCustomForce(hoomd.force.Custom):
             def __init__(self):
                 super().__init__()
+                self.aniso = True
 
             def set_forces(self, timestep):
                 with self.cpu_local_force_arrays as arrays:
@@ -209,6 +210,12 @@ class Custom(Force):
     associated with each rank. To access this read-only ghost data, access the
     property name with either the prefix ``ghost_`` of the suffix
     ``_with_ghost``.
+
+    Note:
+        If updating the torque array in the set_forces method, make sure to set
+        the `aniso` property of the custom force object to `True` so the
+        simulation knows to update the rotational degrees of freedom in the
+        system.
 
     Examples::
 
@@ -241,6 +248,10 @@ class Custom(Force):
 
     def __init__(self):
         super().__init__()
+        aniso_param = ParameterDict(aniso=bool)
+        aniso_param['aniso'] = False
+        self._param_dict.update(aniso_param)
+
         self._state = None  # to be set on attaching
 
     def _attach(self):

--- a/hoomd/md/pytest/test_custom_force.py
+++ b/hoomd/md/pytest/test_custom_force.py
@@ -356,11 +356,11 @@ def test_failure_with_cpu_device_and_gpu_buffer():
 
 
 def test_get_set_aniso():
-    """make sure aniso is settable."""
+    """Make sure aniso is settable."""
     force = MyEmptyForce()
-    assert force.aniso == False
+    assert not force.aniso
     force.aniso = True
-    assert force.aniso == True
+    assert force.aniso
 
 
 def test_torques_update(local_force_names, two_particle_snapshot_factory,
@@ -385,6 +385,5 @@ def test_torques_update(local_force_names, two_particle_snapshot_factory,
 
         snap = sim.state.get_snapshot()
         if sim.device.communicator.rank == 0:
-            assert np.count_nonzero(snap.particles.orientation - initial_orientations)
-
-
+            assert np.count_nonzero(snap.particles.orientation
+                                    - initial_orientations)

--- a/hoomd/md/pytest/test_custom_force.py
+++ b/hoomd/md/pytest/test_custom_force.py
@@ -75,8 +75,7 @@ def _skip_if_gpu_device_and_no_cupy(sim):
 class MyForce(md.force.Custom):
 
     def __init__(self, local_force_name):
-        super().__init__()
-        self.aniso = True
+        super().__init__(aniso=True)
         self._local_force_name = local_force_name
 
     def set_forces(self, timestep):
@@ -353,14 +352,6 @@ def test_failure_with_cpu_device_and_gpu_buffer():
     sim.operations.integrator = integrator
     with pytest.raises(RuntimeError):
         sim.run(1)
-
-
-def test_get_set_aniso():
-    """Make sure aniso is settable."""
-    force = MyEmptyForce()
-    assert not force.aniso
-    force.aniso = True
-    assert force.aniso
 
 
 def test_torques_update(local_force_names, two_particle_snapshot_factory,

--- a/hoomd/md/pytest/test_custom_force.py
+++ b/hoomd/md/pytest/test_custom_force.py
@@ -76,6 +76,7 @@ class MyForce(md.force.Custom):
 
     def __init__(self, local_force_name):
         super().__init__()
+        self.aniso = True
         self._local_force_name = local_force_name
 
     def set_forces(self, timestep):
@@ -352,3 +353,38 @@ def test_failure_with_cpu_device_and_gpu_buffer():
     sim.operations.integrator = integrator
     with pytest.raises(RuntimeError):
         sim.run(1)
+
+
+def test_get_set_aniso():
+    """make sure aniso is settable."""
+    force = MyEmptyForce()
+    assert force.aniso == False
+    force.aniso = True
+    assert force.aniso == True
+
+
+def test_torques_update(local_force_names, two_particle_snapshot_factory,
+                        force_simulation_factory):
+    """Confirm torque'd particles' orientation changes over time."""
+    initial_orientations = np.array([[1, 0, 0, 0], [1, 0, 0, 0]])
+    for local_force_name in local_force_names:
+        snap = two_particle_snapshot_factory()
+        force = MyForce(local_force_name)
+        sim = force_simulation_factory(force, snap)
+        if sim.device.communicator.rank == 0:
+            snap.particles.moment_inertia[:] = [[1, 1, 1], [1, 1, 1]]
+        sim.state.set_snapshot(snap)
+
+        _skip_if_gpu_device_and_no_cupy(sim)
+        sim.operations.integrator.integrate_rotational_dof = True
+
+        if sim.device.communicator.rank == 0:
+            npt.assert_allclose(snap.particles.orientation,
+                                initial_orientations)
+        sim.run(2)
+
+        snap = sim.state.get_snapshot()
+        if sim.device.communicator.rank == 0:
+            assert np.count_nonzero(snap.particles.orientation - initial_orientations)
+
+


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should based on *maint*. -->
<!-- New features should based on *master*. -->

## Description

Added a property that should have been part of #1151 . Adds a settable flag so users can alert the simulation to integrate over the anisotropic degrees of freedom if their python force has a torque.

## Motivation and context

Ideally, this would have been a part of #1151 , but it was merged before we realized it needed to be there.

## How has this been tested?

Tests have been added in the `test_custom_force.py` file;

## Change log

<!-- Propose a change log entry. -->
```
Added flag for integrating over rotational degrees of freedom with custom forces.
```

## Checklist:

- [ ] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [ ] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [ ] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
