### PR TITLE
Add the bond, angle, and dihedral table potentials to the v3 API.

### DIFF
--- a/hoomd/md/BondTablePotential.cc
+++ b/hoomd/md/BondTablePotential.cc
@@ -300,6 +300,7 @@ void export_BondTablePotential(pybind11::module& m)
         m,
         "BondTablePotential")
         .def(pybind11::init<std::shared_ptr<SystemDefinition>, unsigned int>())
+        .def_property_readonly("width", &BondTablePotential::getWidth)
         .def("setParams", &BondTablePotential::setParamsPython)
         .def("getParams", &BondTablePotential::getParams);
     }

--- a/hoomd/md/BondTablePotential.h
+++ b/hoomd/md/BondTablePotential.h
@@ -74,6 +74,12 @@ class PYBIND11_EXPORT BondTablePotential : public ForceCompute
     /// Get the parameters for a particular type.
     pybind11::dict getParams(std::string type);
 
+    /// Get the width
+    unsigned int getWidth()
+        {
+        return m_table_width;
+        }
+
 #ifdef ENABLE_MPI
     //! Get ghost particle fields requested by this pair potential
     /*! \param timestep Current time step

--- a/hoomd/md/BondTablePotential.h
+++ b/hoomd/md/BondTablePotential.h
@@ -68,6 +68,12 @@ class PYBIND11_EXPORT BondTablePotential : public ForceCompute
                           Scalar rmin,
                           Scalar rmax);
 
+    /// Set parameters from Python.
+    void setParamsPython(std::string type, pybind11::dict params);
+
+    /// Get the parameters for a particular type.
+    pybind11::dict getParams(std::string type);
+
 #ifdef ENABLE_MPI
     //! Get ghost particle fields requested by this pair potential
     /*! \param timestep Current time step

--- a/hoomd/md/TableAngleForceCompute.h
+++ b/hoomd/md/TableAngleForceCompute.h
@@ -66,6 +66,18 @@ class PYBIND11_EXPORT TableAngleForceCompute : public ForceCompute
     virtual void
     setTable(unsigned int type, const std::vector<Scalar>& V, const std::vector<Scalar>& T);
 
+    /// Set parameters from Python.
+    void setParamsPython(std::string type, pybind11::dict params);
+
+    /// Get the parameters for a particular type.
+    pybind11::dict getParams(std::string type);
+
+    /// Get the width
+    unsigned int getWidth()
+        {
+        return m_table_width;
+        }
+
 #ifdef ENABLE_MPI
     //! Get ghost particle fields requested by this pair potential
     /*! \param timestep Current time step

--- a/hoomd/md/TableDihedralForceCompute.cc
+++ b/hoomd/md/TableDihedralForceCompute.cc
@@ -87,6 +87,47 @@ void TableDihedralForceCompute::setTable(unsigned int type,
         }
     }
 
+void TableDihedralForceCompute::setParamsPython(std::string type, pybind11::dict params)
+    {
+    auto type_id = m_dihedral_data->getTypeByName(type);
+
+    const auto V_py = params["V"].cast<pybind11::array_t<Scalar>>().unchecked<1>();
+    const auto T_py = params["tau"].cast<pybind11::array_t<Scalar>>().unchecked<1>();
+
+    std::vector<Scalar> V(V_py.size());
+    std::vector<Scalar> T(T_py.size());
+
+    std::copy(V_py.data(0), V_py.data(0) + V_py.size(), V.data());
+    std::copy(T_py.data(0), T_py.data(0) + T_py.size(), T.data());
+
+    setTable(type_id, V, T);
+    }
+
+/// Get the parameters for a particular type.
+pybind11::dict TableDihedralForceCompute::getParams(std::string type)
+    {
+    ArrayHandle<Scalar2> h_tables(m_tables, access_location::host, access_mode::read);
+
+    auto type_id = m_dihedral_data->getTypeByName(type);
+    pybind11::dict params;
+
+    auto V = pybind11::array_t<Scalar>(m_table_width);
+    auto V_unchecked = V.mutable_unchecked<1>();
+    auto T = pybind11::array_t<Scalar>(m_table_width);
+    auto T_unchecked = T.mutable_unchecked<1>();
+
+    for (unsigned int i = 0; i < m_table_width; i++)
+        {
+        V_unchecked(i) = h_tables.data[m_table_value(i, type_id)].x;
+        T_unchecked(i) = h_tables.data[m_table_value(i, type_id)].y;
+        }
+
+    params["V"] = V;
+    params["tau"] = T;
+
+    return params;
+    }
+
 /*! \post The table based forces are computed for the given timestep.
 \param timestep specifies the current time step of the simulation
 */
@@ -340,7 +381,9 @@ void export_TableDihedralForceCompute(pybind11::module& m)
                      std::shared_ptr<TableDihedralForceCompute>>(m, "TableDihedralForceCompute")
         .def(pybind11::init<std::shared_ptr<SystemDefinition>, unsigned int>())
         .def("setTable", &TableDihedralForceCompute::setTable)
-        .def("getEntry", &TableDihedralForceCompute::getEntry);
+        .def_property_readonly("width", &TableDihedralForceCompute::getWidth)
+        .def("setParams", &TableDihedralForceCompute::setParamsPython)
+        .def("getParams", &TableDihedralForceCompute::getParams);
     }
 
     } // end namespace detail

--- a/hoomd/md/TableDihedralForceCompute.cc
+++ b/hoomd/md/TableDihedralForceCompute.cc
@@ -12,9 +12,6 @@
 
 using namespace std;
 
-#undef VT0
-#undef VT1
-
 // SMALL a relatively small number
 #define SMALL 0.001f
 

--- a/hoomd/md/TableDihedralForceCompute.h
+++ b/hoomd/md/TableDihedralForceCompute.h
@@ -66,6 +66,18 @@ class PYBIND11_EXPORT TableDihedralForceCompute : public ForceCompute
     virtual void
     setTable(unsigned int type, const std::vector<Scalar>& V, const std::vector<Scalar>& T);
 
+    /// Set parameters from Python.
+    void setParamsPython(std::string type, pybind11::dict params);
+
+    /// Get the parameters for a particular type.
+    pybind11::dict getParams(std::string type);
+
+    /// Get the width
+    unsigned int getWidth()
+        {
+        return m_table_width;
+        }
+
 #ifdef ENABLE_MPI
     //! Get ghost particle fields requested by this pair potential
     /*! \param timestep Current time step
@@ -78,19 +90,6 @@ class PYBIND11_EXPORT TableDihedralForceCompute : public ForceCompute
         return flags;
         }
 #endif
-
-    //! Get table entry
-    /*! \param type type index
-        \param i index to access
-        \returns the table entries at the index
-
-        For unit testing
-    */
-    Scalar2 getEntry(unsigned int type, unsigned int i)
-        {
-        ArrayHandle<Scalar2> h_tables(m_tables, access_location::host, access_mode::read);
-        return h_tables.data[m_table_value(i, type)];
-        }
 
     protected:
     std::shared_ptr<DihedralData> m_dihedral_data; //!< Bond data to use in computing dihedrals

--- a/hoomd/md/angle.py
+++ b/hoomd/md/angle.py
@@ -78,10 +78,10 @@ class Harmonic(Angle):
         self._add_typeparam(params)
 
 
-class Cosinesq(Angle):
+class CosineSquared(Angle):
     r"""Cosine squared angle potential.
 
-    :py:class:`Cosinesq` specifies a cosine squared potential energy
+    :py:class:`CosineSquared` specifies a cosine squared potential energy
     between every triplet of particles with an angle specified between them.
 
     .. math::
@@ -111,7 +111,7 @@ class Cosinesq(Angle):
 
     Examples::
 
-        cosinesq = angle.Cosinesq()
+        cosinesq = angle.CosineSquared()
         cosinesq.params['polymer'] = dict(k=3.0, t0=0.7851)
         cosinesq.params['backbone'] = dict(k=100.0, t0=1.0)
     """

--- a/hoomd/md/bond.py
+++ b/hoomd/md/bond.py
@@ -3,15 +3,13 @@
 
 """Bond potentials."""
 
-from hoomd import _hoomd
 from hoomd.md import _md
 from hoomd.md.force import Force
-from hoomd.md import force
 from hoomd.data.typeparam import TypeParameter
 from hoomd.data.parameterdicts import TypeParameterDict
 import hoomd
 
-import math
+import numpy
 
 
 class Bond(Force):
@@ -32,7 +30,6 @@ class Bond(Force):
         else:
             cpp_cls = getattr(_md, self._cpp_class_name + "GPU")
 
-        # TODO remove string argument
         self._cpp_obj = cpp_cls(self._simulation.state._cpp_sys_def)
 
         super()._attach()
@@ -150,247 +147,106 @@ class FENEWCA(Bond):
         self._add_typeparam(params)
 
 
-def _table_eval(r, rmin, rmax, V, F, width):
-    dr = (rmax - rmin) / float(width - 1)
-    i = int(round((r - rmin) / dr))
-    return (V[i], F[i])
-
-
-class table(force._force):  # noqa - Will be renamed when updated for v3
-    r"""Tabulated bond potential.
+class Table(Bond):
+    """Tabulated bond potential.
 
     Args:
-        width (int): Number of points to use to interpolate V and F
-        name (str): Name of the potential instance
+        width (int): Number of points in the table.
 
-    :py:class:`table` specifies that a tabulated bond potential should be
-    applied between the two particles in each defined bond.
+    `Table` computes a user-defined potential and force between the two
+    particles in each bond.
 
-    The force :math:`\vec{F}` is (in force units) and the potential :math:`V(r)`
-    is (in energy units):
+    Note:
+        For potentials that diverge near r=0, to set *r_min* to a non-zero
+        value.
+
+    The force :math:`\\vec{F}` is:
 
     .. math::
         :nowrap:
 
-        \begin{eqnarray*}
-        \vec{F}(\vec{r})     = & 0;
-                               & r < r_{\mathrm{min}} \\
-                             = & F_{\mathrm{user}}(r)\hat{r};
-                               & r < r_{\mathrm{max}} \\
-                             = & 0;
-                               & r \ge r_{\mathrm{max}} \\
-                             \\
-        V(r)       = & 0                    & r < r_{\mathrm{min}} \\
-                   = & V_{\mathrm{user}}(r) & r < r_{\mathrm{max}} \\
-                   = & 0                    & r \ge r_{\mathrm{max}} \\
-        \end{eqnarray*}
+        \\begin{eqnarray*}
+        \\vec{F}(\\vec{r}) = & 0; & r < r_{\\mathrm{min}} \\\\
+                           = & F_\\mathrm{table}(r)\\hat{r};
+                             & r_{\\mathrm{min}} \\le r < r_{\\mathrm{max}} \\\\
+                           = & 0; & r \\ge r_{\\mathrm{max}} \\\\
+        \\end{eqnarray*}
 
-    where :math:`r` is the distance from one particle to the other in the bond.
-    Care should be taken to define the range of the bond so that it is not
-    possible for the distance between two bonded particles to be outside the
-    specified range. On the CPU, this will throw an error. On the GPU, this
-    will throw an error if GPU error checking is enabled.
+    and the potential :math:`V(r)` is:
 
-    :math:`F_{\mathrm{user}}(r)` and :math:`V_{\mathrm{user}}(r)` are evaluated
-    on *width* grid points between :math:`r_{\mathrm{min}}` and
-    :math:`r_{\mathrm{max}}`. Values are interpolated linearly between grid
-    points. For correctness, you must specify the force defined by: :math:`F =
-    -\frac{\partial V}{\partial r}`
+    .. math::
+        :nowrap:
 
-    The following coefficients must be set for each bond type:
+        \\begin{eqnarray*}
+        V(r) = & 0; & r < r_{\\mathrm{min}} \\\\
+             = & V_\\mathrm{table}(r);
+               & r_{\\mathrm{min}} \\le r < r_{\\mathrm{max}} \\\\
+             = & 0; & r \\ge r_{\\mathrm{max}} \\\\
+        \\end{eqnarray*}
 
-    - :math:`F_{\mathrm{user}}(r)` and :math:`V_{\mathrm{user}}(r)` - evaluated
-      by ``func`` (see example)
-    - coefficients passed to ``func`` - ``coeff`` (see example)
-    - :math:`r_{\mathrm{min}}` - ``rmin`` :math:`[\mathrm{length}]`
-    - :math:`r_{\mathrm{max}}` - ``rmax`` :math:`[\mathrm{length}]`
+    where :math:`\\vec{r}` is the vector pointing from one particle to the other
+    in the bond.
 
-    The table *width* is set once when bond.table is specified.
-    There are two ways to specify the other parameters.
+    Warning:
+        Bonds that stretch to a length :math:`r \\ge r_{\\mathrm{max}}` result
+        in an error.
 
-    .. rubric:: Set table from a given function
+    Provide :math:`F_\\mathrm{table}(r)` and :math:`V_\\mathrm{table}(r)` on
+    evenly spaced grid points points between :math:`r_{\\mathrm{min}}` and
+    :math:`r_{\\mathrm{max}}`. `Table` linearly interpolates values when
+    :math:`r` lies between grid points and between the last grid point and
+    :math:`r=r_{\\mathrm{max}}`.  The force must be specificed commensurate with
+    the potential: :math:`F = -\\frac{\\partial V}{\\partial r}`.
 
-    When you have a functional form for V and F, you can enter that directly
-    into python. :py:class:`table` will evaluate the given function over *width*
-    points between *rmin* and *rmax* and use the resulting values in the table::
+    Attributes:
+        params (`TypeParameter` [``bond type``, `dict`]):
+          The potential parameters. The dictionary has the following keys:
 
-        def harmonic(r, rmin, rmax, kappa, r0):
-           V = 0.5 * kappa * (r-r0)**2;
-           F = -kappa*(r-r0);
-           return (V, F)
+          * ``r_min`` (`float`, **required**) - the minimum distance to apply
+            the tabulated potential, corresponding to the first element of the
+            energy and force arrays :math:`[\\mathrm{length}]`.
 
-        btable = bond.table(width=1000)
-        btable.bond_coeff.set('bond1', func=harmonic, rmin=0.2, rmax=5.0,
-                              coeff=dict(kappa=330, r0=0.84))
-        btable.bond_coeff.set('bond2', func=harmonic, rmin=0.2, rmax=5.0,
-                              coeff=dict(kappa=30, r0=1.0))
+          * ``r_max`` (`float`, **required**) - the minimum distance to apply
+            the tabulated potential, corresponding to the first element of the
+            energy and force arrays :math:`[\\mathrm{length}]`.
 
-    .. rubric:: Set a table from a file
+          * ``V`` ((*width*,) `numpy.ndarray` of `float`, **required**) -
+            the tabulated energy values :math:`[\\mathrm{energy}]`. Must have
+            a size equal to `width`.
 
-    When you have no function for for *V* or *F*, or you otherwise have the data
-    listed in a file, :py:class:`table` can use the given values directly. You
-    must first specify the number of rows in your tables when initializing
-    bond.table. Then use :py:meth:`set_from_file()` to read the file::
+          * ``F`` ((*width*,) `numpy.ndarray` of `float`, **required**) -
+            the tabulated force values :math:`[\\mathrm{force}]`. Must have a
+            size equal to `width`.
 
-        btable = bond.table(width=1000)
-        btable.set_from_file('polymer', 'btable.file')
-
-    Note:
-        For potentials that diverge near r=0, make sure to set ``rmin`` to a
-        reasonable value. If a potential does
-        not diverge near r=0, then a setting of ``rmin=0`` is valid.
-
-    Note:
-        Ensure that ``rmin`` and ``rmax`` cover the range of possible bond
-        lengths. When gpu error checking is on, a error will
-        be thrown if a bond distance is outside than this range.
+        width (int): Number of points in the table.
     """
 
-    def __init__(self, width, name=None):
+    def __init__(self, width):
+        super().__init__()
+        param_dict = hoomd.data.parameterdicts.ParameterDict(width=int)
+        param_dict['width'] = width
+        self._param_dict = param_dict
 
-        # initialize the base class
-        force._force.__init__(self, name)
+        params = TypeParameter(
+            "params", "bond_types",
+            TypeParameterDict(
+                r_min=float,
+                r_max=float,
+                V=hoomd.data.typeconverter.NDArrayValidator(numpy.float64),
+                F=hoomd.data.typeconverter.NDArrayValidator(numpy.float64),
+                len_keys=1))
+        self._add_typeparam(params)
 
-        # create the c++ mirror class
-        if not hoomd.context.current.device.cpp_exec_conf.isCUDAEnabled():
-            self.cpp_force = _md.BondTablePotential(
-                hoomd.context.current.system_definition, int(width), self.name)
+    def _attach(self):
+        """Create the c++ mirror class."""
+        if isinstance(self._simulation.device, hoomd.device.CPU):
+            cpp_cls = _md.BondTablePotential
         else:
-            self.cpp_force = _md.BondTablePotentialGPU(
-                hoomd.context.current.system_definition, int(width), self.name)
+            cpp_cls = _md.BondTablePotentialGPU
 
-        hoomd.context.current.system.addCompute(self.cpp_force, self.force_name)
+        self._cpp_obj = cpp_cls(self._simulation.state._cpp_sys_def, self.width)
 
-        # setup the coefficients matrix
-        self.bond_coeff = coeff()  # noqa - this will be rewritten for v3
-
-        # stash the width for later use
-        self.width = width
-
-    def update_bond_table(self, btype, func, rmin, rmax, coeff):  # noqa
-        # allocate arrays to store V and F
-        Vtable = _hoomd.std_vector_scalar()
-        Ftable = _hoomd.std_vector_scalar()
-
-        # calculate dr
-        dr = (rmax - rmin) / float(self.width - 1)
-
-        # evaluate each point of the function
-        for i in range(0, self.width):
-            r = rmin + dr * i
-            (V, F) = func(r, rmin, rmax, **coeff)
-
-            # fill out the tables
-            Vtable.append(V)
-            Ftable.append(F)
-
-        # pass the tables on to the underlying cpp compute
-        self.cpp_force.setTable(btype, Vtable, Ftable, rmin, rmax)
-
-    def update_coeffs(self):  # noqa
-        # check that the bond coefficients are valid
-        if not self.bond_coeff.verify(["func", "rmin", "rmax", "coeff"]):
-            hoomd.context.current.device.cpp_msg.error(
-                "Not all bond coefficients are set for bond.table\n")
-            raise RuntimeError("Error updating bond coefficients")
-
-        # set all the params
-        ntypes = hoomd.context.current.system_definition.getBondData(
-        ).getNTypes()
-        type_list = []
-        for i in range(0, ntypes):
-            type_list.append(hoomd.context.current.system_definition
-                             .getBondData().getNameByType(i))
-
-        # loop through all of the unique type bonds and evaluate the table
-        for i in range(0, ntypes):
-            func = self.bond_coeff.get(type_list[i], "func")
-            rmin = self.bond_coeff.get(type_list[i], "rmin")
-            rmax = self.bond_coeff.get(type_list[i], "rmax")
-            coeff = self.bond_coeff.get(type_list[i], "coeff")
-
-            self.update_bond_table(i, func, rmin, rmax, coeff)
-
-    def set_from_file(self, bondname, filename):  # noqa
-        r"""Set a bond pair interaction from a file.
-
-        Args: bondname (str): Name of bond filename (str): Name of the file to
-            read
-
-        The provided file specifies V and F at equally spaced r values.
-        Example::
-
-            #r  V    F
-            1.0 2.0 -3.0
-            1.1 3.0 -4.0
-            1.2 2.0 -3.0
-            1.3 1.0 -2.0
-            1.4 0.0 -1.0
-            1.5 -1.0 0.0
-
-        The first r value sets ``rmin``, the last sets ``rmax``. Any line with
-        # as the first non-whitespace character is
-        is treated as a comment. The ``r`` values must monotonically increase
-        and be equally spaced. The table is read directly into the grid points
-        used to evaluate :math:`F_{\mathrm{user}}(r)` and
-        :math:`V_{\mathrm{user}}(r)`.
-        """
-        # open the file
-        f = open(filename)
-
-        r_table = []
-        V_table = []
-        F_table = []
-
-        # read in lines from the file
-        for line in f.readlines():
-            line = line.strip()
-
-            # skip comment lines
-            if line[0] == '#':
-                continue
-
-            # split out the columns
-            cols = line.split()
-            values = [float(f) for f in cols]
-
-            # validate the input
-            if len(values) != 3:
-                hoomd.context.current.device.cpp_msg.error(
-                    "bond.table: file must have exactly 3 columns\n")
-                raise RuntimeError("Error reading table file")
-
-            # append to the tables
-            r_table.append(values[0])
-            V_table.append(values[1])
-            F_table.append(values[2])
-
-        # validate input
-        if self.width != len(r_table):
-            hoomd.context.current.device.cpp_msg.error(
-                "bond.table: file must have exactly " + str(self.width)
-                + " rows\n")
-            raise RuntimeError("Error reading table file")
-
-        # extract rmin and rmax
-        rmin_table = r_table[0]
-        rmax_table = r_table[-1]
-
-        # check for even spacing
-        dr = (rmax_table - rmin_table) / float(self.width - 1)
-        for i in range(0, self.width):
-            r = rmin_table + dr * i
-            if math.fabs(r - r_table[i]) > 1e-3:
-                hoomd.context.current.device.cpp_msg.error(
-                    "bond.table: r must be monotonically increasing and evenly "
-                    "spaced\n")
-                raise RuntimeError("Error reading table file")
-
-        self.bond_coeff.set(bondname,
-                            func=_table_eval,
-                            rmin=rmin_table,
-                            rmax=rmax_table,
-                            coeff=dict(V=V_table, F=F_table, width=self.width))
+        Force._attach(self)
 
 
 class Tether(Bond):

--- a/hoomd/md/dihedral.py
+++ b/hoomd/md/dihedral.py
@@ -23,14 +23,13 @@ parallel.
     :alt: Dihedral angle definition
 """
 
-from hoomd import _hoomd
 from hoomd.md import _md
-from hoomd.md import force
 from hoomd.md.force import Force
 from hoomd.data.parameterdicts import TypeParameterDict
 from hoomd.data.typeparam import TypeParameter
 import hoomd
 
+import numpy
 import math
 
 
@@ -109,213 +108,74 @@ def _table_eval(theta, V, T, width):
     return (V[i], T[i])
 
 
-class table(force._force):  # noqa
-    r"""Tabulated dihedral potential.
+class Table(Dihedral):
+    """Tabulated dihedral potential.
 
     Args:
-        width (int): Number of points to use to interpolate V and T (see
-            documentation above)
-        name (str): Name of the force instance
+        width (int): Number of points in the table.
 
-    :py:class:`table` specifies that a tabulated dihedral force should be
-    applied to every define dihedral.
+    `Table` computes a user-defined potential and force applied to each
+    dihedral.
 
-    :math:`T_{\mathrm{user}}(\theta)` and :math:`V_{\mathrm{user}}(\theta)` are
-    evaluated on *width* grid points between :math:`-\pi` and :math:`\pi`.
-    Values are interpolated linearly between grid points. For correctness, you
-    must specify the derivative of the potential with respect to the dihedral
-    angle, defined by: :math:`T = -\frac{\partial V}{\partial \theta}`.
+    The torque :math:`\\tau` is:
 
-    Parameters:
-    - :math:`T_{\mathrm{user}}(\theta)` and :math:`V_{\mathrm{user}} (\theta)` -
-      evaluated by ``func`` (see example)
-    - coefficients passed to ``func`` - ``coeff`` (see example)
+    .. math::
+        \\tau(\\phi) = \\tau_\\mathrm{table}(\\phi)
 
-    .. rubric:: Set table from a given function
+    and the potential :math:`V(\\phi)` is:
 
-    When you have a functional form for V and T, you can enter that directly
-    into python. :py:class:`table` will evaluate the given function over *width*
-    points between :math:`-\pi` and :math:`\pi` and use the resulting values in
-    the table::
+    .. math::
+        V(\\phi) =V_\\mathrm{table}(\\phi)
 
-        def harmonic(theta, kappa, theta0):
-           V = 0.5 * kappa * (theta-theta0)**2;
-           F = -kappa*(theta-theta0);
-           return (V, F)
+    where :math:`\\phi` is the dihedral angle for the particles A,B,C,D
+    in the dihedral.
 
-        dtable = dihedral.table(width=1000)
-        dtable.dihedral_coeff.set('dihedral1', func=harmonic,
-                                  coeff=dict(kappa=330, theta_0=0.0))
-        dtable.dihedral_coeff.set('dihedral2', func=harmonic,
-                                  coeff=dict(kappa=30, theta_0=1.0))
+    Provide :math:`\\tau_\\mathrm{table}(\\phi)` and
+    :math:`V_\\mathrm{table}(\\phi)` on evenly spaced grid points points
+    in the range :math:`\\phi \\in [-\\pi,\\pi]`. `Table` linearly
+    interpolates values when :math:`\\phi` lies between grid points. The
+    torque must be specificed commensurate with the potential: :math:`\\tau =
+    -\\frac{\\partial V}{\\partial \\phi}`.
 
-    .. rubric:: Set a table from a file
+    Attributes:
+        params (`TypeParameter` [``dihedral type``, `dict`]):
+          The potential parameters. The dictionary has the following keys:
 
-    When you have no function for for *V* or *T*, or you otherwise have the data
-    listed in a file, dihedral.table can use the given values directly. You must
-    first specify the number of rows in your tables when initializing
-    :py:class:`table`. Then use :py:meth:`set_from_file()` to read the file.
+          * ``V`` ((*width*,) `numpy.ndarray` of `float`, **required**) -
+            the tabulated energy values :math:`[\\mathrm{energy}]`. Must have
+            a size equal to `width`.
 
-        dtable = dihedral.table(width=1000)
-        dtable.set_from_file('polymer', 'dihedral.dat')
+          * ``tau`` ((*width*,) `numpy.ndarray` of `float`, **required**) -
+            the tabulated torque values :math:`[\\mathrm{force} \\cdot
+            \\mathrm{length}]`. Must have a size equal to `width`.
+
+        width (int): Number of points in the table.
     """
 
-    def __init__(self, width, name=None):
+    def __init__(self, width):
+        super().__init__()
+        param_dict = hoomd.data.parameterdicts.ParameterDict(width=int)
+        param_dict['width'] = width
+        self._param_dict = param_dict
 
-        # initialize the base class
-        force._force.__init__(self, name)
+        params = TypeParameter(
+            "params", "dihedral_types",
+            TypeParameterDict(
+                V=hoomd.data.typeconverter.NDArrayValidator(numpy.float64),
+                tau=hoomd.data.typeconverter.NDArrayValidator(numpy.float64),
+                len_keys=1))
+        self._add_typeparam(params)
 
-        # create the c++ mirror class
-        if not hoomd.context.current.device.cpp_exec_conf.isCUDAEnabled():
-            self.cpp_force = _md.TableDihedralForceCompute(
-                hoomd.context.current.system_definition, int(width), self.name)
+    def _attach(self):
+        """Create the c++ mirror class."""
+        if isinstance(self._simulation.device, hoomd.device.CPU):
+            cpp_cls = _md.TableDihedralForceCompute
         else:
-            self.cpp_force = _md.TableDihedralForceComputeGPU(
-                hoomd.context.current.system_definition, int(width), self.name)
+            cpp_cls = _md.TableDihedralForceComputeGPU
 
-        hoomd.context.current.system.addCompute(self.cpp_force, self.force_name)
+        self._cpp_obj = cpp_cls(self._simulation.state._cpp_sys_def, self.width)
 
-        # setup the coefficient matrix
-        self.dihedral_coeff = coeff()  # noqa
-
-        # stash the width for later use
-        self.width = width
-
-    def update_dihedral_table(self, atype, func, coeff):  # noqa
-        # allocate arrays to store V and F
-        Vtable = _hoomd.std_vector_scalar()
-        Ttable = _hoomd.std_vector_scalar()
-
-        # calculate dth
-        dth = 2.0 * math.pi / float(self.width - 1)
-
-        # evaluate each point of the function
-        for i in range(0, self.width):
-            theta = -math.pi + dth * i
-            (V, T) = func(theta, **coeff)
-
-            # fill out the tables
-            Vtable.append(V)
-            Ttable.append(T)
-
-        # pass the tables on to the underlying cpp compute
-        self.cpp_force.setTable(atype, Vtable, Ttable)
-
-    def update_coeffs(self):  # noqa
-        # check that the dihedral coefficients are valid
-        if not self.dihedral_coeff.verify(["func", "coeff"]):
-            hoomd.context.current.device.cpp_msg.error(
-                "Not all dihedral coefficients are set for dihedral.table\n")
-            raise RuntimeError("Error updating dihedral coefficients")
-
-        # set all the params
-        ntypes = hoomd.context.current.system_definition.getDihedralData(
-        ).getNTypes()
-        type_list = []
-        for i in range(0, ntypes):
-            type_list.append(hoomd.context.current.system_definition
-                             .getDihedralData().getNameByType(i))
-
-        # loop through all of the unique type dihedrals and evaluate the table
-        for i in range(0, ntypes):
-            func = self.dihedral_coeff.get(type_list[i], "func")
-            coeff = self.dihedral_coeff.get(type_list[i], "coeff")
-
-            self.update_dihedral_table(i, func, coeff)
-
-    def set_from_file(self, dihedralname, filename):
-        r"""Set a dihedral pair interaction from a file.
-
-        Args:
-            dihedralname (str): Name of dihedral
-            filename (str): Name of the file to read
-
-        The provided file specifies V and F at equally spaced theta values.
-
-        Example::
-
-            #t  V    T
-            -3.141592653589793 2.0 -3.0
-            -1.5707963267948966 3.0 -4.0
-            0.0 2.0 -3.0
-            1.5707963267948966 3.0 -4.0
-            3.141592653589793 2.0 -3.0
-
-        Note:
-            The theta values are not used by the code.  It is assumed that a
-            table that has N rows will start at :math:`-\pi`, end at :math:`\pi`
-            and that :math:`\delta \theta = 2\pi/(N-1)`. The table is read
-            directly into the grid points used to evaluate
-            :math:`T_{\mathrm{user}}(\theta)` and
-            :math:`V_{\mathrm{user}}(\theta)`.
-
-        """
-        # open the file
-        f = open(filename)
-
-        theta_table = []
-        V_table = []
-        T_table = []
-
-        # read in lines from the file
-        for line in f.readlines():
-            line = line.strip()
-
-            # skip comment lines
-            if line[0] == '#':
-                continue
-
-            # split out the columns
-            cols = line.split()
-            values = [float(f) for f in cols]
-
-            # validate the input
-            if len(values) != 3:
-                hoomd.context.current.device.cpp_msg.error(
-                    "dihedral.table: file must have exactly 3 columns\n")
-                raise RuntimeError("Error reading table file")
-
-            # append to the tables
-            theta_table.append(values[0])
-            V_table.append(values[1])
-            T_table.append(values[2])
-
-        # validate input
-        if self.width != len(T_table):
-            hoomd.context.current.device.cpp_msg.error(
-                "dihedral.table: file must have exactly " + str(self.width)
-                + " rows\n")
-            raise RuntimeError("Error reading table file")
-
-        # check for even spacing
-        dth = 2.0 * math.pi / float(self.width - 1)
-        for i in range(0, self.width):
-            theta = -math.pi + dth * i
-            if math.fabs(theta - theta_table[i]) > 1e-3:
-                hoomd.context.current.device.cpp_msg.error(
-                    "dihedral.table: theta must be monotonically increasing and"
-                    "evenly spaced, going from -pi to pi\n")
-                hoomd.context.current.device.cpp_msg.error("row: " + str(i)
-                                                           + " expected: "
-                                                           + str(theta)
-                                                           + " got: "
-                                                           + str(theta_table[i])
-                                                           + "\n")
-
-        self.dihedral_coeff.set(dihedralname,
-                                func=_table_eval,
-                                coeff=dict(V=V_table,
-                                           T=T_table,
-                                           width=self.width))
-
-    def get_metadata(self):  # noqa
-        data = force._force.get_metadata(self)
-
-        # make sure coefficients are up-to-date
-        self.update_coeffs()
-
-        data['dihedral_coeff'] = self.dihedral_coeff
-        return data
+        Force._attach(self)
 
 
 class OPLS(Dihedral):

--- a/hoomd/md/pair/pair.py
+++ b/hoomd/md/pair/pair.py
@@ -676,12 +676,12 @@ class Table(Pair):
     in the pair, ``r_min`` is defined in `params`, and ``r_cut`` is defined in
     `Pair.r_cut`.
 
-    Provide :math:`F(r)` and :math:`V(r)` on an evenly space set of grid points
-    points between :math:`r_{\\mathrm{min}}` and :math:`r_{\\mathrm{cut}}`.
-    `Table` linearly interpolates values when :math:`r` lies between grid points
-    and between the last grid point and :math:`r=r_{\\mathrm{cut}}`.  The force
-    must be specificed commensurate with the potential: :math:`F =
-    -\\frac{\\partial V}{\\partial r}`.
+    Provide :math:`F(r)` and :math:`V(r)` on evenly spaced grid points points
+    between :math:`r_{\\mathrm{min}}` and :math:`r_{\\mathrm{cut}}`. `Table`
+    linearly interpolates values when :math:`r` lies between grid points and
+    between the last grid point and :math:`r=r_{\\mathrm{cut}}`.  The force must
+    be specificed commensurate with the potential: :math:`F = -\\frac{\\partial
+    V}{\\partial r}`.
 
     `Table` does not support energy shifting or smoothing modes.
 

--- a/hoomd/md/pytest/test_angle.py
+++ b/hoomd/md/pytest/test_angle.py
@@ -3,44 +3,61 @@
 
 import hoomd
 import pytest
-import numpy as np
+import numpy
 
-_harmonic_args = {
-    'k': [3.0, 10.0, 5.0],
-    't0': [np.pi / 2, np.pi / 4, np.pi / 6]
-}
-_harmonic_arg_list = [(hoomd.md.angle.Harmonic, dict(zip(_harmonic_args, val)))
-                      for val in zip(*_harmonic_args.values())]
-
-_cosinesq_args = {
-    'k': [3.0, 10.0, 5.0],
-    't0': [np.pi / 2, np.pi / 4, np.pi / 6]
-}
-_cosinesq_arg_list = [(hoomd.md.angle.Cosinesq, dict(zip(_cosinesq_args, val)))
-                      for val in zip(*_cosinesq_args.values())]
-
-
-def get_angle_and_args():
-    return _harmonic_arg_list + _cosinesq_arg_list
-
-
-def get_angle_args_forces_and_energies():
-    harmonic_forces = [-1.5708, 2.6180, 2.6180]
-    harmonic_energies = [0.4112, 0.3427, 0.6854]
-    cosinesq_forces = [-1.29904, 1.7936, 1.58494]
-    cosinesq_energies = [0.375, 0.214466, 0.334936]
-
-    harmonic_args_and_vals = []
-    cosinesq_args_and_vals = []
-    for i in range(3):
-        harmonic_args_and_vals.append(
-            (_harmonic_arg_list[i][0], _harmonic_arg_list[i][1],
-             harmonic_forces[i], harmonic_energies[i]))
-        cosinesq_args_and_vals.append(
-            (_cosinesq_arg_list[i][0], _cosinesq_arg_list[i][1],
-             cosinesq_forces[i], cosinesq_energies[i]))
-
-    return harmonic_args_and_vals + cosinesq_args_and_vals
+# Test parameters include the class, class keyword arguments, bond params,
+# force, and energy.
+angle_test_parameters = [
+    (
+        hoomd.md.angle.Harmonic,
+        dict(),
+        dict(k=3.0, t0=numpy.pi / 2),
+        -1.5708,
+        0.4112,
+    ),
+    (
+        hoomd.md.angle.Harmonic,
+        dict(),
+        dict(k=10.0, t0=numpy.pi / 4),
+        2.6180,
+        0.3427,
+    ),
+    (
+        hoomd.md.angle.Harmonic,
+        dict(),
+        dict(k=5.0, t0=numpy.pi / 6),
+        2.6180,
+        0.6854,
+    ),
+    (
+        hoomd.md.angle.CosineSquared,
+        dict(),
+        dict(k=3.0, t0=numpy.pi / 2),
+        -1.29904,
+        0.375,
+    ),
+    (
+        hoomd.md.angle.CosineSquared,
+        dict(),
+        dict(k=10.0, t0=numpy.pi / 4),
+        1.7936,
+        0.214466,
+    ),
+    (
+        hoomd.md.angle.CosineSquared,
+        dict(),
+        dict(k=5.0, t0=numpy.pi / 6),
+        1.58494,
+        0.334936,
+    ),
+    (
+        hoomd.md.angle.Table,
+        dict(width=2),
+        dict(V=[0, 10], tau=[0, 1]),
+        -1 / 3,
+        10 / 3,
+    ),
+]
 
 
 @pytest.fixture(scope='session')
@@ -51,109 +68,101 @@ def triplet_snapshot_factory(device):
                       particle_types=['A'],
                       dimensions=3,
                       L=20):
-        theta_rad = theta_deg * (np.pi / 180)
-        s = hoomd.Snapshot(device.communicator)
+        theta_rad = theta_deg * (numpy.pi / 180)
+        snapshot = hoomd.Snapshot(device.communicator)
         N = 3
-        if s.communicator.rank == 0:
+        if snapshot.communicator.rank == 0:
             box = [L, L, L, 0, 0, 0]
             if dimensions == 2:
                 box[2] = 0
-            s.configuration.box = box
-            s.particles.N = N
+            snapshot.configuration.box = box
+            snapshot.particles.N = N
 
-            base_positions = np.array(
-                [[-d * np.sin(theta_rad / 2), d * np.cos(theta_rad / 2), 0.0],
-                 [0.0, 0.0, 0.0],
-                 [d * np.sin(theta_rad / 2), d * np.cos(theta_rad / 2), 0.0]])
+            base_positions = numpy.array([
+                [
+                    -d * numpy.sin(theta_rad / 2), d * numpy.cos(theta_rad / 2),
+                    0.0
+                ],
+                [0.0, 0.0, 0.0],
+                [
+                    d * numpy.sin(theta_rad / 2),
+                    d * numpy.cos(theta_rad / 2),
+                    0.0,
+                ],
+            ])
             # move particles slightly in direction of MPI decomposition which
             # varies by simulation dimension
             nudge_dimension = 2 if dimensions == 3 else 1
             base_positions[:, nudge_dimension] += 0.1
-            s.particles.position[:] = base_positions
-            s.particles.types = particle_types
-            s.angles.N = 1
-            s.angles.types = ['backbone']
-            s.angles.typeid[0] = 0
-            s.angles.group[0] = (0, 1, 2)
-        return s
+            snapshot.particles.position[:] = base_positions
+            snapshot.particles.types = particle_types
+            snapshot.angles.N = 1
+            snapshot.angles.types = ['A-A-A']
+            snapshot.angles.typeid[0] = 0
+            snapshot.angles.group[0] = (0, 1, 2)
+        return snapshot
 
     return make_snapshot
 
 
-@pytest.mark.parametrize("angle_cls, potential_kwargs", get_angle_and_args())
-def test_before_attaching(angle_cls, potential_kwargs):
-    angle_potential = angle_cls()
-    angle_potential.params['backbone'] = potential_kwargs
-    for key in potential_kwargs:
-        np.testing.assert_allclose(angle_potential.params['backbone'][key],
-                                   potential_kwargs[key],
-                                   rtol=1e-6)
+@pytest.mark.parametrize('angle_cls, angle_args, params, force, energy',
+                         angle_test_parameters)
+def test_before_attaching(angle_cls, angle_args, params, force, energy):
+    potential = angle_cls(**angle_args)
+    potential.params['A-A-A'] = params
+    for key in params:
+        assert potential.params['A-A-A'][key] == pytest.approx(params[key])
 
 
-@pytest.mark.parametrize("angle_cls, potential_kwargs", get_angle_and_args())
+@pytest.mark.parametrize('angle_cls, angle_args, params, force, energy',
+                         angle_test_parameters)
 def test_after_attaching(triplet_snapshot_factory, simulation_factory,
-                         angle_cls, potential_kwargs):
-    snap = triplet_snapshot_factory()
-    sim = simulation_factory(snap)
+                         angle_cls, angle_args, params, force, energy):
+    sim = simulation_factory(triplet_snapshot_factory())
 
-    angle_potential = angle_cls()
-    angle_potential.params['backbone'] = potential_kwargs
+    potential = angle_cls(**angle_args)
+    potential.params['A-A-A'] = params
 
-    integrator = hoomd.md.Integrator(dt=0.005)
-
-    integrator.forces.append(angle_potential)
-
-    langevin = hoomd.md.methods.Langevin(kT=1,
-                                         filter=hoomd.filter.All(),
-                                         alpha=0.1)
-    integrator.methods.append(langevin)
-    sim.operations.integrator = integrator
+    sim.operations.integrator = hoomd.md.Integrator(dt=0.005,
+                                                    forces=[potential])
 
     sim.run(0)
-    for key in potential_kwargs:
-        np.testing.assert_allclose(angle_potential.params['backbone'][key],
-                                   potential_kwargs[key],
-                                   rtol=1e-6)
+    for key in params:
+        assert potential.params['A-A-A'][key] == pytest.approx(params[key])
 
 
-@pytest.mark.parametrize("angle_cls, potential_kwargs, force, energy",
-                         get_angle_args_forces_and_energies())
+@pytest.mark.parametrize('angle_cls, angle_args, params, force, energy',
+                         angle_test_parameters)
 def test_forces_and_energies(triplet_snapshot_factory, simulation_factory,
-                             angle_cls, potential_kwargs, force, energy):
+                             angle_cls, angle_args, params, force, energy):
     theta_deg = 60
-    theta_rad = theta_deg * (np.pi / 180)
-    snap = triplet_snapshot_factory(theta_deg=theta_deg)
-    sim = simulation_factory(snap)
+    theta_rad = theta_deg * (numpy.pi / 180)
+    snapshot = triplet_snapshot_factory(theta_deg=theta_deg)
+    sim = simulation_factory(snapshot)
 
-    force_array = force * np.asarray(
-        [np.cos(theta_rad / 2), np.sin(theta_rad / 2), 0])
-    angle_potential = angle_cls()
-    angle_potential.params['backbone'] = potential_kwargs
+    force_array = force * numpy.asarray(
+        [numpy.cos(theta_rad / 2),
+         numpy.sin(theta_rad / 2), 0])
+    potential = angle_cls(**angle_args)
+    potential.params['A-A-A'] = params
 
-    integrator = hoomd.md.Integrator(dt=0.005)
-
-    integrator.forces.append(angle_potential)
-
-    langevin = hoomd.md.methods.Langevin(kT=1,
-                                         filter=hoomd.filter.All(),
-                                         alpha=0.1)
-    integrator.methods.append(langevin)
-    sim.operations.integrator = integrator
+    sim.operations.integrator = hoomd.md.Integrator(dt=0.005,
+                                                    forces=[potential])
 
     sim.run(0)
 
-    sim_energies = sim.operations.integrator.forces[0].energy
-    sim_forces = sim.operations.integrator.forces[0].forces
+    sim_energy = potential.energy
+    sim_forces = potential.forces
     if sim.device.communicator.rank == 0:
-        np.testing.assert_allclose(sim_energies, energy, rtol=1e-2, atol=1e-5)
-        np.testing.assert_allclose(sim_forces[0],
-                                   force_array,
-                                   rtol=1e-2,
-                                   atol=1e-5)
-        np.testing.assert_allclose(sim_forces[1], [0, -1 * force, 0],
-                                   rtol=1e-2,
-                                   atol=1e-5)
-        np.testing.assert_allclose(
+        assert sim_energy == pytest.approx(energy, rel=1e-2)
+        numpy.testing.assert_allclose(sim_forces[0],
+                                      force_array,
+                                      rtol=1e-2,
+                                      atol=1e-5)
+        numpy.testing.assert_allclose(sim_forces[1], [0, -1 * force, 0],
+                                      rtol=1e-2,
+                                      atol=1e-5)
+        numpy.testing.assert_allclose(
             sim_forces[2],
             [-1 * force_array[0], force_array[1], force_array[2]],
             rtol=1e-2,

--- a/hoomd/md/pytest/test_bond.py
+++ b/hoomd/md/pytest/test_bond.py
@@ -5,68 +5,86 @@ import hoomd
 import pytest
 import numpy as np
 
-# Test parameters include the class, bond params, force, and energy.
+# Test parameters include the class, class keyword arguments, bond params,
+# force, and energy.
 bond_test_parameters = [
     (
         hoomd.md.bond.Harmonic,
+        dict(),
         dict(k=30.0, r0=1.6),
         -18.9300,
         5.9724,
     ),
     (
         hoomd.md.bond.Harmonic,
+        dict(),
         dict(k=25.0, r0=1.7),
         -18.2750,
         6.6795,
     ),
     (
         hoomd.md.bond.Harmonic,
+        dict(),
         dict(k=20.0, r0=1.8),
         -16.6200,
         6.9056,
     ),
     (
         hoomd.md.bond.FENEWCA,
+        dict(),
         dict(k=30.0, r0=1.6, epsilon=0.9, sigma=1.1, delta=-0.5),
         282.296,
         70.5638,
     ),
     (
         hoomd.md.bond.FENEWCA,
+        dict(),
         dict(k=25.0, r0=1.7, epsilon=1.0, sigma=1.0, delta=-0.5),
         146.288,
         49.2476,
     ),
     (
         hoomd.md.bond.FENEWCA,
+        dict(),
         dict(k=20.0, r0=1.8, epsilon=1.1, sigma=0.9, delta=-0.5),
         88.8238,
         35.3135,
     ),
     (
         hoomd.md.bond.Tether,
+        dict(),
         dict(k_b=5.0, l_min=0.7, l_c1=0.9, l_c0=1.1, l_max=1.3),
         0,
         0,
     ),
     (
         hoomd.md.bond.Tether,
+        dict(),
         dict(k_b=6.0, l_min=0.8, l_c1=1.05, l_c0=1.1, l_max=1.3),
         -0.0244441,
         0.000154384,
     ),
     (
         hoomd.md.bond.Tether,
+        dict(),
         dict(k_b=7.0, l_min=0.9, l_c1=1.1, l_c0=1.3, l_max=1.5),
         -3.57225,
         0.0490934,
     ),
+    (
+        hoomd.md.bond.Table,
+        dict(width=2),
+        dict(r_min=0, r_max=1.0, V=[0, 10], F=[0, -20]),
+        19.38,
+        9.69,
+    ),
 ]
 
 
-@pytest.mark.parametrize('bond_cls, params, force, energy', bond_test_parameters)
-def test_before_attaching(bond_cls, params, force, energy):
-    potential = bond_cls()
+@pytest.mark.parametrize('bond_cls, bond_args, params, force, energy',
+                         bond_test_parameters)
+def test_before_attaching(bond_cls, bond_args, params, force, energy):
+    potential = bond_cls(**bond_args)
     potential.params['A-A'] = params
     for key in params:
         assert potential.params['A-A'][key] == pytest.approx(params[key])
@@ -88,28 +106,34 @@ def snapshot_factory(two_particle_snapshot_factory):
     return make_snapshot
 
 
-@pytest.mark.parametrize('bond_cls, params, force, energy', bond_test_parameters)
-def test_after_attaching(snapshot_factory, simulation_factory, bond_cls, params, force, energy):
+@pytest.mark.parametrize('bond_cls, bond_args, params, force, energy',
+                         bond_test_parameters)
+def test_after_attaching(snapshot_factory, simulation_factory, bond_cls,
+                         bond_args, params, force, energy):
     sim = simulation_factory(snapshot_factory())
 
-    potential = bond_cls()
+    potential = bond_cls(**bond_args)
     potential.params['A-A'] = params
 
-    sim.operations.integrator = hoomd.md.Integrator(dt=0.005, forces=[potential])
+    sim.operations.integrator = hoomd.md.Integrator(dt=0.005,
+                                                    forces=[potential])
     sim.run(0)
 
     for key in params:
         assert potential.params['A-A'][key] == pytest.approx(params[key])
 
 
-@pytest.mark.parametrize('bond_cls, params, force, energy', bond_test_parameters)
-def test_forces_and_energies(snapshot_factory, simulation_factory, bond_cls, params, force, energy):
+@pytest.mark.parametrize('bond_cls, bond_args, params, force, energy',
+                         bond_test_parameters)
+def test_forces_and_energies(snapshot_factory, simulation_factory, bond_cls,
+                             bond_args, params, force, energy):
     sim = simulation_factory(snapshot_factory())
 
-    potential = bond_cls()
+    potential = bond_cls(**bond_args)
     potential.params['A-A'] = params
 
-    sim.operations.integrator = hoomd.md.Integrator(dt=0.005, forces=[potential])
+    sim.operations.integrator = hoomd.md.Integrator(dt=0.005,
+                                                    forces=[potential])
 
     sim.run(0)
 

--- a/hoomd/md/pytest/test_bond.py
+++ b/hoomd/md/pytest/test_bond.py
@@ -5,135 +5,118 @@ import hoomd
 import pytest
 import numpy as np
 
-_harmonic_args = {'k': [30.0, 25.0, 20.0], 'r0': [1.6, 1.7, 1.8]}
-_harmonic_arg_list = [(hoomd.md.bond.Harmonic, dict(zip(_harmonic_args, val)))
-                      for val in zip(*_harmonic_args.values())]
-
-_FENE_args = {
-    'k': [30.0, 25.0, 20.0],
-    'r0': [1.6, 1.7, 1.8],
-    'epsilon': [0.9, 1.0, 1.1],
-    'sigma': [1.1, 1.0, 0.9],
-    'delta': [-0.5, -0.5, -0.5]
-}
-_FENE_arg_list = [(hoomd.md.bond.FENEWCA, dict(zip(_FENE_args, val)))
-                  for val in zip(*_FENE_args.values())]
-
-_Tether_args = {
-    'k_b': [5.0, 6.0, 7.0],
-    'l_min': [0.7, 0.8, 0.9],
-    'l_c1': [0.9, 1.05, 1.1],
-    'l_c0': [1.1, 1.1, 1.3],
-    'l_max': [1.3, 1.3, 1.5]
-}
-_Tether_arg_list = [(hoomd.md.bond.Tether, dict(zip(_Tether_args, val)))
-                    for val in zip(*_Tether_args.values())]
-
-
-def get_bond_and_args():
-    return _harmonic_arg_list + _FENE_arg_list + _Tether_arg_list
-
-
-def get_bond_args_forces_and_energies():
-    harmonic_forces = [-18.9300, -18.2750, -16.6200]
-    harmonic_energies = [5.9724, 6.6795, 6.9056]
-    FENE_forces = [282.296, 146.288, 88.8238]
-    FENE_energies = [70.5638, 49.2476, 35.3135]
-    Tether_forces = [0, -0.0244441, -3.57225]
-    Tether_energies = [0, 0.000154384, 0.0490934]
-
-    harmonic_args_and_vals = []
-    FENE_args_and_vals = []
-    Tether_args_and_vals = []
-    for i in range(3):
-        harmonic_args_and_vals.append(
-            (_harmonic_arg_list[i][0], _harmonic_arg_list[i][1],
-             harmonic_forces[i], harmonic_energies[i]))
-        FENE_args_and_vals.append((_FENE_arg_list[i][0], _FENE_arg_list[i][1],
-                                   FENE_forces[i], FENE_energies[i]))
-        Tether_args_and_vals.append(
-            (_Tether_arg_list[i][0], _Tether_arg_list[i][1], Tether_forces[i],
-             Tether_energies[i]))
-    return harmonic_args_and_vals + FENE_args_and_vals + Tether_args_and_vals
-
-
-@pytest.mark.parametrize("bond_cls, potential_kwargs", get_bond_and_args())
-def test_before_attaching(bond_cls, potential_kwargs):
-    bond_potential = bond_cls()
-    bond_potential.params['bond'] = potential_kwargs
-    for key in potential_kwargs:
-        np.testing.assert_allclose(bond_potential.params['bond'][key],
-                                   potential_kwargs[key],
-                                   rtol=1e-6)
+# Test parameters include the class, bond params, force, and energy.
+bond_test_parameters = [
+    (
+        hoomd.md.bond.Harmonic,
+        dict(k=30.0, r0=1.6),
+        -18.9300,
+        5.9724,
+    ),
+    (
+        hoomd.md.bond.Harmonic,
+        dict(k=25.0, r0=1.7),
+        -18.2750,
+        6.6795,
+    ),
+    (
+        hoomd.md.bond.Harmonic,
+        dict(k=20.0, r0=1.8),
+        -16.6200,
+        6.9056,
+    ),
+    (
+        hoomd.md.bond.FENEWCA,
+        dict(k=30.0, r0=1.6, epsilon=0.9, sigma=1.1, delta=-0.5),
+        282.296,
+        70.5638,
+    ),
+    (
+        hoomd.md.bond.FENEWCA,
+        dict(k=25.0, r0=1.7, epsilon=1.0, sigma=1.0, delta=-0.5),
+        146.288,
+        49.2476,
+    ),
+    (
+        hoomd.md.bond.FENEWCA,
+        dict(k=20.0, r0=1.8, epsilon=1.1, sigma=0.9, delta=-0.5),
+        88.8238,
+        35.3135,
+    ),
+    (
+        hoomd.md.bond.Tether,
+        dict(k_b=5.0, l_min=0.7, l_c1=0.9, l_c0=1.1, l_max=1.3),
+        0,
+        0,
+    ),
+    (
+        hoomd.md.bond.Tether,
+        dict(k_b=6.0, l_min=0.8, l_c1=1.05, l_c0=1.1, l_max=1.3),
+        -0.0244441,
+        0.000154384,
+    ),
+    (
+        hoomd.md.bond.Tether,
+        dict(k_b=7.0, l_min=0.9, l_c1=1.1, l_c0=1.3, l_max=1.5),
+        -3.57225,
+        0.0490934,
+    ),
+]
 
 
-@pytest.mark.parametrize("bond_cls, potential_kwargs", get_bond_and_args())
-def test_after_attaching(two_particle_snapshot_factory, simulation_factory,
-                         bond_cls, potential_kwargs):
-    snap = two_particle_snapshot_factory(d=0.969, L=5)
-    if snap.communicator.rank == 0:
-        snap.bonds.N = 1
-        snap.bonds.types = ['bond']
-        snap.bonds.typeid[0] = 0
-        snap.bonds.group[0] = (0, 1)
-    sim = simulation_factory(snap)
+@pytest.mark.parametrize('bond_cls, params, force, energy', bond_test_parameters)
+def test_before_attaching(bond_cls, params, force, energy):
+    potential = bond_cls()
+    potential.params['A-A'] = params
+    for key in params:
+        assert potential.params['A-A'][key] == pytest.approx(params[key])
 
-    bond_potential = bond_cls()
-    bond_potential.params['bond'] = potential_kwargs
 
-    integrator = hoomd.md.Integrator(dt=0.005)
+@pytest.fixture(scope='session')
+def snapshot_factory(two_particle_snapshot_factory):
 
-    integrator.forces.append(bond_potential)
+    def make_snapshot():
+        snapshot = two_particle_snapshot_factory(d=0.969, L=5)
+        if snapshot.communicator.rank == 0:
+            snapshot.bonds.N = 1
+            snapshot.bonds.types = ['A-A']
+            snapshot.bonds.typeid[0] = 0
+            snapshot.bonds.group[0] = (0, 1)
 
-    langevin = hoomd.md.methods.Langevin(kT=1,
-                                         filter=hoomd.filter.All(),
-                                         alpha=0.1)
-    integrator.methods.append(langevin)
-    sim.operations.integrator = integrator
+        return snapshot
 
+    return make_snapshot
+
+
+@pytest.mark.parametrize('bond_cls, params, force, energy', bond_test_parameters)
+def test_after_attaching(snapshot_factory, simulation_factory, bond_cls, params, force, energy):
+    sim = simulation_factory(snapshot_factory())
+
+    potential = bond_cls()
+    potential.params['A-A'] = params
+
+    sim.operations.integrator = hoomd.md.Integrator(dt=0.005, forces=[potential])
     sim.run(0)
-    for key in potential_kwargs:
-        np.testing.assert_allclose(bond_potential.params['bond'][key],
-                                   potential_kwargs[key],
-                                   rtol=1e-6)
+
+    for key in params:
+        assert potential.params['A-A'][key] == pytest.approx(params[key])
 
 
-@pytest.mark.parametrize("bond_cls, potential_kwargs, force, energy",
-                         get_bond_args_forces_and_energies())
-def test_forces_and_energies(two_particle_snapshot_factory, simulation_factory,
-                             bond_cls, potential_kwargs, force, energy):
-    snap = two_particle_snapshot_factory(d=0.969, L=5)
-    if snap.communicator.rank == 0:
-        snap.bonds.N = 1
-        snap.bonds.types = ['bond']
-        snap.bonds.typeid[0] = 0
-        snap.bonds.group[0] = (0, 1)
-        snap.particles.diameter[0] = 0.5
-        snap.particles.diameter[1] = 0.5
-    sim = simulation_factory(snap)
+@pytest.mark.parametrize('bond_cls, params, force, energy', bond_test_parameters)
+def test_forces_and_energies(snapshot_factory, simulation_factory, bond_cls, params, force, energy):
+    sim = simulation_factory(snapshot_factory())
 
-    bond_potential = bond_cls()
-    bond_potential.params['bond'] = potential_kwargs
+    potential = bond_cls()
+    potential.params['A-A'] = params
 
-    integrator = hoomd.md.Integrator(dt=0.005)
-
-    integrator.forces.append(bond_potential)
-
-    langevin = hoomd.md.methods.Langevin(kT=1,
-                                         filter=hoomd.filter.All(),
-                                         alpha=0.1)
-    integrator.methods.append(langevin)
-    sim.operations.integrator = integrator
+    sim.operations.integrator = hoomd.md.Integrator(dt=0.005, forces=[potential])
 
     sim.run(0)
 
-    sim_energies = sim.operations.integrator.forces[0].energies
-    sim_forces = sim.operations.integrator.forces[0].forces
+    sim_energies = potential.energies
+    sim_forces = potential.forces
     if sim.device.communicator.rank == 0:
-        np.testing.assert_allclose(sum(sim_energies),
-                                   energy,
-                                   rtol=1e-2,
-                                   atol=1e-5)
+        assert sum(sim_energies) == pytest.approx(energy, rel=1e-2)
         np.testing.assert_allclose(sim_forces[0], [force, 0.0, 0.0],
                                    rtol=1e-2,
                                    atol=1e-5)

--- a/hoomd/md/pytest/test_dihedral.py
+++ b/hoomd/md/pytest/test_dihedral.py
@@ -3,167 +3,170 @@
 
 import hoomd
 import pytest
-import numpy as np
+import numpy
 
-_harmonic_args = {
-    'k': [3.0, 10.0, 5.0],
-    'd': [-1, 1, 1],
-    'n': [2, 1, 3],
-    'phi0': [np.pi / 2, np.pi / 4, np.pi / 6]
-}
-_harmonic_arg_list = [(hoomd.md.dihedral.Harmonic,
-                       dict(zip(_harmonic_args, val)))
-                      for val in zip(*_harmonic_args.values())]
-
-_OPLS_args = {
-    'k1': [1.0, 0.5, 2.0],
-    'k2': [1.5, 2.5, 1.0],
-    'k3': [0.5, 1.5, 0.25],
-    'k4': [0.75, 1.0, 3.5]
-}
-_OPLS_arg_list = [(hoomd.md.dihedral.OPLS, dict(zip(_OPLS_args, val)))
-                  for val in zip(*_OPLS_args.values())]
-
-
-def get_dihedral_and_args():
-    return _harmonic_arg_list + _OPLS_arg_list
-
-
-def get_dihedral_args_forces_and_energies():
-    harmonic_forces = [0.0, 5.0, 1.9411]
-    harmonic_energies = [3.0, 5.0, 0.0852]
-    OPLS_forces = [-0.616117, -0.732233, -0.0277282]
-    OPLS_energies = [2.42678, 2.89645, 5.74372]
-
-    harmonic_args_and_vals = []
-    OPLS_args_and_vals = []
-    for i in range(3):
-        harmonic_args_and_vals.append(
-            (_harmonic_arg_list[i][0], _harmonic_arg_list[i][1],
-             harmonic_forces[i], harmonic_energies[i]))
-        OPLS_args_and_vals.append((_OPLS_arg_list[i][0], _OPLS_arg_list[i][1],
-                                   OPLS_forces[i], OPLS_energies[i]))
-
-    return harmonic_args_and_vals + OPLS_args_and_vals
+# Test parameters include the class, class keyword arguments, bond params,
+# force, and energy.
+dihedral_test_parameters = [
+    (
+        hoomd.md.dihedral.Harmonic,
+        dict(),
+        dict(k=3.0, d=-1, n=2, phi0=numpy.pi / 2),
+        0,
+        3,
+    ),
+    (
+        hoomd.md.dihedral.Harmonic,
+        dict(),
+        dict(k=10.0, d=1, n=1, phi0=numpy.pi / 4),
+        5.0,
+        5.0,
+    ),
+    (
+        hoomd.md.dihedral.Harmonic,
+        dict(),
+        dict(k=5.0, d=1, n=3, phi0=numpy.pi / 6),
+        1.9411,
+        0.0852,
+    ),
+    (
+        hoomd.md.dihedral.OPLS,
+        dict(),
+        dict(k1=1.0, k2=1.5, k3=0.5, k4=0.75),
+        -0.616117,
+        2.42678,
+    ),
+    (
+        hoomd.md.dihedral.OPLS,
+        dict(),
+        dict(k1=0.5, k2=2.5, k3=1.5, k4=1.0),
+        -0.732233,
+        2.89645,
+    ),
+    (
+        hoomd.md.dihedral.OPLS,
+        dict(),
+        dict(k1=2.0, k2=1.0, k3=0.25, k4=3.5),
+        -0.0277282,
+        5.74372,
+    ),
+    (
+        hoomd.md.dihedral.Table,
+        dict(width=2),
+        dict(V=[0, 10], tau=[0, 1]),
+        -0.375,
+        3.75,
+    ),
+]
 
 
 @pytest.fixture(scope='session')
 def dihedral_snapshot_factory(device):
 
     def make_snapshot(d=1.0, phi_deg=45, particle_types=['A'], L=20):
-        phi_rad = phi_deg * (np.pi / 180)
+        phi_rad = phi_deg * (numpy.pi / 180)
         # the central particles are along the x-axis, so phi is determined from
         # the angle in the yz plane.
 
-        s = hoomd.Snapshot(device.communicator)
+        snapshot = hoomd.Snapshot(device.communicator)
         N = 4
-        if s.communicator.rank == 0:
+        if snapshot.communicator.rank == 0:
             box = [L, L, L, 0, 0, 0]
-            s.configuration.box = box
-            s.particles.N = N
-            s.particles.types = particle_types
+            snapshot.configuration.box = box
+            snapshot.particles.N = N
+            snapshot.particles.types = particle_types
             # shift particle positions slightly in z so MPI tests pass
-            s.particles.position[:] = [
-                [0.0, d * np.cos(phi_rad / 2), d * np.sin(phi_rad / 2) + 0.1],
-                [0.0, 0.0, 0.1], [d, 0.0, 0.1],
-                [d, d * np.cos(phi_rad / 2), -d * np.sin(phi_rad / 2) + 0.1]
+            snapshot.particles.position[:] = [
+                [
+                    0.0,
+                    d * numpy.cos(phi_rad / 2),
+                    d * numpy.sin(phi_rad / 2) + 0.1,
+                ],
+                [0.0, 0.0, 0.1],
+                [d, 0.0, 0.1],
+                [
+                    d,
+                    d * numpy.cos(phi_rad / 2),
+                    -d * numpy.sin(phi_rad / 2) + 0.1,
+                ],
             ]
 
-            s.dihedrals.N = 1
-            s.dihedrals.types = ['dihedral']
-            s.dihedrals.typeid[0] = 0
-            s.dihedrals.group[0] = (0, 1, 2, 3)
+            snapshot.dihedrals.N = 1
+            snapshot.dihedrals.types = ['A-A-A-A']
+            snapshot.dihedrals.typeid[0] = 0
+            snapshot.dihedrals.group[0] = (0, 1, 2, 3)
 
-        return s
+        return snapshot
 
     return make_snapshot
 
 
-@pytest.mark.parametrize("dihedral_cls, potential_kwargs",
-                         get_dihedral_and_args())
-def test_before_attaching(dihedral_cls, potential_kwargs):
-    dihedral_potential = dihedral_cls()
-    dihedral_potential.params['dihedral'] = potential_kwargs
-    for key in potential_kwargs:
-        np.testing.assert_allclose(dihedral_potential.params['dihedral'][key],
-                                   potential_kwargs[key],
-                                   rtol=1e-6)
+@pytest.mark.parametrize('dihedral_cls, dihedral_args, params, force, energy',
+                         dihedral_test_parameters)
+def test_before_attaching(dihedral_cls, dihedral_args, params, force, energy):
+    potential = dihedral_cls(**dihedral_args)
+    potential.params['A-A-A-A'] = params
+    for key in params:
+        potential.params['A-A-A-A'][key] == pytest.approx(params[key])
 
 
-@pytest.mark.parametrize("dihedral_cls, potential_kwargs",
-                         get_dihedral_and_args())
+@pytest.mark.parametrize('dihedral_cls, dihedral_args, params, force, energy',
+                         dihedral_test_parameters)
 def test_after_attaching(dihedral_snapshot_factory, simulation_factory,
-                         dihedral_cls, potential_kwargs):
-    snap = dihedral_snapshot_factory(d=0.969, L=5)
-    sim = simulation_factory(snap)
+                         dihedral_cls, dihedral_args, params, force, energy):
+    snapshot = dihedral_snapshot_factory(d=0.969, L=5)
+    sim = simulation_factory(snapshot)
 
-    dihedral_potential = dihedral_cls()
-    dihedral_potential.params['dihedral'] = potential_kwargs
+    potential = dihedral_cls(**dihedral_args)
+    potential.params['A-A-A-A'] = params
 
-    integrator = hoomd.md.Integrator(dt=0.005)
-
-    integrator.forces.append(dihedral_potential)
-
-    langevin = hoomd.md.methods.Langevin(kT=1,
-                                         filter=hoomd.filter.All(),
-                                         alpha=0.1)
-    integrator.methods.append(langevin)
-    sim.operations.integrator = integrator
+    sim.operations.integrator = hoomd.md.Integrator(dt=0.005,
+                                                    forces=[potential])
 
     sim.run(0)
-    for key in potential_kwargs:
-        np.testing.assert_allclose(dihedral_potential.params['dihedral'][key],
-                                   potential_kwargs[key],
-                                   rtol=1e-6)
+    for key in params:
+        assert potential.params['A-A-A-A'][key] == pytest.approx(params[key])
 
 
-@pytest.mark.parametrize("dihedral_cls, potential_kwargs, force, energy",
-                         get_dihedral_args_forces_and_energies())
+@pytest.mark.parametrize('dihedral_cls, dihedral_args, params, force, energy',
+                         dihedral_test_parameters)
 def test_forces_and_energies(dihedral_snapshot_factory, simulation_factory,
-                             dihedral_cls, potential_kwargs, force, energy):
+                             dihedral_cls, dihedral_args, params, force,
+                             energy):
     phi_deg = 45
-    phi_rad = phi_deg * (np.pi / 180)
-    snap = dihedral_snapshot_factory(phi_deg=phi_deg)
-    sim = simulation_factory(snap)
+    phi_rad = phi_deg * (numpy.pi / 180)
+    snapshot = dihedral_snapshot_factory(phi_deg=phi_deg)
+    sim = simulation_factory(snapshot)
 
     # the dihedral angle is in yz plane, thus no force along x axis
-    force_array = force * np.asarray(
-        [0, np.sin(-phi_rad / 2), np.cos(-phi_rad / 2)])
-    dihedral_potential = dihedral_cls()
-    dihedral_potential.params['dihedral'] = potential_kwargs
+    force_array = force * numpy.asarray(
+        [0, numpy.sin(-phi_rad / 2),
+         numpy.cos(-phi_rad / 2)])
+    potential = dihedral_cls(**dihedral_args)
+    potential.params['A-A-A-A'] = params
 
-    integrator = hoomd.md.Integrator(dt=0.005)
-
-    integrator.forces.append(dihedral_potential)
-
-    langevin = hoomd.md.methods.Langevin(kT=1,
-                                         filter=hoomd.filter.All(),
-                                         alpha=0.1)
-    integrator.methods.append(langevin)
-    sim.operations.integrator = integrator
+    sim.operations.integrator = hoomd.md.Integrator(dt=0.005,
+                                                    forces=[potential])
 
     sim.run(0)
 
-    sim_energies = sim.operations.integrator.forces[0].energies
-    sim_forces = sim.operations.integrator.forces[0].forces
+    sim_energies = potential.energies
+    sim_forces = potential.forces
     if sim.device.communicator.rank == 0:
-        np.testing.assert_allclose(sum(sim_energies),
-                                   energy,
-                                   rtol=1e-2,
-                                   atol=1e-5)
-        np.testing.assert_allclose(sim_forces[0],
-                                   force_array,
-                                   rtol=1e-2,
-                                   atol=1e-5)
-        np.testing.assert_allclose(sim_forces[1],
-                                   -1 * force_array,
-                                   rtol=1e-2,
-                                   atol=1e-5)
-        np.testing.assert_allclose(sim_forces[2],
-                                   [0, -1 * force_array[1], force_array[2]],
-                                   rtol=1e-2,
-                                   atol=1e-5)
-        np.testing.assert_allclose(sim_forces[3],
-                                   [0, force_array[1], -1 * force_array[2]],
-                                   rtol=1e-2,
-                                   atol=1e-5)
+        assert sum(sim_energies) == pytest.approx(energy, rel=1e-2, abs=1e-5)
+        numpy.testing.assert_allclose(sim_forces[0],
+                                      force_array,
+                                      rtol=1e-2,
+                                      atol=1e-5)
+        numpy.testing.assert_allclose(sim_forces[1],
+                                      -1 * force_array,
+                                      rtol=1e-2,
+                                      atol=1e-5)
+        numpy.testing.assert_allclose(sim_forces[2],
+                                      [0, -1 * force_array[1], force_array[2]],
+                                      rtol=1e-2,
+                                      atol=1e-5)
+        numpy.testing.assert_allclose(sim_forces[3],
+                                      [0, force_array[1], -1 * force_array[2]],
+                                      rtol=1e-2,
+                                      atol=1e-5)

--- a/hoomd/md/pytest/test_special_pair.py
+++ b/hoomd/md/pytest/test_special_pair.py
@@ -67,12 +67,7 @@ def test_after_attaching(snapshot_factory, simulation_factory, special_pair_cls,
     potential.params['A-A'] = params
     potential.r_cut['A-A'] = r_cut
 
-    integrator = hoomd.md.Integrator(dt=0.005)
-    integrator.forces.append(potential)
-
-    langevin = hoomd.md.methods.Langevin(kT=1, filter=hoomd.filter.All())
-    integrator.methods.append(langevin)
-    sim.operations.integrator = integrator
+    sim.operations.integrator = hoomd.md.Integrator(dt=0.005, forces=[potential])
 
     sim.run(0)
     potential.r_cut['A-A'] = r_cut
@@ -91,12 +86,7 @@ def test_forces_and_energies(snapshot_factory, simulation_factory,
     potential.params['A-A'] = params
     potential.r_cut['A-A'] = r_cut
 
-    integrator = hoomd.md.Integrator(dt=0.005)
-    integrator.forces.append(potential)
-
-    langevin = hoomd.md.methods.Langevin(kT=1, filter=hoomd.filter.All())
-    integrator.methods.append(langevin)
-    sim.operations.integrator = integrator
+    sim.operations.integrator = hoomd.md.Integrator(dt=0.005, forces=[potential])
 
     sim.run(0)
 

--- a/hoomd/md/pytest/test_special_pair.py
+++ b/hoomd/md/pytest/test_special_pair.py
@@ -67,7 +67,8 @@ def test_after_attaching(snapshot_factory, simulation_factory, special_pair_cls,
     potential.params['A-A'] = params
     potential.r_cut['A-A'] = r_cut
 
-    sim.operations.integrator = hoomd.md.Integrator(dt=0.005, forces=[potential])
+    sim.operations.integrator = hoomd.md.Integrator(dt=0.005,
+                                                    forces=[potential])
 
     sim.run(0)
     potential.r_cut['A-A'] = r_cut
@@ -86,7 +87,8 @@ def test_forces_and_energies(snapshot_factory, simulation_factory,
     potential.params['A-A'] = params
     potential.r_cut['A-A'] = r_cut
 
-    sim.operations.integrator = hoomd.md.Integrator(dt=0.005, forces=[potential])
+    sim.operations.integrator = hoomd.md.Integrator(dt=0.005,
+                                                    forces=[potential])
 
     sim.run(0)
 

--- a/sphinx-doc/migrating.rst
+++ b/sphinx-doc/migrating.rst
@@ -185,7 +185,6 @@ Not yet ported
 The following v2 functionalities have not yet been ported to the v3 API. They may be added in a
 future 3.x release:
 
-- Tabulated bond, angle, and dihedral potentials.
 - Walls in HPMC.
 - HPMC box volume move size tuner.
 - Harmonic improper potential.

--- a/sphinx-doc/module-md-angle.rst
+++ b/sphinx-doc/module-md-angle.rst
@@ -13,7 +13,7 @@ md.angle
 
     Angle
     Harmonic
-    Cosinesq
+    CosineSquared
     Table
 
 .. rubric:: Details
@@ -22,7 +22,7 @@ md.angle
     :synopsis: Angle potentials.
     :members: Angle,
               Harmonic,
-              Cosinesq,
+              CosineSquared,
               Table
     :no-inherited-members:
     :show-inheritance:

--- a/sphinx-doc/module-md-angle.rst
+++ b/sphinx-doc/module-md-angle.rst
@@ -14,6 +14,7 @@ md.angle
     Angle
     Harmonic
     Cosinesq
+    Table
 
 .. rubric:: Details
 
@@ -21,6 +22,7 @@ md.angle
     :synopsis: Angle potentials.
     :members: Angle,
               Harmonic,
-              Cosinesq
+              Cosinesq,
+              Table
     :no-inherited-members:
     :show-inheritance:

--- a/sphinx-doc/module-md-bond.rst
+++ b/sphinx-doc/module-md-bond.rst
@@ -14,6 +14,7 @@ md.bond
     Bond
     FENEWCA
     Harmonic
+    Table
     Tether
 
 .. rubric:: Details
@@ -23,6 +24,7 @@ md.bond
     :members: Bond,
               FENEWCA,
               Harmonic,
+              Table,
               Tether
     :no-inherited-members:
     :show-inheritance:

--- a/sphinx-doc/module-md-dihedral.rst
+++ b/sphinx-doc/module-md-dihedral.rst
@@ -14,6 +14,7 @@ md.dihedral
     Dihedral
     Harmonic
     OPLS
+    Table
 
 .. rubric:: Details
 
@@ -22,4 +23,5 @@ md.dihedral
     :show-inheritance:
     :members: Dihedral,
               Harmonic,
-              OPLS
+              OPLS,
+              Table


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should based on *maint*. -->
<!-- New features should based on *master*. -->

## Description

<!-- Describe your changes in detail. -->
Add the bond, angle, and dihedral table potentials to the v3 API.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Researchers that utilize these features should be able to upgrade to v3.

<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves #360

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
I added Table tests to the relevant unit tests file. In the process, I refactored the unit tests so it is easier for developers to manage test cases.

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
Added:

* ``md.bond.Table`` - Tabulated bond potential.
* ``md.angle.Table`` - Tabulated angle potential.
* ``md.dihedral.Table`` - Tabulated dihedral potential.

Changed:

* [breaking] - renamed ``md.angle.Cosinesq`` to ``md.angle.CosineSquared``.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
