### PR TITLE
Add Table Potential to CMakeList

### DIFF
--- a/hoomd/md/CMakeLists.txt
+++ b/hoomd/md/CMakeLists.txt
@@ -97,14 +97,14 @@ set(_md_headers ActiveForceComputeGPU.h
                 EvaluatorPairLJ1208.h
                 EvaluatorPairLJ0804.h
                 EvaluatorPairMie.h
-		EvaluatorPairExpandedMie.h
+                EvaluatorPairExpandedMie.h
                 EvaluatorPairMoliere.h
                 EvaluatorPairMorse.h
                 EvaluatorPairOPP.h
                 EvaluatorPairFourier.h
                 EvaluatorPairReactionField.h
                 EvaluatorPairExpandedLJ.h
-		EvaluatorPairTable.h
+                EvaluatorPairTable.h
                 EvaluatorPairTWF.h
                 EvaluatorPairYukawa.h
                 EvaluatorPairZBL.h

--- a/hoomd/md/CMakeLists.txt
+++ b/hoomd/md/CMakeLists.txt
@@ -104,6 +104,7 @@ set(_md_headers ActiveForceComputeGPU.h
                 EvaluatorPairFourier.h
                 EvaluatorPairReactionField.h
                 EvaluatorPairExpandedLJ.h
+		EvaluatorPairTable.h
                 EvaluatorPairTWF.h
                 EvaluatorPairYukawa.h
                 EvaluatorPairZBL.h

--- a/sphinx-doc/credits.rst
+++ b/sphinx-doc/credits.rst
@@ -85,6 +85,7 @@ The following people have contributed to the to HOOMD-blue:
 * Peter Schwendeman, University of Michigan
 * Philipp Mertmann, Ruhr University Bochum
 * Philipp Schönhöfer, University of Michigan
+* Praharsh Suryadevara, New York University
 * Rastko Sknepnek, Northwestern
 * Raymond Asare, University of Michigan
 * Richmond Newman, University of Michigan


### PR DESCRIPTION
## Description

EvaluatorPairTable.h has been added to `_md_headers` in `md/CMakeLists.txt`

## Motivation and context

While building an external component, trying to include pair potentials using `#include<hoomd/md/AllPairPotentials.h>` raises a compilation error due to `EvaluatorPairTable.h` not being copied over

Resolves #1286 

## How has this been tested?

Rebuilt hoomd and installed into a cloned conda environment and checked that `EvaluatorPairTable.h` was copied into `hoomd/md/include` 

## Change log

```

```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
