### PR TITLE
Fix warning about the backtrace return type, add libexecinfo on FreeBSD.

### DIFF
--- a/hoomd/CMakeLists.txt
+++ b/hoomd/CMakeLists.txt
@@ -274,6 +274,9 @@ endif()
 
 # link the library to its dependencies
 target_link_libraries(_hoomd PUBLIC pybind11::pybind11 quickhull Eigen3::Eigen)
+if(CMAKE_SYSTEM_NAME STREQUAL "FreeBSD")
+    target_link_libraries(_hoomd PUBLIC execinfo) # on FreeBSD backtrace() is in libexecinfo
+endif()
 
 # specify required include directories
 target_include_directories(_hoomd PUBLIC

--- a/hoomd/MemoryTraceback.cc
+++ b/hoomd/MemoryTraceback.cc
@@ -32,7 +32,7 @@ void MemoryTraceback::registerAllocation(const void* ptr,
     m_tags[idx] = tag;
 
     // obtain a traceback
-    int num_symbols = backtrace(&m_traces[idx].front(), MAX_TRACEBACK);
+    auto num_symbols = backtrace(&m_traces[idx].front(), MAX_TRACEBACK);
 
     m_traces[idx].resize(num_symbols);
     }


### PR DESCRIPTION
On FreeBSD backtrace returns size_t, on Linux it returns int.
No need to hard-code the type, auto will cover them all.


## Checklist:

- [X] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [X] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [ ] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
