### PR TITLE
Make GSDReader set z box members to 0 in 2D boxes.

### DIFF
--- a/hoomd/GSDReader.cc
+++ b/hoomd/GSDReader.cc
@@ -192,6 +192,13 @@ void GSDReader::readHeader()
 
     float box[6] = {1.0f, 1.0f, 1.0f, 0.0f, 0.0f, 0.0f};
     readChunk(&box, m_frame, "configuration/box", 6 * 4);
+    // Set Lz, xz, and yz to 0 for 2D boxes. Needed for working with hoomd v 2 GSD files.
+    if (dim == 2)
+        {
+        box[2] = 0;
+        box[4] = 0;
+        box[5] = 0;
+        }
     m_snapshot->global_box = std::make_shared<BoxDim>(BoxDim(box[0], box[1], box[2]));
     m_snapshot->global_box->setTiltFactors(box[3], box[4], box[5]);
 

--- a/hoomd/pytest/test_simulation.py
+++ b/hoomd/pytest/test_simulation.py
@@ -265,8 +265,7 @@ def test_state_from_gsd_box_dims(device, simulation_factory,
     checks = range(3)
     if device.communicator.rank == 0:
         for step in checks:
-            if device.communicator.rank == 0:
-                f.append(modify_gsd_snap(make_gsd_snapshot(snap)))
+            f.append(modify_gsd_snap(make_gsd_snapshot(snap)))
         f.close()
 
     for step in checks:

--- a/hoomd/pytest/test_simulation.py
+++ b/hoomd/pytest/test_simulation.py
@@ -240,6 +240,45 @@ def test_state_from_gsd(device, simulation_factory, lattice_snapshot_factory,
 
 
 @skip_gsd
+def test_state_from_gsd_box_dims(device, simulation_factory,
+                                 lattice_snapshot_factory, tmp_path):
+
+    def modify_gsd_snap(gsd_snap):
+        """Add nonzero z values to gsd box for testing."""
+        new_box = list(gsd_snap.configuration.box)
+        new_box[2] = 1e2 * (np.random.random() - 0.5)
+        new_box[4] = 1e2 * (np.random.random() - 0.5)
+        new_box[5] = 1e2 * (np.random.random() - 0.5)
+        gsd_snap.configuration.box = new_box
+        return gsd_snap
+
+    d = tmp_path / "sub"
+    d.mkdir()
+    filename = d / "temporary_test_file.gsd"
+    if device.communicator.rank == 0:
+        f = gsd.hoomd.open(name=filename, mode='wb+')
+
+    sim = simulation_factory(
+        lattice_snapshot_factory(n=10, particle_types=["A", "B"], dimensions=2))
+    snap = sim.state.get_snapshot()
+
+    checks = range(3)
+    if device.communicator.rank == 0:
+        for step in checks:
+            if device.communicator.rank == 0:
+                f.append(modify_gsd_snap(make_gsd_snapshot(snap)))
+        f.close()
+
+    for step in checks:
+        sim = simulation_factory()
+        sim.create_state_from_gsd(filename, frame=step)
+        assert sim.state.box.dimensions == 2
+        assert sim.state.box.Lz == 0.0
+        assert sim.state.box.xz == 0.0
+        assert sim.state.box.yz == 0.0
+
+
+@skip_gsd
 def test_state_from_gsd_snapshot(simulation_factory, lattice_snapshot_factory,
                                  device, state_args, tmp_path):
     snap_params, nsteps = state_args


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should be based on *trunk-patch*. -->
<!-- Backwards compatible new features should be based on *trunk-minor*. -->
<!-- Incompatible API changes should be based on *trunk-major*. -->

## Description

<!-- Describe your changes in detail. -->

Fixes bug with HOOMD 2.x generated GSD files which required non zero Lz
which in v3 is regarded as a 3D box.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves #1312

## How has this been tested?

Test on correct behavior has been added.
<!--- Please describe in detail how you tested your changes. -->

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
- Fixed: Reading in 2D boxes generated in HOOMD v2 now correctly results in a 2D box on both the Python and C++ side.
```

## Checklist:

- [ ] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.md).
- [ ] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [ ] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
