### PR TITLE
Fix compile errors on native ubuntu20.04

### DIFF
--- a/hoomd/CMakeLists.txt
+++ b/hoomd/CMakeLists.txt
@@ -218,7 +218,8 @@ add_library(HOOMD::_hoomd ALIAS _hoomd)
 # Work around support for the delete operator with pybind11 and older versions of clang
 # https://github.com/pybind/pybind11/issues/1604
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-    target_compile_options(_hoomd PUBLIC -fsized-deallocation)
+   target_compile_options(_hoomd PUBLIC $<$<AND:$<COMPILE_LANGUAGE:CUDA>,$<STREQUAL:${HIP_PLATFORM},nvcc>>:-Xcompiler=>;-fsized-deallocation)
+#   target_compile_options(_hoomd PUBLIC -fsized-deallocation)
 endif()
 
 # add quick hull as its own library so that it's symbols can be public

--- a/hoomd/hpmc/IntegratorHPMCMonoGPUDepletants.cu
+++ b/hoomd/hpmc/IntegratorHPMCMonoGPUDepletants.cu
@@ -7,9 +7,12 @@
 #include "hoomd/RNGIdentifiers.h"
 #include "hoomd/RandomNumbers.h"
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wconversion"
 #include <thrust/device_ptr.h>
 #include <thrust/execution_policy.h>
 #include <thrust/reduce.h>
+#pragma GCC diagnostic pop
 
 namespace hoomd
     {

--- a/hoomd/hpmc/ShapeConvexPolygon.h
+++ b/hoomd/hpmc/ShapeConvexPolygon.h
@@ -17,7 +17,7 @@
 #define DEVICE
 #define HOSTDEVICE
 #include <iostream>
-#if defined(__SSE__)
+#if !defined(__HIPCC__) && defined(__SSE__)
 #include <immintrin.h>
 #endif
 #endif

--- a/hoomd/hpmc/ShapeConvexPolyhedron.h
+++ b/hoomd/hpmc/ShapeConvexPolyhedron.h
@@ -20,7 +20,7 @@
 #define DEVICE
 #define HOSTDEVICE
 #include <iostream>
-#if defined(__SSE__)
+#if !defined(__HIPCC__) && defined(__SSE__)
 #include <immintrin.h>
 #endif
 #endif

--- a/hoomd/hpmc/UpdaterClustersGPU.cu
+++ b/hoomd/hpmc/UpdaterClustersGPU.cu
@@ -6,6 +6,8 @@
 #include "hoomd/RNGIdentifiers.h"
 #include "hoomd/RandomNumbers.h"
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wconversion"
 #include <thrust/binary_search.h>
 #include <thrust/copy.h>
 #include <thrust/device_ptr.h>
@@ -14,6 +16,7 @@
 #include <thrust/iterator/discard_iterator.h>
 #include <thrust/iterator/transform_iterator.h>
 #include <thrust/unique.h>
+#pragma GCC diagnostic pop
 
 #ifdef __HIP_PLATFORM_NVCC__
 #include <cusparse.h>

--- a/hoomd/md/CommunicatorGrid.cc
+++ b/hoomd/md/CommunicatorGrid.cc
@@ -27,6 +27,17 @@ inline kiss_fft_cpx operator+(kiss_fft_cpx& lhs, kiss_fft_cpx& rhs)
     return res;
     }
 
+#ifdef ENABLE_HIP
+//! Define plus operator for complex data type (needed by CommunicatorMesh)
+inline hipfftComplex operator+(hipfftComplex& lhs, hipfftComplex& rhs)
+    {
+    hipfftComplex res;
+    res.x = lhs.x + rhs.x;
+    res.y = lhs.y + rhs.y;
+    return res;
+    }
+#endif
+
 namespace hoomd
     {
 namespace md
@@ -271,15 +282,6 @@ template class PYBIND11_EXPORT CommunicatorGrid<unsigned int>;
 template class PYBIND11_EXPORT CommunicatorGrid<kiss_fft_cpx>;
 
 #ifdef ENABLE_HIP
-//! Define plus operator for complex data type (needed by CommunicatorMesh)
-inline hipfftComplex operator+(hipfftComplex& lhs, hipfftComplex& rhs)
-    {
-    hipfftComplex res;
-    res.x = lhs.x + rhs.x;
-    res.y = lhs.y + rhs.y;
-    return res;
-    }
-
 template class PYBIND11_EXPORT CommunicatorGrid<hipfftComplex>;
 #endif
 

--- a/hoomd/md/EvaluatorPairALJ.h
+++ b/hoomd/md/EvaluatorPairALJ.h
@@ -32,7 +32,7 @@
 #define HOSTDEVICE
 #define DEVICE
 
-#if defined(__SSE__)
+#if !defined(__HIPCC__) && defined(__SSE__)
 #include <immintrin.h>
 #endif
 #endif


### PR DESCRIPTION
Also fix compile errors when building with clang and nvcc.

<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should based on *maint*. -->
<!-- New features should based on *master*. -->

## Description

<!-- Describe your changes in detail. -->
Fix a number of compile errors and warnings that result when building on a native ubuntu 20.04 system.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Allow HOOMD-blue to build on such a system.

I don't know why these errors result on a native system and not in the ubuntu20.04 containers that we test in GitHub Actions.

## How has this been tested?

I tested the build locally.

<!--- Please describe in detail how you tested your changes. -->

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
Fixed:

* Compile errors on native ubuntu 20.04 systems.
* Compile errors with ``ENABLE_GPU=on`` and ``clang`` as a host compiler.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
