### PR TITLE
Fix __iadd__ for list type

### DIFF
--- a/hoomd/data/collections.py
+++ b/hoomd/data/collections.py
@@ -409,6 +409,7 @@ class _HOOMDList(_HOOMDSyncedCollection, abc.MutableSequence):
                 validated_item = self._validate(item)
                 self._children.add(validated_item)
                 self._data.append(validated_item)
+        return self
 
     def __le__(self, other):
         if isinstance(other, _HOOMDSyncedCollection):

--- a/hoomd/pytest/test_collections.py
+++ b/hoomd/pytest/test_collections.py
@@ -99,6 +99,14 @@ class TestHoomdList(BaseListTest):
         test_list.clear()
         assert all(item._isolated for item in remaining_items)
 
+    def test_iadd(self, populated_collection):
+        test_list, plain_collection = populated_collection
+        data = self._data._sync_data["lists"]
+        data[self._current_list] += [plain_collection[0]]
+        assert len(data[self._current_list]) == len(plain_collection) + 1
+        assert data[self._current_list][-1] == plain_collection[0]
+        self.final_check(data[self._current_list])
+
 
 class TestHoomdTuple(BaseSequenceTest):
 


### PR DESCRIPTION
## Description

Fixes the `__iadd__` method for `_HOOMDList`. Python magic method convention regarding inplace operations is weird.
<!-- Describe your changes in detail. -->

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves #1245

## How has this been tested?

I added a test that looks at `__iadd__`.
<!--- Please describe in detail how you tested your changes. -->

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
Fixed: bug where using `__iadd__` to certain attributes would fail with an exception.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
