### PR TITLE
Add diagnostic loggable properties to neighbor lists.

### DIFF
--- a/hoomd/Integrator.h
+++ b/hoomd/Integrator.h
@@ -135,6 +135,20 @@ class PYBIND11_EXPORT Integrator : public Updater
     void computeCallback(uint64_t timestep);
 #endif
 
+    /// Reset stats counters for children objects
+    virtual void resetStats()
+        {
+        for (auto& force : m_forces)
+            {
+            force->resetStats();
+            }
+
+        for (auto& constraint_force : m_constraint_forces)
+            {
+            constraint_force->resetStats();
+            }
+        }
+
     protected:
     /// The step size
     Scalar m_deltaT;

--- a/hoomd/md/ManifoldDiamond.h
+++ b/hoomd/md/ManifoldDiamond.h
@@ -105,12 +105,12 @@ class ManifoldDiamond
                      // accepted
         }
 
-    #ifndef __HIPCC__
+#ifndef __HIPCC__
     pybind11::tuple getN()
         {
         return pybind11::make_tuple(Nx, Ny, Nz);
         }
-    #endif
+#endif
 
     Scalar getEpsilon()
         {

--- a/hoomd/md/ManifoldEllipsoid.h
+++ b/hoomd/md/ManifoldEllipsoid.h
@@ -122,12 +122,12 @@ class ManifoldEllipsoid
         return c;
         };
 
-    #ifndef __HIPCC__
+#ifndef __HIPCC__
     pybind11::tuple getP()
         {
         return pybind11::make_tuple(Px, Py, Pz);
         }
-    #endif
+#endif
 
     static unsigned int dimension()
         {

--- a/hoomd/md/ManifoldGyroid.h
+++ b/hoomd/md/ManifoldGyroid.h
@@ -112,12 +112,12 @@ class ManifoldGyroid
         return 2;
         }
 
-    #ifndef __HIPCC__
+#ifndef __HIPCC__
     pybind11::tuple getN()
         {
         return pybind11::make_tuple(Nx, Ny, Nz);
         }
-    #endif
+#endif
 
     Scalar getEpsilon()
         {

--- a/hoomd/md/ManifoldPrimitive.h
+++ b/hoomd/md/ManifoldPrimitive.h
@@ -96,12 +96,12 @@ class ManifoldPrimitive
                      // accepted
         }
 
-    #ifndef __HIPCC__
+#ifndef __HIPCC__
     pybind11::tuple getN()
         {
         return pybind11::make_tuple(Nx, Ny, Nz);
         }
-    #endif
+#endif
 
     Scalar getEpsilon()
         {

--- a/hoomd/md/ManifoldSphere.h
+++ b/hoomd/md/ManifoldSphere.h
@@ -105,12 +105,12 @@ class ManifoldSphere
         return sqrt(R_sq);
         };
 
-    #ifndef __HIPCC__
+#ifndef __HIPCC__
     pybind11::tuple getP()
         {
         return pybind11::make_tuple(Px, Py, Pz);
         }
-    #endif
+#endif
 
     static unsigned int dimension()
         {

--- a/hoomd/md/ManifoldZCylinder.h
+++ b/hoomd/md/ManifoldZCylinder.h
@@ -102,12 +102,12 @@ class ManifoldZCylinder
         return sqrt(R_sq);
         };
 
-    #ifndef __HIPCC__
+#ifndef __HIPCC__
     pybind11::tuple getP()
         {
         return pybind11::make_tuple(Px, Py, Pz);
         }
-    #endif
+#endif
 
     static unsigned int dimension()
         {

--- a/hoomd/md/NeighborList.cc
+++ b/hoomd/md/NeighborList.cc
@@ -1806,7 +1806,8 @@ void export_NeighborList(pybind11::module& m)
         .def("estimateNNeigh", &NeighborList::estimateNNeigh)
         .def("getSmallestRebuild", &NeighborList::getSmallestRebuild)
         .def("getNumUpdates", &NeighborList::getNumUpdates)
-        .def("getNumExclusions", &NeighborList::getNumExclusions);
+        .def("getNumExclusions", &NeighborList::getNumExclusions)
+        .def_property_readonly("num_builds", &NeighborList::getNumUpdates);
 
     pybind11::enum_<NeighborList::storageMode>(nlist, "storageMode")
         .value("half", NeighborList::storageMode::half)

--- a/hoomd/md/NeighborListBinned.cc
+++ b/hoomd/md/NeighborListBinned.cc
@@ -204,7 +204,11 @@ void export_NeighborListBinned(pybind11::module& m)
         .def(pybind11::init<std::shared_ptr<SystemDefinition>, Scalar>())
         .def_property("deterministic",
                       &NeighborListBinned::getDeterministic,
-                      &NeighborListBinned::setDeterministic);
+                      &NeighborListBinned::setDeterministic)
+        .def("getDim",
+             &NeighborListBinned::getDim,
+             pybind11::return_value_policy::reference_internal)
+        .def("getNmax", &NeighborListBinned::getNmax);
     }
 
     } // end namespace detail

--- a/hoomd/md/NeighborListBinned.h
+++ b/hoomd/md/NeighborListBinned.h
@@ -54,6 +54,18 @@ class PYBIND11_EXPORT NeighborListBinned : public NeighborList
         return m_cl->getSortCellList();
         }
 
+    /// Get the dimensions of the cell list
+    const uint3& getDim() const
+        {
+        return m_cl->getDim();
+        }
+
+    /// Get number of memory slots allocated for each cell
+    const unsigned int getNmax() const
+        {
+        return m_cl->getNmax();
+        }
+
     protected:
     std::shared_ptr<CellList> m_cl; //!< The cell list
 

--- a/hoomd/md/NeighborListGPUBinned.cc
+++ b/hoomd/md/NeighborListGPUBinned.cc
@@ -207,7 +207,11 @@ void export_NeighborListGPUBinned(pybind11::module& m)
         .def("setTuningParam", &NeighborListGPUBinned::setTuningParam)
         .def_property("deterministic",
                       &NeighborListGPUBinned::getDeterministic,
-                      &NeighborListGPUBinned::setDeterministic);
+                      &NeighborListGPUBinned::setDeterministic)
+        .def("getDim",
+             &NeighborListGPUBinned::getDim,
+             pybind11::return_value_policy::reference_internal)
+        .def("getNmax", &NeighborListGPUBinned::getNmax);
     }
 
     } // end namespace detail

--- a/hoomd/md/NeighborListGPUBinned.h
+++ b/hoomd/md/NeighborListGPUBinned.h
@@ -75,6 +75,18 @@ class PYBIND11_EXPORT NeighborListGPUBinned : public NeighborListGPU
         return m_cl->getSortCellList();
         }
 
+    /// Get the dimensions of the cell list
+    const uint3& getDim() const
+        {
+        return m_cl->getDim();
+        }
+
+    /// Get number of memory slots allocated for each cell
+    const unsigned int getNmax() const
+        {
+        return m_cl->getNmax();
+        }
+
     protected:
     std::shared_ptr<CellList> m_cl; //!< The cell list
     unsigned int m_block_size;      //!< Block size to execute on the GPU

--- a/hoomd/md/PotentialPair.h
+++ b/hoomd/md/PotentialPair.h
@@ -215,6 +215,12 @@ template<class evaluator> class PotentialPair : public ForceCompute
         return type_shape_mapping;
         }
 
+    /// Reset stats counters for children objects
+    virtual void resetStats()
+        {
+        m_nlist->resetStats();
+        }
+
     protected:
     std::shared_ptr<NeighborList> m_nlist; //!< The neighborlist to use for the computation
     energyShiftMode m_shift_mode; //!< Store the mode with which to handle the energy shift at r_cut

--- a/hoomd/md/nlist.py
+++ b/hoomd/md/nlist.py
@@ -115,9 +115,18 @@ class NeighborList(_HOOMDBaseObject):
         """int: The shortest period between neighbor list rebuilds.
 
         `shortest_rebuild` is the smallest number of time steps between neighbor
-        list rebuilds during the previous `Simulation.run`.
+        list rebuilds since the last call to `Simulation.run`.
         """
         return self._cpp_obj.getSmallestRebuild()
+
+    @log(requires_run=True)
+    def num_builds(self):
+        """int: The number of neighbor list builds.
+
+        `num_builds` is the number of neighbor list rebuilds performed since the
+        last call to `Simulation.run`.
+        """
+        return self._cpp_obj.num_builds
 
     def _remove_dependent(self, obj):
         super()._remove_dependent(obj)

--- a/hoomd/md/nlist.py
+++ b/hoomd/md/nlist.py
@@ -119,7 +119,7 @@ class NeighborList(_HOOMDBaseObject):
         """
         return self._cpp_obj.getSmallestRebuild()
 
-    @log(requires_run=True)
+    @log(requires_run=True, default=False)
     def num_builds(self):
         """int: The number of neighbor list builds.
 
@@ -210,6 +210,28 @@ class Cell(NeighborList):
                                   self.buffer)
 
         super()._attach()
+
+    @log(requires_run=True, default=False, category='sequence')
+    def dimensions(self):
+        """tuple[int, int, int]: Cell list dimensions.
+
+        `dimensions` is the number of cells in the x, y, and z directions.
+
+        See Also:
+            `allocated_particles_per_cell`
+        """
+        print(dir(self._cpp_obj))
+        dimensions = self._cpp_obj.getDim()
+        return (dimensions.x, dimensions.y, dimensions.z)
+
+    @log(requires_run=True, default=False)
+    def allocated_particles_per_cell(self):
+        """int: Number of particle slots allocated per cell.
+
+        The total memory usage of `Cell` is proportional to the product of the
+        three cell list `dimensions` and the `allocated_particles_per_cell`.
+        """
+        return self._cpp_obj.getNmax()
 
 
 class Stencil(NeighborList):

--- a/hoomd/md/nlist.py
+++ b/hoomd/md/nlist.py
@@ -220,7 +220,6 @@ class Cell(NeighborList):
         See Also:
             `allocated_particles_per_cell`
         """
-        print(dir(self._cpp_obj))
         dimensions = self._cpp_obj.getDim()
         return (dimensions.x, dimensions.y, dimensions.z)
 

--- a/hoomd/md/pytest/test_nlist.py
+++ b/hoomd/md/pytest/test_nlist.py
@@ -163,7 +163,6 @@ def test_cell_properties(simulation_factory, lattice_snapshot_factory):
 
     assert nlist.num_builds == 10
     assert nlist.shortest_rebuild == 1
-    dim = nlist._cpp_obj.getDim()
     dim = nlist.dimensions
     assert len(dim) == 3
     assert dim >= (1, 1, 1)

--- a/hoomd/md/pytest/test_nlist.py
+++ b/hoomd/md/pytest/test_nlist.py
@@ -170,28 +170,15 @@ def test_cell_properties(simulation_factory, lattice_snapshot_factory):
 
 
 def test_logging():
+    base_loggables =  {
+        'shortest_rebuild': {'category': LoggerCategories.scalar,  'default': True},
+        'num_builds': {'category': LoggerCategories.scalar, 'default': False}
+    }
     logging_check(
-        hoomd.md.nlist.NeighborList, ('md', 'nlist'), {
-            'shortest_rebuild': {
-                'category': LoggerCategories.scalar,
-                'default': True
-            },
-            'num_builds': {
-                'category': LoggerCategories.scalar,
-                'default': False
-            },
-        })
+        hoomd.md.nlist.NeighborList, ('md', 'nlist'), base_loggables)
 
     logging_check(
-        hoomd.md.nlist.Cell, ('md', 'nlist'), {
-            'shortest_rebuild': {
-                'category': LoggerCategories.scalar,
-                'default': True
-            },
-            'num_builds': {
-                'category': LoggerCategories.scalar,
-                'default': False
-            },
+        hoomd.md.nlist.Cell, ('md', 'nlist'), {**base_loggables,
             'dimensions': {
                 'category': LoggerCategories.sequence,
                 'default': False

--- a/hoomd/md/pytest/test_nlist.py
+++ b/hoomd/md/pytest/test_nlist.py
@@ -170,15 +170,21 @@ def test_cell_properties(simulation_factory, lattice_snapshot_factory):
 
 
 def test_logging():
-    base_loggables =  {
-        'shortest_rebuild': {'category': LoggerCategories.scalar,  'default': True},
-        'num_builds': {'category': LoggerCategories.scalar, 'default': False}
+    base_loggables = {
+        'shortest_rebuild': {
+            'category': LoggerCategories.scalar,
+            'default': True
+        },
+        'num_builds': {
+            'category': LoggerCategories.scalar,
+            'default': False
+        }
     }
-    logging_check(
-        hoomd.md.nlist.NeighborList, ('md', 'nlist'), base_loggables)
+    logging_check(hoomd.md.nlist.NeighborList, ('md', 'nlist'), base_loggables)
 
     logging_check(
-        hoomd.md.nlist.Cell, ('md', 'nlist'), {**base_loggables,
+        hoomd.md.nlist.Cell, ('md', 'nlist'), {
+            **base_loggables,
             'dimensions': {
                 'category': LoggerCategories.sequence,
                 'default': False


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should be based on *trunk-patch*. -->
<!-- Backwards compatible new features should be based on *trunk-minor*. -->
<!-- Incompatible API changes should be based on *trunk-major*. -->

## Description

<!-- Describe your changes in detail. -->
- Add `num_builds` to `hoomd.md.nlist.NeibhborList`.
- Add `dimensions` to `hoomd.md.nlist.Cell`.
- Add `allocated_particles_per_cell` to `hoomd.md.nlist.Cell`.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
When testing and debugging performance and memory usage, it is useful to know how many neighbor list builds are performed and house much memory the cell list uses. HOOMD v2 used to print this information at the end of every run, but that was removed in v3.

v2 also used to provide statistics on the min/max/average neighbors per particle and particles per cell. This takes significant extra time to compute and is not as useful when testing.

<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves #1265

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
I added unit tests.

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
*Added*:

- ``hoomd.md.nlist.Neighborlist.num_builds`` property - The number of neighbor list builds since the last call to ``Simulation.run``.
- ``hoomd.md.nlist.Cell.dimensions`` property - The dimensions of the cell list.
- ``hoomd.md.nlist.Cell.allocated_particles_per_cell`` property -  The number of particle slots allocated per cell.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
