### PR TITLE
Add -O3 to jit compiler options for cpu

### DIFF
--- a/hoomd/_compile.py
+++ b/hoomd/_compile.py
@@ -23,7 +23,7 @@ def _get_hoomd_include_path():
 
 def get_cpu_include_options():
     """Get the source code include path for HOOMD's include files."""
-    return ['-I', str(_get_hoomd_include_path())]
+    return ['-I', str(_get_hoomd_include_path()), '-O3']
 
 
 def get_gpu_compilation_settings(gpu):

--- a/hoomd/_compile.py
+++ b/hoomd/_compile.py
@@ -21,8 +21,11 @@ def _get_hoomd_include_path():
     return hoomd_include_path.resolve()
 
 
-def get_cpu_include_options():
-    """Get the source code include path for HOOMD's include files."""
+def get_cpu_compiler_arguments():
+    """Get the arguments to pass to the compiler.
+
+    These arguments must include the include patch for HOOMD's include files.
+    """
     return ['-I', str(_get_hoomd_include_path()), '-O3']
 
 

--- a/hoomd/hpmc/ClangCompiler.cc
+++ b/hoomd/hpmc/ClangCompiler.cc
@@ -189,27 +189,6 @@ std::unique_ptr<llvm::Module> ClangCompiler::compileCode(const std::string& code
         return nullptr;
         }
 
-    // TODO: Run optimization passes
-    // see the posts following this one:
-    // https://wiki.nervtech.org/doku.php?id=blog:2020:0410_dynamic_cpp_compilation
-
-    //     llvm::PassBuilder passBuilder;
-    //     llvm::LoopAnalysisManager loopAnalysisManager(codeGenOptions.DebugPassManager);
-    //     llvm::FunctionAnalysisManager functionAnalysisManager(codeGenOptions.DebugPassManager);
-    //     llvm::CGSCCAnalysisManager cGSCCAnalysisManager(codeGenOptions.DebugPassManager);
-    //     llvm::ModuleAnalysisManager moduleAnalysisManager(codeGenOptions.DebugPassManager);
-
-    //     passBuilder.registerModuleAnalyses(moduleAnalysisManager);
-    //     passBuilder.registerCGSCCAnalyses(cGSCCAnalysisManager);
-    //     passBuilder.registerFunctionAnalyses(functionAnalysisManager);
-    //     passBuilder.registerLoopAnalyses(loopAnalysisManager);
-    //     passBuilder.crossRegisterProxies(loopAnalysisManager, functionAnalysisManager,
-    //     cGSCCAnalysisManager, moduleAnalysisManager);
-
-    //     llvm::ModulePassManager modulePassManager =
-    //     passBuilder.buildPerModuleDefaultPipeline(llvm::PassBuilder::OptimizationLevel::O3);
-    //     modulePassManager.run(*module, moduleAnalysisManager);
-
     return module;
     }
 

--- a/hoomd/hpmc/external/user.py
+++ b/hoomd/hpmc/external/user.py
@@ -173,7 +173,7 @@ class CPPExternalPotential(ExternalField):
             raise RuntimeError("Unsupported integrator.\n")
 
         cpu_code = self._wrap_cpu_code(self.code)
-        cpu_include_options = _compile.get_cpu_include_options()
+        cpu_include_options = _compile.get_cpu_compiler_arguments()
 
         self._cpp_obj = cpp_cls(self._simulation.state._cpp_sys_def,
                                 self._simulation.device._cpp_exec_conf,

--- a/hoomd/hpmc/pair/user.py
+++ b/hoomd/hpmc/pair/user.py
@@ -550,7 +550,7 @@ class CPPPotentialUnion(CPPPotentialBase):
             cpu_code_isotropic = self._wrap_cpu_code(self.code_isotropic)
         else:
             cpu_code_isotropic = self._wrap_cpu_code('return 0;')
-        cpu_include_options = _compile.get_cpu_include_options()
+        cpu_include_options = _compile.get_cpu_compiler_arguments()
 
         device = self._simulation.device
         if isinstance(self._simulation.device, hoomd.device.GPU):

--- a/hoomd/hpmc/pair/user.py
+++ b/hoomd/hpmc/pair/user.py
@@ -272,7 +272,7 @@ class CPPPotential(CPPPotentialBase):
         cpp_sys_def = self._simulation.state._cpp_sys_def
 
         cpu_code = self._wrap_cpu_code(self.code)
-        cpu_include_options = _compile.get_cpu_include_options()
+        cpu_include_options = _compile.get_cpu_compiler_arguments()
 
         if isinstance(device, hoomd.device.GPU):
             gpu_settings = _compile.get_gpu_compilation_settings(device)


### PR DESCRIPTION
## Description

Adds an optimization flag to the cpu compile options for the user-defined HPMC pair potentials.

## Motivation and context
No optimizations are currently being passed to the JIT compiler for pair potentials, causing poor performance when using the `hpmc.pair.user` classes.


## How has this been tested?
For 1672 hexagons with(out) square-well patches at 80% packing fraction, with mpi and 16 ranks, with docker image  `bridges2` unless otherwise noted, and not including compilation time:
| hoomd version | patches? | mean tps|
| -- | -- | -- | 
| 2.9.6 | no | 2927|
|2.9.6 | yes | 1233|
|3.1.0|no|2300|
|3.1.0|yes|143 (191 on `cheme-hodges`)|
|3.1.0 with "-O3" for patch code compilation | yes | 1169 (on `cheme-hodges`)|
|3.1.0 with "-O3 -funroll-loops" for patch code compilation | yes | 1166 (on `cheme-hodges`)|
<!--- Please describe in detail how you tested your changes. -->

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
- Add optimization flag to compiler options for user-defined pair potentials in HPMC
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
