### PR TITLE
Add support for cereal 1.3.1

### DIFF
--- a/CMake/hoomd/HOOMDMPISetup.cmake
+++ b/CMake/hoomd/HOOMDMPISetup.cmake
@@ -8,13 +8,18 @@ if (ENABLE_MPI)
     find_package(cereal CONFIG)
     if (cereal_FOUND)
         find_package_message(cereal "Found cereal: ${cereal_DIR}" "[${cereal_DIR}]")
+
+        if (NOT TARGET cereal::cereal AND TARGET cereal)
+            message(STATUS "Found cereal target, adding cereal::cereal alias.")
+            add_library(cereal::cereal ALIAS cereal)
+        endif()
     else()
         # work around missing ceralConfig.cmake
 
         find_path(cereal_INCLUDE_DIR NAMES cereal/cereal.hpp
             PATHS ${CMAKE_INSTALL_PREFIX}/include)
-        add_library(cereal INTERFACE IMPORTED)
-        set_target_properties(cereal PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${cereal_INCLUDE_DIR}")
+        add_library(cereal::cereal INTERFACE IMPORTED)
+        set_target_properties(cereal::cereal PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${cereal_INCLUDE_DIR}")
         find_package_message(cereal "Could not find cereal, assuming it is on a default path" "[${cereal_INCLUDE_DIR}]")
     endif()
 

--- a/hoomd-config.cmake.in
+++ b/hoomd-config.cmake.in
@@ -54,6 +54,11 @@ if (ENABLE_MPI)
     find_dependency(cereal CONFIG REQUIRED)
     if (cereal_FOUND)
         find_package_message(cereal "Found cereal: ${cereal_DIR}" "[${cereal_DIR}]")
+
+        if (NOT TARGET cereal::cereal AND TARGET cereal)
+            message(STATUS "Found cereal target, adding cereal::cereal alias.")
+            add_library(cereal::cereal ALIAS cereal)
+        endif()
     endif()
 endif()
 

--- a/hoomd/CMakeLists.txt
+++ b/hoomd/CMakeLists.txt
@@ -338,7 +338,7 @@ endif()
 # Libraries and compile definitions for MPI enabled builds
 if (ENABLE_MPI)
     target_compile_definitions(_hoomd PUBLIC ENABLE_MPI)
-    target_link_libraries(_hoomd PUBLIC MPI::MPI_CXX cereal)
+    target_link_libraries(_hoomd PUBLIC MPI::MPI_CXX cereal::cereal)
 
     if (ENABLE_MPI_CUDA)
           target_compile_definitions(_hoomd PUBLIC ENABLE_MPI_CUDA)


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should based on *maint*. -->
<!-- New features should based on *master*. -->

## Description

<!-- Describe your changes in detail. -->
Use the `cereal::cereal` target when it exists. Otherwise, use the `cereal` target.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
cereal 1.3.1 makes a breaking change to their CMake configuration and renames the target from `cereal` to `cereal::cereal`.

<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves #1204

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
CI tests will ensure this change works with cereal 1.3.0 and possibly older on all test platforms. The `cereal::cereal` target is known to be available by inspection of systems with this version installed.

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
Added:

* Support cereal 1.3.1
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
