### PR TITLE
fix: Adding non-default loggables explicitly.

### DIFF
--- a/hoomd/logging.py
+++ b/hoomd/logging.py
@@ -383,23 +383,23 @@ def log(func=None,
             loggable quantity, defaults to 'scalar'. See `LoggerCategories` for
             available types. Keyword only argument.
         default (`bool`, optional): Whether the quantity should be logged
-            by default, defaults to True. This is orthogonal to the loggable
-            quantity's type. An example would be performance orientated loggable
-            quantities.  Many users may not want to log such quantities even
-            when logging other quantities of that type. The default category
-            allows for these to be pass over by `Logger` objects by default.
-            Keyword only argument.
+            by default. Defaults to True. This is orthogonal to the loggable
+            quantity's type. Many users may not want to log such quantities even
+            when logging other quantities of that type. An example would be
+            performance orientated loggable quantities, like the number of
+            neighborlist builds. The `default` argument allows for these to be
+            skipped by `Logger` objects by default. Keyword only argument.
         requires_run (`bool`, optional): Whether this property requires the
             simulation to run before being accessible.
 
     Note:
         The namespace (where the loggable object is stored in the `Logger`
-        object's nested dictionary, is determined by the module/script and class
+        object's nested dictionary) is determined by the module/script and class
         name the loggable class comes from. In creating subclasses of
         `hoomd.custom.Action`, for instance, if the module the subclass is
         defined in is ``user.custom.action`` and the class name is ``Foo`` then
         the namespace used will be ``('user', 'custom', 'action', 'Foo')``. This
-        helps to prevent naming conflicts, and automate the logging
+        helps to prevent naming conflicts and automates the logging
         specification for developers and users.
 
     Example::
@@ -563,14 +563,14 @@ class Logger(_SafeNamespaceDict):
 
     `Logger` objects support two ways of discriminating what loggable quantities
     they will accept: ``categories`` and ``only_default`` (the constructor
-    arguments). Both of these are static meaning that once instantiated a
+    arguments). Both of these are static, meaning that once instantiated, a
     `Logger` object will not change the values of these two properties.
-    ``categories`` determines what if any types of loggable quantities (see
+    ``categories`` determines what types of loggable quantities (see
     `LoggerCategories`) are appropriate for a given `Logger` object. This helps
     logging backends determine if a `Logger` object is compatible. The
-    ``only_default`` flag determines whether generally undesired quantities
-    (e.g. performance measures) are logged when using `Logger.__iadd__` and
-    `Logger.add` without specifying quantities. In `Logger.add`, you can
+    ``only_default`` flag prevents rarely-used quantities (e.g. the number of
+    neighborlist builds) from being added to the logger when using `Logger.__iadd__`
+    and `Logger.add` without specifying them explicitly. In `Logger.add`, you can
     override the ``only_default`` flag by explicitly listing the quantities you
     want to add. On the other hand, ``categories`` is rigidly obeyed as it is a
     promise to logging backends.
@@ -596,7 +596,7 @@ class Logger(_SafeNamespaceDict):
             the only types of loggable quantities that can be logged by this
             logger. Defaults to allowing every type.
         only_default (`bool`, optional): Whether to log only quantities that are
-            logged by _default_. Defaults to ``True``. Non-default quantities
+            logged by default. Defaults to ``True``. Non-default quantities
             are typically measures of operation performance rather than
             information about simulation state.
     """

--- a/hoomd/logging.py
+++ b/hoomd/logging.py
@@ -568,11 +568,12 @@ class Logger(_SafeNamespaceDict):
     ``categories`` determines what if any types of loggable quantities (see
     `LoggerCategories`) are appropriate for a given `Logger` object. This helps
     logging backends determine if a `Logger` object is compatible. The
-    ``only_default`` flag affects performance by controlling whether available
-    quantities not commonly logged are skipped (the default) or logged.
-    You can override the ``only_default`` flag by explicitly listing the
-    quantities you want in `add`, but the same is not true with regards
-    to ``categories``.
+    ``only_default`` flag determines whether generally undesired quantities
+    (e.g. performance measures) are logged when using `Logger.__iadd__` and
+    `Logger.add` without specifying quantities. In `Logger.add`, you can
+    override the ``only_default`` flag by explicitly listing the quantities you
+    want to add. On the other hand, ``categories`` is rigidly obeyed as it is a
+    promise to logging backends.
 
     Note:
         The logger provides a way for users to create their own logger back
@@ -595,8 +596,9 @@ class Logger(_SafeNamespaceDict):
             the only types of loggable quantities that can be logged by this
             logger. Defaults to allowing every type.
         only_default (`bool`, optional): Whether to log only quantities that are
-            logged by "default". Defaults to ``True``. If ``False``, loggable
-            quantities that would slow performance are not be logged.
+            logged by _default_. Defaults to ``True``. Non-default quantities
+            are typically measures of operation performance rather than
+            information about simulation state.
     """
 
     def __init__(self, categories=None, only_default=True):

--- a/hoomd/logging.py
+++ b/hoomd/logging.py
@@ -624,12 +624,16 @@ class Logger(_SafeNamespaceDict):
         quantities."""
         return self._only_default
 
-    def _filter_quantities(self, quantities):
+    def _filter_quantities(self, quantities, force_quantities=False):
         for quantity in quantities:
+            if quantity.category not in self._categories:
+                continue
+            # Must be before default check to overwrite _only_default
+            if force_quantities:
+                yield quantity
             if self._only_default and not quantity.default:
                 continue
-            elif quantity.category in self._categories:
-                yield quantity
+            yield quantity
 
     def _get_loggables_by_name(self, obj, quantities):
         if quantities is None:
@@ -643,7 +647,7 @@ class Logger(_SafeNamespaceDict):
                     "object {} has not loggable quantities {}.".format(
                         obj, bad_keys))
             yield from self._filter_quantities(
-                map(lambda q: obj._export_dict[q], quantities))
+                map(lambda q: obj._export_dict[q], quantities), True)
 
     def add(self, obj, quantities=None, user_name=None):
         """Add loggables from obj to logger.

--- a/hoomd/logging.py
+++ b/hoomd/logging.py
@@ -629,11 +629,8 @@ class Logger(_SafeNamespaceDict):
             if quantity.category not in self._categories:
                 continue
             # Must be before default check to overwrite _only_default
-            if force_quantities:
+            if not self._only_default or quantity.default or force_quantities:
                 yield quantity
-            if self._only_default and not quantity.default:
-                continue
-            yield quantity
 
     def _get_loggables_by_name(self, obj, quantities):
         if quantities is None:

--- a/hoomd/logging.py
+++ b/hoomd/logging.py
@@ -569,11 +569,11 @@ class Logger(_SafeNamespaceDict):
     `LoggerCategories`) are appropriate for a given `Logger` object. This helps
     logging backends determine if a `Logger` object is compatible. The
     ``only_default`` flag prevents rarely-used quantities (e.g. the number of
-    neighborlist builds) from being added to the logger when using `Logger.__iadd__`
-    and `Logger.add` without specifying them explicitly. In `Logger.add`, you can
-    override the ``only_default`` flag by explicitly listing the quantities you
-    want to add. On the other hand, ``categories`` is rigidly obeyed as it is a
-    promise to logging backends.
+    neighborlist builds) from being added to the logger when
+    using`Logger.__iadd__` and `Logger.add` without specifying them explicitly.
+    In `Logger.add`, you can override the ``only_default`` flag by explicitly
+    listing the quantities you want to add. On the other hand, ``categories`` is
+    rigidly obeyed as it is a promise to logging backends.
 
     Note:
         The logger provides a way for users to create their own logger back

--- a/hoomd/logging.py
+++ b/hoomd/logging.py
@@ -728,10 +728,12 @@ class Logger(_SafeNamespaceDict):
                 name and category. If using a method it should not take
                 arguments or have defaults for all arguments.
         """
-        if isinstance(value, _LoggerEntry):
-            super().__setitem__(namespace, value)
-        else:
-            super().__setitem__(namespace, _LoggerEntry.from_tuple(value))
+        if not isinstance(value, _LoggerEntry):
+            value = _LoggerEntry.from_tuple(value)
+        if value.category not in self.categories:
+            raise ValueError(
+                "User specified loggable is not of an accepted category.")
+        super().__setitem__(namespace, value)
 
     def __iadd__(self, obj):
         """Add quantities from object or list of objects to logger.

--- a/hoomd/logging.py
+++ b/hoomd/logging.py
@@ -568,9 +568,9 @@ class Logger(_SafeNamespaceDict):
     ``categories`` determines what if any types of loggable quantities (see
     `LoggerCategories`) are appropriate for a given `Logger` object. This helps
     logging backends determine if a `Logger` object is compatible. The
-    ``only_default`` flag is mainly a convenience by allowing quantities not
-    commonly logged (but available) to be passed over unless explicitly asked
-    for. You can override the ``only_default`` flag by explicitly listing the
+    ``only_default`` flag affects performance by controlling whether available
+    quantities not commonly logged are skipped (the default) or logged.
+    You can override the ``only_default`` flag by explicitly listing the
     quantities you want in `add`, but the same is not true with regards
     to ``categories``.
 
@@ -595,9 +595,8 @@ class Logger(_SafeNamespaceDict):
             the only types of loggable quantities that can be logged by this
             logger. Defaults to allowing every type.
         only_default (`bool`, optional): Whether to log only quantities that are
-            logged by "default", defaults to ``True``. This mostly means that
-            performance centric loggable quantities will be passed over when
-            logging when false.
+            logged by "default". Defaults to ``True``. If ``False``, loggable
+            quantities that would slow performance are not be logged.
     """
 
     def __init__(self, categories=None, only_default=True):

--- a/hoomd/pytest/test_logging.py
+++ b/hoomd/pytest/test_logging.py
@@ -56,6 +56,10 @@ class DummyLoggable(metaclass=Loggable):
     def proplist(self):
         return [1, 2, 3]
 
+    @log(category="string", default=False)
+    def prop_nondefault(self):
+        return "foo"
+
     def __eq__(self, other):
         return isinstance(other, type(self))
 
@@ -242,7 +246,7 @@ class TestLogger:
         ])
 
         # Check when quantities is given
-        accepted_quantities = ['prop', 'proplist']
+        accepted_quantities = ['proplist', "prop_nondefault"]
         log_quanities = blank_logger._get_loggables_by_name(
             logged_obj, accepted_quantities)
         assert all([
@@ -275,10 +279,9 @@ class TestLogger:
 
         # Test multiple quantities
         blank_logger._dict = dict()
-        blank_logger.add(logged_obj, ['prop', 'proplist'])
-        expected_namespaces = [
-            base_namespace + ('prop',), base_namespace + ('proplist',)
-        ]
+        loggables = ['prop', 'proplist', "prop_nondefault"]
+        blank_logger.add(logged_obj, loggables)
+        expected_namespaces = [base_namespace + (name,) for name in loggables]
         assert all([ns in blank_logger for ns in expected_namespaces])
         assert len(blank_logger) == 2
 

--- a/hoomd/pytest/test_logging.py
+++ b/hoomd/pytest/test_logging.py
@@ -214,15 +214,14 @@ def base_namespace():
 class TestLogger:
 
     def test_setitem(self, blank_logger):
-        logger = blank_logger
-        logger['a'] = (5, '__eq__', 'scalar')
-        logger[('b', 'c')] = (5, '__eq__', 'scalar')
-        logger['c'] = (lambda: [1, 2, 3], 'sequence')
+        blank_logger['a'] = (5, '__eq__', 'scalar')
+        blank_logger[('b', 'c')] = (5, '__eq__', 'scalar')
+        blank_logger['c'] = (lambda: [1, 2, 3], 'sequence')
         for value in [dict(), list(), None, 5, (5, 2), (5, 2, 1)]:
             with raises(ValueError):
-                logger[('c', 'd')] = value
+                blank_logger[('c', 'd')] = value
         with raises(KeyError):
-            logger['a'] = (lambda: [1, 2, 3], 'sequence')
+            blank_logger['a'] = (lambda: [1, 2, 3], 'sequence')
 
     def test_add_single_quantity(self, blank_logger, log_quantity):
         blank_logger._add_single_quantity(None, log_quantity, None)

--- a/hoomd/pytest/test_table.py
+++ b/hoomd/pytest/test_table.py
@@ -32,7 +32,7 @@ class Identity:
 
 @pytest.fixture
 def logger():
-    logger = hoomd.logging.Logger(categories=['scalar'])
+    logger = hoomd.logging.Logger(categories=['scalar', "string"])
     logger[('dummy', 'loggable', 'int')] = (Identity(42000000), 'scalar')
     logger[('dummy', 'loggable', 'float')] = (Identity(3.1415), 'scalar')
     logger[('dummy', 'loggable', 'string')] = (Identity("foobarbaz"), 'string')

--- a/sphinx-doc/conf.py
+++ b/sphinx-doc/conf.py
@@ -59,7 +59,7 @@ author = 'The Regents of the University of Michigan'
 version = '3.1.0'
 release = '3.1.0'
 
-language = None
+language = "en"
 
 default_role = 'any'
 


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail. -->
Fixes #1328, by adding `force_quantities` to internal loggable filtering.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves #1328

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->
A test will be added soon.

## Change log

<!-- Propose a change log entry. -->
```
Fixed: Non-default loggables can now be explicitly specified using Logger.add.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
