### PR TITLE
Allow Ctrl-C to raise an exception during a run.

### DIFF
--- a/hoomd/System.cc
+++ b/hoomd/System.cc
@@ -169,12 +169,12 @@ void System::run(uint64_t nsteps, bool write_at_start)
             }
 
         updateTPS();
-        }
 
-    // propagate Python exceptions related to signals
-    if (PyErr_CheckSignals() != 0)
-        {
-        throw pybind11::error_already_set();
+        // propagate Python exceptions related to signals
+        if (PyErr_CheckSignals() != 0)
+            {
+            throw pybind11::error_already_set();
+            }
         }
 
 #ifdef ENABLE_MPI


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should be based on *trunk-patch*. -->
<!-- Backwards compatible new features should be based on *trunk-minor*. -->
<!-- Incompatible API changes should be based on *trunk-major*. -->

## Description

<!-- Describe your changes in detail. -->
Fix a bug that delayed the `KeyboardInterrupt` exception until the end of the simulation run.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Users should be able to stop long runs with Ctrl-C and Jupyter's "Interrupt Kernel" menu option.

Resolves #1323 

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
I confirmed that Ctrl-C stops a `sim.run(1e9)` immediately.

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
Fixed:

- Pressing Ctrl-C or interrupting the kernel in Jupyter stops the run at the end of the current timestep.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
