### PR TITLE
Use pytest.importorskip instead of catching ImportError.

### DIFF
--- a/hoomd/md/pytest/test_gsd.py
+++ b/hoomd/md/pytest/test_gsd.py
@@ -4,12 +4,11 @@
 import hoomd
 import numpy as np
 import pytest
-try:
-    import gsd.hoomd
-except ImportError:
-    pytest.skip("gsd not available", allow_module_level=True)
 
 from hoomd.pytest.test_snapshot import assert_equivalent_snapshots
+
+gsd = pytest.importorskip("gsd")
+gsd.hoomd = pytest.importorskip("gsd.hoomd")
 
 
 @pytest.fixture(scope='function')

--- a/hoomd/md/pytest/test_rigid.py
+++ b/hoomd/md/pytest/test_rigid.py
@@ -6,16 +6,8 @@ from collections.abc import Sequence
 import numpy as np
 import pytest
 
-try:
-    import rowan
-    skip_rowan = False
-except ImportError:
-    skip_rowan = True
-
 import hoomd
 import hoomd.md as md
-
-skip_rowan = pytest.mark.skipif(skip_rowan, reason="rowan cannot be imported.")
 
 
 @pytest.fixture
@@ -72,6 +64,8 @@ def check_bodies(snapshot, definition):
     This is just to prevent duplication of code from test_create_bodies and
     test_running_simulation.
     """
+    rowan = pytest.importorskip("rowan")
+
     assert snapshot.particles.N == 10
     assert all(snapshot.particles.typeid[3:] == 1)
 
@@ -123,9 +117,10 @@ def check_bodies(snapshot, definition):
                           definition["orientations"][i])
 
 
-@skip_rowan
 def test_create_bodies(simulation_factory, two_particle_snapshot_factory,
                        lattice_snapshot_factory, valid_body_definition):
+    rowan = pytest.importorskip("rowan")  # noqa F841 - used by called method
+
     rigid = md.constrain.Rigid()
     rigid.body["A"] = valid_body_definition
 
@@ -225,9 +220,10 @@ def test_error_on_invalid_body(simulation_factory,
         sim.run(0)
 
 
-@skip_rowan
 def test_running_simulation(simulation_factory, two_particle_snapshot_factory,
                             valid_body_definition):
+    rowan = pytest.importorskip("rowan")  # noqa F841 - used by called method
+
     rigid = md.constrain.Rigid()
     rigid.body["A"] = valid_body_definition
     langevin = md.methods.Langevin(kT=2.0, filter=hoomd.filter.Rigid())

--- a/hoomd/pytest/test_simulation.py
+++ b/hoomd/pytest/test_simulation.py
@@ -8,17 +8,11 @@ from copy import deepcopy
 from hoomd.error import MutabilityError
 from hoomd.logging import LoggerCategories
 from hoomd.conftest import logging_check
-try:
-    import gsd.hoomd
-    skip_gsd = False
-except ImportError:
-    skip_gsd = True
-
-skip_gsd = pytest.mark.skipif(skip_gsd,
-                              reason="gsd Python package was not found.")
 
 
 def make_gsd_snapshot(hoomd_snapshot):
+    gsd = pytest.importorskip("gsd")
+    gsd.hoomd = pytest.importorskip("gsd.hoomd")
     s = gsd.hoomd.Snapshot()
     for attr in dir(hoomd_snapshot):
         if attr[0] != '_' and attr not in [
@@ -161,9 +155,11 @@ def state_args(request):
     return deepcopy(request.param)
 
 
-@skip_gsd
 def test_state_from_gsd(device, simulation_factory, lattice_snapshot_factory,
                         state_args, tmp_path):
+    gsd = pytest.importorskip("gsd")
+    gsd.hoomd = pytest.importorskip("gsd.hoomd")
+
     snap_params, nsteps = state_args
 
     d = tmp_path / "sub"
@@ -203,7 +199,6 @@ def test_state_from_gsd(device, simulation_factory, lattice_snapshot_factory,
         assert_equivalent_snapshots(snap, sim.state.get_snapshot())
 
 
-@skip_gsd
 def test_state_from_gsd_snapshot(simulation_factory, lattice_snapshot_factory,
                                  device, state_args, tmp_path):
     snap_params, nsteps = state_args

--- a/hoomd/pytest/test_snapshot.py
+++ b/hoomd/pytest/test_snapshot.py
@@ -6,14 +6,6 @@ from hoomd import Box
 import numpy
 import pytest
 from hoomd.pytest.test_simulation import make_gsd_snapshot
-try:
-    import gsd.hoomd  # noqa: F401 - need to know if the import fails
-    skip_gsd = False
-except ImportError:
-    skip_gsd = True
-
-skip_gsd = pytest.mark.skipif(skip_gsd,
-                              reason="gsd Python package was not found.")
 
 
 def assert_equivalent_snapshots(gsd_snap, hoomd_snap):
@@ -399,14 +391,12 @@ def test_constraints(s):
         assert s.constraints.group.dtype == numpy.uint32
 
 
-@skip_gsd
 def test_from_gsd_snapshot_empty(s, device):
     gsd_snap = make_gsd_snapshot(s)
     hoomd_snap = Snapshot.from_gsd_snapshot(gsd_snap, device.communicator)
     assert_equivalent_snapshots(gsd_snap, hoomd_snap)
 
 
-@skip_gsd
 def test_from_gsd_snapshot_populated(s, device):
     if s.communicator.rank == 0:
         s.configuration.box = [10, 12, 7, 0.1, 0.4, 0.2]

--- a/hoomd/pytest/test_table.py
+++ b/hoomd/pytest/test_table.py
@@ -9,14 +9,6 @@ from hoomd.conftest import operation_pickling_check
 import hoomd
 import hoomd.write
 
-try:
-    from mpi4py import MPI
-    skip_mpi = False
-except ImportError:
-    skip_mpi = True
-
-skip_mpi = pytest.mark.skipif(skip_mpi, reason="MPI4py is not importable.")
-
 
 class Identity:
 
@@ -115,14 +107,16 @@ def test_values(device, logger, expected_values):
             for hdr, v in zip(headers, values))
 
 
-@skip_mpi
 def test_mpi_write_only(device, logger):
+    mpi4py = pytest.importorskip("mpi4py")
+    mpi4py.MPI = pytest.importorskip("mpi4py.MPI")
+
     output = StringIO("")
     table_writer = hoomd.write.Table(1, logger, output)
     table_writer._comm = device.communicator
     table_writer.write()
 
-    comm = MPI.COMM_WORLD
+    comm = mpi4py.MPI.COMM_WORLD
     if comm.rank == 0:
         assert output.getvalue() != ''
     else:


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should based on *maint*. -->
<!-- New features should based on *master*. -->

## Description

<!-- Describe your changes in detail. -->
Where able, convert unit tests that catch `ImportError` to use `pytest.importorskip` instead.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
This cleans the unit tests and makes them easier to maintain.

<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves #1215 

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
I executed all tests locally in virtual environments with and without the imported modules installed. All tests ran correctly or skipped as appropriate.

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

This is an internal change, no log entry is required.

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
