### PR TITLE
Fix test_energy_shifting for Pair potentials

### DIFF
--- a/hoomd/md/pytest/test_potential.py
+++ b/hoomd/md/pytest/test_potential.py
@@ -734,7 +734,6 @@ def test_energy_shifting(simulation_factory, two_particle_snapshot_factory):
     # A subtle bug existed where we used "shifted" instead of "shift" in Python
     # and in C++ we used else if clauses with no error raised if the set Python
     # mode fell through. This means the actual shift mode was not set.
-    pytest.skip("Test is broken.")
 
     def S_r(r, r_cut, r_on):  # noqa: N802 - allow uppercase function name
         if r < r_on:
@@ -745,76 +744,75 @@ def test_energy_shifting(simulation_factory, two_particle_snapshot_factory):
         denominator = (r_cut**2 - r_on**2)**3
         return numerator / denominator
 
-    r_cut = 2.5
-    r_on = 0.5
-    r = 1.0
+    def set_distance(simulation, distance):
+        snap = sim.state.get_snapshot()
+        if snap.communicator.rank == 0:
+            snap.particles.position[0] = [0, 0, .1]
+            snap.particles.position[1] = [0, 0, distance + .1]
+        sim.state.set_snapshot(snap)
 
-    lj = md.pair.LJ(nlist=md.nlist.Cell(buffer=0.4), default_r_cut=r_cut)
+    def get_energy(simulation):
+        energies = sim.operations.integrator.forces[0].energies
+        if energies is None:
+            return
+        return sum(energies)
+
+    r_cut = 2.5
+    distance = 1.1
+
+    lj = md.pair.LJ(nlist=md.nlist.Cell(buffer=0.4), default_r_cut=r_cut * 1.2)
     lj.params[('A', 'A')] = {'sigma': 1, 'epsilon': 0.5}
 
-    sim = simulation_factory(two_particle_snapshot_factory(dimensions=3, d=r))
+    sim = simulation_factory(
+        two_particle_snapshot_factory(dimensions=3, d=distance))
 
-    integrator = md.Integrator(dt=0.005)
-    integrator.forces.append(lj)
-    integrator.methods.append(
-        hoomd.md.methods.Langevin(hoomd.filter.All(), kT=1))
+    integrator = md.Integrator(dt=0.005, forces=[lj])
     sim.operations.integrator = integrator
     sim.run(0)
 
-    energies = sim.operations.integrator.forces[0].energies
-    if energies is not None:
-        E_r = sum(energies)
+    E_r = get_energy(sim)
 
-    snap = sim.state.get_snapshot()
-    if snap.communicator.rank == 0:
-        snap.particles.position[0] = [0, 0, .1]
-        snap.particles.position[1] = [0, 0, r_cut + .1]
-    sim.state.set_snapshot(snap)
-    energies = sim.operations.integrator.forces[0].energies
-    if energies is not None:
-        E_rcut = sum(energies)
+    # Get energy at r_cut.
+    set_distance(sim, r_cut)
+    E_r_cut = get_energy(sim)
 
     lj_shift = md.pair.LJ(nlist=md.nlist.Cell(buffer=0.4),
                           mode='shift',
                           default_r_cut=r_cut)
     lj_shift.params[('A', 'A')] = {'sigma': 1, 'epsilon': 0.5}
-    integrator = md.Integrator(dt=0.005)
-    integrator.forces.append(lj_shift)
-    integrator.methods.append(
-        hoomd.md.methods.Langevin(hoomd.filter.All(), kT=1))
-    sim.operations.integrator = integrator
-    sim.run(0)
+    integrator.forces = [lj_shift]
 
-    snap = sim.state.get_snapshot()
-    if snap.communicator.rank == 0:
-        snap.particles.position[0] = [0, 0, .1]
-        snap.particles.position[1] = [0, 0, r + .1]
-    sim.state.set_snapshot(snap)
-
+    set_distance(sim, distance)
     energies = sim.operations.integrator.forces[0].energies
     if energies is not None:
-        assert sum(energies) == E_r - E_rcut
+        assert math.isclose(sum(energies), E_r - E_r_cut)
 
+    r_on = 0.5
     lj_xplor = md.pair.LJ(nlist=md.nlist.Cell(buffer=0.4),
                           mode='xplor',
                           default_r_cut=r_cut)
     lj_xplor.params[('A', 'A')] = {'sigma': 1, 'epsilon': 0.5}
-    lj_xplor.r_on[('A', 'A')] = 0.5
-    integrator = md.Integrator(dt=0.005)
-    integrator.forces.append(lj_xplor)
-    integrator.methods.append(
-        hoomd.md.methods.Langevin(hoomd.filter.All(), kT=1))
+    lj_xplor.r_on[('A', 'A')] = r_on
+    integrator.forces = [lj_xplor]
 
-    sim.operations.integrator = integrator
-    sim.run(0)
-
+    # When 0 < r_on < r_ij < r_cut
     energies = sim.operations.integrator.forces[0].energies
     if energies is not None:
-        xplor_E = sum(energies)
-        assert xplor_E == E_r * S_r(r, r_cut, r_on)
+        assert math.isclose(sum(energies), E_r * S_r(distance, r_cut, r_on))
 
-        lj_xplor.r_on[('A', 'A')] = 3.0
-        assert sum(energies) == E_r - E_rcut
+    # When 0 < r_ij < r_on < r_cut
+    lj_xplor.r_on[('A', 'A')] = distance * 1.2
+    sim.run(1)  # recompute forces
+    energies = sim.operations.integrator.forces[0].energies
+    if energies is not None:
+        assert math.isclose(sum(energies), E_r)
+
+    # When 0 < r_ij < r_cut < r_on
+    lj_xplor.r_on[('A', 'A')] = r_cut * 1.2
+    sim.run(1)  # recompute forces
+    energies = sim.operations.integrator.forces[0].energies
+    if energies is not None:
+        assert math.isclose(sum(energies), E_r - E_r_cut)
 
 
 def _calculate_force(sim):


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should be based on *trunk-patch*. -->
<!-- Backwards compatible new features should be based on *trunk-minor*. -->
<!-- Incompatible API changes should be based on *trunk-major*. -->

## Description
Fixes testing of `shift` and `xplor` mode of `PotentialPair` and `Pair`.
<!-- Describe your changes in detail. -->

## Motivation and context
Fixes a broken test.
<!--- Why is this change required? What problem does it solve? -->

<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves #1268

## How has this been tested?
It is a test.
<!--- Please describe in detail how you tested your changes. -->

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log
No need for a changelog entry.
<!-- Propose a change log entry. -->
```

```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
