### PR TITLE
Clarify where constraint_groups are to be set in md.constrain.Distance documentation

### DIFF
--- a/hoomd/md/constrain.py
+++ b/hoomd/md/constrain.py
@@ -72,12 +72,8 @@ class Distance(Constraint):
             - d_{ij}^2 = 0
 
     Where :math:`i` and :math:`j` are the the particle tags in the
-    ``constraint_group`` and :math:`d_{ij}` is the constraint distance.
-    Define any number of constraint groups in the system state.
-
-    Note:
-        Define ``constraint_group`` members and :math:`d_{ij}` in the
-        constraints property of `hoomd.State`.
+    ``constraint_group`` and :math:`d_{ij}` is the constraint distance as given
+    by the `system state <hoomd.State>`_.
 
     The method sets the second derivative of the Lagrange multipliers with
     respect to time to zero, such that both the distance constraints and their

--- a/hoomd/md/constrain.py
+++ b/hoomd/md/constrain.py
@@ -75,6 +75,10 @@ class Distance(Constraint):
     ``constraint_group`` and :math:`d_{ij}` is the constraint distance.
     Define any number of constraint groups in the system state.
 
+    Note:
+        Define ``constraint_group`` members and :math:`d_{ij}` in the
+        constraints property of `hoomd.State`.
+
     The method sets the second derivative of the Lagrange multipliers with
     respect to time to zero, such that both the distance constraints and their
     time derivatives are conserved within the accuracy of the Velocity Verlet


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should be based on *trunk-patch*. -->
<!-- Backwards compatible new features should be based on *trunk-minor*. -->
<!-- Incompatible API changes should be based on *trunk-major*. -->

## Description

<!-- Describe your changes in detail. -->
In `md.constrain.Distance`, clarify that `constraint_group` members should be set in the system `State`.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Some users expressed confusion.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
I built the docs locally and inspected the new Note box.

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
* Improved documentation.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
