### PR TITLE
Update random123

### DIFF
--- a/hoomd/hpmc/pytest/test_pair_user.py
+++ b/hoomd/hpmc/pytest/test_pair_user.py
@@ -71,7 +71,6 @@ def test_valid_setting_before_attach_cpp_potential(device, attr, value):
     assert getattr(patch, attr) == value
 
 
-@pytest.mark.validate
 @pytest.mark.skipif(llvm_disabled, reason='LLVM not enabled')
 def test_attaching(device, simulation_factory, two_particle_snapshot_factory):
     patch = hoomd.hpmc.pair.user.CPPPotential(r_cut=3,


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should based on *maint*. -->
<!-- New features should based on *master*. -->

## Description

<!-- Describe your changes in detail. -->
Update to the latest version of random123 and remove the validate marker from `test_pair_user.test_attaching`.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
I recently learned `random123` is now available on github. I updated our fork and applied the CUDA RTC fixes to the latest version. This change will allow us to more easily follow the latest upstream releases.

While testing this branch, I discovered that `python3 -m pytest hoomd` passed even when the NVRTC builds failed. To catch these problems more easily while still keeping the test time down, I removed the validate mark from one of the NVRTC tests.

<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves #1251

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
I executed unit tests, validation tests, and an external test script locally.

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

Internal change. No change log entry needed.

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
