### PR TITLE
Use Warning consistently on instantiating a base class and remove redundant roles

### DIFF
--- a/hoomd/box.py
+++ b/hoomd/box.py
@@ -152,8 +152,8 @@ class Box:
     ``Lz``, ``xy``, ``xz``, and ``yz``. `Box` provides a way to specify all six
     parameters for a given box and perform some common operations with them. A
     `Box` can be stored in a GSD file, passed to an initialization method or to
-    assigned to a saved :py:class:`State` variable (``state.box = new_box``) to
-    set the simulation box.
+    assigned to a saved `State` variable (``state.box = new_box``) to set the
+    simulation box.
 
     Access attributes directly::
 

--- a/hoomd/data/parameterdicts.py
+++ b/hoomd/data/parameterdicts.py
@@ -382,7 +382,7 @@ class TypeParameterDict(_ValidatedDefaultDict):
     that follow the camel case style version of ``param_name`` as passed to
     `_attach`.
 
-    Note:
+    Warning:
         This class should not be directly instantiated even by developers, but
         the `hoomd.data.type_param.TypeParameter` class should be used to
         automatically handle this in conjunction with

--- a/hoomd/device.py
+++ b/hoomd/device.py
@@ -170,9 +170,8 @@ class GPU(Device):
         num_cpu_threads (int): Number of TBB threads. Set to `None` to
             auto-select.
 
-        communicator (`hoomd.communicator.Communicator`): MPI communicator
-            object.  When `None`, create a default communicator that uses all
-            MPI ranks.
+        communicator (hoomd.communicator.Communicator): MPI communicator object.
+            When `None`, create a default communicator that uses all MPI ranks.
 
         msg_file (str): Filename to write messages to. When `None`, use
             `sys.stdout` and `sys.stderr`. Messages from multiple MPI
@@ -327,9 +326,8 @@ class CPU(Device):
         num_cpu_threads (int): Number of TBB threads. Set to `None` to
             auto-select.
 
-        communicator (`hoomd.communicator.Communicator`): MPI communicator
-            object.  When `None`, create a default communicator that uses all
-            MPI ranks.
+        communicator (hoomd.communicator.Communicator): MPI communicator object.
+            When `None`, create a default communicator that uses all MPI ranks.
 
         msg_file (str): Filename to write messages to. When `None` use
             `sys.stdout` and `sys.stderr`. Messages from multiple MPI
@@ -363,9 +361,8 @@ def auto_select(communicator=None, msg_file=None, notice_level=2):
 
     Args:
 
-        communicator (`hoomd.communicator.Communicator`): MPI communicator
-            object.  When `None`, create a default communicator that uses all
-            MPI ranks.
+        communicator (hoomd.communicator.Communicator): MPI communicator object.
+            When `None`, create a default communicator that uses all MPI ranks.
 
         msg_file (str): Filename to write messages to. When `None` use
             `sys.stdout` and `sys.stderr`. Messages from multiple MPI

--- a/hoomd/hpmc/external/field.py
+++ b/hoomd/hpmc/external/field.py
@@ -45,8 +45,8 @@ class Harmonic(ExternalField):
             minimum, the identity quaternion (``[1, 0, 0, 0]``) must be included
             here :math:`[\mathrm{dimensionless}]`.
 
-    :py:class:`Harmonic` computes harmonic spring energies between the
-    particle positions/orientations and given reference positions/orientations:
+    `Harmonic` computes harmonic spring energies between the particle
+    positions/orientations and given reference positions/orientations:
 
     .. math::
 
@@ -71,10 +71,10 @@ class Harmonic(ExternalField):
         `Harmonic` does not support execution on GPUs.
 
     Attributes:
-        k_translational (`hoomd.variant.Variant`): The translational spring
+        k_translational (hoomd.variant.Variant): The translational spring
             constant :math:`[\mathrm{energy} \cdot \mathrm{length}^{-2}]`.
-        k_rotational (`hoomd.variant.Variant`): The rotational spring
-            constant :math:`[\mathrm{energy}]`.
+        k_rotational (hoomd.variant.Variant): The rotational spring constant
+            :math:`[\mathrm{energy}]`.
         reference_positions ((*N_particles*, 3) `numpy.ndarray` of `float`):
             The reference positions to which particles are restrained
             :math:`[\mathrm{length}]`.

--- a/hoomd/hpmc/external/user.py
+++ b/hoomd/hpmc/external/user.py
@@ -28,18 +28,18 @@ class CPPExternalPotential(ExternalField):
     Args:
         code (str): C++ function body to compile.
 
-    Potentials added using :py:class:`CPPExternalPotential` are added to the
-    total energy calculation in `hoomd.hpmc.integrate.HPMCIntegrator`.
-    :py:class:`CPPExternalPotential` takes C++ code, compiles it at runtime, and
-    executes the code natively in the MC loop with full performance. It enables
-    researchers to quickly and easily implement custom energetic field
-    intractions without the need to modify and recompile HOOMD.
+    Potentials added using `CPPExternalPotential` are added to the total energy
+    calculation in `hoomd.hpmc.integrate.HPMCIntegrator`. `CPPExternalPotential`
+    takes C++ code, compiles it at runtime, and executes the code natively in
+    the MC loop with full performance. It enables researchers to quickly and
+    easily implement custom energetic field intractions without the need to
+    modify and recompile HOOMD.
 
     .. rubric:: C++ code
 
-    Supply C++ code to the *code* argument and :py:class:`CPPExternalPotential`
-    will compile the code and call it to evaluate the energy. The text provided
-    in *code* is the body of a function with the following signature:
+    Supply C++ code to the *code* argument and `CPPExternalPotential` will
+    compile the code and call it to evaluate the energy. The text provided in
+    *code* is the body of a function with the following signature:
 
     .. code::
 
@@ -107,7 +107,7 @@ class CPPExternalPotential(ExternalField):
             with the expected signature.
 
         Args:
-            code (`str`): Body of the C++ function
+            code (str): Body of the C++ function
         """
         cpp_function = """
                         #include "hoomd/HOOMDMath.h"

--- a/hoomd/hpmc/integrate.py
+++ b/hoomd/hpmc/integrate.py
@@ -266,13 +266,16 @@ import json
 class HPMCIntegrator(Integrator):
     """Base class hard particle Monte Carlo integrator.
 
-    :py:class:`HPMCIntegrator` is the base class for all HPMC integrators. Users
-    should not instantiate this class directly. The attributes documented here
-    are available to all HPMC integrators.
+    :py:class:`HPMCIntegrator` is the base class for all HPMC integrators. The
+    attributes documented here are available to all HPMC integrators.
 
     See Also:
         The module level documentation `hoomd.hpmc.integrate` describes the
         hard particle Monte Carlo algorithm.
+
+    Warning:
+        This class should not be instantiated by users. The class can be used
+        for `isinstance` or `issubclass` checks.
 
     .. rubric:: Ignoring overlap checks
 

--- a/hoomd/hpmc/integrate.py
+++ b/hoomd/hpmc/integrate.py
@@ -266,8 +266,8 @@ import json
 class HPMCIntegrator(Integrator):
     """Base class hard particle Monte Carlo integrator.
 
-    :py:class:`HPMCIntegrator` is the base class for all HPMC integrators. The
-    attributes documented here are available to all HPMC integrators.
+    `HPMCIntegrator` is the base class for all HPMC integrators. The attributes
+    documented here are available to all HPMC integrators.
 
     See Also:
         The module level documentation `hoomd.hpmc.integrate` describes the

--- a/hoomd/hpmc/nec/integrate.py
+++ b/hoomd/hpmc/nec/integrate.py
@@ -15,8 +15,12 @@ class HPMCNECIntegrator(HPMCIntegrator):
     """HPMC Chain Integrator base class.
 
     `HPMCNECIntegrator` is the base class for all HPMC Newtonian event chain
-    integrators. Users should not instantiate this class directly. The
-    attributes documented here are available to all HPMC integrators.
+    integrators. The attributes documented here are available to all HPMC
+    integrators.
+
+    Warning:
+        This class should not be instantiated by users. The class can be used
+        for `isinstance` or `issubclass` checks.
     """
     _cpp_cls = None
 

--- a/hoomd/hpmc/nec/tune.py
+++ b/hoomd/hpmc/nec/tune.py
@@ -194,8 +194,8 @@ class ChainTime(_InternalCustomTuner):
             the tuner.
         target (float): The acceptance rate for trial moves that is desired. The
             value should be between 0 and 1.
-        solver (`hoomd.tune.SolverStep`): A solver that tunes chain times to
-            reach the specified target.
+        solver (hoomd.tune.SolverStep): A solver that tunes chain times to reach
+            the specified target.
         max_chain_time (float): The maximum value of chain time to attempt.
 
     Attributes:

--- a/hoomd/hpmc/pair/user.py
+++ b/hoomd/hpmc/pair/user.py
@@ -33,8 +33,8 @@ class CPPPotentialBase(_HOOMDBaseObject):
     type and orientation of the particles and the vector pointing from the *i*
     particle to the *j* particle center.
 
-    Classes derived from :py:class:`CPPPotentialBase` take C++ code, compile it
-    at runtime, and execute the code natively in the MC loop.
+    Classes derived from `CPPPotentialBase` take C++ code, compile it at
+    runtime, and execute the code natively in the MC loop.
 
     Warning:
         `CPPPotentialBase` is **experimental** and subject to change in future
@@ -42,10 +42,9 @@ class CPPPotentialBase(_HOOMDBaseObject):
 
     .. rubric:: C++ code
 
-    Classes derived from :py:class:`CPPPotentialBase` will compile the code
-    provided by the user and call it to evaluate the energy
-    :math:`U_{\\mathrm{pair},ij}`. The text provided is the body of a function
-    with the following signature:
+    Classes derived from `CPPPotentialBase` will compile the code provided by
+    the user and call it to evaluate the energy :math:`U_{\\mathrm{pair},ij}`.
+    The text provided is the body of a function with the following signature:
 
     .. code::
 

--- a/hoomd/hpmc/tune/boxmc_move_size.py
+++ b/hoomd/hpmc/tune/boxmc_move_size.py
@@ -199,8 +199,8 @@ class BoxMCMoveSize(_InternalCustomTuner):
             dimension is tuned independently.
         target (float): The acceptance rate for trial moves that is desired. The
             value should be between 0 and 1.
-        solver (`hoomd.tune.SolverStep`): A solver that tunes move sizes to
-            reach the specified target.
+        solver (hoomd.tune.SolverStep): A solver that tunes move sizes to reach
+            the specified target.
         max_move_size (`dict` [`str`, `float` ], optional): The maximum volume
             move size to attempt for each move time. See the available moves in
             the `moves` attribute documentation. Defaults to no maximum ``None``

--- a/hoomd/hpmc/tune/move_size.py
+++ b/hoomd/hpmc/tune/move_size.py
@@ -197,8 +197,8 @@ class MoveSize(_InternalCustomTuner):
             are ``'a'`` and ``'d'``.
         target (float): The acceptance rate for trial moves that is desired. The
             value should be between 0 and 1.
-        solver (`hoomd.tune.SolverStep`): A solver that tunes move sizes to
-            reach the specified target.
+        solver (hoomd.tune.SolverStep): A solver that tunes move sizes to reach
+            the specified target.
         types (list[str]): A list of string particle types to tune the move
             size for, defaults to None which upon attaching will tune all types
             in the system currently.

--- a/hoomd/md/alchemy/methods.py
+++ b/hoomd/md/alchemy/methods.py
@@ -15,9 +15,9 @@ class Alchemostat(Method):
     """Alchemostat base class.
 
     Note:
-        :py:class:`Alchemostat` is the base class for all alchemical integration
-        methods. Users should use the subclasses and not instantiate
-        `Alchemostat` directly.
+        `Alchemostat` is the base class for all alchemical integration methods.
+        Users should use the subclasses and not instantiate `Alchemostat`
+        directly.
 
     .. versionadded:: 3.1.0
     """
@@ -62,7 +62,7 @@ class NVT(Alchemostat):
         alchemical_dof (`list` [`hoomd.md.alchemy.pair.AlchemicalDOF`]): List
             of alchemical degrees of freedom.
 
-        period (`int`): Timesteps between applications of the alchemostat.
+        period (int): Timesteps between applications of the alchemostat.
 
     Attention:
         `hoomd.md.alchemy.methods.NVT` does not support execution on GPUs.
@@ -83,13 +83,13 @@ class NVT(Alchemostat):
     .. versionadded:: 3.1.0
 
     Attributes:
-        alchemical_kT (`hoomd.variant.Variant`): Temperature set point
+        alchemical_kT (hoomd.variant.Variant): Temperature set point
             for the alchemostat :math:`[\mathrm{energy}]`.
 
         alchemical_dof (`list` [`hoomd.md.alchemy.pair.AlchemicalDOF`]): List of
             alchemical degrees of freedom.
 
-        period (`int`): Timesteps between applications of the alchemostat.
+        period (int): Timesteps between applications of the alchemostat.
     """
 
     def __init__(self, alchemical_kT, alchemical_dof, period=1):

--- a/hoomd/md/alchemy/pair.py
+++ b/hoomd/md/alchemy/pair.py
@@ -102,7 +102,7 @@ class _AlchemicalPairForce(_HOOMDBaseObject):
     Attributes:
         _alchemical_dofs (`list`[ `str`]): A list of all potential degrees of
             freedom. This must match that of the ``params`` type parameter.
-        _dof_cls (`AlchemicalDOF`): The correct DOF class. Automatically set via
+        _dof_cls (AlchemicalDOF): The correct DOF class. Automatically set via
             `_modify_pair_cls_to_alchemical`.
     """
     _alchemical_dofs = []
@@ -143,12 +143,12 @@ class AlchemicalDOF(_HOOMDBaseObject):
     .. versionadded:: 3.1.0
 
     Attributes:
-        mass (`float`): The mass of the alchemical degree of freedom.
-        mu (`float`): The value of the alchemical potential.
-        alpha (`float`): The value of the dimensionless alchemical degree of
+        mass (float): The mass of the alchemical degree of freedom.
+        mu (float): The value of the alchemical potential.
+        alpha (float): The value of the dimensionless alchemical degree of
             freedom :math:`\\alpha_i`.
 
-        alchemical_momentum (`float`): The momentum of the alchemical parameter.
+        alchemical_momentum (float): The momentum of the alchemical parameter.
     """
 
     def __init__(self,
@@ -161,14 +161,14 @@ class AlchemicalDOF(_HOOMDBaseObject):
         """Cache existing instances of AlchemicalDOF.
 
         Args:
-            force (`_AlchemicalPairForce`): Pair force containing the
+            force (_AlchemicalPairForce): Pair force containing the
                 alchemical degree of freedom.
             name (str): The name of the pair force.
             typepair (tuple[str]): The particle types upon which the pair force
                 acts.
-            alpha (`float`): The value of the alchemical parameter.
-            mass (`float`): The mass of the alchemical degree of freedom.
-            mu (`float`): The alchemical potential.
+            alpha (float): The value of the alchemical parameter.
+            mass (float): The mass of the alchemical degree of freedom.
+            mu (float): The alchemical potential.
 
         """
         self._force = force
@@ -261,12 +261,12 @@ class LJGauss(BaseLJGauss, _AlchemicalPairForce):
     r"""Alchemical Lennard Jones Gauss pair force.
 
     Args:
-        nlist (`hoomd.md.nlist.NeighborList`): Neighbor list.
-        default_r_cut (`float`): Default cutoff radius
+        nlist (hoomd.md.nlist.NeighborList): Neighbor list.
+        default_r_cut (float): Default cutoff radius
             :math:`[\mathrm{length}]`.
-        default_r_on (`float`): Default turn-on radius
+        default_r_on (float): Default turn-on radius
             :math:`[\mathrm{length}]`.
-        mode (`str`): Energy shifting/smoothing mode.
+        mode (str): Energy shifting/smoothing mode.
 
     `LJGauss` computes the Lennard-Jones Gauss force on all particles in the
     simulation state, with additional alchemical degrees of freedom:

--- a/hoomd/md/angle.py
+++ b/hoomd/md/angle.py
@@ -44,9 +44,11 @@ import numpy
 class Angle(Force):
     """Base class angle force.
 
-    Note:
-        :py:class:`Angle` is the base class for all angle forces. Users should
-        not instantiate this class directly.
+    :py:class:`Angle` is the base class for all angle forces.
+
+    Warning:
+        This class should not be instantiated by users. The class can be used
+        for `isinstance` or `issubclass` checks.
     """
 
     def __init__(self):

--- a/hoomd/md/angle.py
+++ b/hoomd/md/angle.py
@@ -44,7 +44,7 @@ import numpy
 class Angle(Force):
     """Base class angle force.
 
-    :py:class:`Angle` is the base class for all angle forces.
+    `Angle` is the base class for all angle forces.
 
     Warning:
         This class should not be instantiated by users. The class can be used
@@ -73,8 +73,8 @@ class Angle(Force):
 class Harmonic(Angle):
     r"""Harmonic angle force.
 
-    :py:class:`Harmonic` computes forces, virials, and energies on all angles
-    in the simulation state with:
+    `Harmonic` computes forces, virials, and energies on all angles in the
+    simulation state with:
 
     .. math::
 
@@ -111,8 +111,8 @@ class Harmonic(Angle):
 class CosineSquared(Angle):
     r"""Cosine squared angle force.
 
-    :py:class:`CosineSquared` computes forces, virials, and energies on all
-    angles in the simulation state with:
+    `CosineSquared` computes forces, virials, and energies on all angles in the
+    simulation state with:
 
     .. math::
 

--- a/hoomd/md/bond.py
+++ b/hoomd/md/bond.py
@@ -45,9 +45,11 @@ import numpy
 class Bond(Force):
     """Base class bond force.
 
-    Note:
-        :py:class:`Bond` is the base class for all bond forces. Users should not
-        instantiate this class directly.
+    :py:class:`Bond` is the base class for all bond forces.
+
+    Warning:
+        This class should not be instantiated by users. The class can be used
+        for `isinstance` or `issubclass` checks.
     """
 
     def __init__(self):

--- a/hoomd/md/bond.py
+++ b/hoomd/md/bond.py
@@ -45,7 +45,7 @@ import numpy
 class Bond(Force):
     """Base class bond force.
 
-    :py:class:`Bond` is the base class for all bond forces.
+    `Bond` is the base class for all bond forces.
 
     Warning:
         This class should not be instantiated by users. The class can be used
@@ -70,8 +70,8 @@ class Bond(Force):
 class Harmonic(Bond):
     r"""Harmonic bond force.
 
-    :py:class:`Harmonic` computes forces, virials, and energies on all bonds
-    in the simulation state with:
+    `Harmonic` computes forces, virials, and energies on all bonds in the
+    simulation state with:
 
     .. math::
 
@@ -106,8 +106,8 @@ class Harmonic(Bond):
 class FENEWCA(Bond):
     r"""FENE and WCA bond force.
 
-    :py:class:`FENEWCA` computes forces, virials, and energies on all bonds
-    in the simulation state with:
+    `FENEWCA` computes forces, virials, and energies on all bonds in the
+    simulation state with:
 
     .. math::
 
@@ -283,8 +283,8 @@ class Tether(Bond):
     `Noguchi, H. & Gompper, G., Phys. Rev. E 72 011901 (2005)
     <https://link.aps.org/doi/10.1103/PhysRevE.72.011901>`__.
 
-    :py:class:`Tether` computes forces, virials, and energies on all bonds in
-    the simulation state with:
+    `Tether` computes forces, virials, and energies on all bonds in the
+    simulation state with:
 
     .. math::
 

--- a/hoomd/md/compute.py
+++ b/hoomd/md/compute.py
@@ -22,10 +22,10 @@ class ThermodynamicQuantities(Compute):
         filter (`hoomd.filter`): Particle filter to compute thermodynamic
             properties for.
 
-    :py:class:`ThermodynamicQuantities` acts on a subset of particles in the
-    system and calculates thermodynamic properties of those particles. Add a
-    :py:class:`ThermodynamicQuantities` instance to a logger to save these
-    quantities to a file, see :py:class:`hoomd.logging.Logger` for more details.
+    `ThermodynamicQuantities` acts on a subset of particles in the system and
+    calculates thermodynamic properties of those particles. Add a
+    `ThermodynamicQuantities` instance to a logger to save these quantities to a
+    file, see `hoomd.logging.Logger` for more details.
 
     Note:
         For compatibility with `hoomd.md.constrain.Rigid`,
@@ -292,7 +292,7 @@ class HarmonicAveragedThermodynamicQuantities(Compute):
     """Compute harmonic averaged thermodynamic properties of particles.
 
     Args:
-        filter (``hoomd.filter``): Particle filter to compute thermodynamic
+        filter (`hoomd.filter`): Particle filter to compute thermodynamic
             properties for.
         kT (float): Temperature of the system :math:`[\\mathrm{energy}]`.
         harmonic_pressure (float): Harmonic contribution to the pressure
@@ -300,14 +300,14 @@ class HarmonicAveragedThermodynamicQuantities(Compute):
             still be computed, but will be similar in precision to
             the conventional pressure.
 
-    :py:class:`HarmonicAveragedThermodynamicQuantities` acts on a given subset
-    of particles and calculates harmonically mapped average (HMA) properties
-    of those particles when requested. HMA computes properties more precisely
-    (with less variance) for atomic crystals in NVT simulations.  The presence
-    of diffusion (vacancy hopping, etc.) will prevent HMA from providing
-    improvement.  HMA tracks displacements from the lattice positions, which
-    are saved either during first call to `Simulation.run` or when the compute
-    is first added to the simulation, whichever occurs last.
+    `HarmonicAveragedThermodynamicQuantities` acts on a given subset of
+    particles and calculates harmonically mapped average (HMA) properties of
+    those particles when requested. HMA computes properties more precisely (with
+    less variance) for atomic crystals in NVT simulations.  The presence of
+    diffusion (vacancy hopping, etc.) will prevent HMA from providing
+    improvement.  HMA tracks displacements from the lattice positions, which are
+    saved either during first call to `Simulation.run` or when the compute is
+    first added to the simulation, whichever occurs last.
 
     Note:
         `HarmonicAveragedThermodynamicQuantities` is an implementation of the

--- a/hoomd/md/constrain.py
+++ b/hoomd/md/constrain.py
@@ -30,9 +30,11 @@ from hoomd.operation import _HOOMDBaseObject
 class Constraint(_HOOMDBaseObject):
     """Constraint force base class.
 
-    Note:
-        :py:class:`Constraint` is the base class for all constraint forces.
-        Users should not instantiate this class directly.
+    :py:class:`Constraint` is the base class for all constraint forces.
+
+    Warning:
+        This class should not be instantiated by users. The class can be used
+        for `isinstance` or `issubclass` checks.
     """
 
     def _attach(self):

--- a/hoomd/md/constrain.py
+++ b/hoomd/md/constrain.py
@@ -30,7 +30,7 @@ from hoomd.operation import _HOOMDBaseObject
 class Constraint(_HOOMDBaseObject):
     """Constraint force base class.
 
-    :py:class:`Constraint` is the base class for all constraint forces.
+    `Constraint` is the base class for all constraint forces.
 
     Warning:
         This class should not be instantiated by users. The class can be used

--- a/hoomd/md/dihedral.py
+++ b/hoomd/md/dihedral.py
@@ -54,9 +54,11 @@ import math
 class Dihedral(Force):
     """Base class dihedral force.
 
-    Note:
-        :py:class:`Dihedral` is the base class for all dihedral forces. Users
-        should not instantiate this class directly.
+    :py:class:`Dihedral` is the base class for all dihedral forces.
+
+    Warning:
+        This class should not be instantiated by users. The class can be used
+        for `isinstance` or `issubclass` checks.
     """
 
     def __init__(self):

--- a/hoomd/md/dihedral.py
+++ b/hoomd/md/dihedral.py
@@ -54,7 +54,7 @@ import math
 class Dihedral(Force):
     """Base class dihedral force.
 
-    :py:class:`Dihedral` is the base class for all dihedral forces.
+    `Dihedral` is the base class for all dihedral forces.
 
     Warning:
         This class should not be instantiated by users. The class can be used

--- a/hoomd/md/external/field.py
+++ b/hoomd/md/external/field.py
@@ -16,9 +16,9 @@ class Field(force.Force):
     External potentials represent forces which are applied to all particles in
     the simulation by an external agent.
 
-    Note:
-        :py:class:`Field` is the base class for all external field forces. Users
-        should not instantiate this class directly.
+    Warning:
+        This class should not be instantiated by users. The class can be used
+        for `isinstance` or `issubclass` checks.
     """
 
     def _attach(self):

--- a/hoomd/md/external/wall.py
+++ b/hoomd/md/external/wall.py
@@ -405,9 +405,8 @@ class Morse(WallPotential):
         walls (`list` [`hoomd.wall.WallGeometry` ]): A list of wall definitions
             to use for the force.
 
-    Wall force evaluated using the Morse force.  See
-    :py:class:`hoomd.md.pair.Morse` for the functional form of the force and
-    parameter definitions.
+    Wall force evaluated using the Morse force.  See `hoomd.md.pair.Morse` for
+    the functional form of the force and parameter definitions.
 
     Example::
 

--- a/hoomd/md/force.py
+++ b/hoomd/md/force.py
@@ -20,8 +20,8 @@ import numpy
 class Force(_HOOMDBaseObject):
     r"""Defines a force for molecular dynamics simulations.
 
-    :py:class:`Force` is the base class for all molecular dynamics forces and
-    provides common methods.
+    `Force` is the base class for all molecular dynamics forces and provides
+    common methods.
 
     A `Force` class computes the force and torque on each particle in the
     simulation state :math:`\vec{F}_i` and :math:`\vec{\tau}_i`. With a few
@@ -311,11 +311,11 @@ class Active(Force):
     r"""Active force.
 
     Args:
-        filter (:py:mod:`hoomd.filter`): Subset of particles on which to apply
-            active forces.
+        filter (`hoomd.filter`): Subset of particles on which to
+            apply active forces.
 
-    :py:class:`Active` computes an active force and torque on all
-    particles selected by the filter:
+    `Active` computes an active force and torque on all particles selected by
+    the filter:
 
     .. math::
 
@@ -352,8 +352,8 @@ class Active(Force):
         The energy and virial associated with the active force are 0.
 
     Attributes:
-        filter (:py:mod:`hoomd.filter`): Subset of particles on which to apply
-            active forces.
+        filter (`hoomd.filter`): Subset of particles on which to
+            apply active forces.
 
     .. py:attribute:: active_force
 
@@ -442,14 +442,14 @@ class ActiveOnManifold(Active):
     r"""Active force on a manifold.
 
     Args:
-        filter (`hoomd.filter.ParticleFilter`): Subset of particles on which to
+        filter (`hoomd.filter`): Subset of particles on which to
             apply active forces.
-        manifold_constraint (`hoomd.md.manifold.Manifold`): Manifold constraint.
+        manifold_constraint (hoomd.md.manifold.Manifold): Manifold constraint.
 
-    :py:class:`ActiveOnManifold` computes a constrained active force and torque
-    on all particles selected by the filter similar to :py:class:`Active`.
-    `ActiveOnManifold` restricts the forces to the local tangent plane of the
-    manifold constraint. For more information see :py:class:`Active`.
+    `ActiveOnManifold` computes a constrained active force and torque on all
+    particles selected by the filter similar to `Active`. `ActiveOnManifold`
+    restricts the forces to the local tangent plane of the manifold constraint.
+    For more information see `Active`.
 
     Hint:
         Use `ActiveOnManifold` with a `md.methods.rattle` integration method
@@ -476,9 +476,9 @@ class ActiveOnManifold(Active):
         active.active_torque['A','B'] = (0,0,0)
 
     Attributes:
-        filter (`hoomd.filter.ParticleFilter`): Subset of particles on which to
+        filter (`hoomd.filter`): Subset of particles on which to
             apply active forces.
-        manifold_constraint (`hoomd.md.manifold.Manifold`): Manifold constraint.
+        manifold_constraint (hoomd.md.manifold.Manifold): Manifold constraint.
 
     .. py:attribute:: active_force
 

--- a/hoomd/md/force.py
+++ b/hoomd/md/force.py
@@ -20,6 +20,9 @@ import numpy
 class Force(_HOOMDBaseObject):
     r"""Defines a force for molecular dynamics simulations.
 
+    :py:class:`Force` is the base class for all molecular dynamics forces and
+    provides common methods.
+
     A `Force` class computes the force and torque on each particle in the
     simulation state :math:`\vec{F}_i` and :math:`\vec{\tau}_i`. With a few
     exceptions (noted in the documentation of the specific force classes),
@@ -56,10 +59,9 @@ class Force(_HOOMDBaseObject):
         W^{kl}_i = \sum_j F^k_{ij} \cdot
         \mathrm{minimum\_image}(\vec{r}_j - \vec{r}_i)^l
 
-    Note:
-        :py:class:`Force` is the base class for all molecular dynamics forces
-        and provides common methods. Users should not instantiate this class
-        directly.
+    Warning:
+        This class should not be instantiated by users. The class can be used
+        for `isinstance` or `issubclass` checks.
     """
 
     def __init__(self):

--- a/hoomd/md/improper.py
+++ b/hoomd/md/improper.py
@@ -43,9 +43,11 @@ from hoomd import md  # required because hoomd.md is not yet available
 class Improper(md.force.Force):
     """Base class improper force.
 
-    Note:
-        :py:class:`Improper` is the base class for all improper forces. Users
-        should not instantiate this class directly.
+    :py:class:`Improper` is the base class for all improper forces.
+
+    Warning:
+        This class should not be instantiated by users. The class can be used
+        for `isinstance` or `issubclass` checks.
     """
 
     def __init__(self):

--- a/hoomd/md/improper.py
+++ b/hoomd/md/improper.py
@@ -43,7 +43,7 @@ from hoomd import md  # required because hoomd.md is not yet available
 class Improper(md.force.Force):
     """Base class improper force.
 
-    :py:class:`Improper` is the base class for all improper forces.
+    `Improper` is the base class for all improper forces.
 
     Warning:
         This class should not be instantiated by users. The class can be used

--- a/hoomd/md/long_range/pppm.py
+++ b/hoomd/md/long_range/pppm.py
@@ -13,7 +13,7 @@ def make_pppm_coulomb_forces(nlist, resolution, order, r_cut, alpha=0):
     """Long range Coulomb interactions evaluated using the PPPM method.
 
     Args:
-        nlist (`hoomd.md.nlist.NeighborList`): Neighbor list.
+        nlist (hoomd.md.nlist.NeighborList): Neighbor list.
         resolution (tuple[int, int, int]): Number of grid points in the x, y,
           and z directions :math:`\\mathrm{[dimensionless]}`.
         order (int): Number of grid points in each direction to assign charges

--- a/hoomd/md/manifold.py
+++ b/hoomd/md/manifold.py
@@ -25,7 +25,7 @@ from collections.abc import Sequence
 class Manifold(_HOOMDBaseObject):
     r"""Base class manifold object.
 
-    Note:
+    Warning:
         Users should not instantiate :py:class:`Manifold` directly, but should
         instead instantiate one of its subclasses defining a specific manifold
         geometry.

--- a/hoomd/md/manifold.py
+++ b/hoomd/md/manifold.py
@@ -26,7 +26,7 @@ class Manifold(_HOOMDBaseObject):
     r"""Base class manifold object.
 
     Warning:
-        Users should not instantiate :py:class:`Manifold` directly, but should
+        Users should not instantiate `Manifold` directly, but should
         instead instantiate one of its subclasses defining a specific manifold
         geometry.
 
@@ -63,12 +63,12 @@ class Cylinder(Manifold):
     r"""Cylinder manifold.
 
     Args:
-        r (`float`): radius of the cylinder constraint
+        r (float): radius of the cylinder constraint
           :math:`[\mathrm{length}]`.
         P (`tuple` [`float`, `float`, `float`]): point defining position of
             the cylinder axis (default origin) :math:`[\mathrm{length}]`.
 
-    :py:class:`Cylinder` defines a right circular cylinder along the z axis:
+    `Cylinder` defines a right circular cylinder along the z axis:
 
     .. math::
         F(x,y,z) = (x - P_x)^{2} + (y - P_y)^{2} - r^{2}
@@ -103,10 +103,10 @@ class Diamond(Manifold):
         N (`tuple` [`int`, `int`, `int`] or `int`): number of unit cells in all
             3 directions.  :math:`[N_x, N_y, N_z]`. In case number of unit cells
             u in all direction the same (:math:`[u, u, u]`), use ``N = u``.
-        epsilon (`float`): defines CMC companion of the Diamond surface (default
+        epsilon (float): defines CMC companion of the Diamond surface (default
             0)
 
-    :py:class:`Diamond` defines a periodic diamond surface . The diamond (or
+    `Diamond` defines a periodic diamond surface . The diamond (or
     Schwarz D) belongs to the family of triply periodic minimal surfaces:
 
     .. math::
@@ -156,16 +156,16 @@ class Ellipsoid(Manifold):
     r"""Ellipsoid manifold.
 
     Args:
-        a (`float`): length of the a-axis of the ellipsoidal constraint
+        a (float): length of the a-axis of the ellipsoidal constraint
             :math:`[\mathrm{length}]`.
-        b (`float`): length of the b-axis of the ellipsoidal constraint
+        b (float): length of the b-axis of the ellipsoidal constraint
             :math:`[\mathrm{length}]`.
-        c (`float`): length of the c-axis of the ellipsoidal constraint
+        c (float): length of the c-axis of the ellipsoidal constraint
             :math:`[\mathrm{length}]`.
         P (`tuple` [`float`, `float`, `float`]): center of the ellipsoid
             constraint (default origin) :math:`[\mathrm{length}]`.
 
-    :py:class:`Ellipsoid` defines an ellipsoid:
+    `Ellipsoid` defines an ellipsoid:
 
     .. rubric:: Implicit function
 
@@ -207,10 +207,10 @@ class Gyroid(Manifold):
         N (`tuple` [`int`, `int`, `int`] or `int`): number of unit cells in all
             3 directions.  :math:`[N_x, N_y, N_z]`. In case number of unit cells
             u in all direction the same (:math:`[u, u, u]`), use ``N = u``.
-        epsilon (`float`): defines CMC companion of the Gyroid surface (default
+        epsilon (float): defines CMC companion of the Gyroid surface (default
             0)
 
-    :py:class:`Gyroid` defines a periodic gyroid surface. The gyroid belongs to
+    `Gyroid` defines a periodic gyroid surface. The gyroid belongs to
     the family of triply periodic minimal surfaces:
 
     .. math::
@@ -261,9 +261,9 @@ class Plane(Manifold):
     r"""Plane manifold.
 
     Args:
-        shift (`float`): z-shift of the xy-plane :math:`[\mathrm{length}]`.
+        shift (float): z-shift of the xy-plane :math:`[\mathrm{length}]`.
 
-    :py:class:`Plane` defines an xy-plane at a given value of z:
+    `Plane` defines an xy-plane at a given value of z:
 
     .. math::
         F(x,y,z) = z - \textrm{shift}
@@ -292,12 +292,12 @@ class Primitive(Manifold):
         N (`tuple` [`int`, `int`, `int`] or `int`): number of unit cells in all
             3 directions.  :math:`[N_x, N_y, N_z]`. In case number of unit cells
             u in all direction the same (:math:`[u, u, u]`), use ``N = u``.
-        epsilon (`float`): defines CMC companion of the Primitive surface
+        epsilon (float): defines CMC companion of the Primitive surface
             (default 0)
 
-    :py:class:`Primitive` specifies a periodic primitive surface as a
-    constraint.  The primitive (or Schwarz P) belongs to the family of triply
-    periodic minimal surfaces:
+    `Primitive` specifies a periodic primitive surface as a constraint.  The
+    primitive (or Schwarz P) belongs to the family of triply periodic minimal
+    surfaces:
 
     .. math::
         F(x,y,z) = \cos{\frac{2 \pi}{B_x} x} + \cos{\frac{2 \pi}{B_y} y}
@@ -343,12 +343,12 @@ class Sphere(Manifold):
     """Sphere manifold.
 
     Args:
-        r (`float`): radius of the a-axis of the spherical constraint
+        r (float): radius of the a-axis of the spherical constraint
           :math:`[\\mathrm{length}]`.
         P (`tuple` [`float`, `float`, `float`] ): center of the spherical
             constraint (default origin) :math:`[\\mathrm{length}]`.
 
-    :py:class:`Sphere` defines a sphere:
+    `Sphere` defines a sphere:
 
     .. math::
         F(x,y,z) = (x-P_x)^{2} + (y-P_y)^{2} + (z-P_z)^{2} - r^{2}

--- a/hoomd/md/many_body.py
+++ b/hoomd/md/many_body.py
@@ -51,9 +51,11 @@ from hoomd.md.force import Force
 class Triplet(Force):
     """Base class triplet force.
 
-    Note:
-        :py:class:`Triplet` is the base class for many-body triplet forces.
-        Users should not instantiate this class directly.
+    :py:class:`Triplet` is the base class for many-body triplet forces.
+
+    Warning:
+        This class should not be instantiated by users. The class can be used
+        for `isinstance` or `issubclass` checks.
 
     .. py:attribute:: r_cut
 

--- a/hoomd/md/many_body.py
+++ b/hoomd/md/many_body.py
@@ -51,7 +51,7 @@ from hoomd.md.force import Force
 class Triplet(Force):
     """Base class triplet force.
 
-    :py:class:`Triplet` is the base class for many-body triplet forces.
+    `Triplet` is the base class for many-body triplet forces.
 
     Warning:
         This class should not be instantiated by users. The class can be used
@@ -155,7 +155,7 @@ class Tersoff(Triplet):
     r"""Tersoff force.
 
     Args:
-        nlist (:py:class:`hoomd.md.nlist.NeighborList`): Neighbor list
+        nlist (hoomd.md.nlist.NeighborList): Neighbor list
         default_r_cut (float): Default cutoff radius :math:`[\mathrm{length}]`.
 
     The Tersoff potential is a bond-order potential based on the Morse potential
@@ -287,7 +287,7 @@ class RevCross(Triplet):
     r"""Reversible crosslinker three-body force.
 
     Args:
-        nlist (:py:mod:`hoomd.md.nlist`): Neighbor list
+        nlist (hoomd.md.nlist.NeighborList): Neighbor list
         default_r_cut (float): Default cutoff radius :math:`[\mathrm{length}]`.
 
     `RevCross` computes the revcross three-body force on every particle in the
@@ -411,7 +411,7 @@ class SquareDensity(Triplet):
     r"""Soft force for simulating a van der Waals liquid.
 
     Args:
-        nlist (:py:mod:`hoomd.md.nlist`): Neighbor list
+        nlist (hoomd.md.nlist.NeighborList): Neighbor list
         default_r_cut (float): Default cutoff radius :math:`[\mathrm{length}]`.
 
     `SquareDensity` that the square density three-body force should on every

--- a/hoomd/md/mesh/bond.py
+++ b/hoomd/md/mesh/bond.py
@@ -54,7 +54,7 @@ class Harmonic(MeshPotential):
     in ``mesh`` with the harmonic potential (see `hoomd.md.bond.Harmonic`).
 
     Args:
-        mesh (`hoomd.mesh.Mesh`): Mesh data structure constraint.
+        mesh (hoomd.mesh.Mesh): Mesh data structure constraint.
 
     Attributes:
         params (TypeParameter[``mesh name``,dict]):
@@ -90,7 +90,7 @@ class FENEWCA(MeshPotential):
     in ``mesh`` with the harmonic potential (see `hoomd.md.bond.FENEWCA`).
 
     Args:
-        mesh (`hoomd.mesh.Mesh`): Mesh data structure constraint.
+        mesh (hoomd.mesh.Mesh): Mesh data structure constraint.
 
     Attributes:
         params (TypeParameter[``bond type``, dict]):
@@ -143,7 +143,7 @@ class Tether(MeshPotential):
     in ``mesh`` with the harmonic potential (see `hoomd.md.bond.Tether`).
 
     Args:
-        mesh (`hoomd.mesh.Mesh`): Mesh data structure constraint.
+        mesh (hoomd.mesh.Mesh): Mesh data structure constraint.
 
     Attributes:
         params (TypeParameter[``mesh name``,dict]):

--- a/hoomd/md/mesh/potential.py
+++ b/hoomd/md/mesh/potential.py
@@ -17,9 +17,12 @@ validate_mesh = OnlyTypes(Mesh)
 class MeshPotential(Force):
     """Constructs the bond potential applied to a mesh.
 
-    Note:
-        :py:class:`MeshPotential` is the base class for all bond potentials
-        applied to meshes. Users should not instantiate this class directly.
+    :py:class:`MeshPotential` is the base class for all bond potentials applied
+    to meshes.
+
+    Warning:
+        This class should not be instantiated by users. The class can be used
+        for `isinstance` or `issubclass` checks.
     """
 
     def __init__(self, mesh):

--- a/hoomd/md/mesh/potential.py
+++ b/hoomd/md/mesh/potential.py
@@ -17,8 +17,7 @@ validate_mesh = OnlyTypes(Mesh)
 class MeshPotential(Force):
     """Constructs the bond potential applied to a mesh.
 
-    :py:class:`MeshPotential` is the base class for all bond potentials applied
-    to meshes.
+    `MeshPotential` is the base class for all bond potentials applied to meshes.
 
     Warning:
         This class should not be instantiated by users. The class can be used

--- a/hoomd/md/methods/methods.py
+++ b/hoomd/md/methods/methods.py
@@ -36,13 +36,13 @@ class NVT(Method):
     r"""Constant volume, constant temperature dynamics.
 
     Args:
-        filter (`hoomd.filter.ParticleFilter`): Subset of particles on which
+        filter (hoomd.filter.ParticleFilter): Subset of particles on which
             to apply this method.
 
         kT (`hoomd.variant.Variant` or `float`): Temperature set point
             for the Nosé-Hoover thermostat :math:`[\mathrm{energy}]`.
 
-        tau (`float`): Coupling constant for the Nosé-Hoover thermostat
+        tau (float): Coupling constant for the Nosé-Hoover thermostat
             :math:`[\mathrm{time}]`.
 
     `NVT` integrates particles forward in time in the canonical ensemble
@@ -163,13 +163,13 @@ class NPT(Method):
     r"""Constant pressure, constant temperature dynamics.
 
     Args:
-        filter (`hoomd.filter.ParticleFilter`): Subset of particles on which to
+        filter (hoomd.filter.ParticleFilter): Subset of particles on which to
             apply this method.
 
         kT (`hoomd.variant.Variant` or `float`): Temperature set point for the
             thermostat :math:`[\mathrm{energy}]`.
 
-        tau (`float`): Coupling constant for the thermostat
+        tau (float): Coupling constant for the thermostat
             :math:`[\mathrm{time}]`.
 
         S: Stress components set point for the barostat.
@@ -180,10 +180,10 @@ class NPT(Method):
            Accepts: `tuple` [ `hoomd.variant.Variant` or `float`, ... ] or
            `hoomd.variant.Variant` or `float`.
 
-        tauS (`float`): Coupling constant for the barostat
+        tauS (float): Coupling constant for the barostat
            :math:`[\mathrm{time}]`.
 
-        couple (`str`): Couplings of diagonal elements of the stress tensor,
+        couple (str): Couplings of diagonal elements of the stress tensor,
             can be "none", "xy", "xz","yz", or "xyz".
 
         box_dof(`list` [ `bool` ]): Box degrees of freedom with six boolean
@@ -192,10 +192,10 @@ class NPT(Method):
             rescale corresponding lengths or tilt factors and components of
             particle coordinates and velocities.
 
-        rescale_all (`bool`): if True, rescale all particles, not only those
+        rescale_all (bool): if True, rescale all particles, not only those
             in the group, Default to False.
 
-        gamma (`float`): Dimensionless damping factor for the box degrees of
+        gamma (float): Dimensionless damping factor for the box degrees of
             freedom, Default to 0.
 
     `NPT` integrates particles forward in time in the Isothermal-isobaric
@@ -654,7 +654,7 @@ class NVE(Method):
     r"""Constant volume, constant energy dynamics.
 
     Args:
-        filter (`hoomd.filter.ParticleFilter`): Subset of particles on which to
+        filter (hoomd.filter.ParticleFilter): Subset of particles on which to
             apply this method.
 
     `NVE` integrates particles forward in time in the microcanonical ensemble.
@@ -708,19 +708,19 @@ class Langevin(Method):
     r"""Langevin dynamics.
 
     Args:
-        filter (`hoomd.filter.ParticleFilter`): Subset of particles to
+        filter (hoomd.filter.ParticleFilter): Subset of particles to
             apply this method to.
 
         kT (`hoomd.variant.Variant` or `float`): Temperature of the
             simulation :math:`[\mathrm{energy}]`.
 
-        alpha (`float`): When set, use :math:`\alpha d_i` for the drag
+        alpha (float): When set, use :math:`\alpha d_i` for the drag
             coefficient where :math:`d_i` is particle diameter
             :math:`[\mathrm{mass} \cdot
             \mathrm{length}^{-1} \cdot \mathrm{time}^{-1}]`.
             Defaults to None.
 
-        tally_reservoir_energy (`bool`): If true, the energy exchange
+        tally_reservoir_energy (bool): If true, the energy exchange
             between the thermal reservoir and the particles is tracked. Total
             energy conservation can then be monitored by adding
             ``langevin_reservoir_energy_groupname`` to the logged quantities.
@@ -883,13 +883,13 @@ class Brownian(Method):
     r"""Brownian dynamics.
 
     Args:
-        filter (`hoomd.filter.ParticleFilter`): Subset of particles to
+        filter (hoomd.filter.ParticleFilter): Subset of particles to
             apply this method to.
 
         kT (`hoomd.variant.Variant` or `float`): Temperature of the
             simulation :math:`[\mathrm{energy}]`.
 
-        alpha (`float`): When set, use :math:`\alpha d_i` for the
+        alpha (float): When set, use :math:`\alpha d_i` for the
             drag coefficient where :math:`d_i` is particle diameter
             :math:`[\mathrm{mass} \cdot \mathrm{length}^{-1}
             \cdot \mathrm{time}^{-1}]`.
@@ -1068,17 +1068,17 @@ class Berendsen(Method):
     r"""Applies the Berendsen thermostat.
 
     Args:
-        filter (`hoomd.filter.ParticleFilter`): Subset of particles to
+        filter (hoomd.filter.ParticleFilter): Subset of particles to
             apply this method to.
 
         kT (`hoomd.variant.Variant` or `float`): Temperature of the
             simulation. :math:`[energy]`
 
-        tau (`float`): Time constant of thermostat. :math:`[time]`
+        tau (float): Time constant of thermostat. :math:`[time]`
 
-    :py:class:`Berendsen` rescales the velocities of all particles on each time
-    step. The rescaling is performed so that the difference in the current
-    temperature from the set point decays exponentially:
+    `Berendsen` rescales the velocities of all particles on each time step. The
+    rescaling is performed so that the difference in the current temperature
+    from the set point decays exponentially:
     `Berendsen et. al. 1984 <http://dx.doi.org/10.1063/1.448118>`_.
 
     .. math::
@@ -1086,10 +1086,10 @@ class Berendsen(Method):
         \frac{dT_\mathrm{cur}}{dt} = \frac{T - T_\mathrm{cur}}{\tau}
 
     .. attention::
-        :py:class:`Berendsen` does not function with MPI parallel simulations.
+        `Berendsen` does not function with MPI parallel simulations.
 
     .. attention::
-        :py:class:`Berendsen` does not integrate rotational degrees of freedom.
+        `Berendsen` does not integrate rotational degrees of freedom.
 
         Examples::
 
@@ -1145,10 +1145,10 @@ class OverdampedViscous(Method):
     r"""Overdamped viscous dynamics.
 
     Args:
-        filter (`hoomd.filter.ParticleFilter`): Subset of particles to
+        filter (hoomd.filter.ParticleFilter): Subset of particles to
             apply this method to.
 
-        alpha (`float`): When set, use :math:`\alpha d_i` for the
+        alpha (float): When set, use :math:`\alpha d_i` for the
             drag coefficient where :math:`d_i` is particle diameter
             :math:`[\mathrm{mass} \cdot \mathrm{length}^{-1}
             \cdot \mathrm{time}^{-1}]`.

--- a/hoomd/md/methods/rattle.py
+++ b/hoomd/md/methods/rattle.py
@@ -62,17 +62,16 @@ class NVE(MethodRATTLE):
     r"""NVE Integration via Velocity-Verlet with RATTLE constraint.
 
     Args:
-        filter (`hoomd.filter.ParticleFilter`): Subset of particles on which to
+        filter (hoomd.filter.ParticleFilter): Subset of particles on which to
          apply this method.
 
-        manifold_constraint (:py:mod:`hoomd.md.manifold.Manifold`): Manifold
+        manifold_constraint (hoomd.md.manifold.Manifold): Manifold
             constraint.
 
-        tolerance (`float`): Defines the tolerated error particles are
-            allowed to deviate from the manifold in terms of the implicit
-            function.
-            The units of tolerance match that of the selected manifold's
-            implicit function. Defaults to 1e-6
+        tolerance (float): Defines the tolerated error particles are allowed to
+            deviate from the manifold in terms of the implicit function. The
+            units of tolerance match that of the selected manifold's implicit
+            function. Defaults to 1e-6
 
     `NVE` performs constant volume, constant energy simulations as described
     in `hoomd.md.methods.NVE`. In addition the particles are constrained to a
@@ -96,9 +95,9 @@ class NVE(MethodRATTLE):
             method.
 
         tolerance (float): Defines the tolerated error particles are allowed to
-            deviate from the manifold in terms of the implicit function.
-            The units of tolerance match that of the selected manifold's
-            implicit function. Defaults to 1e-6
+            deviate from the manifold in terms of the implicit function. The
+            units of tolerance match that of the selected manifold's implicit
+            function. Defaults to 1e-6
 
     """
 
@@ -143,28 +142,28 @@ class Langevin(MethodRATTLE):
     r"""Langevin dynamics with RATTLE constraint.
 
     Args:
-        filter (`hoomd.filter.ParticleFilter`): Subset of particles to
+        filter (hoomd.filter.ParticleFilter): Subset of particles to
             apply this method to.
 
         kT (`hoomd.variant.Variant` or `float`): Temperature of the
             simulation :math:`[\mathrm{energy}]`.
 
-        manifold_constraint (:py:mod:`hoomd.md.manifold.Manifold`): Manifold
+        manifold_constraint (hoomd.md.manifold.Manifold): Manifold
             constraint.
 
-        alpha (`float`): When set, use :math:`\alpha d_i` for the drag
+        alpha (float): When set, use :math:`\alpha d_i` for the drag
             coefficient where :math:`d_i` is particle diameter
             :math:`[\mathrm{mass} \cdot
             \mathrm{length}^{-1} \cdot \mathrm{time}^{-1}]`.
             Defaults to None.
 
-        tally_reservoir_energy (`bool`): If true, the energy exchange
+        tally_reservoir_energy (bool): If true, the energy exchange
             between the thermal reservoir and the particles is tracked. Total
             energy conservation can then be monitored by adding
             ``langevin_reservoir_energy_groupname`` to the logged quantities.
             Defaults to False :math:`[\mathrm{energy}]`.
 
-        tolerance (`float`): Defines the tolerated error particles are allowed
+        tolerance (float): Defines the tolerated error particles are allowed
             to deviate from the manifold in terms of the implicit function.
             The units of tolerance match that of the selected manifold's
             implicit function. Defaults to 1e-6
@@ -298,22 +297,22 @@ class Brownian(MethodRATTLE):
     r"""Brownian dynamics with RATTLE constraint.
 
     Args:
-        filter (`hoomd.filter.ParticleFilter`): Subset of particles to
+        filter (hoomd.filter.ParticleFilter): Subset of particles to
             apply this method to.
 
         kT (`hoomd.variant.Variant` or `float`): Temperature of the
             simulation :math:`[\mathrm{energy}]`.
 
-        manifold_constraint (:py:mod:`hoomd.md.manifold.Manifold`): Manifold
+        manifold_constraint (hoomd.md.manifold.Manifold): Manifold
             constraint.
 
-        alpha (`float`): When set, use :math:`\alpha d_i` for the
+        alpha (float): When set, use :math:`\alpha d_i` for the
             drag coefficient where :math:`d_i` is particle diameter.
             Defaults to None
             :math:`[\mathrm{mass} \cdot \mathrm{length}^{-1}
             \cdot \mathrm{time}^{-1}]`.
 
-        tolerance (`float`): Defines the tolerated error particles are allowed
+        tolerance (float): Defines the tolerated error particles are allowed
             to deviate from the manifold in terms of the implicit function.
             The units of tolerance match that of the selected manifold's
             implicit function. Defaults to 1e-6
@@ -437,29 +436,27 @@ class OverdampedViscous(MethodRATTLE):
     r"""Overdamped viscous dynamics with RATTLE constraint.
 
     Args:
-        filter (`hoomd.filter.ParticleFilter`): Subset of particles to
-            apply this method to.
+        filter (hoomd.filter.ParticleFilter): Subset of particles to apply this
+            method to.
 
-        manifold_constraint (:py:mod:`hoomd.md.manifold.Manifold`): Manifold
-            constraint.
+        manifold_constraint (hoomd.md.manifold.Manifold): Manifold constraint.
 
-        alpha (`float`): When set, use :math:`\alpha d_i` for the
-            drag coefficient where :math:`d_i` is particle diameter.
-            Defaults to None
+        alpha (float): When set, use :math:`\alpha d_i` for the drag coefficient
+            where :math:`d_i` is particle diameter. Defaults to None
             :math:`[\mathrm{mass} \cdot \mathrm{length}^{-1}
             \cdot \mathrm{time}^{-1}]`.
 
-        tolerance (`float`): Defines the tolerated error particles are allowed
-            to deviate from the manifold in terms of the implicit function.
-            The units of tolerance match that of the selected manifold's
-            implicit function. Defaults to 1e-6
+        tolerance (float): Defines the tolerated error particles are allowed to
+            deviate from the manifold in terms of the implicit function. The
+            units of tolerance match that of the selected manifold's implicit
+            function. Defaults to 1e-6
 
     `OverdampedViscous` uses the same integrator as
     `hoomd.md.methods.OverdampedViscous`, with the additional force term
-    :math:`- \lambda \vec{F}_\mathrm{M}`. The force
-    :math:`\vec{F}_\mathrm{M}` keeps the particles on the manifold constraint,
-    where the Lagrange multiplier :math:`\lambda` is calculated via the RATTLE
-    algorithm. For more details about overdamped viscous dynamics see
+    :math:`- \lambda \vec{F}_\mathrm{M}`. The force :math:`\vec{F}_\mathrm{M}`
+    keeps the particles on the manifold constraint, where the Lagrange
+    multiplier :math:`\lambda` is calculated via the RATTLE algorithm. For more
+    details about overdamped viscous dynamics see
     `hoomd.md.methods.OverdampedViscous`.
 
     Examples of using ``manifold_constraint``::
@@ -473,22 +470,22 @@ class OverdampedViscous(MethodRATTLE):
 
 
     Attributes:
-        filter (hoomd.filter.ParticleFilter): Subset of particles to
-            apply this method to.
+        filter (hoomd.filter.ParticleFilter): Subset of particles to apply this
+            method to.
 
         manifold_constraint (hoomd.md.manifold.Manifold): Manifold constraint
             which is used by and as a trigger for the RATTLE algorithm of this
             method.
 
-        alpha (float): When set, use :math:`\alpha d_i` for the drag
-            coefficient where :math:`d_i` is particle diameter
+        alpha (float): When set, use :math:`\alpha d_i` for the drag coefficient
+            where :math:`d_i` is particle diameter
             :math:`[\mathrm{mass} \cdot \mathrm{length}^{-1}
             \cdot \mathrm{time}^{-1}]`. Defaults to None.
 
         tolerance (float): Defines the tolerated error particles are allowed to
-            deviate from the manifold in terms of the implicit function.
-            The units of tolerance match that of the selected manifold's
-            implicit function. Defaults to 1e-6
+            deviate from the manifold in terms of the implicit function. The
+            units of tolerance match that of the selected manifold's implicit
+            function. Defaults to 1e-6
 
         gamma (TypeParameter[ ``particle type``, `float` ]): The drag
             coefficient can be directly set instead of the ratio of particle

--- a/hoomd/md/pair/aniso.py
+++ b/hoomd/md/pair/aniso.py
@@ -62,7 +62,7 @@ class Dipole(AnisotropicPair):
     r"""Screened dipole-dipole pair forces.
 
     Args:
-        nlist (`hoomd.md.nlist.NeighborList`): Neighbor list
+        nlist (hoomd.md.nlist.NeighborList): Neighbor list
         default_r_cut (float): Default cutoff radius :math:`[\mathrm{length}]`.
         mode (str): energy shifting/smoothing mode (ignored).
 
@@ -144,7 +144,7 @@ class GayBerne(AnisotropicPair):
     r"""Gay-Berne anisotropic pair force.
 
     Args:
-        nlist (`hoomd.md.nlist.NeighborList`): Neighbor list
+        nlist (hoomd.md.nlist.NeighborList): Neighbor list
         default_r_cut (float): Default cutoff radius :math:`[\mathrm{length}]`.
         mode (str): energy shifting/smoothing mode.
 

--- a/hoomd/md/pair/aniso.py
+++ b/hoomd/md/pair/aniso.py
@@ -33,9 +33,11 @@ from hoomd.data.typeconverter import OnlyIf, to_type_converter
 class AnisotropicPair(Pair):
     r"""Base class anisotropic pair force.
 
-    Note:
-        `AnisotropicPair` is the base class for all anisotropic pair forces.
-        Users not not instantiate this class directly.
+    `AnisotropicPair` is the base class for all anisotropic pair forces.
+
+    Warning:
+        This class should not be instantiated by users. The class can be used
+        for `isinstance` or `issubclass` checks.
 
     Args:
         nlist (hoomd.md.nlist.NeighborList) : The neighbor list.

--- a/hoomd/md/pair/pair.py
+++ b/hoomd/md/pair/pair.py
@@ -18,7 +18,7 @@ from hoomd.data.typeconverter import OnlyFrom, nonnegative_real
 class Pair(force.Force):
     r"""Base class pair force.
 
-    :py:class:`Pair` is the base class for all pair forces.
+    `Pair` is the base class for all pair forces.
 
     Warning:
         This class should not be instantiated by users. The class can be used
@@ -190,7 +190,7 @@ class LJ(Pair):
     r"""Lennard-Jones pair force.
 
     Args:
-        nlist (`hoomd.md.nlist.NeighborList`): Neighbor list.
+        nlist (hoomd.md.nlist.NeighborList): Neighbor list.
         default_r_cut (float): Default cutoff radius :math:`[\mathrm{length}]`.
         default_r_on (float): Default turn-on radius :math:`[\mathrm{length}]`.
         mode (str): Energy shifting/smoothing mode.
@@ -257,7 +257,7 @@ class Gauss(Pair):
     r"""Gaussian pair force.
 
     Args:
-        nlist (`hoomd.md.nlist.NeighborList`): Neighbor list.
+        nlist (hoomd.md.nlist.NeighborList): Neighbor list.
         default_r_cut (float): Default cutoff radius :math:`[\mathrm{length}]`.
         default_r_on (float): Default turn-on radius :math:`[\mathrm{length}]`.
         mode (str): Energy shifting/smoothing mode.
@@ -309,7 +309,7 @@ class ExpandedLJ(Pair):
     r"""Expanded Lennard-Jones pair force.
 
     Args:
-        nlist (`hoomd.md.nlist.NeighborList`): Neighbor list.
+        nlist (hoomd.md.nlist.NeighborList): Neighbor list.
         default_r_cut (float): Default cutoff radius :math:`[\mathrm{length}]`.
         default_r_on (float): Default turn-on radius :math:`[\mathrm{length}]`.
         mode (str): Energy shifting mode.
@@ -376,7 +376,7 @@ class Yukawa(Pair):
     r"""Yukawa pair force.
 
     Args:
-        nlist (`hoomd.md.nlist.NeighborList`): Neighbor list.
+        nlist (hoomd.md.nlist.NeighborList): Neighbor list.
         default_r_cut (float): Default cutoff radius :math:`[\mathrm{length}]`.
         default_r_on (float): Default turn-on radius :math:`[\mathrm{length}]`.
         mode (str): Energy shifting/smoothing mode.
@@ -429,7 +429,7 @@ class Ewald(Pair):
     r"""Ewald pair force.
 
     Args:
-        nlist (`hoomd.md.nlist.NeighborList`): Neighbor list.
+        nlist (hoomd.md.nlist.NeighborList): Neighbor list.
         default_r_cut (float): Default cutoff radius :math:`[\mathrm{length}]`.
 
     `Ewald` computes the Ewald pair force on every particle in the simulation
@@ -492,7 +492,7 @@ class Table(Pair):
     """Tabulated pair force.
 
     Args:
-        nlist (`hoomd.md.nlist.NeighborList`): Neighbor list
+        nlist (hoomd.md.nlist.NeighborList): Neighbor list
         default_r_cut (float): Default cutoff radius :math:`[\\mathrm{length}]`.
 
     `Table` computes the tabulated pair force on every particle in the
@@ -593,7 +593,7 @@ class Morse(Pair):
     r"""Morse pair force.
 
     Args:
-        nlist (`hoomd.md.nlist.NeighborList`): Neighbor list.
+        nlist (hoomd.md.nlist.NeighborList): Neighbor list.
         default_r_cut (float): Default cutoff radius :math:`[\mathrm{length}]`.
         default_r_on (float): Default turn-on radius :math:`[\mathrm{length}]`.
         mode (str): Energy shifting/smoothing mode.
@@ -648,7 +648,7 @@ class DPD(Pair):
     r"""Dissipative Particle Dynamics.
 
     Args:
-        nlist (`hoomd.md.nlist.NeighborList`): Neighbor list
+        nlist (hoomd.md.nlist.NeighborList): Neighbor list
         kT (`hoomd.variant` or `float`): Temperature of
             thermostat :math:`[\mathrm{energy}]`.
         default_r_cut (float): Default cutoff radius :math:`[\mathrm{length}]`.
@@ -758,7 +758,7 @@ class DPDConservative(Pair):
     r"""DPD Conservative pair force.
 
     Args:
-        nlist (`hoomd.md.nlist.NeighborList`): Neighbor list.
+        nlist (hoomd.md.nlist.NeighborList): Neighbor list.
         default_r_cut (float): Default cutoff radius :math:`[\mathrm{length}]`.
 
     `DPDConservative` computes the conservative part of the `DPD` pair force on
@@ -813,7 +813,7 @@ class DPDLJ(Pair):
     r"""Dissipative Particle Dynamics with the LJ conservative force.
 
     Args:
-        nlist (`hoomd.md.nlist.NeighborList`): Neighbor list.
+        nlist (hoomd.md.nlist.NeighborList): Neighbor list.
         kT (`hoomd.variant` or `float`): Temperature of
             thermostat :math:`[\mathrm{energy}]`.
         default_r_cut (float): Default cutoff radius :math:`[\mathrm{length}]`.
@@ -918,7 +918,7 @@ class ForceShiftedLJ(Pair):
     r"""Force-shifted Lennard-Jones pair force.
 
     Args:
-        nlist (`hoomd.md.nlist.NeighborList`): Neighbor list.
+        nlist (hoomd.md.nlist.NeighborList): Neighbor list.
         default_r_cut (float): Default cutoff radius :math:`[\mathrm{length}]`.
         mode (str): Energy shifting/smoothing mode.
 
@@ -984,7 +984,7 @@ class Moliere(Pair):
     r"""Moliere pair force.
 
     Args:
-        nlist (`hoomd.md.nlist.NeighborList`): Neighbor list.
+        nlist (hoomd.md.nlist.NeighborList): Neighbor list.
         default_r_cut (float): Default cutoff radius :math:`[\mathrm{length}]`.
         default_r_on (float): Default turn-on radius :math:`[\mathrm{length}]`.
         mode (str): Energy shifting/smoothing mode.
@@ -1061,7 +1061,7 @@ class ZBL(Pair):
     r"""ZBL pair force.
 
     Args:
-        nlist (`hoomd.md.nlist.NeighborList`): Neighbor list.
+        nlist (hoomd.md.nlist.NeighborList): Neighbor list.
         default_r_cut (float): Default cutoff radius :math:`[\mathrm{length}]`.
         default_r_on (float): Default turn-on radius :math:`[\mathrm{length}]`.
 
@@ -1138,7 +1138,7 @@ class Mie(Pair):
     r"""Mie pair force.
 
     Args:
-        nlist (`hoomd.md.nlist.NeighborList`): Neighbor list
+        nlist (hoomd.md.nlist.NeighborList): Neighbor list
         default_r_cut (float): Default cutoff radius :math:`[\mathrm{length}]`.
         default_r_on (float): Default turn-on radius :math:`[\mathrm{length}]`.
         mode (str): Energy shifting/smoothing mode.
@@ -1202,7 +1202,7 @@ class ExpandedMie(Pair):
     r"""Expanded Mie pair force.
 
     Args:
-        nlist (`hoomd.md.nlist.NeighborList`): Neighbor list.
+        nlist (hoomd.md.nlist.NeighborList): Neighbor list.
         default_r_cut (float): Default cutoff radius :math:`[\mathrm{length}]`.
         default_r_on (float): Default turn-on radius :math:`[\mathrm{length}]`.
         mode (str): Energy shifting/smoothing mode.
@@ -1275,7 +1275,7 @@ class ReactionField(Pair):
     r"""Onsager reaction field pair force.
 
     Args:
-        nlist (`hoomd.md.nlist.NeighborList`): Neighbor list.
+        nlist (hoomd.md.nlist.NeighborList): Neighbor list.
         default_r_cut (float): Default cutoff radius :math:`[\mathrm{length}]`.
         default_r_on (float): Default turn-on radius :math:`[\mathrm{length}]`.
         mode (str): Energy shifting/smoothing mode.
@@ -1355,7 +1355,7 @@ class DLVO(Pair):
     r"""DLVO colloidal interaction.
 
     Args:
-        nlist (`hoomd.md.nlist.NeighborList`): Neighbor list.
+        nlist (hoomd.md.nlist.NeighborList): Neighbor list.
         default_r_cut (float): Default cutoff radius :math:`[\mathrm{length}]`.
         default_r_on (float): Default turn-on radius :math:`[\mathrm{length}]`.
         name (str): Name of the force instance.
@@ -1439,7 +1439,7 @@ class Buckingham(Pair):
     r"""Buckingham pair force.
 
     Args:
-        nlist (`hoomd.md.nlist.NeighborList`): Neighbor list.
+        nlist (hoomd.md.nlist.NeighborList): Neighbor list.
         default_r_cut (float): Default cutoff radius :math:`[\mathrm{length}]`.
         default_r_on (float): Default turn-on radius :math:`[\mathrm{length}]`.
         mode (str): Energy shifting/smoothing mode.
@@ -1491,7 +1491,7 @@ class LJ1208(Pair):
     r"""Lennard-Jones 12-8 pair force.
 
     Args:
-        nlist (`hoomd.md.nlist.NeighborList`): Neighbor list.
+        nlist (hoomd.md.nlist.NeighborList): Neighbor list.
         default_r_cut (float): Default cutoff radius :math:`[\mathrm{length}]`.
         default_r_on (float): Default turn-on radius :math:`[\mathrm{length}]`.
         mode (str): Energy shifting/smoothing mode.
@@ -1542,7 +1542,7 @@ class LJ0804(Pair):
     r"""Lennard-Jones 8-4 pair force.
 
     Args:
-        nlist (`hoomd.md.nlist.NeighborList`): Neighbor list.
+        nlist (hoomd.md.nlist.NeighborList): Neighbor list.
         default_r_cut (float): Default cutoff radius :math:`[\mathrm{length}]`.
         default_r_on (float): Default turn-on radius :math:`[\mathrm{length}]`.
         mode (str): Energy shifting/smoothing mode.
@@ -1594,7 +1594,7 @@ class Fourier(Pair):
     r"""Fourier pair force.
 
     Args:
-        nlist (`hoomd.md.nlist.NeighborList`): Neighbor list.
+        nlist (hoomd.md.nlist.NeighborList): Neighbor list.
         default_r_cut (float): Default cutoff radius :math:`[\mathrm{length}]`.
         default_r_on (float): Default turn-on radius :math:`[\mathrm{length}]`.
         mode (str): Energy shifting/smoothing mode.
@@ -1657,7 +1657,7 @@ class OPP(Pair):
     r"""Oscillating pair force.
 
     Args:
-        nlist (:py:mod:`hoomd.md.nlist.NeighborList`): Neighbor list.
+        nlist (hoomd.md.nlist.NeighborList): Neighbor list.
         default_r_cut (float): Default cutoff radius :math:`[\mathrm{length}]`.
         default_r_on (float): Default turn-on radius :math:`[\mathrm{length}]`.
         mode (str): Energy shifting/smoothing mode.
@@ -1733,7 +1733,7 @@ class TWF(Pair):
     r"""Pair potential model for globular proteins.
 
     Args:
-        nlist (`hoomd.md.nlist.NeighborList`): Neighbor list.
+        nlist (hoomd.md.nlist.NeighborList): Neighbor list.
         default_r_cut (float): Default cutoff radius :math:`[\mathrm{length}]`.
         default_r_on (float): Default turn-on radius :math:`[\mathrm{length}]`.
         mode (str): Energy shifting/smoothing mode.
@@ -1800,7 +1800,7 @@ class LJGauss(Pair):
     r"""Lennard-Jones-Gauss pair potential.
 
     Args:
-        nlist (`hoomd.md.nlist.NeighborList`): Neighbor list.
+        nlist (hoomd.md.nlist.NeighborList): Neighbor list.
         default_r_cut (float): Default cutoff radius :math:`[\mathrm{length}]`.
         default_r_on (float): Default turn-on radius :math:`[\mathrm{length}]`.
         mode (str): Energy shifting/smoothing mode.

--- a/hoomd/md/pair/pair.py
+++ b/hoomd/md/pair/pair.py
@@ -18,9 +18,11 @@ from hoomd.data.typeconverter import OnlyFrom, nonnegative_real
 class Pair(force.Force):
     r"""Base class pair force.
 
-    Note:
-        :py:class:`Pair` is the base class for all pair forces. Users should
-        not instantiate this class directly.
+    :py:class:`Pair` is the base class for all pair forces.
+
+    Warning:
+        This class should not be instantiated by users. The class can be used
+        for `isinstance` or `issubclass` checks.
 
     .. py:attribute:: r_cut
 

--- a/hoomd/md/special_pair.py
+++ b/hoomd/md/special_pair.py
@@ -48,7 +48,7 @@ import hoomd
 class SpecialPair(Force):
     """Base class special pair forces.
 
-    :py:class:`SpecialPair` is the base class for all special pair forces.
+    `SpecialPair` is the base class for all special pair forces.
 
     Warning:
         This class should not be instantiated by users. The class can be used

--- a/hoomd/md/special_pair.py
+++ b/hoomd/md/special_pair.py
@@ -48,9 +48,11 @@ import hoomd
 class SpecialPair(Force):
     """Base class special pair forces.
 
-    Note:
-        :py:class:`SpecialPair` is the base class for all special pair
-        forces. Users should not instantiate this class directly.
+    :py:class:`SpecialPair` is the base class for all special pair forces.
+
+    Warning:
+        This class should not be instantiated by users. The class can be used
+        for `isinstance` or `issubclass` checks.
     """
 
     def __init__(self):

--- a/hoomd/md/update.py
+++ b/hoomd/md/update.py
@@ -74,10 +74,10 @@ class ReversePerturbationFlow(Updater):
     "max" and "min" slab might be swapped.
 
     Args:
-        filter (`hoomd.filter.ParticleFilter`): Subset of particles on which to
+        filter (hoomd.filter.ParticleFilter): Subset of particles on which to
             apply this updater.
 
-        flow_target (`hoomd.variant.Variant`): Target value of the
+        flow_target (hoomd.variant.Variant): Target value of the
             time-integrated momentum flux.
             :math:`[\\delta t \\cdot \\mathrm{mass} \\cdot \\mathrm{length}
             \\cdot \\mathrm{time}^{-1}]` - where :math:`\\delta t` is the

--- a/hoomd/operation.py
+++ b/hoomd/operation.py
@@ -297,6 +297,10 @@ class Operation(_HOOMDBaseObject):
     inherit from one of these five base classes. To find the purpose of each
     class see its documentation.
 
+    Warning:
+        This class should not be instantiated by users. The class can be used
+        for `isinstance` or `issubclass` checks.
+
     Note:
         Developers or those contributing to HOOMD-blue, see our architecture
         `file`_ for information on HOOMD-blue's architecture decisions regarding
@@ -310,7 +314,7 @@ class Operation(_HOOMDBaseObject):
 class TriggeredOperation(Operation):
     """Operations that include a trigger to determine when to run.
 
-    Note:
+    Warning:
         This class should not be instantiated by users. The class can be used
         for `isinstance` or `issubclass` checks.
     """
@@ -326,7 +330,7 @@ class Updater(TriggeredOperation):
 
     An updater is an operation which modifies a simulation's state.
 
-    Note:
+    Warning:
         This class should not be instantiated by users. The class can be used
         for `isinstance` or `issubclass` checks.
     """
@@ -338,7 +342,7 @@ class Writer(TriggeredOperation):
 
     A writer is an operation which writes out a simulation's state.
 
-    Note:
+    Warning:
         This class should not be instantiated by users. The class can be used
         for `isinstance` or `issubclass` checks.
     """
@@ -351,7 +355,7 @@ class Compute(Operation):
     A compute is an operation which computes some property for another operation
     or use by a user.
 
-    Note:
+    Warning:
         This class should not be instantiated by users. The class can be used
         for `isinstance` or `issubclass` checks.
     """
@@ -366,7 +370,7 @@ class Tuner(TriggeredOperation):
     of the simulation. That is a tuner does not change quantities like
     temperature, particle position, or the number of bonds in a simulation.
 
-    Note:
+    Warning:
         This class should not be instantiated by users. The class can be used
         for `isinstance` or `issubclass` checks.
     """
@@ -381,7 +385,7 @@ class Integrator(Operation):
     `hoomd.md`, the `hoomd.md.Integrator` class organizes the forces, equations
     of motion, and other factors of the given simulation.
 
-    Note:
+    Warning:
         This class should not be instantiated by users. The class can be used
         for `isinstance` or `issubclass` checks.
     """

--- a/hoomd/operations.py
+++ b/hoomd/operations.py
@@ -83,7 +83,7 @@ class Operations(Collection):
         `Operations` instance.
 
         Args:
-            operation (`hoomd.operation.Operation`): A HOOMD-blue tuner,
+            operation (hoomd.operation.Operation): A HOOMD-blue tuner,
                 updater, integrator, writer, or compute to add to the
                 collection.
 
@@ -118,7 +118,7 @@ class Operations(Collection):
         """Works the same as `Operations.add`.
 
         Args:
-            operation (`hoomd.operation.Operation`): A HOOMD-blue tuner,
+            operation (hoomd.operation.Operation): A HOOMD-blue tuner,
                 updater, integrator, writer, or compute to add to the object.
         """
         self.add(operation)
@@ -131,7 +131,7 @@ class Operations(Collection):
         as ``operation``.
 
         Args:
-            operation (`hoomd.operation.Operation`): A HOOMD-blue integrator,
+            operation (hoomd.operation.Operation): A HOOMD-blue integrator,
                 tuner, updater, integrator, or compute to remove from the
                 container.
 
@@ -153,7 +153,7 @@ class Operations(Collection):
         """Works the same as `Operations.remove`.
 
         Args:
-            operation (`hoomd.operation.Operation`): A HOOMD-blue integrator,
+            operation (hoomd.operation.Operation): A HOOMD-blue integrator,
                 tuner, updater, integrator, analyzer, or compute to remove from
                 the collection.
         """

--- a/hoomd/simulation.py
+++ b/hoomd/simulation.py
@@ -19,7 +19,7 @@ class Simulation(metaclass=Loggable):
     """Define a simulation.
 
     Args:
-        device (`hoomd.device.Device`): Device to execute the simulation.
+        device (hoomd.device.Device): Device to execute the simulation.
         seed (int): Random number seed.
 
     `Simulation` is the central class that defines a simulation, including the
@@ -350,11 +350,11 @@ class Simulation(metaclass=Loggable):
         """bool: Always compute the virial and pressure (defaults to ``False``).
 
         By default, HOOMD only computes the virial and pressure on timesteps
-        where it is needed (when :py:class:`hoomd.write.GSD` writes
+        where it is needed (when `hoomd.write.GSD` writes
         log data to a file or when using an NPT integrator). Set
         `always_compute_pressure` to True to make the per particle virial,
         net virial, and system pressure available to query any time by property
-        or through the :py:class:`hoomd.logging.Logger` interface.
+        or through the `hoomd.logging.Logger` interface.
 
         Note:
             Enabling this flag will result in a moderate performance penalty

--- a/hoomd/snapshot.py
+++ b/hoomd/snapshot.py
@@ -327,7 +327,7 @@ class Snapshot:
         """Constructs a `hoomd.Snapshot` from a `gsd.hoomd.Snapshot` object.
 
         Args:
-            gsd_snap (`gsd.hoomd.Snapshot`): The gsd snapshot to convert to a
+            gsd_snap (gsd.hoomd.Snapshot): The gsd snapshot to convert to a
                 `hoomd.Snapshot`.
             communicator (hoomd.communicator.Communicator): The MPI communicator
                 to use for the snapshot. This prevents the snapshot from being

--- a/hoomd/tune/attr_tuner.py
+++ b/hoomd/tune/attr_tuner.py
@@ -249,7 +249,7 @@ class SolverStep(metaclass=ABCMeta):
         """Takes in a tunable object and attempts to solve x for a specified y.
 
         Args:
-            tunable (`hoomd.tune.ManualTuneDefinition`): A tunable object that
+            tunable (hoomd.tune.ManualTuneDefinition): A tunable object that
                 represents a relationship of f(x) = y.
 
         Returns:

--- a/hoomd/tune/balance.py
+++ b/hoomd/tune/balance.py
@@ -15,11 +15,11 @@ class LoadBalancer(Tuner):
     Args:
         trigger (hoomd.trigger.Trigger): Select the timesteps on which to
             perform load balancing.
-        x (`bool`): Balance the **x** direction when `True`.
-        y (`bool`): Balance the **y** direction when `True`.
-        z (`bool`): Balance the **z** direction when `True`.
-        tolerance (`float`): Load imbalance tolerance.
-        max_iterations (`int`): Maximum number of iterations to
+        x (bool): Balance the **x** direction when `True`.
+        y (bool): Balance the **y** direction when `True`.
+        z (bool): Balance the **z** direction when `True`.
+        tolerance (float): Load imbalance tolerance.
+        max_iterations (int): Maximum number of iterations to
             attempt in a single step.
 
     `LoadBalancer` adjusts the boundaries of the MPI domains to distribute
@@ -77,11 +77,11 @@ class LoadBalancer(Tuner):
     Attributes:
         trigger (hoomd.trigger.Trigger): Select the timesteps on which to
             perform load balancing.
-        x (`bool`): Balance the **x** direction when `True`.
-        y (`bool`): Balance the **y** direction when `True`.
-        z (`bool`): Balance the **z** direction when `True`.
-        tolerance (`float`): Load imbalance tolerance.
-        max_iterations (`int`): Maximum number of iterations to
+        x (bool): Balance the **x** direction when `True`.
+        y (bool): Balance the **y** direction when `True`.
+        z (bool): Balance the **z** direction when `True`.
+        tolerance (float): Load imbalance tolerance.
+        max_iterations (int): Maximum number of iterations to
             attempt in a single step.
     """
 

--- a/hoomd/update/remove_drift.py
+++ b/hoomd/update/remove_drift.py
@@ -17,7 +17,7 @@ class RemoveDrift(Updater):
     Args:
         reference_positions ((*N_particles*, 3) `numpy.ndarray` of `float`):
             the reference positions :math:`[\mathrm{length}]`.
-        trigger (`hoomd.trigger.Trigger`): Select the timesteps to remove drift.
+        trigger (hoomd.trigger.Trigger): Select the timesteps to remove drift.
 
     `RemoveDrift` computes the mean drift :math:`\vec{D}` from the
     given `reference_positions` (:math:`\vec{r}_{ref, i}`):
@@ -42,7 +42,7 @@ class RemoveDrift(Updater):
     Attributes:
         reference_positions ((*N_particles*, 3) `numpy.ndarray` of `float`):
             the reference positions :math:`[\mathrm{length}]`.
-        trigger (`hoomd.trigger.Trigger`): The timesteps to remove drift.
+        trigger (hoomd.trigger.Trigger): The timesteps to remove drift.
     """
 
     def __init__(self, reference_positions, trigger=1):

--- a/hoomd/variant.py
+++ b/hoomd/variant.py
@@ -140,11 +140,11 @@ class Cycle(_hoomd.VariantCycle, Variant):
         t_B (int): The hold time at the second value.
         t_BA (int): The time spent ramping from B to A.
 
-    :py:class:`Cycle` holds the value *A* until time *t_start*. It continues
-    holding that value until *t_start + t_A*. Then it ramps linearly from *A* to
-    *B* over *t_AB* steps and holds the value *B* for *t_B* steps. After this,
-    it ramps back from *B* to *A* over *t_BA* steps and repeats the cycle
-    starting with *t_A*. :py:class:`Cycle` repeats this cycle indefinitely.
+    `Cycle` holds the value *A* until time *t_start*. It continues holding that
+    value until *t_start + t_A*. Then it ramps linearly from *A* to *B* over
+    *t_AB* steps and holds the value *B* for *t_B* steps. After this, it ramps
+    back from *B* to *A* over *t_BA* steps and repeats the cycle starting with
+    *t_A*. `Cycle` repeats this cycle indefinitely.
 
     .. image:: variant-cycle.svg
        :alt: Example plot of a cycle variant.
@@ -177,9 +177,9 @@ class Power(_hoomd.VariantPower, Variant):
         t_start (int): The start time step.
         t_ramp (int): The length of the ramp.
 
-    :py:class:`Power` holds the value *A* until time *t_start*. Then it
-    progresses at :math:`t^{\\mathrm{power}}` from *A* to *B* over *t_ramp*
-    steps and holds the value *B* after that.
+    `Power` holds the value *A* until time *t_start*. Then it progresses at
+    :math:`t^{\\mathrm{power}}` from *A* to *B* over *t_ramp* steps and holds
+    the value *B* after that.
 
     .. code-block:: python
 

--- a/hoomd/wall.py
+++ b/hoomd/wall.py
@@ -53,7 +53,7 @@ class Sphere(WallGeometry):
     r"""A sphere.
 
     Args:
-        radius (`float`):
+        radius (float):
             The radius of the sphere :math:`[\mathrm{length}]`.
         origin (`tuple` [`float`, `float`, `float`], optional):
             The origin of the sphere, defaults to ``(0, 0, 0)``
@@ -134,7 +134,7 @@ class Cylinder(WallGeometry):
     r"""A right circular cylinder.
 
     Args:
-        radius (`float`):
+        radius (float):
             The radius of the circle faces of the cylinder
             :math:`[\mathrm{length}]`.
         axis (`tuple` [`float`, `float`, `float`]):

--- a/hoomd/write/gsd.py
+++ b/hoomd/write/gsd.py
@@ -201,10 +201,9 @@ class GSD(Writer):
         Args:
             state (State): Simulation state.
             filename (str): File name to write.
-            filter (`hoomd.filter.ParticleFilter`): Select the particles to
-              write.
+            filter (hoomd.filter.ParticleFilter): Select the particles to write.
             mode (str): The file open mode. Defaults to ``'wb'``.
-            log (`hoomd.logging.Logger`): Provide log quantities to write.
+            log (hoomd.logging.Logger): Provide log quantities to write.
 
         The valid file modes for `write` are ``'wb'`` and ``'xb'``.
         """


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should be based on *trunk-patch*. -->
<!-- Backwards compatible new features should be based on *trunk-minor*. -->
<!-- Incompatible API changes should be based on *trunk-major*. -->

## Description

Uses the Warning label for a warning to not directly instantiate a base class.
Also remove redundant roles and backticks.

<!-- Describe your changes in detail. -->

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves #1307

## How has this been tested?

Documentation builds without warning
<!--- Please describe in detail how you tested your changes. -->

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```

```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
