### PR TITLE
Add stale action.

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -4,6 +4,9 @@ on:
   schedule:
     - cron: '0 19 * * *'
 
+  # Trigger on request.
+  workflow_dispatch:
+
 jobs:
   stale:
     runs-on: ubuntu-latest

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,33 @@
+name: Close stale issues and PRs
+
+on:
+  schedule:
+    - cron: '0 19 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/stale@v4.1.0
+      with:
+        days-before-close: 10
+        stale-issue-label: stale
+        stale-pr-label: stale
+        exempt-issue-labels: essential
+        exempt-pr-labels: essential
+
+        days-before-issue-stale: 260
+        stale-issue-message: >
+          This issue has been automatically marked as stale because it has not had
+          recent activity. It will be closed if no further activity occurs.
+        close-issue-message: >
+          This issue has been automatically closed because it has not had
+          recent activity.
+
+        days-before-pr-stale: 20
+        stale-pr-message: >
+          This pull request has been automatically marked as stale because it has not had
+          recent activity. It will be closed if no further activity occurs.
+        close-pr-message: >
+          This pull request has been automatically closed because it has not had
+          recent activity.


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should based on *maint*. -->
<!-- New features should based on *master*. -->

## Description

<!-- Describe your changes in detail. -->
Add the [stale](https://github.com/actions/stale) GitHub action.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Automatically mark issues and pull requests as stale and close them after a period of inactivity. This will help clean up the issue and pull request list automatically. Additionally, a bot closing issues is less personal than a developer doing so.

The configuration proposed here is very generous, allowing for approximately ~9 months of inactivity before closing an issue and ~1 month before closing a pull request. Even if the bug still exists, such a long period without any comment indicates that it is not affecting any users adversely.

Developers can mark issues and pull requests with the `essential` label to keep them open indefinitely.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
I have used this same configuration in the [gsd](https://github.com/glotzerlab/gsd) and [fresnel](https://github.com/glotzerlab/fresnel) repositories.

## Change log

Administrative change, no log entry needed.

## NOTE

Merge this after the 3.0.0 release. Posting this now to allow for review.

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/master/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/master/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
