### PR TITLE
Fix Tag equality check behavior

### DIFF
--- a/hoomd/filter/tags.py
+++ b/hoomd/filter/tags.py
@@ -35,8 +35,7 @@ class Tags(ParticleFilter, ParticleFilterTags):
     def __eq__(self, other):
         """Test for equality between two particle filters."""
         return type(self) == type(other) and np.array_equal(
-                self.tags, other.tags
-        )
+            self.tags, other.tags)
 
     @property
     def tags(self):

--- a/hoomd/filter/tags.py
+++ b/hoomd/filter/tags.py
@@ -34,7 +34,9 @@ class Tags(ParticleFilter, ParticleFilterTags):
 
     def __eq__(self, other):
         """Test for equality between two particle filters."""
-        return type(self) == type(other) and all(self.tags == other.tags)
+        return type(self) == type(other) and np.array_equal(
+                self.tags, other.tags
+        )
 
     @property
     def tags(self):

--- a/hoomd/pytest/test_filter.py
+++ b/hoomd/pytest/test_filter.py
@@ -125,9 +125,9 @@ def test_tag_filter_equality():
     filter_b = Tags(tags=[2, 3, 4, 5, 6])
     filter_c = Tags(tags=[0, 1, 2, 3, 4])
     filter_d = Tags(tags=[0, 1, 2, 3])
-    assert filter_a.__eq__(filter_b) == False
-    assert filter_b.__eq__(filter_c) == False
-    assert filter_d.__eq__(filter_a) == True
+    assert filter_a != filter_b
+    assert filter_b != filter_c
+    assert filter_d == filter_a
 
 
 def type_not_in_combo(combo, particle_types):

--- a/hoomd/pytest/test_filter.py
+++ b/hoomd/pytest/test_filter.py
@@ -128,7 +128,7 @@ def test_tag_filter_equality():
     assert filter_a.__eq__(filter_b) == False
     assert filter_b.__eq__(filter_c) == False
     assert filter_d.__eq__(filter_a) == True
- 
+
 
 def type_not_in_combo(combo, particle_types):
     for particle_type in particle_types:

--- a/hoomd/pytest/test_filter.py
+++ b/hoomd/pytest/test_filter.py
@@ -120,7 +120,7 @@ def set_indices(request):
     return deepcopy(request.param)
 
 
-def test_filter_equality(make_filter_snapshot):
+def test_tag_filter_equality():
     filter_a = Tags(tags=[0, 1, 2, 3])
     filter_b = Tags(tags=[2, 3, 4, 5, 6])
     filter_c = Tags(tags=[0, 1, 2, 3, 4])

--- a/hoomd/pytest/test_filter.py
+++ b/hoomd/pytest/test_filter.py
@@ -120,6 +120,16 @@ def set_indices(request):
     return deepcopy(request.param)
 
 
+def test_filter_equality(make_filter_snapshot):
+    filter_a = Tags(tags=[0, 1, 2, 3])
+    filter_b = Tags(tags=[2, 3, 4, 5, 6])
+    filter_c = Tags(tags=[0, 1, 2, 3, 4])
+    filter_d = Tags(tags=[0, 1, 2, 3])
+    assert filter_a.__eq__(filter_b) == False
+    assert filter_b.__eq__(filter_c) == False
+    assert filter_d.__eq__(filter_a) == True
+ 
+
 def type_not_in_combo(combo, particle_types):
     for particle_type in particle_types:
         if particle_type not in combo:


### PR DESCRIPTION
## Description

Creating a set filter from two tag filters would give an attribute error when checking for equivalence when the tag filters were of different sizes. This PR replaces `all()` with `np.array_equal()`

## Motivation and context

See #1285 

## How has this been tested?

I added a unit test that tests the `__eq__` function in `tags.py` directly. If this isn't sufficient I can add a test that creates a Union from two tag filters as well. 

## Change log

<!-- Propose a change log entry. -->
```

```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
