### PR TITLE
Clean up workspace and HOME at end of test run.

### DIFF
--- a/.github/workflows/templates/test.yml
+++ b/.github/workflows/templates/test.yml
@@ -162,12 +162,15 @@ env:
     steps:
     - name: Clean workspace
       run: ( shopt -s dotglob nullglob; rm -rf ./* )
+      shell: bash
 <% endset %>
 <% set post_cleanup_steps %>
     - name: Clean workspace
       run: ( shopt -s dotglob nullglob; rm -rf ./* )
+      shell: bash
     - name: Clean HOME
       run: ( shopt -s dotglob nullglob; rm -rf $HOME/* )
+      shell: bash
 <% endset %>
 <% block jobs %>
 # Use multiple jobs to reduce the amount of time spent on GPU runners. Use CPU runners for

--- a/.github/workflows/templates/test.yml
+++ b/.github/workflows/templates/test.yml
@@ -161,13 +161,13 @@ env:
 <% set prepare_steps %>
     steps:
     - name: Clean workspace
-      run: rm -rf ./*
+      run: ( shopt -s dotglob nullglob; rm -rf ./* )
 <% endset %>
 <% set post_cleanup_steps %>
     - name: Clean workspace
-      run: rm -rf ./*
+      run: ( shopt -s dotglob nullglob; rm -rf ./* )
     - name: Clean HOME
-      run: rm -rf $HOME
+      run: ( shopt -s dotglob nullglob; rm -rf $HOME/* )
 <% endset %>
 <% block jobs %>
 # Use multiple jobs to reduce the amount of time spent on GPU runners. Use CPU runners for

--- a/.github/workflows/templates/test.yml
+++ b/.github/workflows/templates/test.yml
@@ -163,6 +163,12 @@ env:
     - name: Clean workspace
       run: rm -rf ./*
 <% endset %>
+<% set post_cleanup_steps %>
+    - name: Clean workspace
+      run: rm -rf ./*
+    - name: Clean HOME
+      run: rm -rf $HOME
+<% endset %>
 <% block jobs %>
 # Use multiple jobs to reduce the amount of time spent on GPU runners. Use CPU runners for
 # compiling all tests configurations (GPU and CPU), then upload the build directory (sans object
@@ -180,18 +186,21 @@ jobs:
 << prepare_steps >>
 << build_steps >>
 << upload_steps >>
+<< post_cleanup_steps >>
 
   pytest:
 << job(name='Run pytest', run_tests=True, configurations=unit_test_configurations, needs='build') >>
 << prepare_steps >>
 << download_install_steps >>
 << pytest_steps >>
+<< post_cleanup_steps >>
 
   ctest:
 << job(name='Run ctest', run_tests=True, configurations=unit_test_configurations, needs='build') >>
 << prepare_steps >>
 << download_build_steps >>
 << ctest_steps >>
+<< post_cleanup_steps >>
 
   validate:
 << job(name='Validate', run_tests=True, configurations=validate_configurations, needs='build') >>
@@ -199,6 +208,7 @@ jobs:
 << prepare_steps >>
 << download_install_steps >>
 << pytest_validate_steps >>
+<< post_cleanup_steps >>
 
   build_release:
 << job(name='Build', run_tests=False, configurations=release_test_configurations) >>
@@ -206,6 +216,7 @@ jobs:
 << prepare_steps >>
 << build_steps >>
 << upload_steps >>
+<< post_cleanup_steps >>
 
   pytest_release:
 << job(name='Run pytest', run_tests=True, configurations=release_test_configurations, needs='build_release') >>
@@ -213,6 +224,7 @@ jobs:
 << prepare_steps >>
 << download_install_steps >>
 << pytest_steps >>
+<< post_cleanup_steps >>
 
   ctest_release:
 << job(name='Run ctest', run_tests=True, configurations=release_test_configurations, needs='build_release') >>
@@ -220,6 +232,7 @@ jobs:
 << prepare_steps >>
 << download_build_steps >>
 << ctest_steps >>
+<< post_cleanup_steps >>
 
   # This job is used to provide a single requirement for branch merge conditions. GitHub considers
   # the check passing even if it is skipped, so this job raises errors when required jobs were not

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,6 +66,7 @@ jobs:
     steps:
     - name: Clean workspace
       run: ( shopt -s dotglob nullglob; rm -rf ./* )
+      shell: bash
 
     - name: Checkout
       uses: actions/checkout@v3.0.2
@@ -123,8 +124,10 @@ jobs:
 
     - name: Clean workspace
       run: ( shopt -s dotglob nullglob; rm -rf ./* )
+      shell: bash
     - name: Clean HOME
       run: ( shopt -s dotglob nullglob; rm -rf $HOME/* )
+      shell: bash
 
 
   pytest:
@@ -148,6 +151,7 @@ jobs:
     steps:
     - name: Clean workspace
       run: ( shopt -s dotglob nullglob; rm -rf ./* )
+      shell: bash
 
     - name: Download install
       uses: actions/download-artifact@v3.0.0
@@ -174,8 +178,10 @@ jobs:
 
     - name: Clean workspace
       run: ( shopt -s dotglob nullglob; rm -rf ./* )
+      shell: bash
     - name: Clean HOME
       run: ( shopt -s dotglob nullglob; rm -rf $HOME/* )
+      shell: bash
 
 
   ctest:
@@ -199,6 +205,7 @@ jobs:
     steps:
     - name: Clean workspace
       run: ( shopt -s dotglob nullglob; rm -rf ./* )
+      shell: bash
 
     - name: Download build
       uses: actions/download-artifact@v3.0.0
@@ -218,8 +225,10 @@ jobs:
 
     - name: Clean workspace
       run: ( shopt -s dotglob nullglob; rm -rf ./* )
+      shell: bash
     - name: Clean HOME
       run: ( shopt -s dotglob nullglob; rm -rf $HOME/* )
+      shell: bash
 
 
   validate:
@@ -241,6 +250,7 @@ jobs:
     steps:
     - name: Clean workspace
       run: ( shopt -s dotglob nullglob; rm -rf ./* )
+      shell: bash
 
     - name: Download install
       uses: actions/download-artifact@v3.0.0
@@ -258,8 +268,10 @@ jobs:
 
     - name: Clean workspace
       run: ( shopt -s dotglob nullglob; rm -rf ./* )
+      shell: bash
     - name: Clean HOME
       run: ( shopt -s dotglob nullglob; rm -rf $HOME/* )
+      shell: bash
 
 
   build_release:
@@ -292,6 +304,7 @@ jobs:
     steps:
     - name: Clean workspace
       run: ( shopt -s dotglob nullglob; rm -rf ./* )
+      shell: bash
 
     - name: Checkout
       uses: actions/checkout@v3.0.2
@@ -349,8 +362,10 @@ jobs:
 
     - name: Clean workspace
       run: ( shopt -s dotglob nullglob; rm -rf ./* )
+      shell: bash
     - name: Clean HOME
       run: ( shopt -s dotglob nullglob; rm -rf $HOME/* )
+      shell: bash
 
 
   pytest_release:
@@ -385,6 +400,7 @@ jobs:
     steps:
     - name: Clean workspace
       run: ( shopt -s dotglob nullglob; rm -rf ./* )
+      shell: bash
 
     - name: Download install
       uses: actions/download-artifact@v3.0.0
@@ -411,8 +427,10 @@ jobs:
 
     - name: Clean workspace
       run: ( shopt -s dotglob nullglob; rm -rf ./* )
+      shell: bash
     - name: Clean HOME
       run: ( shopt -s dotglob nullglob; rm -rf $HOME/* )
+      shell: bash
 
 
   ctest_release:
@@ -447,6 +465,7 @@ jobs:
     steps:
     - name: Clean workspace
       run: ( shopt -s dotglob nullglob; rm -rf ./* )
+      shell: bash
 
     - name: Download build
       uses: actions/download-artifact@v3.0.0
@@ -466,8 +485,10 @@ jobs:
 
     - name: Clean workspace
       run: ( shopt -s dotglob nullglob; rm -rf ./* )
+      shell: bash
     - name: Clean HOME
       run: ( shopt -s dotglob nullglob; rm -rf $HOME/* )
+      shell: bash
 
 
   # This job is used to provide a single requirement for branch merge conditions. GitHub considers

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,7 +65,7 @@ jobs:
       CXXFLAGS: '-Werror'
     steps:
     - name: Clean workspace
-      run: rm -rf ./*
+      run: ( shopt -s dotglob nullglob; rm -rf ./* )
 
     - name: Checkout
       uses: actions/checkout@v3.0.2
@@ -122,9 +122,9 @@ jobs:
         retention-days: 7
 
     - name: Clean workspace
-      run: rm -rf ./*
+      run: ( shopt -s dotglob nullglob; rm -rf ./* )
     - name: Clean HOME
-      run: rm -rf $HOME
+      run: ( shopt -s dotglob nullglob; rm -rf $HOME/* )
 
 
   pytest:
@@ -147,7 +147,7 @@ jobs:
 
     steps:
     - name: Clean workspace
-      run: rm -rf ./*
+      run: ( shopt -s dotglob nullglob; rm -rf ./* )
 
     - name: Download install
       uses: actions/download-artifact@v3.0.0
@@ -173,9 +173,9 @@ jobs:
         _HOOMD_DISALLOW_CUPY_: 1
 
     - name: Clean workspace
-      run: rm -rf ./*
+      run: ( shopt -s dotglob nullglob; rm -rf ./* )
     - name: Clean HOME
-      run: rm -rf $HOME
+      run: ( shopt -s dotglob nullglob; rm -rf $HOME/* )
 
 
   ctest:
@@ -198,7 +198,7 @@ jobs:
 
     steps:
     - name: Clean workspace
-      run: rm -rf ./*
+      run: ( shopt -s dotglob nullglob; rm -rf ./* )
 
     - name: Download build
       uses: actions/download-artifact@v3.0.0
@@ -217,9 +217,9 @@ jobs:
       working-directory: build
 
     - name: Clean workspace
-      run: rm -rf ./*
+      run: ( shopt -s dotglob nullglob; rm -rf ./* )
     - name: Clean HOME
-      run: rm -rf $HOME
+      run: ( shopt -s dotglob nullglob; rm -rf $HOME/* )
 
 
   validate:
@@ -240,7 +240,7 @@ jobs:
     if: ${{ contains(github.event.pull_request.labels.*.name, 'validate') }}
     steps:
     - name: Clean workspace
-      run: rm -rf ./*
+      run: ( shopt -s dotglob nullglob; rm -rf ./* )
 
     - name: Download install
       uses: actions/download-artifact@v3.0.0
@@ -257,9 +257,9 @@ jobs:
       run: mpirun -n 2 ${GITHUB_WORKSPACE}/install/hoomd/pytest/pytest-openmpi.sh -x --pyargs hoomd -v -ra --durations=0 --durations-min=0.1 -p hoomd.pytest_plugin_validate -m validate --validate || (( cat pytest.out.1 && exit 1 ))
 
     - name: Clean workspace
-      run: rm -rf ./*
+      run: ( shopt -s dotglob nullglob; rm -rf ./* )
     - name: Clean HOME
-      run: rm -rf $HOME
+      run: ( shopt -s dotglob nullglob; rm -rf $HOME/* )
 
 
   build_release:
@@ -291,7 +291,7 @@ jobs:
     if: ${{ contains(github.event.pull_request.labels.*.name, 'release') }}
     steps:
     - name: Clean workspace
-      run: rm -rf ./*
+      run: ( shopt -s dotglob nullglob; rm -rf ./* )
 
     - name: Checkout
       uses: actions/checkout@v3.0.2
@@ -348,9 +348,9 @@ jobs:
         retention-days: 7
 
     - name: Clean workspace
-      run: rm -rf ./*
+      run: ( shopt -s dotglob nullglob; rm -rf ./* )
     - name: Clean HOME
-      run: rm -rf $HOME
+      run: ( shopt -s dotglob nullglob; rm -rf $HOME/* )
 
 
   pytest_release:
@@ -384,7 +384,7 @@ jobs:
     if: ${{ contains(github.event.pull_request.labels.*.name, 'release') }}
     steps:
     - name: Clean workspace
-      run: rm -rf ./*
+      run: ( shopt -s dotglob nullglob; rm -rf ./* )
 
     - name: Download install
       uses: actions/download-artifact@v3.0.0
@@ -410,9 +410,9 @@ jobs:
         _HOOMD_DISALLOW_CUPY_: 1
 
     - name: Clean workspace
-      run: rm -rf ./*
+      run: ( shopt -s dotglob nullglob; rm -rf ./* )
     - name: Clean HOME
-      run: rm -rf $HOME
+      run: ( shopt -s dotglob nullglob; rm -rf $HOME/* )
 
 
   ctest_release:
@@ -446,7 +446,7 @@ jobs:
     if: ${{ contains(github.event.pull_request.labels.*.name, 'release') }}
     steps:
     - name: Clean workspace
-      run: rm -rf ./*
+      run: ( shopt -s dotglob nullglob; rm -rf ./* )
 
     - name: Download build
       uses: actions/download-artifact@v3.0.0
@@ -465,9 +465,9 @@ jobs:
       working-directory: build
 
     - name: Clean workspace
-      run: rm -rf ./*
+      run: ( shopt -s dotglob nullglob; rm -rf ./* )
     - name: Clean HOME
-      run: rm -rf $HOME
+      run: ( shopt -s dotglob nullglob; rm -rf $HOME/* )
 
 
   # This job is used to provide a single requirement for branch merge conditions. GitHub considers

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -121,6 +121,11 @@ jobs:
         path: install.tar
         retention-days: 7
 
+    - name: Clean workspace
+      run: rm -rf ./*
+    - name: Clean HOME
+      run: rm -rf $HOME
+
 
   pytest:
     name: Run pytest [${{ join(matrix.config, '_') }}]
@@ -167,6 +172,11 @@ jobs:
       env:
         _HOOMD_DISALLOW_CUPY_: 1
 
+    - name: Clean workspace
+      run: rm -rf ./*
+    - name: Clean HOME
+      run: rm -rf $HOME
+
 
   ctest:
     name: Run ctest [${{ join(matrix.config, '_') }}]
@@ -206,6 +216,11 @@ jobs:
         --test-output-size-passed 1048576
       working-directory: build
 
+    - name: Clean workspace
+      run: rm -rf ./*
+    - name: Clean HOME
+      run: rm -rf $HOME
+
 
   validate:
     name: Validate [${{ join(matrix.config, '_') }}]
@@ -240,6 +255,11 @@ jobs:
     - name: Run pytest (mpi)
       if: ${{ contains(matrix.config, 'mpi') }}
       run: mpirun -n 2 ${GITHUB_WORKSPACE}/install/hoomd/pytest/pytest-openmpi.sh -x --pyargs hoomd -v -ra --durations=0 --durations-min=0.1 -p hoomd.pytest_plugin_validate -m validate --validate || (( cat pytest.out.1 && exit 1 ))
+
+    - name: Clean workspace
+      run: rm -rf ./*
+    - name: Clean HOME
+      run: rm -rf $HOME
 
 
   build_release:
@@ -327,6 +347,11 @@ jobs:
         path: install.tar
         retention-days: 7
 
+    - name: Clean workspace
+      run: rm -rf ./*
+    - name: Clean HOME
+      run: rm -rf $HOME
+
 
   pytest_release:
     name: Run pytest [${{ join(matrix.config, '_') }}]
@@ -384,6 +409,11 @@ jobs:
       env:
         _HOOMD_DISALLOW_CUPY_: 1
 
+    - name: Clean workspace
+      run: rm -rf ./*
+    - name: Clean HOME
+      run: rm -rf $HOME
+
 
   ctest_release:
     name: Run ctest [${{ join(matrix.config, '_') }}]
@@ -433,6 +463,11 @@ jobs:
         --test-output-size-failed 1048576
         --test-output-size-passed 1048576
       working-directory: build
+
+    - name: Clean workspace
+      run: rm -rf ./*
+    - name: Clean HOME
+      run: rm -rf $HOME
 
 
   # This job is used to provide a single requirement for branch merge conditions. GitHub considers


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should be based on *trunk-patch*. -->
<!-- Backwards compatible new features should be based on *trunk-minor*. -->
<!-- Incompatible API changes should be based on *trunk-major*. -->

## Description

<!-- Describe your changes in detail. -->
Delete the workspace and HOME directories at the end of GitHub Actions test runs.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
The self-update process on the self-hosted GitHub Actions runners fails to restart the runner. The only error I see in the logs is: `Access to the path '/home/azure/actions-runner/_work/_temp/_github_home/.nv' is denied.`. This path is owned by root because GitHub Actions bind mounts `/home/azure/actions-runner/_work/_temp/_github_home/` as the home directory, then runs jobs in the container as root. This process is hard coded in the runner and is not configurable.

This fix cleans up all files that could be made as the docker root user before exiting so that error should not longer occur.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
I will check the logs after the CI tests on this pull request run.

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

Internal change, no entry needed.

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
