### PR TITLE
Fix TPS updating

### DIFF
--- a/hoomd/System.cc
+++ b/hoomd/System.cc
@@ -167,9 +167,9 @@ void System::run(uint64_t nsteps, bool write_at_start)
             if ((*analyzer->getTrigger())(m_cur_tstep))
                 analyzer->analyze(m_cur_tstep);
             }
-        }
 
-    updateTPS();
+        updateTPS();
+        }
 
     // propagate Python exceptions related to signals
     if (PyErr_CheckSignals() != 0)

--- a/hoomd/pytest/test_simulation.py
+++ b/hoomd/pytest/test_simulation.py
@@ -123,7 +123,7 @@ def test_tps(simulation_factory, two_particle_snapshot_factory):
     assert sim.tps == 0
 
     list_writer = ListWriter(sim, "tps")
-    sim.operations += list_writer
+    sim.operations.writers.append(hoomd.write.CustomWriter(action=list_writer, trigger=hoomd.trigger.Periodic(1)))
     sim.run(10)
     tps = list_writer.data
     assert len(np.unique(tps)) > 1
@@ -137,7 +137,7 @@ def test_walltime(simulation_factory, two_particle_snapshot_factory):
     assert sim.walltime == 0
 
     list_writer = ListWriter(sim, "walltime")
-    sim.operations += list_writer
+    sim.operations.writers.append(hoomd.write.CustomWriter(action=list_writer, trigger=hoomd.trigger.Periodic(1)))
     sim.run(10)
     walltime = list_writer.data
     assert all(a > b for a, b in zip(walltime[1:], walltime[:-1]))

--- a/hoomd/pytest/test_simulation.py
+++ b/hoomd/pytest/test_simulation.py
@@ -123,7 +123,7 @@ def test_tps(simulation_factory, two_particle_snapshot_factory):
     assert sim.tps == 0
 
     list_writer = ListWriter(sim, "tps")
-    sim += list_writer
+    sim.operations += list_writer
     sim.run(10)
     tps = list_writer.data
     assert len(np.unique(tps)) > 1
@@ -137,7 +137,7 @@ def test_walltime(simulation_factory, two_particle_snapshot_factory):
     assert sim.walltime == 0
 
     list_writer = ListWriter(sim, "walltime")
-    sim += list_writer
+    sim.operations += list_writer
     sim.run(10)
     walltime = list_writer.data
     assert all(a > b for a, b in zip(walltime[1:], walltime[:-1]))

--- a/hoomd/pytest/test_simulation.py
+++ b/hoomd/pytest/test_simulation.py
@@ -123,7 +123,9 @@ def test_tps(simulation_factory, two_particle_snapshot_factory):
     assert sim.tps == 0
 
     list_writer = ListWriter(sim, "tps")
-    sim.operations.writers.append(hoomd.write.CustomWriter(action=list_writer, trigger=hoomd.trigger.Periodic(1)))
+    sim.operations.writers.append(
+        hoomd.write.CustomWriter(action=list_writer,
+                                 trigger=hoomd.trigger.Periodic(1)))
     sim.run(10)
     tps = list_writer.data
     assert len(np.unique(tps)) > 1
@@ -137,7 +139,9 @@ def test_walltime(simulation_factory, two_particle_snapshot_factory):
     assert sim.walltime == 0
 
     list_writer = ListWriter(sim, "walltime")
-    sim.operations.writers.append(hoomd.write.CustomWriter(action=list_writer, trigger=hoomd.trigger.Periodic(1)))
+    sim.operations.writers.append(
+        hoomd.write.CustomWriter(action=list_writer,
+                                 trigger=hoomd.trigger.Periodic(1)))
     sim.run(10)
     walltime = list_writer.data
     assert all(a > b for a, b in zip(walltime[1:], walltime[:-1]))

--- a/hoomd/pytest/test_simulation.py
+++ b/hoomd/pytest/test_simulation.py
@@ -115,14 +115,21 @@ def test_run(simulation_factory, lattice_snapshot_factory):
     assert sim.operations._scheduled
 
 
-def test_tps(simulation_factory, lattice_snapshot_factory):
+def test_tps(simulation_factory, two_particle_snapshot_factory):
     sim = simulation_factory()
     assert sim.tps is None
 
-    sim = simulation_factory(lattice_snapshot_factory())
-    sim.run(100)
+    sim = simulation_factory(two_particle_snapshot_factory())
+    assert sim.tps == 0
 
-    assert sim.tps > 0
+    sim.run(10)
+    tps = sim.tps
+    assert tps > 0
+    assert tps == sim.tps
+
+    # Test that tps updates
+    sim.run(10)
+    assert sim.tps != tps
 
 
 def test_timestep(simulation_factory, lattice_snapshot_factory):

--- a/hoomd/pytest/test_simulation.py
+++ b/hoomd/pytest/test_simulation.py
@@ -129,6 +129,20 @@ def test_tps(simulation_factory, two_particle_snapshot_factory):
     assert len(np.unique(tps)) > 1
 
 
+def test_walltime(simulation_factory, two_particle_snapshot_factory):
+    sim = simulation_factory()
+    assert sim.walltime == 0
+
+    sim = simulation_factory(two_particle_snapshot_factory())
+    assert sim.walltime == 0
+
+    list_writer = ListWriter(sim, "walltime")
+    sim += list_writer
+    sim.run(10)
+    walltime = list_writer.data
+    assert all(a > b for a, b in zip(walltime[1:], walltime[:-1]))
+
+
 def test_timestep(simulation_factory, lattice_snapshot_factory):
     sim = simulation_factory()
     assert sim.timestep is None

--- a/hoomd/pytest/test_simulation.py
+++ b/hoomd/pytest/test_simulation.py
@@ -7,7 +7,7 @@ import pytest
 from copy import deepcopy
 from hoomd.error import MutabilityError
 from hoomd.logging import LoggerCategories
-from hoomd.conftest import logging_check
+from hoomd.conftest import logging_check, ListWriter
 try:
     import gsd.hoomd
     skip_gsd = False
@@ -122,14 +122,11 @@ def test_tps(simulation_factory, two_particle_snapshot_factory):
     sim = simulation_factory(two_particle_snapshot_factory())
     assert sim.tps == 0
 
+    list_writer = ListWriter(sim, "tps")
+    sim += list_writer
     sim.run(10)
-    tps = sim.tps
-    assert tps > 0
-    assert tps == sim.tps
-
-    # Test that tps updates
-    sim.run(10)
-    assert sim.tps != tps
+    tps = list_writer.data
+    assert len(np.unique(tps)) > 1
 
 
 def test_timestep(simulation_factory, lattice_snapshot_factory):

--- a/hoomd/simulation.py
+++ b/hoomd/simulation.py
@@ -329,7 +329,7 @@ class Simulation(metaclass=Loggable):
             `walltime` resets to 0 at the beginning of each call to `run`.
         """
         if self._state is None:
-            return 0
+            return 0.0
         else:
             return self._cpp_sys.walltime
 


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should be based on *trunk-patch*. -->
<!-- Backwards compatible new features should be based on *trunk-minor*. -->
<!-- Incompatible API changes should be based on *trunk-major*. -->

## Description

Fixes a bug that only updates simulation TPS at the end of every run call.
<!-- Describe your changes in detail. -->

## Motivation and context

This makes it difficult to accurately measure performance and unintuitive logger output.
<!--- Why is this change required? What problem does it solve? -->

<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves #???

## How has this been tested?

A check for TPS updating has been added to the tests.
<!--- Please describe in detail how you tested your changes. -->

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
Fixed: ``Simulation.tps`` now updates every step of the run.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
