### PR TITLE
Run GPU jobs on the jetstream2 runners.

### DIFF
--- a/.github/workflows/make_workflows.py
+++ b/.github/workflows/make_workflows.py
@@ -30,16 +30,8 @@ if __name__ == '__main__':
     for name, configuration in configurations.items():
         for entry in configuration:
             if entry['config'].startswith('[cuda'):
-                entry['runner'] = "[self-hosted,GPU]"
-                # device options needed to access the GPU devices on the runners
-                # because the nvidia container toolkit is built without cgroups
-                # support:
-                # https://aur.archlinux.org/packages/nvidia-container-toolkit
-                entry['docker_options'] = "--gpus=all --device /dev/nvidia0 " \
-                    "--device /dev/nvidia1 " \
-                    "--device /dev/nvidia-uvm " \
-                    "--device /dev/nvidia-uvm-tools " \
-                    "--device /dev/nvidiactl"
+                entry['runner'] = "[self-hosted,jetstream2]"
+                entry['docker_options'] = "--gpus=all"
             else:
                 entry['runner'] = "ubuntu-latest"
                 entry['docker_options'] = ""

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,8 +56,8 @@ jobs:
         include:
         - {config: [clang12_py310, mpi, tbb, llvm], runner: ubuntu-latest, docker_options: '' }
         - {config: [gcc11_py310], runner: ubuntu-latest, docker_options: '' }
-        - {config: [cuda115_gcc9_py38, mpi, llvm], runner: [self-hosted,GPU], docker_options: '--gpus=all --device /dev/nvidia0 --device /dev/nvidia1 --device /dev/nvidia-uvm --device /dev/nvidia-uvm-tools --device /dev/nvidiactl' }
-        - {config: [cuda115_gcc9_py38], runner: [self-hosted,GPU], docker_options: '--gpus=all --device /dev/nvidia0 --device /dev/nvidia1 --device /dev/nvidia-uvm --device /dev/nvidia-uvm-tools --device /dev/nvidiactl' }
+        - {config: [cuda115_gcc9_py38, mpi, llvm], runner: [self-hosted,jetstream2], docker_options: '--gpus=all' }
+        - {config: [cuda115_gcc9_py38], runner: [self-hosted,jetstream2], docker_options: '--gpus=all' }
 
     env:
       CXXFLAGS: '-Werror'
@@ -125,8 +125,8 @@ jobs:
         include:
         - {config: [clang12_py310, mpi, tbb, llvm], runner: ubuntu-latest, docker_options: '' }
         - {config: [gcc11_py310], runner: ubuntu-latest, docker_options: '' }
-        - {config: [cuda115_gcc9_py38, mpi, llvm], runner: [self-hosted,GPU], docker_options: '--gpus=all --device /dev/nvidia0 --device /dev/nvidia1 --device /dev/nvidia-uvm --device /dev/nvidia-uvm-tools --device /dev/nvidiactl' }
-        - {config: [cuda115_gcc9_py38], runner: [self-hosted,GPU], docker_options: '--gpus=all --device /dev/nvidia0 --device /dev/nvidia1 --device /dev/nvidia-uvm --device /dev/nvidia-uvm-tools --device /dev/nvidiactl' }
+        - {config: [cuda115_gcc9_py38, mpi, llvm], runner: [self-hosted,jetstream2], docker_options: '--gpus=all' }
+        - {config: [cuda115_gcc9_py38], runner: [self-hosted,jetstream2], docker_options: '--gpus=all' }
 
     steps:
     - name: Clean workspace
@@ -168,8 +168,8 @@ jobs:
         include:
         - {config: [clang12_py310, mpi, tbb, llvm], runner: ubuntu-latest, docker_options: '' }
         - {config: [gcc11_py310], runner: ubuntu-latest, docker_options: '' }
-        - {config: [cuda115_gcc9_py38, mpi, llvm], runner: [self-hosted,GPU], docker_options: '--gpus=all --device /dev/nvidia0 --device /dev/nvidia1 --device /dev/nvidia-uvm --device /dev/nvidia-uvm-tools --device /dev/nvidiactl' }
-        - {config: [cuda115_gcc9_py38], runner: [self-hosted,GPU], docker_options: '--gpus=all --device /dev/nvidia0 --device /dev/nvidia1 --device /dev/nvidia-uvm --device /dev/nvidia-uvm-tools --device /dev/nvidiactl' }
+        - {config: [cuda115_gcc9_py38, mpi, llvm], runner: [self-hosted,jetstream2], docker_options: '--gpus=all' }
+        - {config: [cuda115_gcc9_py38], runner: [self-hosted,jetstream2], docker_options: '--gpus=all' }
 
     steps:
     - name: Clean workspace
@@ -204,8 +204,8 @@ jobs:
         include:
         - {config: [clang12_py310, mpi, tbb, llvm], runner: ubuntu-latest, docker_options: '' }
         - {config: [gcc11_py310], runner: ubuntu-latest, docker_options: '' }
-        - {config: [cuda115_gcc9_py38, mpi, llvm], runner: [self-hosted,GPU], docker_options: '--gpus=all --device /dev/nvidia0 --device /dev/nvidia1 --device /dev/nvidia-uvm --device /dev/nvidia-uvm-tools --device /dev/nvidiactl' }
-        - {config: [cuda115_gcc9_py38], runner: [self-hosted,GPU], docker_options: '--gpus=all --device /dev/nvidia0 --device /dev/nvidia1 --device /dev/nvidia-uvm --device /dev/nvidia-uvm-tools --device /dev/nvidiactl' }
+        - {config: [cuda115_gcc9_py38, mpi, llvm], runner: [self-hosted,jetstream2], docker_options: '--gpus=all' }
+        - {config: [cuda115_gcc9_py38], runner: [self-hosted,jetstream2], docker_options: '--gpus=all' }
 
     if: ${{ contains(github.event.pull_request.labels.*.name, 'validate') }}
     steps:
@@ -238,11 +238,11 @@ jobs:
         - {config: [clang13_py310], runner: ubuntu-latest, docker_options: '' }
         - {config: [clang11_py39, llvm], runner: ubuntu-latest, docker_options: '' }
         - {config: [gcc10_py39], runner: ubuntu-latest, docker_options: '' }
-        - {config: [cuda114_gcc9_py38, mpi, llvm], runner: [self-hosted,GPU], docker_options: '--gpus=all --device /dev/nvidia0 --device /dev/nvidia1 --device /dev/nvidia-uvm --device /dev/nvidia-uvm-tools --device /dev/nvidiactl' }
-        - {config: [cuda113_gcc9_py38, mpi, llvm], runner: [self-hosted,GPU], docker_options: '--gpus=all --device /dev/nvidia0 --device /dev/nvidia1 --device /dev/nvidia-uvm --device /dev/nvidia-uvm-tools --device /dev/nvidiactl' }
-        - {config: [cuda112_gcc9_py38, mpi, llvm], runner: [self-hosted,GPU], docker_options: '--gpus=all --device /dev/nvidia0 --device /dev/nvidia1 --device /dev/nvidia-uvm --device /dev/nvidia-uvm-tools --device /dev/nvidiactl' }
-        - {config: [cuda111_gcc9_py38, mpi, llvm], runner: [self-hosted,GPU], docker_options: '--gpus=all --device /dev/nvidia0 --device /dev/nvidia1 --device /dev/nvidia-uvm --device /dev/nvidia-uvm-tools --device /dev/nvidiactl' }
-        - {config: [cuda10_gcc7_py37, llvm], runner: [self-hosted,GPU], docker_options: '--gpus=all --device /dev/nvidia0 --device /dev/nvidia1 --device /dev/nvidia-uvm --device /dev/nvidia-uvm-tools --device /dev/nvidiactl' }
+        - {config: [cuda114_gcc9_py38, mpi, llvm], runner: [self-hosted,jetstream2], docker_options: '--gpus=all' }
+        - {config: [cuda113_gcc9_py38, mpi, llvm], runner: [self-hosted,jetstream2], docker_options: '--gpus=all' }
+        - {config: [cuda112_gcc9_py38, mpi, llvm], runner: [self-hosted,jetstream2], docker_options: '--gpus=all' }
+        - {config: [cuda111_gcc9_py38, mpi, llvm], runner: [self-hosted,jetstream2], docker_options: '--gpus=all' }
+        - {config: [cuda10_gcc7_py37, llvm], runner: [self-hosted,jetstream2], docker_options: '--gpus=all' }
         - {config: [clang10_py38, llvm], runner: ubuntu-latest, docker_options: '' }
         - {config: [gcc9_py38], runner: ubuntu-latest, docker_options: '' }
         - {config: [clang9_py38], runner: ubuntu-latest, docker_options: '' }
@@ -319,11 +319,11 @@ jobs:
         - {config: [clang13_py310], runner: ubuntu-latest, docker_options: '' }
         - {config: [clang11_py39, llvm], runner: ubuntu-latest, docker_options: '' }
         - {config: [gcc10_py39], runner: ubuntu-latest, docker_options: '' }
-        - {config: [cuda114_gcc9_py38, mpi, llvm], runner: [self-hosted,GPU], docker_options: '--gpus=all --device /dev/nvidia0 --device /dev/nvidia1 --device /dev/nvidia-uvm --device /dev/nvidia-uvm-tools --device /dev/nvidiactl' }
-        - {config: [cuda113_gcc9_py38, mpi, llvm], runner: [self-hosted,GPU], docker_options: '--gpus=all --device /dev/nvidia0 --device /dev/nvidia1 --device /dev/nvidia-uvm --device /dev/nvidia-uvm-tools --device /dev/nvidiactl' }
-        - {config: [cuda112_gcc9_py38, mpi, llvm], runner: [self-hosted,GPU], docker_options: '--gpus=all --device /dev/nvidia0 --device /dev/nvidia1 --device /dev/nvidia-uvm --device /dev/nvidia-uvm-tools --device /dev/nvidiactl' }
-        - {config: [cuda111_gcc9_py38, mpi, llvm], runner: [self-hosted,GPU], docker_options: '--gpus=all --device /dev/nvidia0 --device /dev/nvidia1 --device /dev/nvidia-uvm --device /dev/nvidia-uvm-tools --device /dev/nvidiactl' }
-        - {config: [cuda10_gcc7_py37, llvm], runner: [self-hosted,GPU], docker_options: '--gpus=all --device /dev/nvidia0 --device /dev/nvidia1 --device /dev/nvidia-uvm --device /dev/nvidia-uvm-tools --device /dev/nvidiactl' }
+        - {config: [cuda114_gcc9_py38, mpi, llvm], runner: [self-hosted,jetstream2], docker_options: '--gpus=all' }
+        - {config: [cuda113_gcc9_py38, mpi, llvm], runner: [self-hosted,jetstream2], docker_options: '--gpus=all' }
+        - {config: [cuda112_gcc9_py38, mpi, llvm], runner: [self-hosted,jetstream2], docker_options: '--gpus=all' }
+        - {config: [cuda111_gcc9_py38, mpi, llvm], runner: [self-hosted,jetstream2], docker_options: '--gpus=all' }
+        - {config: [cuda10_gcc7_py37, llvm], runner: [self-hosted,jetstream2], docker_options: '--gpus=all' }
         - {config: [clang10_py38, llvm], runner: ubuntu-latest, docker_options: '' }
         - {config: [gcc9_py38], runner: ubuntu-latest, docker_options: '' }
         - {config: [clang9_py38], runner: ubuntu-latest, docker_options: '' }
@@ -376,11 +376,11 @@ jobs:
         - {config: [clang13_py310], runner: ubuntu-latest, docker_options: '' }
         - {config: [clang11_py39, llvm], runner: ubuntu-latest, docker_options: '' }
         - {config: [gcc10_py39], runner: ubuntu-latest, docker_options: '' }
-        - {config: [cuda114_gcc9_py38, mpi, llvm], runner: [self-hosted,GPU], docker_options: '--gpus=all --device /dev/nvidia0 --device /dev/nvidia1 --device /dev/nvidia-uvm --device /dev/nvidia-uvm-tools --device /dev/nvidiactl' }
-        - {config: [cuda113_gcc9_py38, mpi, llvm], runner: [self-hosted,GPU], docker_options: '--gpus=all --device /dev/nvidia0 --device /dev/nvidia1 --device /dev/nvidia-uvm --device /dev/nvidia-uvm-tools --device /dev/nvidiactl' }
-        - {config: [cuda112_gcc9_py38, mpi, llvm], runner: [self-hosted,GPU], docker_options: '--gpus=all --device /dev/nvidia0 --device /dev/nvidia1 --device /dev/nvidia-uvm --device /dev/nvidia-uvm-tools --device /dev/nvidiactl' }
-        - {config: [cuda111_gcc9_py38, mpi, llvm], runner: [self-hosted,GPU], docker_options: '--gpus=all --device /dev/nvidia0 --device /dev/nvidia1 --device /dev/nvidia-uvm --device /dev/nvidia-uvm-tools --device /dev/nvidiactl' }
-        - {config: [cuda10_gcc7_py37, llvm], runner: [self-hosted,GPU], docker_options: '--gpus=all --device /dev/nvidia0 --device /dev/nvidia1 --device /dev/nvidia-uvm --device /dev/nvidia-uvm-tools --device /dev/nvidiactl' }
+        - {config: [cuda114_gcc9_py38, mpi, llvm], runner: [self-hosted,jetstream2], docker_options: '--gpus=all' }
+        - {config: [cuda113_gcc9_py38, mpi, llvm], runner: [self-hosted,jetstream2], docker_options: '--gpus=all' }
+        - {config: [cuda112_gcc9_py38, mpi, llvm], runner: [self-hosted,jetstream2], docker_options: '--gpus=all' }
+        - {config: [cuda111_gcc9_py38, mpi, llvm], runner: [self-hosted,jetstream2], docker_options: '--gpus=all' }
+        - {config: [cuda10_gcc7_py37, llvm], runner: [self-hosted,jetstream2], docker_options: '--gpus=all' }
         - {config: [clang10_py38, llvm], runner: ubuntu-latest, docker_options: '' }
         - {config: [gcc9_py38], runner: ubuntu-latest, docker_options: '' }
         - {config: [clang9_py38], runner: ubuntu-latest, docker_options: '' }


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should based on *maint*. -->
<!-- New features should based on *master*. -->

## Description

<!-- Describe your changes in detail. -->
Configure GitHub Actions to run GPU jobs on the jetstream2 runners.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Jetstream2 provides cloud resources through the XSEDE program. By using actions runners on Jetstream2, we can scale our tests to as many runners as needed and free up local workstations for development and testing.

- [ ] Test that runner can accept jobs and run them without error.
- [ ] Automatically shutdown and shelve VMs not in use.
- [ ] Automatically start VMs when needed.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
The GitHub actions in this pull request are the test.

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

No change log entry is required.

## Checklist:

- [X] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [X] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [X] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
