### PR TITLE
Refactor actions workflow to separate build and test runners.

### DIFF
--- a/.github/workflows/make_workflows.py
+++ b/.github/workflows/make_workflows.py
@@ -30,19 +30,23 @@ if __name__ == '__main__':
     for name, configuration in configurations.items():
         for entry in configuration:
             if entry['config'].startswith('[cuda'):
-                entry['runner'] = "[self-hosted,GPU]"
+                entry['build_runner'] = "[self-hosted,jetstream2,CPU]"
+
+                entry['test_runner'] = "[self-hosted,GPU]"
                 # device options needed to access the GPU devices on the runners
                 # because the nvidia container toolkit is built without cgroups
                 # support:
                 # https://aur.archlinux.org/packages/nvidia-container-toolkit
-                entry['docker_options'] = "--gpus=all --device /dev/nvidia0 " \
+                entry['test_docker_options'] = \
+                    "--gpus=all --device /dev/nvidia0 " \
                     "--device /dev/nvidia1 " \
                     "--device /dev/nvidia-uvm " \
                     "--device /dev/nvidia-uvm-tools " \
                     "--device /dev/nvidiactl"
             else:
-                entry['runner'] = "ubuntu-latest"
-                entry['docker_options'] = ""
+                entry['test_runner'] = "ubuntu-latest"
+                entry['build_runner'] = "ubuntu-latest"
+                entry['test_docker_options'] = ""
 
     with open('test.yml', 'w') as f:
         f.write(template.render(configurations))

--- a/.github/workflows/make_workflows.py
+++ b/.github/workflows/make_workflows.py
@@ -45,7 +45,7 @@ if __name__ == '__main__':
                     "--device /dev/nvidiactl"
             else:
                 entry['test_runner'] = "ubuntu-latest"
-                entry['build_runner'] = "ubuntu-latest"
+                entry['build_runner'] = "[self-hosted,jetstream2,CPU]"
                 entry['test_docker_options'] = ""
 
     with open('test.yml', 'w') as f:

--- a/.github/workflows/start-action-runners.py
+++ b/.github/workflows/start-action-runners.py
@@ -12,7 +12,7 @@ TIME_BETWEEN_ATTEMPTS = 20
 
 
 def bring_runners_online(connection):
-    """Bring all actions-runner servers oneline.
+    """Bring all actions-runner servers online.
 
     Returns:
         True when all actions-runner servers are online, False otherwise.

--- a/.github/workflows/start-action-runners.py
+++ b/.github/workflows/start-action-runners.py
@@ -20,7 +20,7 @@ def bring_runners_online(connection):
     try:
         servers = list(connection.compute.servers())
     except Exception as e:
-        print('Warning: Failed to enumerate servers:', str(e))
+        print('::warning:: Failed to enumerate servers:', str(e))
         return False
 
     total_runners = 0
@@ -40,7 +40,8 @@ def bring_runners_online(connection):
                 try:
                     connection.compute.unshelve_server(server)
                 except Exception as e:
-                    print('... warning: failed to unshelve server:', str(e))
+                    print(f'::warning:: Failed to unshelve {server.name}:',
+                          str(e))
 
             elif server.status == 'SHUTOFF' and server.task_state is None:
                 print(f'... starting {server.name}.')
@@ -48,7 +49,8 @@ def bring_runners_online(connection):
                 try:
                     connection.compute.start_server(server)
                 except Exception as e:
-                    print('... warning: failed to start server:', str(e))
+                    print(f'::warning:: Failed to start server {server.name}:',
+                          str(e))
 
             elif server.status == 'ACTIVE':
                 active_runners += 1
@@ -67,7 +69,7 @@ if __name__ == '__main__':
     try:
         connection = openstack.connect()
     except Exception as e:
-        print('Warning: Failed to connect to cloud:', str(e))
+        print('::warning:: Failed to connect to cloud:', str(e))
         sys.exit(0)
 
     # attempt to bring the servers online several times before returning

--- a/.github/workflows/start-action-runners.py
+++ b/.github/workflows/start-action-runners.py
@@ -1,0 +1,77 @@
+# Copyright (c) 2009-2022 The Regents of the University of Michigan.
+# Part of HOOMD-blue, released under the BSD 3-Clause License.
+
+"""Start all the actions runner instances in jetstream2."""
+
+import openstack
+import sys
+import time
+
+NUM_ATTEMPTS = 8
+TIME_BETWEEN_ATTEMPTS = 20
+
+
+def bring_runners_online(connection):
+    """Bring all actions-runner servers oneline.
+
+    Returns:
+        True when all actions-runner servers are online, False otherwise.
+    """
+    try:
+        servers = list(connection.compute.servers())
+    except Exception as e:
+        print('Warning: Failed to enumerate servers:', str(e))
+        return False
+
+    total_runners = 0
+    active_runners = 0
+
+    for server in servers:
+        if server.name.startswith('actions-runner'):
+            total_runners += 1
+
+            print(
+                f'Server {server.name} is {server.status}({server.task_state}).'
+            )
+            if (server.status == 'SHELVED_OFFLOADED'
+                    and server.task_state is None):
+                print(f'... unshelving {server.name}.')
+
+                try:
+                    connection.compute.unshelve_server(server)
+                except Exception as e:
+                    print('... warning: failed to unshelve server:', str(e))
+
+            elif server.status == 'SHUTOFF' and server.task_state is None:
+                print(f'... starting {server.name}.')
+
+                try:
+                    connection.compute.start_server(server)
+                except Exception as e:
+                    print('... warning: failed to start server:', str(e))
+
+            elif server.status == 'ACTIVE':
+                active_runners += 1
+
+    if total_runners == active_runners:
+        print("Success: All actions-runner servers are active.")
+
+    return total_runners == active_runners
+
+
+if __name__ == '__main__':
+    # catch errors and return success so that this script doesn't stop the whole
+    # actions job
+    try:
+        connection = openstack.connect()
+    except Exception as e:
+        print('Warning: Failed to connect to cloud:', str(e))
+        sys.exit(0)
+
+    # attempt to bring the servers online several times before returning
+    attempts = 0
+    while (not bring_runners_online(connection) and attempts < NUM_ATTEMPTS):
+        attempts += 1
+        print(f'Waiting {TIME_BETWEEN_ATTEMPTS} seconds...')
+        time.sleep(TIME_BETWEEN_ATTEMPTS)
+        print('')

--- a/.github/workflows/start-action-runners.py
+++ b/.github/workflows/start-action-runners.py
@@ -56,6 +56,8 @@ def bring_runners_online(connection):
     if total_runners == active_runners:
         print("Success: All actions-runner servers are active.")
 
+    sys.stdout.flush()
+
     return total_runners == active_runners
 
 

--- a/.github/workflows/start-action-runners.py
+++ b/.github/workflows/start-action-runners.py
@@ -74,6 +74,6 @@ if __name__ == '__main__':
     attempts = 0
     while (not bring_runners_online(connection) and attempts < NUM_ATTEMPTS):
         attempts += 1
-        print(f'Waiting {TIME_BETWEEN_ATTEMPTS} seconds...')
+        print(f'Waiting {TIME_BETWEEN_ATTEMPTS} seconds...', flush=True)
         time.sleep(TIME_BETWEEN_ATTEMPTS)
-        print('')
+        print('', flush=True)

--- a/.github/workflows/templates/configurations.yml
+++ b/.github/workflows/templates/configurations.yml
@@ -1,10 +1,13 @@
 # configurations to build and test on every pull request
 # each entry is a mapping with:
 # - config: a string encoded list containing the docker image name and any number of build options.
-# - The build options are `mpi`, `tbb`, and `llvm`.
+# - The build options are `mpi`, `tbb`, `llvm`, `nomd`, and `nohpmc`.
 unit_test_configurations:
 - config: "[clang12_py310, mpi, tbb, llvm]"
 - config: "[gcc11_py310]"
+- config: "[gcc11_py310, nomd]"
+- config: "[gcc11_py310, nohpmc]"
+- config: "[gcc11_py310, nomd, nohpmc]"
 - config: "[cuda115_gcc9_py38, mpi, llvm]"
 - config: "[cuda115_gcc9_py38]"
 

--- a/.github/workflows/templates/test.yml
+++ b/.github/workflows/templates/test.yml
@@ -250,12 +250,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2.4.0
+      - uses: actions/checkout@v2.1.7
         with:
           path: code
-      - uses: syphar/restore-pip-download-cache@v1
+      - uses: actions/cache@v2
         with:
-          custom_cache_key_element: "openstacksdk-0.61.0"
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-openstacksdk==0.61.0
+          restore-keys: |
+            ${{ runner.os }}-pip-
       - name: Install openstack
         run: python3 -m pip install openstacksdk==0.61.0
       - name: Start actions runners

--- a/.github/workflows/templates/test.yml
+++ b/.github/workflows/templates/test.yml
@@ -250,10 +250,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2.1.7
+      - uses: actions/checkout@v2.4.0
         with:
           path: code
-      - uses: actions/cache@v2
+      - uses: actions/cache@v2.1.7
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-openstacksdk==0.61.0

--- a/.github/workflows/templates/test.yml
+++ b/.github/workflows/templates/test.yml
@@ -64,6 +64,8 @@ env:
                       -DENABLE_TBB=${ENABLE_TBB:-"OFF"} \
                       -DENABLE_LLVM=${ENABLE_LLVM:-"OFF"} \
                       -DBUILD_MD=${BUILD_MD:-"ON"} \
+                      -DBUILD_MPCD=${BUILD_MD:-"ON"} \
+                      -DBUILD_METAL=${BUILD_MD:-"ON"} \
                       -DBUILD_HPMC=${BUILD_HPMC:-"ON"} \
                       -DCUDA_ARCH_LIST="60;70" \
                       -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install

--- a/.github/workflows/templates/test.yml
+++ b/.github/workflows/templates/test.yml
@@ -245,7 +245,7 @@ jobs:
         run: echo "::error ::Validation tests failed." && exit 1
       - run: echo "Done!"
 
-  start_actions_runners:
+  start_action_runners:
     name: Start action runners
     runs-on: ubuntu-latest
 

--- a/.github/workflows/templates/test.yml
+++ b/.github/workflows/templates/test.yml
@@ -25,18 +25,18 @@ env:
   PYTHONPATH: ${{ github.workspace }}/install
 <% endblock %>
 <% set tar_command="tar --use-compress-program='zstd -10 -T0'" %>
-<% macro job(name, use_gpu_runners, configurations, needs='') %>
+<% macro job(name, run_tests, configurations, needs='') %>
     name: << name >> [${{ join(matrix.config, '_') }}]
     <% if needs != '' %>
     needs: << needs >>
     <% endif %>
-    <% if use_gpu_runners %>
-    runs-on: ${{ matrix.runner }}
+    <% if run_tests %>
+    runs-on: ${{ matrix.test_runner }}
     container:
       image: << container_prefix >>-${{ matrix.config[0] }}
-      options: ${{ matrix.docker_options }} -e CUDA_VISIBLE_DEVICES
+      options: ${{ matrix.test_docker_options }} -e CUDA_VISIBLE_DEVICES
     <% else %>
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.build_runner }}
     container:
       image: << container_prefix >>-${{ matrix.config[0] }}
     <% endif %>
@@ -44,7 +44,7 @@ env:
       matrix:
         include:
     <% for configuration in configurations %>
-        - {config: << configuration.config >>, runner: << configuration.runner >>, docker_options: '<< configuration.docker_options >>' }
+        - {config: << configuration.config >>, build_runner: << configuration.build_runner >>, test_runner: << configuration.test_runner >>, test_docker_options: '<< configuration.test_docker_options >>' }
     <% endfor %>
 <% endmacro %>
 <% set build_steps %>
@@ -63,6 +63,7 @@ env:
                       -DENABLE_MPI=${ENABLE_MPI:-"OFF"} \
                       -DENABLE_TBB=${ENABLE_TBB:-"OFF"} \
                       -DENABLE_LLVM=${ENABLE_LLVM:-"OFF"} \
+                      -CUDA_ARCH_LIST=60;70 \
                       -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install
       env:
         ENABLE_GPU: ${{ contains(matrix.config[0], 'cuda') }}
@@ -157,7 +158,7 @@ env:
       run: rm -rf ./*
 <% endset %>
 <% block jobs %>
-# Use multiple jobs to reduce the amount of time spent on GPU runners. Use GitHub Hosted runners for
+# Use multiple jobs to reduce the amount of time spent on GPU runners. Use CPU runners for
 # compiling all tests configurations (GPU and CPU), then upload the build directory (sans object
 # files) as an artifact. Test jobs depend on the build job, download the install directory, and run
 # the tests. Upload each build configuration to a separate artifact.
@@ -167,7 +168,7 @@ env:
 # [image, (mpi), (tbb)]
 jobs:
   build:
-<< job(name='Build', use_gpu_runners=False, configurations=unit_test_configurations) >>
+<< job(name='Build', run_tests=False, configurations=unit_test_configurations) >>
     env:
       CXXFLAGS: '-Werror'
 << prepare_steps >>
@@ -175,40 +176,40 @@ jobs:
 << upload_steps >>
 
   pytest:
-<< job(name='Run pytest', use_gpu_runners=True, configurations=unit_test_configurations, needs='build') >>
+<< job(name='Run pytest', run_tests=True, configurations=unit_test_configurations, needs='build') >>
 << prepare_steps >>
 << download_install_steps >>
 << pytest_steps >>
 
   ctest:
-<< job(name='Run ctest', use_gpu_runners=True, configurations=unit_test_configurations, needs='build') >>
+<< job(name='Run ctest', run_tests=True, configurations=unit_test_configurations, needs='build') >>
 << prepare_steps >>
 << download_build_steps >>
 << ctest_steps >>
 
   validate:
-<< job(name='Validate', use_gpu_runners=True, configurations=validate_configurations, needs='build') >>
+<< job(name='Validate', run_tests=True, configurations=validate_configurations, needs='build') >>
     if: ${{ contains(github.event.pull_request.labels.*.name, 'validate') }}
 << prepare_steps >>
 << download_install_steps >>
 << pytest_validate_steps >>
 
   build_release:
-<< job(name='Build', use_gpu_runners=False, configurations=release_test_configurations) >>
+<< job(name='Build', run_tests=False, configurations=release_test_configurations) >>
     if: ${{ contains(github.event.pull_request.labels.*.name, 'release') }}
 << prepare_steps >>
 << build_steps >>
 << upload_steps >>
 
   pytest_release:
-<< job(name='Run pytest', use_gpu_runners=True, configurations=release_test_configurations, needs='build_release') >>
+<< job(name='Run pytest', run_tests=True, configurations=release_test_configurations, needs='build_release') >>
     if: ${{ contains(github.event.pull_request.labels.*.name, 'release') }}
 << prepare_steps >>
 << download_install_steps >>
 << pytest_steps >>
 
   ctest_release:
-<< job(name='Run ctest', use_gpu_runners=True, configurations=release_test_configurations, needs='build_release') >>
+<< job(name='Run ctest', run_tests=True, configurations=release_test_configurations, needs='build_release') >>
     if: ${{ contains(github.event.pull_request.labels.*.name, 'release') }}
 << prepare_steps >>
 << download_build_steps >>

--- a/.github/workflows/templates/test.yml
+++ b/.github/workflows/templates/test.yml
@@ -246,7 +246,7 @@ jobs:
       - run: echo "Done!"
 
   start_actions_runners:
-    name: Start actions runners
+    name: Start action runners
     runs-on: ubuntu-latest
 
     steps:
@@ -261,12 +261,13 @@ jobs:
             ${{ runner.os }}-pip-
       - name: Install openstack
         run: python3 -m pip install openstacksdk==0.61.0
-      - name: Start actions runners
+      - name: Start action runners
         run: python3 code/.github/workflows/start-action-runners.py
         env:
           OS_APPLICATION_CREDENTIAL_ID: ${{ secrets.OS_APPLICATION_CREDENTIAL_ID }}
           OS_APPLICATION_CREDENTIAL_SECRET: ${{ secrets.OS_APPLICATION_CREDENTIAL_SECRET }}
           OS_AUTH_TYPE: v3applicationcredential
+          OS_AUTH_URL: https://js2.jetstream-cloud.org:5000/v3/
           OS_IDENTITY_API_VERSION: 3
           OS_REGION_NAME: "IU"
           OS_INTERFACE: public

--- a/.github/workflows/templates/test.yml
+++ b/.github/workflows/templates/test.yml
@@ -63,7 +63,7 @@ env:
                       -DENABLE_MPI=${ENABLE_MPI:-"OFF"} \
                       -DENABLE_TBB=${ENABLE_TBB:-"OFF"} \
                       -DENABLE_LLVM=${ENABLE_LLVM:-"OFF"} \
-                      -DCUDA_ARCH_LIST=60;70 \
+                      -DCUDA_ARCH_LIST="60;70" \
                       -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install
       env:
         ENABLE_GPU: ${{ contains(matrix.config[0], 'cuda') }}

--- a/.github/workflows/templates/test.yml
+++ b/.github/workflows/templates/test.yml
@@ -63,7 +63,7 @@ env:
                       -DENABLE_MPI=${ENABLE_MPI:-"OFF"} \
                       -DENABLE_TBB=${ENABLE_TBB:-"OFF"} \
                       -DENABLE_LLVM=${ENABLE_LLVM:-"OFF"} \
-                      -CUDA_ARCH_LIST=60;70 \
+                      -DCUDA_ARCH_LIST=60;70 \
                       -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install
       env:
         ENABLE_GPU: ${{ contains(matrix.config[0], 'cuda') }}

--- a/.github/workflows/templates/test.yml
+++ b/.github/workflows/templates/test.yml
@@ -244,4 +244,23 @@ jobs:
         if: needs.validate.result != 'success'
         run: echo "::error ::Validation tests failed." && exit 1
       - run: echo "Done!"
+
+  start_actions_runners:
+    name: Start actions runners
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2.4.0
+        with:
+          path: code
+      - uses: syphar/restore-pip-download-cache@v1
+        with:
+          custom_cache_key_element: "openstacksdk-0.61.0"
+      - name: Install openstack
+        run: python3 -m pip install openstacksdk==0.61.0
+      - name: Start actions runners
+        run: python3 code/.github/workflows/start-action-runners.py
+        env:
+          OS_APPLICATION_CREDENTIAL_ID: ${{ secrets.OS_APPLICATION_CREDENTIAL_ID }}
+          OS_APPLICATION_CREDENTIAL_SECRET: ${{ secrets.OS_APPLICATION_CREDENTIAL_SECRET }}
 <% endblock %>

--- a/.github/workflows/templates/test.yml
+++ b/.github/workflows/templates/test.yml
@@ -63,6 +63,8 @@ env:
                       -DENABLE_MPI=${ENABLE_MPI:-"OFF"} \
                       -DENABLE_TBB=${ENABLE_TBB:-"OFF"} \
                       -DENABLE_LLVM=${ENABLE_LLVM:-"OFF"} \
+                      -DBUILD_MD=${BUILD_MD:-"ON"} \
+                      -DBUILD_HPMC=${BUILD_HPMC:-"ON"} \
                       -DCUDA_ARCH_LIST="60;70" \
                       -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install
       env:
@@ -70,6 +72,8 @@ env:
         ENABLE_MPI: ${{ contains(matrix.config, 'mpi') }}
         ENABLE_TBB: ${{ contains(matrix.config, 'tbb') }}
         ENABLE_LLVM: ${{ contains(matrix.config, 'llvm') }}
+        BUILD_MD: ${{ !contains(matrix.config, 'nomd') }}
+        BUILD_HPMC: ${{ !contains(matrix.config, 'nohpmc') }}
     - name: Build
       run: ninja install -j $(($(getconf _NPROCESSORS_ONLN) + 2))
       working-directory: build

--- a/.github/workflows/templates/test.yml
+++ b/.github/workflows/templates/test.yml
@@ -266,4 +266,9 @@ jobs:
         env:
           OS_APPLICATION_CREDENTIAL_ID: ${{ secrets.OS_APPLICATION_CREDENTIAL_ID }}
           OS_APPLICATION_CREDENTIAL_SECRET: ${{ secrets.OS_APPLICATION_CREDENTIAL_SECRET }}
+          OS_AUTH_TYPE: v3applicationcredential
+          OS_AUTH_URL: https://js2.jetstream-cloud.org:5000/v3/
+          OS_IDENTITY_API_VERSION: 3
+          OS_REGION_NAME: "IU"
+          OS_INTERFACE: public
 <% endblock %>

--- a/.github/workflows/templates/test.yml
+++ b/.github/workflows/templates/test.yml
@@ -267,7 +267,6 @@ jobs:
           OS_APPLICATION_CREDENTIAL_ID: ${{ secrets.OS_APPLICATION_CREDENTIAL_ID }}
           OS_APPLICATION_CREDENTIAL_SECRET: ${{ secrets.OS_APPLICATION_CREDENTIAL_SECRET }}
           OS_AUTH_TYPE: v3applicationcredential
-          OS_AUTH_URL: https://js2.jetstream-cloud.org:5000/v3/
           OS_IDENTITY_API_VERSION: 3
           OS_REGION_NAME: "IU"
           OS_INTERFACE: public

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -482,7 +482,6 @@ jobs:
           OS_APPLICATION_CREDENTIAL_ID: ${{ secrets.OS_APPLICATION_CREDENTIAL_ID }}
           OS_APPLICATION_CREDENTIAL_SECRET: ${{ secrets.OS_APPLICATION_CREDENTIAL_SECRET }}
           OS_AUTH_TYPE: v3applicationcredential
-          OS_AUTH_URL: https://js2.jetstream-cloud.org:5000/v3/
           OS_IDENTITY_API_VERSION: 3
           OS_REGION_NAME: "IU"
           OS_INTERFACE: public

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,7 +80,7 @@ jobs:
                       -DENABLE_MPI=${ENABLE_MPI:-"OFF"} \
                       -DENABLE_TBB=${ENABLE_TBB:-"OFF"} \
                       -DENABLE_LLVM=${ENABLE_LLVM:-"OFF"} \
-                      -DCUDA_ARCH_LIST=60;70 \
+                      -DCUDA_ARCH_LIST="60;70" \
                       -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install
       env:
         ENABLE_GPU: ${{ contains(matrix.config[0], 'cuda') }}
@@ -274,7 +274,7 @@ jobs:
                       -DENABLE_MPI=${ENABLE_MPI:-"OFF"} \
                       -DENABLE_TBB=${ENABLE_TBB:-"OFF"} \
                       -DENABLE_LLVM=${ENABLE_LLVM:-"OFF"} \
-                      -DCUDA_ARCH_LIST=60;70 \
+                      -DCUDA_ARCH_LIST="60;70" \
                       -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install
       env:
         ENABLE_GPU: ${{ contains(matrix.config[0], 'cuda') }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -465,12 +465,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2.4.0
+      - uses: actions/checkout@v2.1.7
         with:
           path: code
-      - uses: syphar/restore-pip-download-cache@v1
+      - uses: actions/cache@v2
         with:
-          custom_cache_key_element: "openstacksdk-0.61.0"
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-openstacksdk==0.61.0
+          restore-keys: |
+            ${{ runner.os }}-pip-
       - name: Install openstack
         run: python3 -m pip install openstacksdk==0.61.0
       - name: Start actions runners

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,6 +56,9 @@ jobs:
         include:
         - {config: [clang12_py310, mpi, tbb, llvm], build_runner: [self-hosted,jetstream2,CPU], test_runner: ubuntu-latest, test_docker_options: '' }
         - {config: [gcc11_py310], build_runner: [self-hosted,jetstream2,CPU], test_runner: ubuntu-latest, test_docker_options: '' }
+        - {config: [gcc11_py310, nomd], build_runner: [self-hosted,jetstream2,CPU], test_runner: ubuntu-latest, test_docker_options: '' }
+        - {config: [gcc11_py310, nohpmc], build_runner: [self-hosted,jetstream2,CPU], test_runner: ubuntu-latest, test_docker_options: '' }
+        - {config: [gcc11_py310, nomd, nohpmc], build_runner: [self-hosted,jetstream2,CPU], test_runner: ubuntu-latest, test_docker_options: '' }
         - {config: [cuda115_gcc9_py38, mpi, llvm], build_runner: [self-hosted,jetstream2,CPU], test_runner: [self-hosted,GPU], test_docker_options: '--gpus=all --device /dev/nvidia0 --device /dev/nvidia1 --device /dev/nvidia-uvm --device /dev/nvidia-uvm-tools --device /dev/nvidiactl' }
         - {config: [cuda115_gcc9_py38], build_runner: [self-hosted,jetstream2,CPU], test_runner: [self-hosted,GPU], test_docker_options: '--gpus=all --device /dev/nvidia0 --device /dev/nvidia1 --device /dev/nvidia-uvm --device /dev/nvidia-uvm-tools --device /dev/nvidiactl' }
 
@@ -80,6 +83,8 @@ jobs:
                       -DENABLE_MPI=${ENABLE_MPI:-"OFF"} \
                       -DENABLE_TBB=${ENABLE_TBB:-"OFF"} \
                       -DENABLE_LLVM=${ENABLE_LLVM:-"OFF"} \
+                      -DBUILD_MD=${BUILD_MD:-"ON"} \
+                      -DBUILD_HPMC=${BUILD_HPMC:-"ON"} \
                       -DCUDA_ARCH_LIST="60;70" \
                       -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install
       env:
@@ -87,6 +92,8 @@ jobs:
         ENABLE_MPI: ${{ contains(matrix.config, 'mpi') }}
         ENABLE_TBB: ${{ contains(matrix.config, 'tbb') }}
         ENABLE_LLVM: ${{ contains(matrix.config, 'llvm') }}
+        BUILD_MD: ${{ !contains(matrix.config, 'nomd') }}
+        BUILD_HPMC: ${{ !contains(matrix.config, 'nohpmc') }}
     - name: Build
       run: ninja install -j $(($(getconf _NPROCESSORS_ONLN) + 2))
       working-directory: build
@@ -126,6 +133,9 @@ jobs:
         include:
         - {config: [clang12_py310, mpi, tbb, llvm], build_runner: [self-hosted,jetstream2,CPU], test_runner: ubuntu-latest, test_docker_options: '' }
         - {config: [gcc11_py310], build_runner: [self-hosted,jetstream2,CPU], test_runner: ubuntu-latest, test_docker_options: '' }
+        - {config: [gcc11_py310, nomd], build_runner: [self-hosted,jetstream2,CPU], test_runner: ubuntu-latest, test_docker_options: '' }
+        - {config: [gcc11_py310, nohpmc], build_runner: [self-hosted,jetstream2,CPU], test_runner: ubuntu-latest, test_docker_options: '' }
+        - {config: [gcc11_py310, nomd, nohpmc], build_runner: [self-hosted,jetstream2,CPU], test_runner: ubuntu-latest, test_docker_options: '' }
         - {config: [cuda115_gcc9_py38, mpi, llvm], build_runner: [self-hosted,jetstream2,CPU], test_runner: [self-hosted,GPU], test_docker_options: '--gpus=all --device /dev/nvidia0 --device /dev/nvidia1 --device /dev/nvidia-uvm --device /dev/nvidia-uvm-tools --device /dev/nvidiactl' }
         - {config: [cuda115_gcc9_py38], build_runner: [self-hosted,jetstream2,CPU], test_runner: [self-hosted,GPU], test_docker_options: '--gpus=all --device /dev/nvidia0 --device /dev/nvidia1 --device /dev/nvidia-uvm --device /dev/nvidia-uvm-tools --device /dev/nvidiactl' }
 
@@ -169,6 +179,9 @@ jobs:
         include:
         - {config: [clang12_py310, mpi, tbb, llvm], build_runner: [self-hosted,jetstream2,CPU], test_runner: ubuntu-latest, test_docker_options: '' }
         - {config: [gcc11_py310], build_runner: [self-hosted,jetstream2,CPU], test_runner: ubuntu-latest, test_docker_options: '' }
+        - {config: [gcc11_py310, nomd], build_runner: [self-hosted,jetstream2,CPU], test_runner: ubuntu-latest, test_docker_options: '' }
+        - {config: [gcc11_py310, nohpmc], build_runner: [self-hosted,jetstream2,CPU], test_runner: ubuntu-latest, test_docker_options: '' }
+        - {config: [gcc11_py310, nomd, nohpmc], build_runner: [self-hosted,jetstream2,CPU], test_runner: ubuntu-latest, test_docker_options: '' }
         - {config: [cuda115_gcc9_py38, mpi, llvm], build_runner: [self-hosted,jetstream2,CPU], test_runner: [self-hosted,GPU], test_docker_options: '--gpus=all --device /dev/nvidia0 --device /dev/nvidia1 --device /dev/nvidia-uvm --device /dev/nvidia-uvm-tools --device /dev/nvidiactl' }
         - {config: [cuda115_gcc9_py38], build_runner: [self-hosted,jetstream2,CPU], test_runner: [self-hosted,GPU], test_docker_options: '--gpus=all --device /dev/nvidia0 --device /dev/nvidia1 --device /dev/nvidia-uvm --device /dev/nvidia-uvm-tools --device /dev/nvidiactl' }
 
@@ -274,6 +287,8 @@ jobs:
                       -DENABLE_MPI=${ENABLE_MPI:-"OFF"} \
                       -DENABLE_TBB=${ENABLE_TBB:-"OFF"} \
                       -DENABLE_LLVM=${ENABLE_LLVM:-"OFF"} \
+                      -DBUILD_MD=${BUILD_MD:-"ON"} \
+                      -DBUILD_HPMC=${BUILD_HPMC:-"ON"} \
                       -DCUDA_ARCH_LIST="60;70" \
                       -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install
       env:
@@ -281,6 +296,8 @@ jobs:
         ENABLE_MPI: ${{ contains(matrix.config, 'mpi') }}
         ENABLE_TBB: ${{ contains(matrix.config, 'tbb') }}
         ENABLE_LLVM: ${{ contains(matrix.config, 'llvm') }}
+        BUILD_MD: ${{ !contains(matrix.config, 'nomd') }}
+        BUILD_HPMC: ${{ !contains(matrix.config, 'nohpmc') }}
     - name: Build
       run: ninja install -j $(($(getconf _NPROCESSORS_ONLN) + 2))
       working-directory: build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -460,7 +460,7 @@ jobs:
         run: echo "::error ::Validation tests failed." && exit 1
       - run: echo "Done!"
 
-  start_actions_runners:
+  start_action_runners:
     name: Start action runners
     runs-on: ubuntu-latest
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -465,10 +465,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2.1.7
+      - uses: actions/checkout@v2.4.0
         with:
           path: code
-      - uses: actions/cache@v2
+      - uses: actions/cache@v2.1.7
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-openstacksdk==0.61.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -481,3 +481,8 @@ jobs:
         env:
           OS_APPLICATION_CREDENTIAL_ID: ${{ secrets.OS_APPLICATION_CREDENTIAL_ID }}
           OS_APPLICATION_CREDENTIAL_SECRET: ${{ secrets.OS_APPLICATION_CREDENTIAL_SECRET }}
+          OS_AUTH_TYPE: v3applicationcredential
+          OS_AUTH_URL: https://js2.jetstream-cloud.org:5000/v3/
+          OS_IDENTITY_API_VERSION: 3
+          OS_REGION_NAME: "IU"
+          OS_INTERFACE: public

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -461,7 +461,7 @@ jobs:
       - run: echo "Done!"
 
   start_actions_runners:
-    name: Start actions runners
+    name: Start action runners
     runs-on: ubuntu-latest
 
     steps:
@@ -476,12 +476,13 @@ jobs:
             ${{ runner.os }}-pip-
       - name: Install openstack
         run: python3 -m pip install openstacksdk==0.61.0
-      - name: Start actions runners
+      - name: Start action runners
         run: python3 code/.github/workflows/start-action-runners.py
         env:
           OS_APPLICATION_CREDENTIAL_ID: ${{ secrets.OS_APPLICATION_CREDENTIAL_ID }}
           OS_APPLICATION_CREDENTIAL_SECRET: ${{ secrets.OS_APPLICATION_CREDENTIAL_SECRET }}
           OS_AUTH_TYPE: v3applicationcredential
+          OS_AUTH_URL: https://js2.jetstream-cloud.org:5000/v3/
           OS_IDENTITY_API_VERSION: 3
           OS_REGION_NAME: "IU"
           OS_INTERFACE: public

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,8 +54,8 @@ jobs:
     strategy:
       matrix:
         include:
-        - {config: [clang12_py310, mpi, tbb, llvm], build_runner: ubuntu-latest, test_runner: ubuntu-latest, test_docker_options: '' }
-        - {config: [gcc11_py310], build_runner: ubuntu-latest, test_runner: ubuntu-latest, test_docker_options: '' }
+        - {config: [clang12_py310, mpi, tbb, llvm], build_runner: [self-hosted,jetstream2,CPU], test_runner: ubuntu-latest, test_docker_options: '' }
+        - {config: [gcc11_py310], build_runner: [self-hosted,jetstream2,CPU], test_runner: ubuntu-latest, test_docker_options: '' }
         - {config: [cuda115_gcc9_py38, mpi, llvm], build_runner: [self-hosted,jetstream2,CPU], test_runner: [self-hosted,GPU], test_docker_options: '--gpus=all --device /dev/nvidia0 --device /dev/nvidia1 --device /dev/nvidia-uvm --device /dev/nvidia-uvm-tools --device /dev/nvidiactl' }
         - {config: [cuda115_gcc9_py38], build_runner: [self-hosted,jetstream2,CPU], test_runner: [self-hosted,GPU], test_docker_options: '--gpus=all --device /dev/nvidia0 --device /dev/nvidia1 --device /dev/nvidia-uvm --device /dev/nvidia-uvm-tools --device /dev/nvidiactl' }
 
@@ -124,8 +124,8 @@ jobs:
     strategy:
       matrix:
         include:
-        - {config: [clang12_py310, mpi, tbb, llvm], build_runner: ubuntu-latest, test_runner: ubuntu-latest, test_docker_options: '' }
-        - {config: [gcc11_py310], build_runner: ubuntu-latest, test_runner: ubuntu-latest, test_docker_options: '' }
+        - {config: [clang12_py310, mpi, tbb, llvm], build_runner: [self-hosted,jetstream2,CPU], test_runner: ubuntu-latest, test_docker_options: '' }
+        - {config: [gcc11_py310], build_runner: [self-hosted,jetstream2,CPU], test_runner: ubuntu-latest, test_docker_options: '' }
         - {config: [cuda115_gcc9_py38, mpi, llvm], build_runner: [self-hosted,jetstream2,CPU], test_runner: [self-hosted,GPU], test_docker_options: '--gpus=all --device /dev/nvidia0 --device /dev/nvidia1 --device /dev/nvidia-uvm --device /dev/nvidia-uvm-tools --device /dev/nvidiactl' }
         - {config: [cuda115_gcc9_py38], build_runner: [self-hosted,jetstream2,CPU], test_runner: [self-hosted,GPU], test_docker_options: '--gpus=all --device /dev/nvidia0 --device /dev/nvidia1 --device /dev/nvidia-uvm --device /dev/nvidia-uvm-tools --device /dev/nvidiactl' }
 
@@ -167,8 +167,8 @@ jobs:
     strategy:
       matrix:
         include:
-        - {config: [clang12_py310, mpi, tbb, llvm], build_runner: ubuntu-latest, test_runner: ubuntu-latest, test_docker_options: '' }
-        - {config: [gcc11_py310], build_runner: ubuntu-latest, test_runner: ubuntu-latest, test_docker_options: '' }
+        - {config: [clang12_py310, mpi, tbb, llvm], build_runner: [self-hosted,jetstream2,CPU], test_runner: ubuntu-latest, test_docker_options: '' }
+        - {config: [gcc11_py310], build_runner: [self-hosted,jetstream2,CPU], test_runner: ubuntu-latest, test_docker_options: '' }
         - {config: [cuda115_gcc9_py38, mpi, llvm], build_runner: [self-hosted,jetstream2,CPU], test_runner: [self-hosted,GPU], test_docker_options: '--gpus=all --device /dev/nvidia0 --device /dev/nvidia1 --device /dev/nvidia-uvm --device /dev/nvidia-uvm-tools --device /dev/nvidiactl' }
         - {config: [cuda115_gcc9_py38], build_runner: [self-hosted,jetstream2,CPU], test_runner: [self-hosted,GPU], test_docker_options: '--gpus=all --device /dev/nvidia0 --device /dev/nvidia1 --device /dev/nvidia-uvm --device /dev/nvidia-uvm-tools --device /dev/nvidiactl' }
 
@@ -203,8 +203,8 @@ jobs:
     strategy:
       matrix:
         include:
-        - {config: [clang12_py310, mpi, tbb, llvm], build_runner: ubuntu-latest, test_runner: ubuntu-latest, test_docker_options: '' }
-        - {config: [gcc11_py310], build_runner: ubuntu-latest, test_runner: ubuntu-latest, test_docker_options: '' }
+        - {config: [clang12_py310, mpi, tbb, llvm], build_runner: [self-hosted,jetstream2,CPU], test_runner: ubuntu-latest, test_docker_options: '' }
+        - {config: [gcc11_py310], build_runner: [self-hosted,jetstream2,CPU], test_runner: ubuntu-latest, test_docker_options: '' }
         - {config: [cuda115_gcc9_py38, mpi, llvm], build_runner: [self-hosted,jetstream2,CPU], test_runner: [self-hosted,GPU], test_docker_options: '--gpus=all --device /dev/nvidia0 --device /dev/nvidia1 --device /dev/nvidia-uvm --device /dev/nvidia-uvm-tools --device /dev/nvidiactl' }
         - {config: [cuda115_gcc9_py38], build_runner: [self-hosted,jetstream2,CPU], test_runner: [self-hosted,GPU], test_docker_options: '--gpus=all --device /dev/nvidia0 --device /dev/nvidia1 --device /dev/nvidia-uvm --device /dev/nvidia-uvm-tools --device /dev/nvidiactl' }
 
@@ -236,23 +236,23 @@ jobs:
     strategy:
       matrix:
         include:
-        - {config: [clang13_py310], build_runner: ubuntu-latest, test_runner: ubuntu-latest, test_docker_options: '' }
-        - {config: [clang11_py39, llvm], build_runner: ubuntu-latest, test_runner: ubuntu-latest, test_docker_options: '' }
-        - {config: [gcc10_py39], build_runner: ubuntu-latest, test_runner: ubuntu-latest, test_docker_options: '' }
+        - {config: [clang13_py310], build_runner: [self-hosted,jetstream2,CPU], test_runner: ubuntu-latest, test_docker_options: '' }
+        - {config: [clang11_py39, llvm], build_runner: [self-hosted,jetstream2,CPU], test_runner: ubuntu-latest, test_docker_options: '' }
+        - {config: [gcc10_py39], build_runner: [self-hosted,jetstream2,CPU], test_runner: ubuntu-latest, test_docker_options: '' }
         - {config: [cuda114_gcc9_py38, mpi, llvm], build_runner: [self-hosted,jetstream2,CPU], test_runner: [self-hosted,GPU], test_docker_options: '--gpus=all --device /dev/nvidia0 --device /dev/nvidia1 --device /dev/nvidia-uvm --device /dev/nvidia-uvm-tools --device /dev/nvidiactl' }
         - {config: [cuda113_gcc9_py38, mpi, llvm], build_runner: [self-hosted,jetstream2,CPU], test_runner: [self-hosted,GPU], test_docker_options: '--gpus=all --device /dev/nvidia0 --device /dev/nvidia1 --device /dev/nvidia-uvm --device /dev/nvidia-uvm-tools --device /dev/nvidiactl' }
         - {config: [cuda112_gcc9_py38, mpi, llvm], build_runner: [self-hosted,jetstream2,CPU], test_runner: [self-hosted,GPU], test_docker_options: '--gpus=all --device /dev/nvidia0 --device /dev/nvidia1 --device /dev/nvidia-uvm --device /dev/nvidia-uvm-tools --device /dev/nvidiactl' }
         - {config: [cuda111_gcc9_py38, mpi, llvm], build_runner: [self-hosted,jetstream2,CPU], test_runner: [self-hosted,GPU], test_docker_options: '--gpus=all --device /dev/nvidia0 --device /dev/nvidia1 --device /dev/nvidia-uvm --device /dev/nvidia-uvm-tools --device /dev/nvidiactl' }
         - {config: [cuda10_gcc7_py37, llvm], build_runner: [self-hosted,jetstream2,CPU], test_runner: [self-hosted,GPU], test_docker_options: '--gpus=all --device /dev/nvidia0 --device /dev/nvidia1 --device /dev/nvidia-uvm --device /dev/nvidia-uvm-tools --device /dev/nvidiactl' }
-        - {config: [clang10_py38, llvm], build_runner: ubuntu-latest, test_runner: ubuntu-latest, test_docker_options: '' }
-        - {config: [gcc9_py38], build_runner: ubuntu-latest, test_runner: ubuntu-latest, test_docker_options: '' }
-        - {config: [clang9_py38], build_runner: ubuntu-latest, test_runner: ubuntu-latest, test_docker_options: '' }
-        - {config: [clang8_py38], build_runner: ubuntu-latest, test_runner: ubuntu-latest, test_docker_options: '' }
-        - {config: [clang7_py38], build_runner: ubuntu-latest, test_runner: ubuntu-latest, test_docker_options: '' }
-        - {config: [gcc8_py37], build_runner: ubuntu-latest, test_runner: ubuntu-latest, test_docker_options: '' }
-        - {config: [gcc7_py37], build_runner: ubuntu-latest, test_runner: ubuntu-latest, test_docker_options: '' }
-        - {config: [clang6_py37], build_runner: ubuntu-latest, test_runner: ubuntu-latest, test_docker_options: '' }
-        - {config: [gcc7_py36], build_runner: ubuntu-latest, test_runner: ubuntu-latest, test_docker_options: '' }
+        - {config: [clang10_py38, llvm], build_runner: [self-hosted,jetstream2,CPU], test_runner: ubuntu-latest, test_docker_options: '' }
+        - {config: [gcc9_py38], build_runner: [self-hosted,jetstream2,CPU], test_runner: ubuntu-latest, test_docker_options: '' }
+        - {config: [clang9_py38], build_runner: [self-hosted,jetstream2,CPU], test_runner: ubuntu-latest, test_docker_options: '' }
+        - {config: [clang8_py38], build_runner: [self-hosted,jetstream2,CPU], test_runner: ubuntu-latest, test_docker_options: '' }
+        - {config: [clang7_py38], build_runner: [self-hosted,jetstream2,CPU], test_runner: ubuntu-latest, test_docker_options: '' }
+        - {config: [gcc8_py37], build_runner: [self-hosted,jetstream2,CPU], test_runner: ubuntu-latest, test_docker_options: '' }
+        - {config: [gcc7_py37], build_runner: [self-hosted,jetstream2,CPU], test_runner: ubuntu-latest, test_docker_options: '' }
+        - {config: [clang6_py37], build_runner: [self-hosted,jetstream2,CPU], test_runner: ubuntu-latest, test_docker_options: '' }
+        - {config: [gcc7_py36], build_runner: [self-hosted,jetstream2,CPU], test_runner: ubuntu-latest, test_docker_options: '' }
 
     if: ${{ contains(github.event.pull_request.labels.*.name, 'release') }}
     steps:
@@ -318,23 +318,23 @@ jobs:
     strategy:
       matrix:
         include:
-        - {config: [clang13_py310], build_runner: ubuntu-latest, test_runner: ubuntu-latest, test_docker_options: '' }
-        - {config: [clang11_py39, llvm], build_runner: ubuntu-latest, test_runner: ubuntu-latest, test_docker_options: '' }
-        - {config: [gcc10_py39], build_runner: ubuntu-latest, test_runner: ubuntu-latest, test_docker_options: '' }
+        - {config: [clang13_py310], build_runner: [self-hosted,jetstream2,CPU], test_runner: ubuntu-latest, test_docker_options: '' }
+        - {config: [clang11_py39, llvm], build_runner: [self-hosted,jetstream2,CPU], test_runner: ubuntu-latest, test_docker_options: '' }
+        - {config: [gcc10_py39], build_runner: [self-hosted,jetstream2,CPU], test_runner: ubuntu-latest, test_docker_options: '' }
         - {config: [cuda114_gcc9_py38, mpi, llvm], build_runner: [self-hosted,jetstream2,CPU], test_runner: [self-hosted,GPU], test_docker_options: '--gpus=all --device /dev/nvidia0 --device /dev/nvidia1 --device /dev/nvidia-uvm --device /dev/nvidia-uvm-tools --device /dev/nvidiactl' }
         - {config: [cuda113_gcc9_py38, mpi, llvm], build_runner: [self-hosted,jetstream2,CPU], test_runner: [self-hosted,GPU], test_docker_options: '--gpus=all --device /dev/nvidia0 --device /dev/nvidia1 --device /dev/nvidia-uvm --device /dev/nvidia-uvm-tools --device /dev/nvidiactl' }
         - {config: [cuda112_gcc9_py38, mpi, llvm], build_runner: [self-hosted,jetstream2,CPU], test_runner: [self-hosted,GPU], test_docker_options: '--gpus=all --device /dev/nvidia0 --device /dev/nvidia1 --device /dev/nvidia-uvm --device /dev/nvidia-uvm-tools --device /dev/nvidiactl' }
         - {config: [cuda111_gcc9_py38, mpi, llvm], build_runner: [self-hosted,jetstream2,CPU], test_runner: [self-hosted,GPU], test_docker_options: '--gpus=all --device /dev/nvidia0 --device /dev/nvidia1 --device /dev/nvidia-uvm --device /dev/nvidia-uvm-tools --device /dev/nvidiactl' }
         - {config: [cuda10_gcc7_py37, llvm], build_runner: [self-hosted,jetstream2,CPU], test_runner: [self-hosted,GPU], test_docker_options: '--gpus=all --device /dev/nvidia0 --device /dev/nvidia1 --device /dev/nvidia-uvm --device /dev/nvidia-uvm-tools --device /dev/nvidiactl' }
-        - {config: [clang10_py38, llvm], build_runner: ubuntu-latest, test_runner: ubuntu-latest, test_docker_options: '' }
-        - {config: [gcc9_py38], build_runner: ubuntu-latest, test_runner: ubuntu-latest, test_docker_options: '' }
-        - {config: [clang9_py38], build_runner: ubuntu-latest, test_runner: ubuntu-latest, test_docker_options: '' }
-        - {config: [clang8_py38], build_runner: ubuntu-latest, test_runner: ubuntu-latest, test_docker_options: '' }
-        - {config: [clang7_py38], build_runner: ubuntu-latest, test_runner: ubuntu-latest, test_docker_options: '' }
-        - {config: [gcc8_py37], build_runner: ubuntu-latest, test_runner: ubuntu-latest, test_docker_options: '' }
-        - {config: [gcc7_py37], build_runner: ubuntu-latest, test_runner: ubuntu-latest, test_docker_options: '' }
-        - {config: [clang6_py37], build_runner: ubuntu-latest, test_runner: ubuntu-latest, test_docker_options: '' }
-        - {config: [gcc7_py36], build_runner: ubuntu-latest, test_runner: ubuntu-latest, test_docker_options: '' }
+        - {config: [clang10_py38, llvm], build_runner: [self-hosted,jetstream2,CPU], test_runner: ubuntu-latest, test_docker_options: '' }
+        - {config: [gcc9_py38], build_runner: [self-hosted,jetstream2,CPU], test_runner: ubuntu-latest, test_docker_options: '' }
+        - {config: [clang9_py38], build_runner: [self-hosted,jetstream2,CPU], test_runner: ubuntu-latest, test_docker_options: '' }
+        - {config: [clang8_py38], build_runner: [self-hosted,jetstream2,CPU], test_runner: ubuntu-latest, test_docker_options: '' }
+        - {config: [clang7_py38], build_runner: [self-hosted,jetstream2,CPU], test_runner: ubuntu-latest, test_docker_options: '' }
+        - {config: [gcc8_py37], build_runner: [self-hosted,jetstream2,CPU], test_runner: ubuntu-latest, test_docker_options: '' }
+        - {config: [gcc7_py37], build_runner: [self-hosted,jetstream2,CPU], test_runner: ubuntu-latest, test_docker_options: '' }
+        - {config: [clang6_py37], build_runner: [self-hosted,jetstream2,CPU], test_runner: ubuntu-latest, test_docker_options: '' }
+        - {config: [gcc7_py36], build_runner: [self-hosted,jetstream2,CPU], test_runner: ubuntu-latest, test_docker_options: '' }
 
     if: ${{ contains(github.event.pull_request.labels.*.name, 'release') }}
     steps:
@@ -375,23 +375,23 @@ jobs:
     strategy:
       matrix:
         include:
-        - {config: [clang13_py310], build_runner: ubuntu-latest, test_runner: ubuntu-latest, test_docker_options: '' }
-        - {config: [clang11_py39, llvm], build_runner: ubuntu-latest, test_runner: ubuntu-latest, test_docker_options: '' }
-        - {config: [gcc10_py39], build_runner: ubuntu-latest, test_runner: ubuntu-latest, test_docker_options: '' }
+        - {config: [clang13_py310], build_runner: [self-hosted,jetstream2,CPU], test_runner: ubuntu-latest, test_docker_options: '' }
+        - {config: [clang11_py39, llvm], build_runner: [self-hosted,jetstream2,CPU], test_runner: ubuntu-latest, test_docker_options: '' }
+        - {config: [gcc10_py39], build_runner: [self-hosted,jetstream2,CPU], test_runner: ubuntu-latest, test_docker_options: '' }
         - {config: [cuda114_gcc9_py38, mpi, llvm], build_runner: [self-hosted,jetstream2,CPU], test_runner: [self-hosted,GPU], test_docker_options: '--gpus=all --device /dev/nvidia0 --device /dev/nvidia1 --device /dev/nvidia-uvm --device /dev/nvidia-uvm-tools --device /dev/nvidiactl' }
         - {config: [cuda113_gcc9_py38, mpi, llvm], build_runner: [self-hosted,jetstream2,CPU], test_runner: [self-hosted,GPU], test_docker_options: '--gpus=all --device /dev/nvidia0 --device /dev/nvidia1 --device /dev/nvidia-uvm --device /dev/nvidia-uvm-tools --device /dev/nvidiactl' }
         - {config: [cuda112_gcc9_py38, mpi, llvm], build_runner: [self-hosted,jetstream2,CPU], test_runner: [self-hosted,GPU], test_docker_options: '--gpus=all --device /dev/nvidia0 --device /dev/nvidia1 --device /dev/nvidia-uvm --device /dev/nvidia-uvm-tools --device /dev/nvidiactl' }
         - {config: [cuda111_gcc9_py38, mpi, llvm], build_runner: [self-hosted,jetstream2,CPU], test_runner: [self-hosted,GPU], test_docker_options: '--gpus=all --device /dev/nvidia0 --device /dev/nvidia1 --device /dev/nvidia-uvm --device /dev/nvidia-uvm-tools --device /dev/nvidiactl' }
         - {config: [cuda10_gcc7_py37, llvm], build_runner: [self-hosted,jetstream2,CPU], test_runner: [self-hosted,GPU], test_docker_options: '--gpus=all --device /dev/nvidia0 --device /dev/nvidia1 --device /dev/nvidia-uvm --device /dev/nvidia-uvm-tools --device /dev/nvidiactl' }
-        - {config: [clang10_py38, llvm], build_runner: ubuntu-latest, test_runner: ubuntu-latest, test_docker_options: '' }
-        - {config: [gcc9_py38], build_runner: ubuntu-latest, test_runner: ubuntu-latest, test_docker_options: '' }
-        - {config: [clang9_py38], build_runner: ubuntu-latest, test_runner: ubuntu-latest, test_docker_options: '' }
-        - {config: [clang8_py38], build_runner: ubuntu-latest, test_runner: ubuntu-latest, test_docker_options: '' }
-        - {config: [clang7_py38], build_runner: ubuntu-latest, test_runner: ubuntu-latest, test_docker_options: '' }
-        - {config: [gcc8_py37], build_runner: ubuntu-latest, test_runner: ubuntu-latest, test_docker_options: '' }
-        - {config: [gcc7_py37], build_runner: ubuntu-latest, test_runner: ubuntu-latest, test_docker_options: '' }
-        - {config: [clang6_py37], build_runner: ubuntu-latest, test_runner: ubuntu-latest, test_docker_options: '' }
-        - {config: [gcc7_py36], build_runner: ubuntu-latest, test_runner: ubuntu-latest, test_docker_options: '' }
+        - {config: [clang10_py38, llvm], build_runner: [self-hosted,jetstream2,CPU], test_runner: ubuntu-latest, test_docker_options: '' }
+        - {config: [gcc9_py38], build_runner: [self-hosted,jetstream2,CPU], test_runner: ubuntu-latest, test_docker_options: '' }
+        - {config: [clang9_py38], build_runner: [self-hosted,jetstream2,CPU], test_runner: ubuntu-latest, test_docker_options: '' }
+        - {config: [clang8_py38], build_runner: [self-hosted,jetstream2,CPU], test_runner: ubuntu-latest, test_docker_options: '' }
+        - {config: [clang7_py38], build_runner: [self-hosted,jetstream2,CPU], test_runner: ubuntu-latest, test_docker_options: '' }
+        - {config: [gcc8_py37], build_runner: [self-hosted,jetstream2,CPU], test_runner: ubuntu-latest, test_docker_options: '' }
+        - {config: [gcc7_py37], build_runner: [self-hosted,jetstream2,CPU], test_runner: ubuntu-latest, test_docker_options: '' }
+        - {config: [clang6_py37], build_runner: [self-hosted,jetstream2,CPU], test_runner: ubuntu-latest, test_docker_options: '' }
+        - {config: [gcc7_py36], build_runner: [self-hosted,jetstream2,CPU], test_runner: ubuntu-latest, test_docker_options: '' }
 
     if: ${{ contains(github.event.pull_request.labels.*.name, 'release') }}
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,7 +80,7 @@ jobs:
                       -DENABLE_MPI=${ENABLE_MPI:-"OFF"} \
                       -DENABLE_TBB=${ENABLE_TBB:-"OFF"} \
                       -DENABLE_LLVM=${ENABLE_LLVM:-"OFF"} \
-                      -CUDA_ARCH_LIST=60;70 \
+                      -DCUDA_ARCH_LIST=60;70 \
                       -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install
       env:
         ENABLE_GPU: ${{ contains(matrix.config[0], 'cuda') }}
@@ -274,7 +274,7 @@ jobs:
                       -DENABLE_MPI=${ENABLE_MPI:-"OFF"} \
                       -DENABLE_TBB=${ENABLE_TBB:-"OFF"} \
                       -DENABLE_LLVM=${ENABLE_LLVM:-"OFF"} \
-                      -CUDA_ARCH_LIST=60;70 \
+                      -DCUDA_ARCH_LIST=60;70 \
                       -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install
       env:
         ENABLE_GPU: ${{ contains(matrix.config[0], 'cuda') }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ env:
   PYTHONPATH: ${{ github.workspace }}/install
 
 
-# Use multiple jobs to reduce the amount of time spent on GPU runners. Use GitHub Hosted runners for
+# Use multiple jobs to reduce the amount of time spent on GPU runners. Use CPU runners for
 # compiling all tests configurations (GPU and CPU), then upload the build directory (sans object
 # files) as an artifact. Test jobs depend on the build job, download the install directory, and run
 # the tests. Upload each build configuration to a separate artifact.
@@ -48,16 +48,16 @@ env:
 jobs:
   build:
     name: Build [${{ join(matrix.config, '_') }}]
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.build_runner }}
     container:
       image: glotzerlab/ci:2022.01-${{ matrix.config[0] }}
     strategy:
       matrix:
         include:
-        - {config: [clang12_py310, mpi, tbb, llvm], runner: ubuntu-latest, docker_options: '' }
-        - {config: [gcc11_py310], runner: ubuntu-latest, docker_options: '' }
-        - {config: [cuda115_gcc9_py38, mpi, llvm], runner: [self-hosted,GPU], docker_options: '--gpus=all --device /dev/nvidia0 --device /dev/nvidia1 --device /dev/nvidia-uvm --device /dev/nvidia-uvm-tools --device /dev/nvidiactl' }
-        - {config: [cuda115_gcc9_py38], runner: [self-hosted,GPU], docker_options: '--gpus=all --device /dev/nvidia0 --device /dev/nvidia1 --device /dev/nvidia-uvm --device /dev/nvidia-uvm-tools --device /dev/nvidiactl' }
+        - {config: [clang12_py310, mpi, tbb, llvm], build_runner: ubuntu-latest, test_runner: ubuntu-latest, test_docker_options: '' }
+        - {config: [gcc11_py310], build_runner: ubuntu-latest, test_runner: ubuntu-latest, test_docker_options: '' }
+        - {config: [cuda115_gcc9_py38, mpi, llvm], build_runner: [self-hosted,jetstream2,CPU], test_runner: [self-hosted,GPU], test_docker_options: '--gpus=all --device /dev/nvidia0 --device /dev/nvidia1 --device /dev/nvidia-uvm --device /dev/nvidia-uvm-tools --device /dev/nvidiactl' }
+        - {config: [cuda115_gcc9_py38], build_runner: [self-hosted,jetstream2,CPU], test_runner: [self-hosted,GPU], test_docker_options: '--gpus=all --device /dev/nvidia0 --device /dev/nvidia1 --device /dev/nvidia-uvm --device /dev/nvidia-uvm-tools --device /dev/nvidiactl' }
 
     env:
       CXXFLAGS: '-Werror'
@@ -80,6 +80,7 @@ jobs:
                       -DENABLE_MPI=${ENABLE_MPI:-"OFF"} \
                       -DENABLE_TBB=${ENABLE_TBB:-"OFF"} \
                       -DENABLE_LLVM=${ENABLE_LLVM:-"OFF"} \
+                      -CUDA_ARCH_LIST=60;70 \
                       -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install
       env:
         ENABLE_GPU: ${{ contains(matrix.config[0], 'cuda') }}
@@ -116,17 +117,17 @@ jobs:
   pytest:
     name: Run pytest [${{ join(matrix.config, '_') }}]
     needs: build
-    runs-on: ${{ matrix.runner }}
+    runs-on: ${{ matrix.test_runner }}
     container:
       image: glotzerlab/ci:2022.01-${{ matrix.config[0] }}
-      options: ${{ matrix.docker_options }} -e CUDA_VISIBLE_DEVICES
+      options: ${{ matrix.test_docker_options }} -e CUDA_VISIBLE_DEVICES
     strategy:
       matrix:
         include:
-        - {config: [clang12_py310, mpi, tbb, llvm], runner: ubuntu-latest, docker_options: '' }
-        - {config: [gcc11_py310], runner: ubuntu-latest, docker_options: '' }
-        - {config: [cuda115_gcc9_py38, mpi, llvm], runner: [self-hosted,GPU], docker_options: '--gpus=all --device /dev/nvidia0 --device /dev/nvidia1 --device /dev/nvidia-uvm --device /dev/nvidia-uvm-tools --device /dev/nvidiactl' }
-        - {config: [cuda115_gcc9_py38], runner: [self-hosted,GPU], docker_options: '--gpus=all --device /dev/nvidia0 --device /dev/nvidia1 --device /dev/nvidia-uvm --device /dev/nvidia-uvm-tools --device /dev/nvidiactl' }
+        - {config: [clang12_py310, mpi, tbb, llvm], build_runner: ubuntu-latest, test_runner: ubuntu-latest, test_docker_options: '' }
+        - {config: [gcc11_py310], build_runner: ubuntu-latest, test_runner: ubuntu-latest, test_docker_options: '' }
+        - {config: [cuda115_gcc9_py38, mpi, llvm], build_runner: [self-hosted,jetstream2,CPU], test_runner: [self-hosted,GPU], test_docker_options: '--gpus=all --device /dev/nvidia0 --device /dev/nvidia1 --device /dev/nvidia-uvm --device /dev/nvidia-uvm-tools --device /dev/nvidiactl' }
+        - {config: [cuda115_gcc9_py38], build_runner: [self-hosted,jetstream2,CPU], test_runner: [self-hosted,GPU], test_docker_options: '--gpus=all --device /dev/nvidia0 --device /dev/nvidia1 --device /dev/nvidia-uvm --device /dev/nvidia-uvm-tools --device /dev/nvidiactl' }
 
     steps:
     - name: Clean workspace
@@ -159,17 +160,17 @@ jobs:
   ctest:
     name: Run ctest [${{ join(matrix.config, '_') }}]
     needs: build
-    runs-on: ${{ matrix.runner }}
+    runs-on: ${{ matrix.test_runner }}
     container:
       image: glotzerlab/ci:2022.01-${{ matrix.config[0] }}
-      options: ${{ matrix.docker_options }} -e CUDA_VISIBLE_DEVICES
+      options: ${{ matrix.test_docker_options }} -e CUDA_VISIBLE_DEVICES
     strategy:
       matrix:
         include:
-        - {config: [clang12_py310, mpi, tbb, llvm], runner: ubuntu-latest, docker_options: '' }
-        - {config: [gcc11_py310], runner: ubuntu-latest, docker_options: '' }
-        - {config: [cuda115_gcc9_py38, mpi, llvm], runner: [self-hosted,GPU], docker_options: '--gpus=all --device /dev/nvidia0 --device /dev/nvidia1 --device /dev/nvidia-uvm --device /dev/nvidia-uvm-tools --device /dev/nvidiactl' }
-        - {config: [cuda115_gcc9_py38], runner: [self-hosted,GPU], docker_options: '--gpus=all --device /dev/nvidia0 --device /dev/nvidia1 --device /dev/nvidia-uvm --device /dev/nvidia-uvm-tools --device /dev/nvidiactl' }
+        - {config: [clang12_py310, mpi, tbb, llvm], build_runner: ubuntu-latest, test_runner: ubuntu-latest, test_docker_options: '' }
+        - {config: [gcc11_py310], build_runner: ubuntu-latest, test_runner: ubuntu-latest, test_docker_options: '' }
+        - {config: [cuda115_gcc9_py38, mpi, llvm], build_runner: [self-hosted,jetstream2,CPU], test_runner: [self-hosted,GPU], test_docker_options: '--gpus=all --device /dev/nvidia0 --device /dev/nvidia1 --device /dev/nvidia-uvm --device /dev/nvidia-uvm-tools --device /dev/nvidiactl' }
+        - {config: [cuda115_gcc9_py38], build_runner: [self-hosted,jetstream2,CPU], test_runner: [self-hosted,GPU], test_docker_options: '--gpus=all --device /dev/nvidia0 --device /dev/nvidia1 --device /dev/nvidia-uvm --device /dev/nvidia-uvm-tools --device /dev/nvidiactl' }
 
     steps:
     - name: Clean workspace
@@ -195,17 +196,17 @@ jobs:
   validate:
     name: Validate [${{ join(matrix.config, '_') }}]
     needs: build
-    runs-on: ${{ matrix.runner }}
+    runs-on: ${{ matrix.test_runner }}
     container:
       image: glotzerlab/ci:2022.01-${{ matrix.config[0] }}
-      options: ${{ matrix.docker_options }} -e CUDA_VISIBLE_DEVICES
+      options: ${{ matrix.test_docker_options }} -e CUDA_VISIBLE_DEVICES
     strategy:
       matrix:
         include:
-        - {config: [clang12_py310, mpi, tbb, llvm], runner: ubuntu-latest, docker_options: '' }
-        - {config: [gcc11_py310], runner: ubuntu-latest, docker_options: '' }
-        - {config: [cuda115_gcc9_py38, mpi, llvm], runner: [self-hosted,GPU], docker_options: '--gpus=all --device /dev/nvidia0 --device /dev/nvidia1 --device /dev/nvidia-uvm --device /dev/nvidia-uvm-tools --device /dev/nvidiactl' }
-        - {config: [cuda115_gcc9_py38], runner: [self-hosted,GPU], docker_options: '--gpus=all --device /dev/nvidia0 --device /dev/nvidia1 --device /dev/nvidia-uvm --device /dev/nvidia-uvm-tools --device /dev/nvidiactl' }
+        - {config: [clang12_py310, mpi, tbb, llvm], build_runner: ubuntu-latest, test_runner: ubuntu-latest, test_docker_options: '' }
+        - {config: [gcc11_py310], build_runner: ubuntu-latest, test_runner: ubuntu-latest, test_docker_options: '' }
+        - {config: [cuda115_gcc9_py38, mpi, llvm], build_runner: [self-hosted,jetstream2,CPU], test_runner: [self-hosted,GPU], test_docker_options: '--gpus=all --device /dev/nvidia0 --device /dev/nvidia1 --device /dev/nvidia-uvm --device /dev/nvidia-uvm-tools --device /dev/nvidiactl' }
+        - {config: [cuda115_gcc9_py38], build_runner: [self-hosted,jetstream2,CPU], test_runner: [self-hosted,GPU], test_docker_options: '--gpus=all --device /dev/nvidia0 --device /dev/nvidia1 --device /dev/nvidia-uvm --device /dev/nvidia-uvm-tools --device /dev/nvidiactl' }
 
     if: ${{ contains(github.event.pull_request.labels.*.name, 'validate') }}
     steps:
@@ -229,29 +230,29 @@ jobs:
 
   build_release:
     name: Build [${{ join(matrix.config, '_') }}]
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.build_runner }}
     container:
       image: glotzerlab/ci:2022.01-${{ matrix.config[0] }}
     strategy:
       matrix:
         include:
-        - {config: [clang13_py310], runner: ubuntu-latest, docker_options: '' }
-        - {config: [clang11_py39, llvm], runner: ubuntu-latest, docker_options: '' }
-        - {config: [gcc10_py39], runner: ubuntu-latest, docker_options: '' }
-        - {config: [cuda114_gcc9_py38, mpi, llvm], runner: [self-hosted,GPU], docker_options: '--gpus=all --device /dev/nvidia0 --device /dev/nvidia1 --device /dev/nvidia-uvm --device /dev/nvidia-uvm-tools --device /dev/nvidiactl' }
-        - {config: [cuda113_gcc9_py38, mpi, llvm], runner: [self-hosted,GPU], docker_options: '--gpus=all --device /dev/nvidia0 --device /dev/nvidia1 --device /dev/nvidia-uvm --device /dev/nvidia-uvm-tools --device /dev/nvidiactl' }
-        - {config: [cuda112_gcc9_py38, mpi, llvm], runner: [self-hosted,GPU], docker_options: '--gpus=all --device /dev/nvidia0 --device /dev/nvidia1 --device /dev/nvidia-uvm --device /dev/nvidia-uvm-tools --device /dev/nvidiactl' }
-        - {config: [cuda111_gcc9_py38, mpi, llvm], runner: [self-hosted,GPU], docker_options: '--gpus=all --device /dev/nvidia0 --device /dev/nvidia1 --device /dev/nvidia-uvm --device /dev/nvidia-uvm-tools --device /dev/nvidiactl' }
-        - {config: [cuda10_gcc7_py37, llvm], runner: [self-hosted,GPU], docker_options: '--gpus=all --device /dev/nvidia0 --device /dev/nvidia1 --device /dev/nvidia-uvm --device /dev/nvidia-uvm-tools --device /dev/nvidiactl' }
-        - {config: [clang10_py38, llvm], runner: ubuntu-latest, docker_options: '' }
-        - {config: [gcc9_py38], runner: ubuntu-latest, docker_options: '' }
-        - {config: [clang9_py38], runner: ubuntu-latest, docker_options: '' }
-        - {config: [clang8_py38], runner: ubuntu-latest, docker_options: '' }
-        - {config: [clang7_py38], runner: ubuntu-latest, docker_options: '' }
-        - {config: [gcc8_py37], runner: ubuntu-latest, docker_options: '' }
-        - {config: [gcc7_py37], runner: ubuntu-latest, docker_options: '' }
-        - {config: [clang6_py37], runner: ubuntu-latest, docker_options: '' }
-        - {config: [gcc7_py36], runner: ubuntu-latest, docker_options: '' }
+        - {config: [clang13_py310], build_runner: ubuntu-latest, test_runner: ubuntu-latest, test_docker_options: '' }
+        - {config: [clang11_py39, llvm], build_runner: ubuntu-latest, test_runner: ubuntu-latest, test_docker_options: '' }
+        - {config: [gcc10_py39], build_runner: ubuntu-latest, test_runner: ubuntu-latest, test_docker_options: '' }
+        - {config: [cuda114_gcc9_py38, mpi, llvm], build_runner: [self-hosted,jetstream2,CPU], test_runner: [self-hosted,GPU], test_docker_options: '--gpus=all --device /dev/nvidia0 --device /dev/nvidia1 --device /dev/nvidia-uvm --device /dev/nvidia-uvm-tools --device /dev/nvidiactl' }
+        - {config: [cuda113_gcc9_py38, mpi, llvm], build_runner: [self-hosted,jetstream2,CPU], test_runner: [self-hosted,GPU], test_docker_options: '--gpus=all --device /dev/nvidia0 --device /dev/nvidia1 --device /dev/nvidia-uvm --device /dev/nvidia-uvm-tools --device /dev/nvidiactl' }
+        - {config: [cuda112_gcc9_py38, mpi, llvm], build_runner: [self-hosted,jetstream2,CPU], test_runner: [self-hosted,GPU], test_docker_options: '--gpus=all --device /dev/nvidia0 --device /dev/nvidia1 --device /dev/nvidia-uvm --device /dev/nvidia-uvm-tools --device /dev/nvidiactl' }
+        - {config: [cuda111_gcc9_py38, mpi, llvm], build_runner: [self-hosted,jetstream2,CPU], test_runner: [self-hosted,GPU], test_docker_options: '--gpus=all --device /dev/nvidia0 --device /dev/nvidia1 --device /dev/nvidia-uvm --device /dev/nvidia-uvm-tools --device /dev/nvidiactl' }
+        - {config: [cuda10_gcc7_py37, llvm], build_runner: [self-hosted,jetstream2,CPU], test_runner: [self-hosted,GPU], test_docker_options: '--gpus=all --device /dev/nvidia0 --device /dev/nvidia1 --device /dev/nvidia-uvm --device /dev/nvidia-uvm-tools --device /dev/nvidiactl' }
+        - {config: [clang10_py38, llvm], build_runner: ubuntu-latest, test_runner: ubuntu-latest, test_docker_options: '' }
+        - {config: [gcc9_py38], build_runner: ubuntu-latest, test_runner: ubuntu-latest, test_docker_options: '' }
+        - {config: [clang9_py38], build_runner: ubuntu-latest, test_runner: ubuntu-latest, test_docker_options: '' }
+        - {config: [clang8_py38], build_runner: ubuntu-latest, test_runner: ubuntu-latest, test_docker_options: '' }
+        - {config: [clang7_py38], build_runner: ubuntu-latest, test_runner: ubuntu-latest, test_docker_options: '' }
+        - {config: [gcc8_py37], build_runner: ubuntu-latest, test_runner: ubuntu-latest, test_docker_options: '' }
+        - {config: [gcc7_py37], build_runner: ubuntu-latest, test_runner: ubuntu-latest, test_docker_options: '' }
+        - {config: [clang6_py37], build_runner: ubuntu-latest, test_runner: ubuntu-latest, test_docker_options: '' }
+        - {config: [gcc7_py36], build_runner: ubuntu-latest, test_runner: ubuntu-latest, test_docker_options: '' }
 
     if: ${{ contains(github.event.pull_request.labels.*.name, 'release') }}
     steps:
@@ -273,6 +274,7 @@ jobs:
                       -DENABLE_MPI=${ENABLE_MPI:-"OFF"} \
                       -DENABLE_TBB=${ENABLE_TBB:-"OFF"} \
                       -DENABLE_LLVM=${ENABLE_LLVM:-"OFF"} \
+                      -CUDA_ARCH_LIST=60;70 \
                       -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install
       env:
         ENABLE_GPU: ${{ contains(matrix.config[0], 'cuda') }}
@@ -309,30 +311,30 @@ jobs:
   pytest_release:
     name: Run pytest [${{ join(matrix.config, '_') }}]
     needs: build_release
-    runs-on: ${{ matrix.runner }}
+    runs-on: ${{ matrix.test_runner }}
     container:
       image: glotzerlab/ci:2022.01-${{ matrix.config[0] }}
-      options: ${{ matrix.docker_options }} -e CUDA_VISIBLE_DEVICES
+      options: ${{ matrix.test_docker_options }} -e CUDA_VISIBLE_DEVICES
     strategy:
       matrix:
         include:
-        - {config: [clang13_py310], runner: ubuntu-latest, docker_options: '' }
-        - {config: [clang11_py39, llvm], runner: ubuntu-latest, docker_options: '' }
-        - {config: [gcc10_py39], runner: ubuntu-latest, docker_options: '' }
-        - {config: [cuda114_gcc9_py38, mpi, llvm], runner: [self-hosted,GPU], docker_options: '--gpus=all --device /dev/nvidia0 --device /dev/nvidia1 --device /dev/nvidia-uvm --device /dev/nvidia-uvm-tools --device /dev/nvidiactl' }
-        - {config: [cuda113_gcc9_py38, mpi, llvm], runner: [self-hosted,GPU], docker_options: '--gpus=all --device /dev/nvidia0 --device /dev/nvidia1 --device /dev/nvidia-uvm --device /dev/nvidia-uvm-tools --device /dev/nvidiactl' }
-        - {config: [cuda112_gcc9_py38, mpi, llvm], runner: [self-hosted,GPU], docker_options: '--gpus=all --device /dev/nvidia0 --device /dev/nvidia1 --device /dev/nvidia-uvm --device /dev/nvidia-uvm-tools --device /dev/nvidiactl' }
-        - {config: [cuda111_gcc9_py38, mpi, llvm], runner: [self-hosted,GPU], docker_options: '--gpus=all --device /dev/nvidia0 --device /dev/nvidia1 --device /dev/nvidia-uvm --device /dev/nvidia-uvm-tools --device /dev/nvidiactl' }
-        - {config: [cuda10_gcc7_py37, llvm], runner: [self-hosted,GPU], docker_options: '--gpus=all --device /dev/nvidia0 --device /dev/nvidia1 --device /dev/nvidia-uvm --device /dev/nvidia-uvm-tools --device /dev/nvidiactl' }
-        - {config: [clang10_py38, llvm], runner: ubuntu-latest, docker_options: '' }
-        - {config: [gcc9_py38], runner: ubuntu-latest, docker_options: '' }
-        - {config: [clang9_py38], runner: ubuntu-latest, docker_options: '' }
-        - {config: [clang8_py38], runner: ubuntu-latest, docker_options: '' }
-        - {config: [clang7_py38], runner: ubuntu-latest, docker_options: '' }
-        - {config: [gcc8_py37], runner: ubuntu-latest, docker_options: '' }
-        - {config: [gcc7_py37], runner: ubuntu-latest, docker_options: '' }
-        - {config: [clang6_py37], runner: ubuntu-latest, docker_options: '' }
-        - {config: [gcc7_py36], runner: ubuntu-latest, docker_options: '' }
+        - {config: [clang13_py310], build_runner: ubuntu-latest, test_runner: ubuntu-latest, test_docker_options: '' }
+        - {config: [clang11_py39, llvm], build_runner: ubuntu-latest, test_runner: ubuntu-latest, test_docker_options: '' }
+        - {config: [gcc10_py39], build_runner: ubuntu-latest, test_runner: ubuntu-latest, test_docker_options: '' }
+        - {config: [cuda114_gcc9_py38, mpi, llvm], build_runner: [self-hosted,jetstream2,CPU], test_runner: [self-hosted,GPU], test_docker_options: '--gpus=all --device /dev/nvidia0 --device /dev/nvidia1 --device /dev/nvidia-uvm --device /dev/nvidia-uvm-tools --device /dev/nvidiactl' }
+        - {config: [cuda113_gcc9_py38, mpi, llvm], build_runner: [self-hosted,jetstream2,CPU], test_runner: [self-hosted,GPU], test_docker_options: '--gpus=all --device /dev/nvidia0 --device /dev/nvidia1 --device /dev/nvidia-uvm --device /dev/nvidia-uvm-tools --device /dev/nvidiactl' }
+        - {config: [cuda112_gcc9_py38, mpi, llvm], build_runner: [self-hosted,jetstream2,CPU], test_runner: [self-hosted,GPU], test_docker_options: '--gpus=all --device /dev/nvidia0 --device /dev/nvidia1 --device /dev/nvidia-uvm --device /dev/nvidia-uvm-tools --device /dev/nvidiactl' }
+        - {config: [cuda111_gcc9_py38, mpi, llvm], build_runner: [self-hosted,jetstream2,CPU], test_runner: [self-hosted,GPU], test_docker_options: '--gpus=all --device /dev/nvidia0 --device /dev/nvidia1 --device /dev/nvidia-uvm --device /dev/nvidia-uvm-tools --device /dev/nvidiactl' }
+        - {config: [cuda10_gcc7_py37, llvm], build_runner: [self-hosted,jetstream2,CPU], test_runner: [self-hosted,GPU], test_docker_options: '--gpus=all --device /dev/nvidia0 --device /dev/nvidia1 --device /dev/nvidia-uvm --device /dev/nvidia-uvm-tools --device /dev/nvidiactl' }
+        - {config: [clang10_py38, llvm], build_runner: ubuntu-latest, test_runner: ubuntu-latest, test_docker_options: '' }
+        - {config: [gcc9_py38], build_runner: ubuntu-latest, test_runner: ubuntu-latest, test_docker_options: '' }
+        - {config: [clang9_py38], build_runner: ubuntu-latest, test_runner: ubuntu-latest, test_docker_options: '' }
+        - {config: [clang8_py38], build_runner: ubuntu-latest, test_runner: ubuntu-latest, test_docker_options: '' }
+        - {config: [clang7_py38], build_runner: ubuntu-latest, test_runner: ubuntu-latest, test_docker_options: '' }
+        - {config: [gcc8_py37], build_runner: ubuntu-latest, test_runner: ubuntu-latest, test_docker_options: '' }
+        - {config: [gcc7_py37], build_runner: ubuntu-latest, test_runner: ubuntu-latest, test_docker_options: '' }
+        - {config: [clang6_py37], build_runner: ubuntu-latest, test_runner: ubuntu-latest, test_docker_options: '' }
+        - {config: [gcc7_py36], build_runner: ubuntu-latest, test_runner: ubuntu-latest, test_docker_options: '' }
 
     if: ${{ contains(github.event.pull_request.labels.*.name, 'release') }}
     steps:
@@ -366,30 +368,30 @@ jobs:
   ctest_release:
     name: Run ctest [${{ join(matrix.config, '_') }}]
     needs: build_release
-    runs-on: ${{ matrix.runner }}
+    runs-on: ${{ matrix.test_runner }}
     container:
       image: glotzerlab/ci:2022.01-${{ matrix.config[0] }}
-      options: ${{ matrix.docker_options }} -e CUDA_VISIBLE_DEVICES
+      options: ${{ matrix.test_docker_options }} -e CUDA_VISIBLE_DEVICES
     strategy:
       matrix:
         include:
-        - {config: [clang13_py310], runner: ubuntu-latest, docker_options: '' }
-        - {config: [clang11_py39, llvm], runner: ubuntu-latest, docker_options: '' }
-        - {config: [gcc10_py39], runner: ubuntu-latest, docker_options: '' }
-        - {config: [cuda114_gcc9_py38, mpi, llvm], runner: [self-hosted,GPU], docker_options: '--gpus=all --device /dev/nvidia0 --device /dev/nvidia1 --device /dev/nvidia-uvm --device /dev/nvidia-uvm-tools --device /dev/nvidiactl' }
-        - {config: [cuda113_gcc9_py38, mpi, llvm], runner: [self-hosted,GPU], docker_options: '--gpus=all --device /dev/nvidia0 --device /dev/nvidia1 --device /dev/nvidia-uvm --device /dev/nvidia-uvm-tools --device /dev/nvidiactl' }
-        - {config: [cuda112_gcc9_py38, mpi, llvm], runner: [self-hosted,GPU], docker_options: '--gpus=all --device /dev/nvidia0 --device /dev/nvidia1 --device /dev/nvidia-uvm --device /dev/nvidia-uvm-tools --device /dev/nvidiactl' }
-        - {config: [cuda111_gcc9_py38, mpi, llvm], runner: [self-hosted,GPU], docker_options: '--gpus=all --device /dev/nvidia0 --device /dev/nvidia1 --device /dev/nvidia-uvm --device /dev/nvidia-uvm-tools --device /dev/nvidiactl' }
-        - {config: [cuda10_gcc7_py37, llvm], runner: [self-hosted,GPU], docker_options: '--gpus=all --device /dev/nvidia0 --device /dev/nvidia1 --device /dev/nvidia-uvm --device /dev/nvidia-uvm-tools --device /dev/nvidiactl' }
-        - {config: [clang10_py38, llvm], runner: ubuntu-latest, docker_options: '' }
-        - {config: [gcc9_py38], runner: ubuntu-latest, docker_options: '' }
-        - {config: [clang9_py38], runner: ubuntu-latest, docker_options: '' }
-        - {config: [clang8_py38], runner: ubuntu-latest, docker_options: '' }
-        - {config: [clang7_py38], runner: ubuntu-latest, docker_options: '' }
-        - {config: [gcc8_py37], runner: ubuntu-latest, docker_options: '' }
-        - {config: [gcc7_py37], runner: ubuntu-latest, docker_options: '' }
-        - {config: [clang6_py37], runner: ubuntu-latest, docker_options: '' }
-        - {config: [gcc7_py36], runner: ubuntu-latest, docker_options: '' }
+        - {config: [clang13_py310], build_runner: ubuntu-latest, test_runner: ubuntu-latest, test_docker_options: '' }
+        - {config: [clang11_py39, llvm], build_runner: ubuntu-latest, test_runner: ubuntu-latest, test_docker_options: '' }
+        - {config: [gcc10_py39], build_runner: ubuntu-latest, test_runner: ubuntu-latest, test_docker_options: '' }
+        - {config: [cuda114_gcc9_py38, mpi, llvm], build_runner: [self-hosted,jetstream2,CPU], test_runner: [self-hosted,GPU], test_docker_options: '--gpus=all --device /dev/nvidia0 --device /dev/nvidia1 --device /dev/nvidia-uvm --device /dev/nvidia-uvm-tools --device /dev/nvidiactl' }
+        - {config: [cuda113_gcc9_py38, mpi, llvm], build_runner: [self-hosted,jetstream2,CPU], test_runner: [self-hosted,GPU], test_docker_options: '--gpus=all --device /dev/nvidia0 --device /dev/nvidia1 --device /dev/nvidia-uvm --device /dev/nvidia-uvm-tools --device /dev/nvidiactl' }
+        - {config: [cuda112_gcc9_py38, mpi, llvm], build_runner: [self-hosted,jetstream2,CPU], test_runner: [self-hosted,GPU], test_docker_options: '--gpus=all --device /dev/nvidia0 --device /dev/nvidia1 --device /dev/nvidia-uvm --device /dev/nvidia-uvm-tools --device /dev/nvidiactl' }
+        - {config: [cuda111_gcc9_py38, mpi, llvm], build_runner: [self-hosted,jetstream2,CPU], test_runner: [self-hosted,GPU], test_docker_options: '--gpus=all --device /dev/nvidia0 --device /dev/nvidia1 --device /dev/nvidia-uvm --device /dev/nvidia-uvm-tools --device /dev/nvidiactl' }
+        - {config: [cuda10_gcc7_py37, llvm], build_runner: [self-hosted,jetstream2,CPU], test_runner: [self-hosted,GPU], test_docker_options: '--gpus=all --device /dev/nvidia0 --device /dev/nvidia1 --device /dev/nvidia-uvm --device /dev/nvidia-uvm-tools --device /dev/nvidiactl' }
+        - {config: [clang10_py38, llvm], build_runner: ubuntu-latest, test_runner: ubuntu-latest, test_docker_options: '' }
+        - {config: [gcc9_py38], build_runner: ubuntu-latest, test_runner: ubuntu-latest, test_docker_options: '' }
+        - {config: [clang9_py38], build_runner: ubuntu-latest, test_runner: ubuntu-latest, test_docker_options: '' }
+        - {config: [clang8_py38], build_runner: ubuntu-latest, test_runner: ubuntu-latest, test_docker_options: '' }
+        - {config: [clang7_py38], build_runner: ubuntu-latest, test_runner: ubuntu-latest, test_docker_options: '' }
+        - {config: [gcc8_py37], build_runner: ubuntu-latest, test_runner: ubuntu-latest, test_docker_options: '' }
+        - {config: [gcc7_py37], build_runner: ubuntu-latest, test_runner: ubuntu-latest, test_docker_options: '' }
+        - {config: [clang6_py37], build_runner: ubuntu-latest, test_runner: ubuntu-latest, test_docker_options: '' }
+        - {config: [gcc7_py36], build_runner: ubuntu-latest, test_runner: ubuntu-latest, test_docker_options: '' }
 
     if: ${{ contains(github.event.pull_request.labels.*.name, 'release') }}
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -459,3 +459,22 @@ jobs:
         if: needs.validate.result != 'success'
         run: echo "::error ::Validation tests failed." && exit 1
       - run: echo "Done!"
+
+  start_actions_runners:
+    name: Start actions runners
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2.4.0
+        with:
+          path: code
+      - uses: syphar/restore-pip-download-cache@v1
+        with:
+          custom_cache_key_element: "openstacksdk-0.61.0"
+      - name: Install openstack
+        run: python3 -m pip install openstacksdk==0.61.0
+      - name: Start actions runners
+        run: python3 code/.github/workflows/start-action-runners.py
+        env:
+          OS_APPLICATION_CREDENTIAL_ID: ${{ secrets.OS_APPLICATION_CREDENTIAL_ID }}
+          OS_APPLICATION_CREDENTIAL_SECRET: ${{ secrets.OS_APPLICATION_CREDENTIAL_SECRET }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -84,6 +84,8 @@ jobs:
                       -DENABLE_TBB=${ENABLE_TBB:-"OFF"} \
                       -DENABLE_LLVM=${ENABLE_LLVM:-"OFF"} \
                       -DBUILD_MD=${BUILD_MD:-"ON"} \
+                      -DBUILD_MPCD=${BUILD_MD:-"ON"} \
+                      -DBUILD_METAL=${BUILD_MD:-"ON"} \
                       -DBUILD_HPMC=${BUILD_HPMC:-"ON"} \
                       -DCUDA_ARCH_LIST="60;70" \
                       -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install
@@ -288,6 +290,8 @@ jobs:
                       -DENABLE_TBB=${ENABLE_TBB:-"OFF"} \
                       -DENABLE_LLVM=${ENABLE_LLVM:-"OFF"} \
                       -DBUILD_MD=${BUILD_MD:-"ON"} \
+                      -DBUILD_MPCD=${BUILD_MD:-"ON"} \
+                      -DBUILD_METAL=${BUILD_MD:-"ON"} \
                       -DBUILD_HPMC=${BUILD_HPMC:-"ON"} \
                       -DCUDA_ARCH_LIST="60;70" \
                       -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install

--- a/hoomd/CMakeLists.txt
+++ b/hoomd/CMakeLists.txt
@@ -218,8 +218,11 @@ add_library(HOOMD::_hoomd ALIAS _hoomd)
 # Work around support for the delete operator with pybind11 and older versions of clang
 # https://github.com/pybind/pybind11/issues/1604
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-   target_compile_options(_hoomd PUBLIC $<$<AND:$<COMPILE_LANGUAGE:CUDA>,$<STREQUAL:${HIP_PLATFORM},nvcc>>:-Xcompiler=>;-fsized-deallocation)
-#   target_compile_options(_hoomd PUBLIC -fsized-deallocation)
+    if (${CMAKE_VERSION} VERSION_GREATER_EQUAL 3.11)
+        target_compile_options(_hoomd PUBLIC $<$<AND:$<COMPILE_LANGUAGE:CUDA>,$<STREQUAL:${HIP_PLATFORM},nvcc>>:-Xcompiler=>;-fsized-deallocation)
+    else()
+        target_compile_options(_hoomd PUBLIC -fsized-deallocation)
+    endif()
 endif()
 
 # add quick hull as its own library so that it's symbols can be public

--- a/hoomd/pytest/test_custom_writer.py
+++ b/hoomd/pytest/test_custom_writer.py
@@ -42,10 +42,9 @@ class TestCustomWriter:
         assert not writer.action._attached
         assert not writer._attached
 
+    @pytest.mark.skipif(not hoomd.version.md_built,
+                        reason="BUILD_MD=on required")
     def test_flags(self, simulation_factory, two_particle_snapshot_factory):
-        # md is needed for this test
-        pytest.skipif(not hoomd.version.md_built, "BUILD_MD=on required")
-
         sim = simulation_factory(two_particle_snapshot_factory())
         action = WriteTimestep()
         action.flags = [hoomd.custom.Action.Flags.PRESSURE_TENSOR]

--- a/hoomd/pytest/test_custom_writer.py
+++ b/hoomd/pytest/test_custom_writer.py
@@ -2,6 +2,7 @@
 # Part of HOOMD-blue, released under the BSD 3-Clause License.
 
 import hoomd
+import pytest
 from hoomd import conftest
 
 
@@ -42,6 +43,9 @@ class TestCustomWriter:
         assert not writer._attached
 
     def test_flags(self, simulation_factory, two_particle_snapshot_factory):
+        # md is needed for this test
+        pytest.skipif(not hoomd.version.md_built, "BUILD_MD=on required")
+
         sim = simulation_factory(two_particle_snapshot_factory())
         action = WriteTimestep()
         action.flags = [hoomd.custom.Action.Flags.PRESSURE_TENSOR]


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should based on *maint*. -->
<!-- New features should based on *master*. -->

## Description

<!-- Describe your changes in detail. -->
* Refactor the GitHub Actions workflows to reduce build times.
* Use jetstream2 to compile hoomd and reduce the latency to run a full batch of unit tests in CI.
* Remove CUDA compute arches that aren't in the test pool.
* Add builds with `BUILD_MD=off`, `BUILD_HPMC=off` and both `BUILD_MD` and `BUILD_HPMC` off.
* Fix failing build with `BUILD_MD=off`.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Reducing the build time will improve developer productivity. Adding tests with components disabled ensures that tests will pass with these configurations.

The jetstream2 instances make fewer total CPU cores available than hosted runners, but individual runners have 8 cores - allowing CPU builds of HOOMD in 2-3 minutes (compare to 12 on minutes on hosted runners) and GPU builds in 13 minutes (compare to 80+ minutes on hosted runners). This reduces the time to complete a single build, but *many* queued builds may take longer. If this becomes a problem, we can always explore the possibility expanding the jetstream2 pool.

At this time, jetstream2 GPUs cannot be used to run the GPU tests as A100 vGPUs do not support unified memory. It is not clear whether this will ever be supported.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
The CI runs on this pull request are the test.

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
