### PR TITLE
Zero forces in CustomForceCompute

### DIFF
--- a/hoomd/md/CustomForceCompute.cc
+++ b/hoomd/md/CustomForceCompute.cc
@@ -38,6 +38,22 @@ CustomForceCompute::~CustomForceCompute()
 */
 void CustomForceCompute::computeForces(uint64_t timestep)
     {
+        // zero necessary arrays
+        {
+        ArrayHandle<Scalar4> h_force(m_force, access_location::host, access_mode::overwrite);
+        memset(h_force.data, 0, sizeof(Scalar4) * m_pdata->getN());
+        }
+    if (m_aniso)
+        {
+        ArrayHandle<Scalar4> h_torque(m_torque, access_location::host, access_mode::overwrite);
+        memset(h_torque.data, 0, sizeof(Scalar4) * m_pdata->getN());
+        }
+
+    if (m_pdata->getFlags()[pdata_flag::pressure_tensor])
+        {
+        ArrayHandle<Scalar> h_virial(m_virial, access_location::host, access_mode::overwrite);
+        memset(h_virial.data, 0, sizeof(Scalar) * m_virial.getNumElements());
+        }
     // execute python callback to update the forces, if present
     m_setForces(timestep);
     }

--- a/hoomd/md/pytest/test_custom_force.py
+++ b/hoomd/md/pytest/test_custom_force.py
@@ -392,7 +392,6 @@ def test_force_zeroing(force_simulation_factory, two_particle_snapshot_factory):
                 force.force[:] += timestep
                 force.torque[:] += timestep
                 force.virial[:] += timestep
-                print(f"{force.virial.shape=}")
 
     snap = two_particle_snapshot_factory()
     test_force = TestForceZeroing()

--- a/hoomd/md/pytest/test_custom_force.py
+++ b/hoomd/md/pytest/test_custom_force.py
@@ -378,3 +378,40 @@ def test_torques_update(local_force_names, two_particle_snapshot_factory,
         if sim.device.communicator.rank == 0:
             assert np.count_nonzero(snap.particles.orientation
                                     - initial_orientations)
+
+
+def test_force_zeroing(force_simulation_factory, two_particle_snapshot_factory):
+
+    class TestForceZeroing(hoomd.md.force.Custom):
+
+        def __init__(self):
+            super().__init__(aniso=True)
+
+        def set_forces(self, timestep):
+            with self.cpu_local_force_arrays as force:
+                force.force[:] += timestep
+                force.torque[:] += timestep
+                force.virial[:] += timestep
+                print(f"{force.virial.shape=}")
+
+    snap = two_particle_snapshot_factory()
+    test_force = TestForceZeroing()
+    sim = force_simulation_factory(test_force, snap)
+    if sim.device.communicator.rank == 0:
+        snap.particles.moment_inertia[:] = [[1, 1, 1], [1, 1, 1]]
+    sim.state.set_snapshot(snap)
+
+    _skip_if_gpu_device_and_no_cupy(sim)
+    sim.operations.integrator.integrate_rotational_dof = True
+    sim.always_compute_pressure = True
+
+    for _ in range(3):
+        sim.run(1)
+        forces = test_force.forces
+        torques = test_force.torques
+        virials = test_force.virials
+        timestep = sim.timestep
+        if sim.device.communicator.rank == 0:
+            assert np.allclose(forces, timestep)
+            assert np.allclose(torques, timestep)
+            assert np.allclose(virials, timestep)


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should be based on *trunk-patch*. -->
<!-- Backwards compatible new features should be based on *trunk-minor*. -->
<!-- Incompatible API changes should be based on *trunk-major*. -->

## Description

Zero forces in `hoomd.md.force.CustomForce`.
<!-- Describe your changes in detail. -->

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves #1298

## How has this been tested?

Test has been added.
<!--- Please describe in detail how you tested your changes. -->

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
Fixed: Forces are zeroed in ``hoomd.md.CustomForce`` between time steps.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
