### PR TITLE
Find clang correctly in relocated conda-forge builds

### DIFF
--- a/hoomd/hpmc/ClangCompiler.cc
+++ b/hoomd/hpmc/ClangCompiler.cc
@@ -126,7 +126,11 @@ std::unique_ptr<llvm::Module> ClangCompiler::compileCode(const std::string& code
     std::cout << "##  ###  ###     ###     ##     ##        ##  ##" << std::endl;
     std::cout << "################################################" << std::endl;
     std::cout << "resource_path = " << resource_path << std::endl;
-    std::cout << "clang_args = " << clang_arg_c_strings << std::endl;
+    std::cout << "clang_args = " << std::endl;
+    for (int i = 0; i < clang_args.size(); i++)
+        {
+        std::cout << clang_args[i] << std::endl;
+        }
     clang::driver::Driver driver(resource_path + "/bin/clang",
                                  llvm::sys::getDefaultTargetTriple(),
                                  diagnostics_engine);

--- a/hoomd/hpmc/ClangCompiler.cc
+++ b/hoomd/hpmc/ClangCompiler.cc
@@ -126,7 +126,7 @@ std::unique_ptr<llvm::Module> ClangCompiler::compileCode(const std::string& code
     std::cout << "##  ###  ###     ###     ##     ##        ##  ##" << std::endl;
     std::cout << "################################################" << std::endl;
     std::cout << "resource_path = " << resource_path << std::endl;
-    std::cout << "clang_args = " << clang_args_c_strings << std::endl;
+    std::cout << "clang_args = " << clang_arg_c_strings << std::endl;
     clang::driver::Driver driver(resource_path + "/bin/clang",
                                  llvm::sys::getDefaultTargetTriple(),
                                  diagnostics_engine);

--- a/hoomd/hpmc/ClangCompiler.cc
+++ b/hoomd/hpmc/ClangCompiler.cc
@@ -95,13 +95,14 @@ std::unique_ptr<llvm::Module> ClangCompiler::compileCode(const std::string& code
     // Store the LLVM installation prefix in a volatile char array so that "/bin/clang" can be added
     // at runtime instead of compile time. When it is added at compile time, conda rewrites an
     // embedded string "$BUILD_PREFIX/bin/clang" with "$INSTALL_PREFIX", truncating the string.
-    volatile const char *llvm_install_prefix = HOOMD_LLVM_INSTALL_PREFIX;
+    volatile const char* llvm_install_prefix = HOOMD_LLVM_INSTALL_PREFIX;
 
     // standard string methods do not accept volatile char arrays, extract the string manually
     std::string clang_exec_with_path;
-    for (volatile const char* c = llvm_install_prefix ; *c != 0; ++c) {
+    for (volatile const char* c = llvm_install_prefix; *c != 0; ++c)
+        {
         clang_exec_with_path.push_back(*c);
-    }
+        }
     clang_exec_with_path += "/bin/clang";
 
     // build up the argument list
@@ -129,7 +130,7 @@ std::unique_ptr<llvm::Module> ClangCompiler::compileCode(const std::string& code
     // see also:
     // https://cpp.hotexamples.com/examples/-/CompilerInstance/-/cpp-compilerinstance-class-examples.html
     struct stat buffer;
-    if (stat (clang_exec_with_path.c_str(), &buffer) != 0)
+    if (stat(clang_exec_with_path.c_str(), &buffer) != 0)
         {
         out << "Error: cannot find " << clang_exec_with_path << std::endl;
         return nullptr;

--- a/hoomd/hpmc/ClangCompiler.cc
+++ b/hoomd/hpmc/ClangCompiler.cc
@@ -30,7 +30,7 @@
 
 #include <iostream>
 #include <sstream>
-#include <filesystem>
+#include <sys/stat.h>
 
 namespace hoomd
     {
@@ -128,7 +128,8 @@ std::unique_ptr<llvm::Module> ClangCompiler::compileCode(const std::string& code
     // https://cpp.hotexamples.com/site/file?hash=0xd4e048edbee7a77d7b2181909e61ab1a1213629fe8aa79248fea8ae17f8dc7fc&fullName=safecode-mirror-master/tools/clang/examples/main.cpp&project=lygstate/safecode-mirror
     // see also:
     // https://cpp.hotexamples.com/examples/-/CompilerInstance/-/cpp-compilerinstance-class-examples.html
-    if (!std::filesystem::exists(clang_exec_with_path))
+    struct stat buffer;
+    if (stat (clang_exec_with_path.c_str(), &buffer) != 0)
         {
         out << "Error: cannot find " << clang_exec_with_path << std::endl;
         return nullptr;

--- a/hoomd/hpmc/ClangCompiler.cc
+++ b/hoomd/hpmc/ClangCompiler.cc
@@ -125,7 +125,7 @@ std::unique_ptr<llvm::Module> ClangCompiler::compileCode(const std::string& code
     std::cout << "##  ###  ###  ######  #####  #####  ####  ######" << std::endl;
     std::cout << "##  ###  ###     ###     ##     ##        ##  ##" << std::endl;
     std::cout << "################################################" << std::endl;
-    std::cout << "HOOMD_LLVM_INSTALL_PREFIX " << HOOMD_LLVM_INSTALL_PREFIX << std::endl;
+    std::cout << "HOOMD_LLVM_INSTALL_PREFIX =" << HOOMD_LLVM_INSTALL_PREFIX << std::endl;
     std::cout << "resource_path = " << resource_path << std::endl;
     std::cout << "clang_args = " << std::endl;
     for (int i = 0; i < clang_args.size(); i++)

--- a/hoomd/hpmc/ClangCompiler.cc
+++ b/hoomd/hpmc/ClangCompiler.cc
@@ -28,7 +28,6 @@
 
 #pragma GCC diagnostic pop
 
-#include <fstream>
 #include <iostream>
 #include <sstream>
 #include <filesystem>
@@ -129,28 +128,10 @@ std::unique_ptr<llvm::Module> ClangCompiler::compileCode(const std::string& code
     // https://cpp.hotexamples.com/site/file?hash=0xd4e048edbee7a77d7b2181909e61ab1a1213629fe8aa79248fea8ae17f8dc7fc&fullName=safecode-mirror-master/tools/clang/examples/main.cpp&project=lygstate/safecode-mirror
     // see also:
     // https://cpp.hotexamples.com/examples/-/CompilerInstance/-/cpp-compilerinstance-class-examples.html
-    std::cout << "################################################" << std::endl;
-    std::cout << "##  ###  ###     ###  #####  #####        ##  ##" << std::endl;
-    std::cout << "##  ###  ###  ######  #####  #####  ####  ##  ##" << std::endl;
-    std::cout << "##       ###     ###  #####  #####  ####  ##  ##" << std::endl;
-    std::cout << "##  ###  ###  ######  #####  #####  ####  ######" << std::endl;
-    std::cout << "##  ###  ###     ###     ##     ##        ##  ##" << std::endl;
-    std::cout << "################################################" << std::endl;
-    std::cout << "HOOMD_LLVM_INSTALL_PREFIX =" << HOOMD_LLVM_INSTALL_PREFIX << std::endl;
-    std::cout << "clang_exec_with_path = " << clang_exec_with_path << std::endl;
-    std::cout << "clang_args = " << std::endl;
-    for (unsigned int i = 0; i < clang_args.size(); i++)
-        {
-        std::cout << clang_args[i] << std::endl;
-        }
-
     if (!std::filesystem::exists(clang_exec_with_path))
         {
-        throw std::runtime_error("cannot find $PREFIX/bin/clang");
-        }
-    else
-        {
-        std::cout << "found clang in " << clang_exec_with_path << std::endl;
+        out << "Error: cannot find " << clang_exec_with_path << std::endl;
+        return nullptr;
         }
 
     clang::driver::Driver driver(clang_exec_with_path,

--- a/hoomd/hpmc/ClangCompiler.cc
+++ b/hoomd/hpmc/ClangCompiler.cc
@@ -28,6 +28,7 @@
 
 #pragma GCC diagnostic pop
 
+#include <fstream>
 #include <iostream>
 #include <sstream>
 

--- a/hoomd/hpmc/ClangCompiler.cc
+++ b/hoomd/hpmc/ClangCompiler.cc
@@ -125,6 +125,7 @@ std::unique_ptr<llvm::Module> ClangCompiler::compileCode(const std::string& code
     std::cout << "##  ###  ###  ######  #####  #####  ####  ######" << std::endl;
     std::cout << "##  ###  ###     ###     ##     ##        ##  ##" << std::endl;
     std::cout << "################################################" << std::endl;
+    std::cout << "HOOMD_LLVM_INSTALL_PREFIX " << HOOMD_LLVM_INSTALL_PREFIX << std::endl;
     std::cout << "resource_path = " << resource_path << std::endl;
     std::cout << "clang_args = " << std::endl;
     for (int i = 0; i < clang_args.size(); i++)

--- a/hoomd/hpmc/ClangCompiler.cc
+++ b/hoomd/hpmc/ClangCompiler.cc
@@ -134,11 +134,17 @@ std::unique_ptr<llvm::Module> ClangCompiler::compileCode(const std::string& code
         std::cout << clang_args[i] << std::endl;
         }
     std::string clang_exec_with_path = resource_path + "/bin/clang";
-    std::ifstream f(clang_exec_with_path.c_str());
-    if (!f.good())
+    std::ifstream clang_file;
+    clang_file.open(clang_exec_with_path.c_str());
+    if (!clang_file)
         {
         throw std::runtime_error("cannot find $PREFIX/bin/clang");
         }
+    else
+        {
+        std::cout << "found clang in " << clang_exec_with_path.c_str() << std::endl;
+        }
+    clang_file.close();
 
     clang::driver::Driver driver(resource_path + "/bin/clang",
                                  llvm::sys::getDefaultTargetTriple(),

--- a/hoomd/hpmc/ClangCompiler.cc
+++ b/hoomd/hpmc/ClangCompiler.cc
@@ -118,6 +118,15 @@ std::unique_ptr<llvm::Module> ClangCompiler::compileCode(const std::string& code
     // https://cpp.hotexamples.com/site/file?hash=0xd4e048edbee7a77d7b2181909e61ab1a1213629fe8aa79248fea8ae17f8dc7fc&fullName=safecode-mirror-master/tools/clang/examples/main.cpp&project=lygstate/safecode-mirror
     // see also:
     // https://cpp.hotexamples.com/examples/-/CompilerInstance/-/cpp-compilerinstance-class-examples.html
+    std::cout << "################################################" << std::endl;
+    std::cout << "##  ###  ###     ###  #####  #####        ##  ##" << std::endl;
+    std::cout << "##  ###  ###  ######  #####  #####  ####  ##  ##" << std::endl;
+    std::cout << "##       ###     ###  #####  #####  ####  ##  ##" << std::endl;
+    std::cout << "##  ###  ###  ######  #####  #####  ####  ######" << std::endl;
+    std::cout << "##  ###  ###     ###     ##     ##        ##  ##" << std::endl;
+    std::cout << "################################################" << std::endl;
+    std::cout << "resource_path = " << resource_path << std::endl;
+    std::cout << "clang_args = " << clang_args_c_strings << std::endl;
     clang::driver::Driver driver(resource_path + "/bin/clang",
                                  llvm::sys::getDefaultTargetTriple(),
                                  diagnostics_engine);

--- a/hoomd/hpmc/ClangCompiler.cc
+++ b/hoomd/hpmc/ClangCompiler.cc
@@ -92,8 +92,7 @@ std::unique_ptr<llvm::Module> ClangCompiler::compileCode(const std::string& code
                                                 false);
 
     // determine the clang resource path
-    // std::string resource_path(HOOMD_LLVM_INSTALL_PREFIX);
-    std::string resource_path = "$PREFIX";
+    std::string resource_path(HOOMD_LLVM_INSTALL_PREFIX);
 
     // build up the argument list
     std::vector<std::string> clang_args;
@@ -133,6 +132,13 @@ std::unique_ptr<llvm::Module> ClangCompiler::compileCode(const std::string& code
         {
         std::cout << clang_args[i] << std::endl;
         }
+    std::string clang_exec_with_path = resource_path + "/bin/clang";
+    ifstream f(clang_exec_with_path.c_str());
+    if (!f.good())
+        {
+        throw std::runtime_error("cannot find $PREFIX/bin/clang");
+        }
+
     clang::driver::Driver driver(resource_path + "/bin/clang",
                                  llvm::sys::getDefaultTargetTriple(),
                                  diagnostics_engine);

--- a/hoomd/hpmc/ClangCompiler.cc
+++ b/hoomd/hpmc/ClangCompiler.cc
@@ -133,7 +133,7 @@ std::unique_ptr<llvm::Module> ClangCompiler::compileCode(const std::string& code
         std::cout << clang_args[i] << std::endl;
         }
     std::string clang_exec_with_path = resource_path + "/bin/clang";
-    ifstream f(clang_exec_with_path.c_str());
+    std::ifstream f(clang_exec_with_path.c_str());
     if (!f.good())
         {
         throw std::runtime_error("cannot find $PREFIX/bin/clang");

--- a/hoomd/hpmc/ClangCompiler.cc
+++ b/hoomd/hpmc/ClangCompiler.cc
@@ -92,7 +92,8 @@ std::unique_ptr<llvm::Module> ClangCompiler::compileCode(const std::string& code
                                                 false);
 
     // determine the clang resource path
-    std::string resource_path(HOOMD_LLVM_INSTALL_PREFIX);
+    // std::string resource_path(HOOMD_LLVM_INSTALL_PREFIX);
+    std::string resource_path = "$PREFIX";
 
     // build up the argument list
     std::vector<std::string> clang_args;


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should be based on *trunk-patch*. -->
<!-- Backwards compatible new features should be based on *trunk-minor*. -->
<!-- Incompatible API changes should be based on *trunk-major*. -->

## Description

<!-- Describe your changes in detail. -->
Store the LLVM prefix path by itself in the data segment and append `/bin/clang` at runtime.

## Motivation and context

We would like to build the conda-forge binaries with `ENABLE_LLVM=on`.

Even though HOOMD uses `libclang` to perform the compilation, a `clang` executable is still needed to discover the correct header search path. To ensure that we use the correct `clang` executable, HOOMD embeds the path to LLVM found at compile time. In conda binary installations, the user install path is different from the install path at build time, so conda performs a search and replace to update these hard coded paths: https://docs.conda.io/projects/conda-build/en/latest/resources/make-relocatable.html

However, we found that conda replaced `BUILD_PREFIX/bin/clang` with `INSTALL_PREFIX`, truncating the `/bin/clang` (likely because it inserts a NULL character after the end of `INSTALL_PREFIX`). This leads to build errors when using HPMC patch potentials in conda environments with hoomd installed.

## How has this been tested?

This `hoomd-feedstock` pull request: https://github.com/conda-forge/hoomd-feedstock/pull/65

<!--- Please describe in detail how you tested your changes. -->

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
*Added*

- Set `ENABLE_LLVM=on` in conda binary builds.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
