### PR TITLE
Remove HPMCIntegrator.test_overlap

### DIFF
--- a/hoomd/hpmc/IntegratorHPMCMono.h
+++ b/hoomd/hpmc/IntegratorHPMCMono.h
@@ -295,21 +295,6 @@ class IntegratorHPMCMono : public IntegratorHPMC
         //! Return a vector that is an unwrapped overlap map
         virtual std::vector<std::pair<unsigned int, unsigned int> > mapOverlaps();
 
-        //! Test overlap for a given pair of particle coordinates
-        /*! \param type_i Type of first particle
-            \param type_j Type of second particle
-            \param rij Separation vector rj-ri
-            \param qi Orientation quaternion of first particle
-            \param qj Orientation quaternion of second particle
-            \param use_images if true, take into account periodic boundary conditions
-            \param exclude_self if true, exclude the self-image
-
-            \returns true if particles overlap
-         */
-        virtual bool py_test_overlap(unsigned int type_i, unsigned int type_j,
-            pybind11::list rij, pybind11::list qi, pybind11::list qj,
-            bool use_images, bool exclude_self);
-
         //! Return the requested ghost layer width
         virtual Scalar getGhostLayerWidth(unsigned int type)
             {
@@ -1976,63 +1961,6 @@ bool IntegratorHPMCMono<Shape>::restoreStateGSD( std::shared_ptr<GSDReader> read
     return success;
     }
 
-template<class Shape>
-bool IntegratorHPMCMono<Shape>::py_test_overlap(unsigned int type_i, unsigned int type_j,
-    pybind11::list rij, pybind11::list qi, pybind11::list qj,
-    bool use_images, bool exclude_self)
-    {
-    if (len(rij) != 3)
-        throw std::runtime_error("rij needs to be a 3d vector.\n");
-    if (len(qi) != 4 || len(qj) != 4)
-        throw std::runtime_error("qi and qj need to be quaternions.\n");
-
-    assert(type_i <= m_pdata->getNTypes());
-    assert(type_j <= m_pdata->getNTypes());
-
-    vec3<Scalar> dr(pybind11::cast<Scalar>(rij[0]), pybind11::cast<Scalar>(rij[1]), pybind11::cast<Scalar>(rij[2]));
-    quat<Scalar> quat_i(pybind11::cast<Scalar>(qi[0]),
-        vec3<Scalar>(pybind11::cast<Scalar>(qi[1]), pybind11::cast<Scalar>(qi[2]), pybind11::cast<Scalar>(qi[3])));
-    quat<Scalar> quat_j(pybind11::cast<Scalar>(qj[0]),
-        vec3<Scalar>(pybind11::cast<Scalar>(qj[1]), pybind11::cast<Scalar>(qj[2]), pybind11::cast<Scalar>(qj[3])));
-
-    Shape shape_i(quat_i, m_params[type_i]);
-    Shape shape_j(quat_j, m_params[type_j]);
-
-    unsigned int err = 0;
-    bool overlap = false;
-    if (use_images)
-        {
-        #ifdef ENABLE_MPI
-        if (m_pdata->getDomainDecomposition())
-            {
-            throw std::runtime_error("test_overlap does not support MPI parallel jobs");
-            }
-        #endif
-
-        updateImageList();
-
-        const unsigned int n_images = (unsigned int)m_image_list.size();
-        for (unsigned int cur_image = 0; cur_image < n_images; cur_image++)
-            {
-            if (exclude_self && cur_image == 0)
-                continue;
-
-            if (check_circumsphere_overlap(dr + m_image_list[cur_image], shape_i, shape_j) &&
-                test_overlap(dr + m_image_list[cur_image], shape_i, shape_j, err))
-                overlap = true;
-            }
-        }
-    else
-        {
-        overlap = check_circumsphere_overlap(dr, shape_i, shape_j) && test_overlap(dr, shape_i, shape_j, err);
-        }
-
-    if (err)
-        m_exec_conf->msg->warning() << "test_overlap() reports an error due to finite numerical precision." << std::endl;
-
-    return overlap;
-    }
-
 /*! \param i The particle id in the list
     \param pos_i Particle position being tested
     \param shape_i Particle shape (including orientation) being tested
@@ -3062,7 +2990,6 @@ template < class Shape > void export_IntegratorHPMCMono(pybind11::module& m, con
           .def("connectGSDStateSignal", &IntegratorHPMCMono<Shape>::connectGSDStateSignal)
           .def("connectGSDShapeSpec", &IntegratorHPMCMono<Shape>::connectGSDShapeSpec)
           .def("restoreStateGSD", &IntegratorHPMCMono<Shape>::restoreStateGSD)
-          .def("py_test_overlap", &IntegratorHPMCMono<Shape>::py_test_overlap)
           .def("getImplicitCounters", &IntegratorHPMCMono<Shape>::getImplicitCounters)
           .def("getDepletantNtrial", &IntegratorHPMCMono<Shape>::getNtrialPy)
           .def("setDepletantNtrial", &IntegratorHPMCMono<Shape>::setNtrialPy)

--- a/hoomd/hpmc/integrate.py
+++ b/hoomd/hpmc/integrate.py
@@ -256,52 +256,6 @@ class HPMCIntegrator(Integrator):
         self._cpp_obj.communicate(True)
         return self._cpp_obj.countOverlaps(False)
 
-    def test_overlap(self,
-                     type_i,
-                     type_j,
-                     rij,
-                     qi,
-                     qj,
-                     use_images=True,
-                     exclude_self=False):
-        """Test overlap between two particles.
-
-        Args:
-            type_i (str): Type of first particle
-            type_j (str): Type of second particle
-            rij (tuple): Separation vector **rj**-**ri** between the particle
-              centers
-            qi (tuple): Orientation quaternion of first particle
-            qj (tuple): Orientation quaternion of second particle
-            use_images (bool): If True, check for overlap between the periodic
-              images of the particles by adding
-              the image vector to the separation vector
-            exclude_self (bool): If both **use_images** and **exclude_self** are
-              true, exclude the primary image
-
-        For two-dimensional shapes, pass the third dimension of **rij** as zero.
-
-        Attention:
-            `test_overlap` is not yet implemented in HOOMD v3.x.
-
-        Returns:
-            True if the particles overlap.
-        """
-        raise NotImplementedError("map_energies will be implemented in a future"
-                                  "release.")
-        self.update_forces()
-
-        ti = hoomd.context.current.system_definition.getParticleData(
-        ).getTypeByName(type_i)
-        tj = hoomd.context.current.system_definition.getParticleData(
-        ).getTypeByName(type_j)
-
-        rij = hoomd.util.listify(rij)
-        qi = hoomd.util.listify(qi)
-        qj = hoomd.util.listify(qj)
-        return self._cpp_obj.py_test_overlap(ti, tj, rij, qi, qj, use_images,
-                                             exclude_self)
-
     @log(category='sequence', requires_run=True)
     def translate_moves(self):
         """tuple[int, int]: Count of the accepted and rejected translate moves.


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should based on *maint*. -->
<!-- New features should based on *master*. -->

## Description

<!-- Describe your changes in detail. -->
Remove the method `HPMCIntegrator.test_overlap` and the associated C++ code.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Simplify the codebase by removing unimplemented features. I am not aware of any use-cases for this method.

<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves #1236

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
No tests needed outside CI.

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

No change log entry required.

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
