### PR TITLE
Fix FIRE.converged missing before run.

### DIFF
--- a/hoomd/md/minimize/fire.py
+++ b/hoomd/md/minimize/fire.py
@@ -266,6 +266,9 @@ class FIRE(_DynamicIntegrator):
     @log(default=False)
     def converged(self):
         """bool: True when the minimizer has converged, else False."""
+        if not self._attached:
+            return False
+
         return self._cpp_obj.converged
 
     def reset(self):

--- a/hoomd/md/pytest/test_minimize_fire.py
+++ b/hoomd/md/pytest/test_minimize_fire.py
@@ -129,6 +129,8 @@ def test_run_minimization(lattice_snapshot_factory, simulation_factory):
                             min_steps_conv=3)
 
     sim.operations.integrator = fire
+    assert not fire.converged
+
     sim.run(0)
 
     initial_energy = fire.energy


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should based on *maint*. -->
<!-- New features should based on *master*. -->

## Description

<!-- Describe your changes in detail. -->
Return `False` in `FIRE.converged` when it is not yet attached.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
This makes `FIRE.converged` available before `Simulation.run` so that users can write scripts like in the example:

```
    fire = hoomd.md.minimize.FIRE(dt=0.05,
                            force_tol=1e-2,
                            angmom_tol=1e-2,
                            energy_tol=1e-7,methods=all_forces)
    fire.methods.append(hoomd.md.methods.NVE(hoomd.filter.All()))
    sim.operations.integrator = fire
    while not(fire.converged):
        sim.run(100)
```

<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves #1247

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
I added a test that fails before the fix and passes afterit.

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
Fixed:

* ``FIRE.converged`` may be queried before calling ``Simulation.run``.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
