### PR TITLE
Add linear_momentum loggable.

### DIFF
--- a/hoomd/Integrator.h
+++ b/hoomd/Integrator.h
@@ -124,8 +124,8 @@ class PYBIND11_EXPORT Integrator : public Updater
     /// Count the total number of degrees of freedom removed by all constraint forces
     Scalar getNDOFRemoved(std::shared_ptr<ParticleGroup> query);
 
-    /// helper function to compute total momentum
-    virtual Scalar computeTotalMomentum(uint64_t timestep);
+    /// Compute the linear momentum of the system
+    virtual vec3<double> computeLinearMomentum();
 
     /// Prepare for the run
     virtual void prepRun(uint64_t timestep);

--- a/hoomd/md/integrate.py
+++ b/hoomd/md/integrate.py
@@ -5,6 +5,7 @@
 
 import itertools
 
+import hoomd
 from hoomd.md import _md
 from hoomd.data.parameterdicts import ParameterDict
 from hoomd.data.typeconverter import OnlyTypes
@@ -256,3 +257,15 @@ class Integrator(_DynamicIntegrator):
         if (attr == 'integrate_rotational_dof' and self._simulation is not None
                 and self._simulation.state is not None):
             self._simulation.state.update_group_dof()
+
+    @hoomd.logging.log(requires_run=True)
+    def linear_momentum(self):
+        """float: The linear momentum vector of the system \
+            :math:`[\\mathrm{mass} \\cdot \\mathrm{velocity}]`.
+
+        .. math::
+
+            \\vec{p} = \\sum_i^\\mathrm{N_particles} m_i \\vec{v}_i
+        """
+        v = self._cpp_obj.computeLinearMomentum()
+        return (v.x, v.y, v.z)

--- a/hoomd/md/integrate.py
+++ b/hoomd/md/integrate.py
@@ -260,7 +260,7 @@ class Integrator(_DynamicIntegrator):
 
     @hoomd.logging.log(requires_run=True)
     def linear_momentum(self):
-        """float: The linear momentum vector of the system \
+        """tuple(float,float,float): The linear momentum vector of the system \
             :math:`[\\mathrm{mass} \\cdot \\mathrm{velocity}]`.
 
         .. math::

--- a/hoomd/md/integrate.py
+++ b/hoomd/md/integrate.py
@@ -265,7 +265,7 @@ class Integrator(_DynamicIntegrator):
 
         .. math::
 
-            \\vec{p} = \\sum_i^\\mathrm{N_particles} m_i \\vec{v}_i
+            \\vec{p} = \\sum_{i=0}^\\mathrm{N_particles} m_i \\vec{v}_i
         """
         v = self._cpp_obj.computeLinearMomentum()
         return (v.x, v.y, v.z)

--- a/hoomd/md/integrate.py
+++ b/hoomd/md/integrate.py
@@ -45,9 +45,9 @@ class _DynamicIntegrator(BaseIntegrator):
         self._param_dict.update(param_dict)
 
     def _attach(self):
-        self.forces._sync(self._simulation, self._cpp_obj.forces)
-        self.constraints._sync(self._simulation, self._cpp_obj.constraints)
-        self.methods._sync(self._simulation, self._cpp_obj.methods)
+        self._forces._sync(self._simulation, self._cpp_obj.forces)
+        self._constraints._sync(self._simulation, self._cpp_obj.constraints)
+        self._methods._sync(self._simulation, self._cpp_obj.methods)
         if self.rigid is not None:
             self.rigid._attach()
         super()._attach()

--- a/hoomd/md/pytest/CMakeLists.txt
+++ b/hoomd/md/pytest/CMakeLists.txt
@@ -10,6 +10,7 @@ set(files __init__.py
     test_custom_force.py
     test_external.py
     test_filter_md.py
+    test_integrate.py
     test_bond.py
     test_dihedral.py
     test_flags.py

--- a/hoomd/md/pytest/test_integrate.py
+++ b/hoomd/md/pytest/test_integrate.py
@@ -4,6 +4,7 @@
 import pytest
 
 import hoomd
+import hoomd.conftest
 import hoomd.md as md
 import numpy
 
@@ -85,3 +86,9 @@ def test_linear_momentum(simulation_factory, lattice_snapshot_factory):
                               * snapshot.particles.velocity,
                               axis=0)
         numpy.testing.assert_allclose(linear_momentum, reference)
+
+
+def test_pickling(make_simulation, integrator_elements):
+    sim = make_simulation()
+    integrator = hoomd.md.Integrator(0.005, **integrator_elements)
+    hoomd.conftest.operation_pickling_check(integrator, sim)


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should based on *maint*. -->
<!-- New features should based on *master*. -->

## Description

<!-- Describe your changes in detail. -->
Add the `linear_momentum` loggable quantity to the md Integrator.

## Motivation and context

Users can use this to check on the momentum conservation of the system, such as the the test in #992.

<!--- Why is this change required? What problem does it solve? -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
The pull request adds a unit test.

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
Added:

* ``md.Integrator.linear_momentum`` - Compute the total system linear momentum. Loggable.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
