### PR TITLE
Fix for HPMC in hoomd-blue 2.9.7

### DIFF
--- a/hoomd/hpmc/ShapePolyhedron.h
+++ b/hoomd/hpmc/ShapePolyhedron.h
@@ -590,7 +590,7 @@ DEVICE inline bool test_narrow_phase_overlap( vec3<OverlapReal> dr,
             for (unsigned int ivert = 0; ivert < 3; ++ivert)
                 {
                 unsigned int idx_a = a.data.face_verts[offs_a+ivert];
-                vec3<float> v = a.data.verts[idx_a];
+                vec3<OverlapReal> v = a.data.verts[idx_a];
                 v = rotate(q,v) + dr;
                 U[ivert][0] = v.x; U[ivert][1] = v.y; U[ivert][2] = v.z;
                 }


### PR DESCRIPTION
## Description

Fixes https://github.com/glotzerlab/hoomd-blue/issues/1222

## Motivation and context

Compilation of HOOMD-blue 2.9.7 fails when HPMC is enabled and single precision is set to `OFF`.

When single precision is set to OFF and HPMC is enabled, the OverlapReal type is set to double, defined in HPMCPrecisionSetup.h. 
However, inside of the `test_narrow_phase_overlap` function, `v` is hardcoded as vec3 of float but rotate function only expects OverlapReal type, double in this case.
```
vec3<float> v = a.data.verts[idx_a];
v = rotate(q,v) + dr;
```
Thus the compiler returned an error that no instance of overloaded function "rotate" matches the argument list.

The fix was to set `vec3<float>` to `vec3<OverlapReal>`.

This was not visible in tests where single precision is enabled as in that case the OverlapReal type matches float.

This resolves #1222 

## How has this been tested?

* Compiled from source using GCC 10.3.0 on Rocky 8.5 using the following platform
- Linux: Rocky 8.5
- GPU: A100, CUDA 11.3.1
- CPU: AMD Rome 2x64c
- Python version: 3.9.5
- HOOMD-blue version: 2.9.7
- GCC 10.3.0
- CUDA 11.3.1
- CMake 3.20.1

## Change log

```
Fixes HPMC compilation error when single precision is set to `OFF` and HPMC is enabled.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [ ] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
