### PR TITLE
Point download link to GitHub releases.

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -12,6 +12,8 @@ values =
 	beta
 	rc
 
+[bumpversion:file:BUILDING.rst]
+
 [bumpversion:file:CMakeLists.txt]
 
 [bumpversion:file:sphinx-doc/conf.py]

--- a/BUILDING.rst
+++ b/BUILDING.rst
@@ -138,7 +138,7 @@ Clone using Git_::
 
    $ git clone --recursive https://github.com/glotzerlab/hoomd-blue
 
-Release tarballs are also available on the `downloads page`_.
+Release tarballs are also available as `GitHub release`_ assets: `Download hoomd-v3.0.1.tar.gz`_.
 
 .. seealso::
 
@@ -151,7 +151,8 @@ Release tarballs are also available on the `downloads page`_.
     Execute ``git submodule update --init`` to fetch the submodules each time you switch branches
     and the submodules show as modified.
 
-.. _downloads page: https://glotzerlab.engin.umich.edu/Downloads/hoomd
+.. _Download hoomd-v3.0.1.tar.gz: https://github.com/glotzerlab/hoomd-blue/releases/download/v3.0.1/hoomd-v3.0.1.tar.gz
+.. _GitHub release: https://github.com/glotzerlab/hoomd-blue/releases
 .. _git book: https://git-scm.com/book
 .. _Git: https://git-scm.com/
 


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should be based on *trunk-patch*. -->
<!-- Backwards compatible new features should be based on *trunk-minor*. -->
<!-- Incompatible API changes should be based on *trunk-major*. -->

## Description

<!-- Describe your changes in detail. -->
Change the tarball download link from https://glotzerlab.engin.umich.edu/Downloads/hoomd to https://github.com/glotzerlab/hoomd-blue/releases. Also add a direct link to the current version's tarball.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
The GitHub release page is automatically updated and takes less time and effort to maintain than the manually updated https://glotzerlab.engin.umich.edu/Downloads/hoomd.

Add the additional direct link because users may not be capable of reading the release page to find the asset for download.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
I build the documentation locally and tested the links. I also tested that bumpversion updates the links for new releases.

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
Fixed:

* Point tarball download link to https://github.com/glotzerlab/hoomd-blue/releases.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
