### PR TITLE
A few documentation fixes

### DIFF
--- a/hoomd/md/external/wall.py
+++ b/hoomd/md/external/wall.py
@@ -358,7 +358,6 @@ class Yukawa(WallPotential):
             "epsilon": 1.0, "kappa": 1.0, "r_cut": 3.0}
         yukawa_wall.params[['A','B']] = {
             "epsilon": 0.5, "kappa": 3.0, "r_cut": 3.2}
-        walls=wall.group()
 
     Attributes:
         walls (`list` [`hoomd.wall.WallGeometry` ]): A list of wall definitions

--- a/hoomd/md/pair/aniso.py
+++ b/hoomd/md/pair/aniso.py
@@ -92,7 +92,7 @@ class Dipole(AnisotropicPair):
     Example::
 
         nl = nlist.Cell()
-        dipole = md.pair.Dipole(nl, default_r_cut=3.0)
+        dipole = md.pair.ansio.Dipole(nl, default_r_cut=3.0)
         dipole.params[('A', 'B')] = dict(A=1.0, kappa=4.0)
         dipole.mu['A'] = (4.0, 1.0, 0.0)
 
@@ -184,7 +184,7 @@ class GayBerne(AnisotropicPair):
     Example::
 
         nl = nlist.Cell()
-        gay_berne = md.pair.GayBerne(nlist=nl, default_r_cut=2.5)
+        gay_berne = md.pair.aniso.GayBerne(nlist=nl, default_r_cut=2.5)
         gay_berne.params[('A', 'A')] = dict(epsilon=1.0, lperp=0.45, lpar=0.5)
         gay_berne.r_cut[('A', 'B')] = 2 ** (1.0 / 6.0)
 

--- a/hoomd/md/pair/pair.py
+++ b/hoomd/md/pair/pair.py
@@ -537,15 +537,15 @@ class Table(Pair):
 
     Note:
         The implicitly defined :math:`r` values are those that would be returned
-        by ``numpy.linspace(r_min, r_cut, len(V), endpoint=False)``.
+        by ``numpy.linspace(r_min, r_cut, len(U), endpoint=False)``.
 
     Tip:
         Define non-interacting potentials with::
 
-            table.params[(type1, type2)] = dict(r_min=0, V=[0], F=[0])
+            table.params[(type1, type2)] = dict(r_min=0, U=[0], F=[0])
             table.r_cut[(type1, type2)] = 0
 
-        There must be at least one element in V and F, and the ``r_cut`` value
+        There must be at least one element in U and F, and the ``r_cut`` value
         of 0 disables the interaction entirely.
 
     Attributes:
@@ -563,7 +563,7 @@ class Table(Pair):
 
           * ``F`` ((*N*,) `numpy.ndarray` of `float`, **required**) -
             the tabulated force values :math:`[\\mathrm{force}]`. Must have the
-            same length as ``V``.
+            same length as ``U``.
 
         mode (str): Energy shifting/smoothing mode: ``"none"``.
     """


### PR DESCRIPTION
## Description
While updating one of my projects from version 2 to version 3 I noticed a few possible errors in the documentation.

## Motivation and context

- Aniso pairs: Some of the examples were missing `.aniso` when creating the aniso pair objects

- Wall forces: It looks like there was one line left over from the hoomd2 wall documentation

- Table Potentials: The section on table pair potentials switches between U and V, which seemed confusing to me. Also, it looks like it uses the wrong parameter name when passing in the params. I replaced "V" with "U" in the documentation so that it matches the paramters `r_min, U, F`

## How has this been tested?
Built the sphinx documentation

## Change log

<!-- Propose a change log entry. -->
```
```

## Checklist:

- [X] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.md).
- [X] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [X] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
