### PR TITLE
Miscellaneous Logger fixes

### DIFF
--- a/hoomd/logging.py
+++ b/hoomd/logging.py
@@ -201,6 +201,7 @@ class _NamespaceFilter:
             yield name
         # Reset for next call of filter
         self._skip_next = False
+        self._last_name = None
 
 
 class _LoggerQuantity:

--- a/hoomd/logging.py
+++ b/hoomd/logging.py
@@ -139,7 +139,7 @@ class _NamespaceFilter:
             the logging namespace whenever encountered.
         base_names (set[str], optional): A set of names which indicate that the
             next encountered name in the string should be skipped. For example,
-            if a module hierarchy went like ``project.foo.bar.Bar`` and ``foo``
+            if a module hierarchy was structured as ``project.foo.bar.Bar`` and ``foo``
             directly imports ``Bar``, ``bar`` may not be desirable to have in
             the logging namespace since users interact with it via ``foo.Bar``.
             Currently, this only handles a single level of nesting like this.

--- a/hoomd/logging.py
+++ b/hoomd/logging.py
@@ -139,10 +139,11 @@ class _NamespaceFilter:
             the logging namespace whenever encountered.
         base_names (set[str], optional): A set of names which indicate that the
             next encountered name in the string should be skipped. For example,
-            if a module hierarchy was structured as ``project.foo.bar.Bar`` and ``foo``
-            directly imports ``Bar``, ``bar`` may not be desirable to have in
-            the logging namespace since users interact with it via ``foo.Bar``.
-            Currently, this only handles a single level of nesting like this.
+            if a module hierarchy was structured as ``project.foo.bar.Bar`` and
+            ``foo`` directly imports ``Bar``, ``bar`` may not be desirable to
+            have in the logging namespace since users interact with it via
+            ``foo.Bar``. Currently, this only handles a single level of nesting
+            like this.
         non_native_remove (set[str], optional): A set of names which to remove
             for the logging namespace when found in non-native loggables.
         skip_duplicates (bool, optional): Whether or not to remove consecutive

--- a/hoomd/logging.py
+++ b/hoomd/logging.py
@@ -135,14 +135,16 @@ class _NamespaceFilter:
     """Filter for creating the proper namespace for logging object properties.
 
     Attributes:
-        remove_names (set[str]): A set of names which to remove for the logging
-            namespace whenever encountered.
-        base_names (set[str]): A set of names which indicate that the next
-            encountered name in the string should be skipped. For example, if a
-            module hierarchy went like ``project.foo.bar.Bar`` and ``foo``
+        remove_names (set[str], optional): A set of names which to remove for
+            the logging namespace whenever encountered.
+        base_names (set[str], optional): A set of names which indicate that the
+            next encountered name in the string should be skipped. For example,
+            if a module hierarchy went like ``project.foo.bar.Bar`` and ``foo``
             directly imports ``Bar``, ``bar`` may not be desirable to have in
             the logging namespace since users interact with it via ``foo.Bar``.
             Currently, this only handles a single level of nesting like this.
+        non_native_remove (set[str], optional): A set of names which to remove
+            for the logging namespace when found in non-native loggables.
         skip_duplicates (bool, optional): Whether or not to remove consecutive
             duplicates from a logging namespace (e.g. ``foo.foo.bar`` ->
             ``foo.bar``), default ``True``. By default we assume that this
@@ -152,15 +154,30 @@ class _NamespaceFilter:
     def __init__(self,
                  remove_names=None,
                  base_names=None,
+                 non_native_remove=None,
                  skip_duplicates=True):
         self.remove_names = set() if remove_names is None else remove_names
+        if non_native_remove is None:
+            self.non_native_remove = set()
+        else:
+            self.non_native_remove = non_native_remove
         self.base_names = set() if base_names is None else base_names
         self._skip_next = False
         self.skip_duplicates = skip_duplicates
         if skip_duplicates:
             self._last_name = None
 
-    def __call__(self, namespace):
+    def __call__(self, namespace, native=True):
+        """Filter out parts of the namespace.
+
+        Args:
+            namespace (tuple[str]): The namespace of the loggable.
+            native (bool, optional): Whether the loggable comes internally from
+                hoomd or not.
+
+        Yields:
+             str: The filtered parts of a namespace.
+        """
         for name in namespace:
             # check for duplicates in the namespace and remove them (e.g.
             # `md.pair.pair.LJ` -> `md.pair.LJ`).
@@ -169,6 +186,10 @@ class _NamespaceFilter:
                 self._last_name = name
                 if last_name == name:
                     continue
+            if not native:
+                if name not in self.non_native_remove:
+                    yield name
+                continue
             if name in self.remove_names:
                 continue
             elif self._skip_next:
@@ -199,11 +220,12 @@ class _LoggerQuantity:
 
     namespace_filter = _NamespaceFilter(
         # Names that are imported directly into the hoomd namespace
-        remove_names={'simulation', 'state', 'operations', 'snapshot'},
+        remove_names={"hoomd", 'simulation', 'state', 'operations', 'snapshot'},
         # Names that have their submodules' classes directly imported into them
         # (e.g. `hoomd.update.box_resize.BoxResize` gets used as
         # `hoomd.update.BoxResize`)
         base_names={'update', 'tune', 'write'},
+        non_native_remove={"__main__"},
         skip_duplicates=True)
 
     def __init__(self, name, cls, category='scalar', default=True):
@@ -255,10 +277,7 @@ class _LoggerQuantity:
         ns = tuple(loggable_cls.__module__.split('.'))
         cls_name = loggable_cls.__name__
         # Only filter namespaces of objects in the hoomd package
-        if ns[0] == 'hoomd':
-            return tuple(cls.namespace_filter(ns[1:])) + (cls_name,)
-        else:
-            return ns + (cls_name,)
+        return tuple(cls.namespace_filter(ns, ns[0] == "hoomd")) + (cls_name,)
 
 
 class Loggable(type):

--- a/hoomd/pytest/test_logging.py
+++ b/hoomd/pytest/test_logging.py
@@ -415,3 +415,17 @@ class TestLogger:
     def test_pickling(self, blank_logger, logged_obj):
         blank_logger.add(logged_obj)
         pickling_check(blank_logger)
+
+    def test_iter(self):
+        logger = Logger()
+        logger[("a", "b", "c")] = (lambda: 4, "scalar")
+        logger[("b", "c")] = (lambda: "hello", "string")
+        logger[("a", "a")] = (lambda: 17, "scalar")
+        keys = list(logger)
+        assert len(keys) == 3
+        assert ("a",) not in keys
+        assert ("a", "b") not in keys
+        assert ("b",) not in keys
+        assert ("a", "b", "c") in keys
+        assert ("a", "a") in keys
+        assert ("b", "c") in keys

--- a/hoomd/util.py
+++ b/hoomd/util.py
@@ -154,6 +154,7 @@ def _keys_helper(dict_, key=()):
     for k in dict_:
         if isinstance(dict_[k], dict):
             yield from _keys_helper(dict_[k], key + (k,))
+            continue
         yield key + (k,)
 
 


### PR DESCRIPTION
## Description

Removes "__main__" from custom action loggables defined in a script #1336, and fixes error in the iteration of `hoomd.util._NamespaceDict`.

## Motivation and context

Resolves #1336

## How has this been tested?

A test for `__iter__` has been added in `test_logging.py`; however, the main change is somewhat difficult to test. We test the `_NamespaceFilter` class through the logging infrastructure, but testing the removal of `__main__` is not easy to do in pytest. @tommy-waltmann could you test this locally? If desired I can add tests for the internal `_NamespaceFilter` class.

## Change log

<!-- Propose a change log entry. -->
```
Changed: Removes ``"__main__"`` from some user custom action logging namespaces.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
