### PR TITLE
Remove get_ordered_vertices

### DIFF
--- a/BUILDING.rst
+++ b/BUILDING.rst
@@ -120,10 +120,6 @@ Install prerequisites
 
 - LLVM >= 10.0, < 13
 
-**To use** `md.pair.aniso.ALJ.get_ordered_vertices`:
-
-- coxeter
-
 **To build the documentation:**
 
 - sphinx

--- a/hoomd/md/pair/aniso.py
+++ b/hoomd/md/pair/aniso.py
@@ -342,8 +342,9 @@ class ALJ(AnisotropicPair):
           **required**) - The semimajor axes of a rounding ellipsoid. If a
           single value is specified, the rounding ellipsoid is a sphere.
         * ``faces`` (`list` [`list` [`int`]], **required**) - The faces of the
-          polyhedron specified as a list of list of integers.  The vertices
-          must be ordered.
+          polyhedron specified as a list of list of integers.  The indices
+          corresponding to the vertices must be ordered counterclockwise with
+          respect to the face normal vector pointing outward from the origin.
 
         Type: `hoomd.data.typeparam.TypeParameter` [``particle_types``, `dict`]
 
@@ -387,9 +388,9 @@ class ALJ(AnisotropicPair):
                               faces=cube_faces,
                               rounding_radii=1)
 
-    The following example shows how to easily get the faces for a shape with
-    known vertices by using the `coxeter <https://coxeter.readthedocs.io/>`_
-    package:
+    The following example shows how to easily get the faces, with vertex indices
+    properly ordered, for a shape with known vertices by using the
+    `coxeter <https://coxeter.readthedocs.io/>`_ package:
 
     Example::
 


### PR DESCRIPTION
## Description

This PR removes the convenience method `get_ordered_vertices` of the ALJ potential in favor of having users just use `coxeter` in their scripts. This PR removes coxeter as an optional dependency for hoomd.

## Motivation and context

On #1244 we fixed the way ALJ tests were written and the decision was also made that `get_ordered_vertices` was no longer necessary as a convenience method for ALJ.

## How has this been tested?

No updates to testing are needed for this, because all tests were removed of their coxeter dependency in #1244

## Change log

<!-- Propose a change log entry. -->
```
Remove `get_ordered_vertices` and optional coxeter dependency from `hoomd.md.pair.aniso.ALJ`.
```

## Checklist:

- [ ] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [ ] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [ ] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
