### PR TITLE
Check if rcut is zero before computing tail correction

### DIFF
--- a/hoomd/md/EvaluatorPairLJ.h
+++ b/hoomd/md/EvaluatorPairLJ.h
@@ -233,6 +233,10 @@ class EvaluatorPairLJ
 
     DEVICE Scalar evalPressureLRCIntegral()
         {
+        if (rcutsq == 0)
+            {
+            return Scalar(0.0);
+            }
         // lj1 = 4.0 * epsilon * pow(sigma,12.0)
         // lj2 = 4.0 * epsilon * pow(sigma,6.0);
         // The complete integral is as follows
@@ -247,6 +251,10 @@ class EvaluatorPairLJ
 
     DEVICE Scalar evalEnergyLRCIntegral()
         {
+        if (rcutsq == 0)
+            {
+            return Scalar(0.0);
+            }
         // Note that lj1 and lj2 are defined above.
         // lj1 = 4.0 * epsilon * pow(sigma,12.0)
         // lj2 = 4.0 * epsilon * pow(sigma,6.0);


### PR DESCRIPTION
## Description

I don't know how this didn't get included in #1138 because at some point I'm sure I had this locally. (Sorry!) Anyway, this checks whether rcut is 0 before computing the tail correction term. 

## Motivation and context

Without this fix if any rcut value is 0, `lj.additional_energy` will be nan

<!-- Replace ??? with the issue number that this pull request resolves. -->

## How has this been tested?

I am testing this in the [reproducibility_study](https://github.com/mosdef-hub/reproducibility_study).
What would be the best way to add a test that would catch this failure? My idea would be something like a MWE of lennard-jonesium with tail correction enabled, run 0 steps, and assert that lj.additional_energy is a float value.

## Change log

<!-- Propose a change log entry. -->
```
Fix bug where hoomd.md.pair.LJ.additional_energy is nan when tail_correction is enabled with pairs for which r_cut is 0
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
