### PR TITLE
Fix badges

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,12 +10,11 @@ on:
   # Trigger on pull requests.
   pull_request:
 
-  # Trigger on pushes to the mainline branches. This prevents building commits twice when the pull
+  # Trigger on pushes to the trunk branches. This prevents building commits twice when the pull
   # request source branch is in the same repository.
   push:
     branches:
-    - "master"
-    - "maint"
+    - "trunk-*"
     # Trigger on tags. Tag builds create GitHub releases with the change log and source tarball.
     tags:
       - "v*"

--- a/.github/workflows/templates/workflow.yml
+++ b/.github/workflows/templates/workflow.yml
@@ -19,13 +19,12 @@ on:
   <% endblock %>
 
   <% block on_push %>
-  # Trigger on pushes to the mainline branches. This prevents building commits twice when the pull
+  # Trigger on pushes to the trunk branches. This prevents building commits twice when the pull
   # request source branch is in the same repository.
   push:
     <% block on_push_branches %>
     branches:
-    - "master"
-    - "maint"
+    - "trunk-*"
     <% endblock %>
     <% block on_push_tags %>
     <% endblock %>

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,12 +10,11 @@ on:
   pull_request:
       types: [opened, labeled, reopened, synchronize]
 
-  # Trigger on pushes to the mainline branches. This prevents building commits twice when the pull
+  # Trigger on pushes to the trunk branches. This prevents building commits twice when the pull
   # request source branch is in the same repository.
   push:
     branches:
-    - "master"
-    - "maint"
+    - "trunk-*"
 
   # Trigger on request.
   workflow_dispatch:

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Citing HOOMD](https://img.shields.io/badge/cite-hoomd-blue.svg)](https://hoomd-blue.readthedocs.io/en/latest/citing.html)
 [![conda-forge](https://img.shields.io/conda/vn/conda-forge/hoomd.svg?style=flat)](https://anaconda.org/conda-forge/hoomd)
 [![conda-forge Downloads](https://img.shields.io/conda/dn/conda-forge/hoomd.svg?style=flat)](https://anaconda.org/conda-forge/hoomd)
-[![GitHub Actions](https://github.com/glotzerlab/hoomd-blue/actions/workflows/test.yml/badge.svg)](https://github.com/glotzerlab/hoomd-blue/actions/workflows/test.yml)
+[![GitHub Actions](https://github.com/glotzerlab/hoomd-blue/actions/workflows/test.yml/badge.svg?branch=trunk-patch)](https://github.com/glotzerlab/hoomd-blue/actions/workflows/test.yml)
 [![Read the Docs](https://img.shields.io/readthedocs/hoomd-blue/latest.svg)](https://hoomd-blue.readthedocs.io/en/latest/?badge=latest)
 [![Contributors](https://img.shields.io/github/contributors-anon/glotzerlab/hoomd-blue.svg?style=flat)](https://hoomd-blue.readthedocs.io/en/latest/credits.html)
 [![License](https://img.shields.io/badge/license-BSD--3--Clause-green.svg)](LICENSE)

--- a/sphinx-doc/index.rst
+++ b/sphinx-doc/index.rst
@@ -21,7 +21,7 @@ HOOMD-blue
         :target: https://anaconda.org/conda-forge/hoomd
     .. |conda-forge-Downloads| image:: https://img.shields.io/conda/dn/conda-forge/hoomd.svg?style=flat
         :target: https://anaconda.org/conda-forge/hoomd
-    .. |GitHub Actions| image:: https://github.com/glotzerlab/hoomd-blue/actions/workflows/test.yml/badge.svg
+    .. |GitHub Actions| image:: https://github.com/glotzerlab/hoomd-blue/actions/workflows/test.yml/badge.svg?branch=trunk-patch
         :target: https://github.com/glotzerlab/hoomd-blue/actions/workflows/test.yml
     .. |Contributors| image:: https://img.shields.io/github/contributors-anon/glotzerlab/hoomd-blue.svg?style=flat
         :target: https://hoomd-blue.readthedocs.io/en/latest/credits.html


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should be based on *trunk-patch*. -->
<!-- Backwards compatible new features should be based on *trunk-minor*. -->
<!-- Incompatible API changes should be based on *trunk-major*. -->

## Description

<!-- Describe your changes in detail. -->
Run GitHub actions on the trunk badges and display the status of the `trunk-patch` branch in the badge.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Currently, the GitHub actions badge in the README and documentation index page are reporting that tests fail. This is because tests failed on the branch for a pull request. The badge should reflect the test status of the most stable trunk branch.

Note: I manually triggered tests on `trunk-patch`, so the badge will read `no status` until some those complete.
![not status](https://github.com/glotzerlab/hoomd-blue/actions/workflows/test.yml/badge.svg?branch=trunk-patch)

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->

I ensured that the badge shows `no status` in the README and rendered sphinx documentation at the time of submission. The change to the actions branch trigger itself will not take effect until after this is merged.

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
Fixed:

* Display status of `trunk-patch` branch in the GitHub actions badge.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
