### PR TITLE
Create *_like typing objects

### DIFF
--- a/hoomd/__init__.py
+++ b/hoomd/__init__.py
@@ -52,7 +52,7 @@ outside the hoomd source directory, execute `python3 -m pytest --pyargs hoomd`.
 from hoomd import version
 from hoomd import trigger
 from hoomd import variant
-from hoomd.box import Box
+from hoomd.box import Box, box_like
 from hoomd import data
 from hoomd import filter
 from hoomd import device

--- a/hoomd/box.py
+++ b/hoomd/box.py
@@ -3,6 +3,9 @@
 
 """Implement Box."""
 
+import abc
+import typing
+
 import numpy as np
 from functools import partial
 import hoomd._hoomd as _hoomd
@@ -259,25 +262,16 @@ class Box:
         r"""Initialize a Box instance from a box-like object.
 
         Args:
-            box:
-                A box-like object
+            box (box_like): A box-like object.
 
         Note:
-           Objects that can be converted to HOOMD-blue boxes include lists like
-           ``[Lx, Ly, Lz, xy, xz, yz]``, dictionaries with keys ``'Lx',
-           'Ly', 'Lz', 'xy', 'xz', 'yz'``, objects with attributes ``Lx, Ly,
-           Lz, xy, xz, yz``, 3x3 matrices (see `from_matrix`), or existing
-           `hoomd.Box` objects.
-
-           If any of ``Lz, xy, xz, yz`` are not provided, they will be set to 0.
-
            If all values are provided, a triclinic box will be constructed.
            If only ``Lx, Ly, Lz`` are provided, an orthorhombic box will
            be constructed. If only ``Lx, Ly`` are provided, a rectangular
            (2D) box will be constructed.
 
         Returns:
-            :class:`hoomd.Box`: The resulting box object.
+            hoomd.Box: The resulting box object.
         """
         if np.asarray(box).shape == (3, 3):
             # Handles 3x3 matrices
@@ -511,3 +505,67 @@ class Box:
     def __reduce__(self):
         """Reduce values to picklable format."""
         return (type(self), (*self.L, *self.tilts))
+
+
+class BoxInterface(abc.ABC):
+    """The class interface which HOOMD considers to be a box-like object.
+
+    Note:
+        This class is exclusively used for help with typing and documentation in
+        HOOMD, and is not meant to be used.
+    """
+
+    @property
+    @abc.abstractmethod
+    def Lx(self) -> float:  # noqa: N802: Allow function name
+        """Length in x direction."""
+        pass
+
+    @property
+    @abc.abstractmethod
+    def Ly(self) -> float:  # noqa: N802: Allow function name
+        """Length in y direction."""
+        pass
+
+    @property
+    @abc.abstractmethod
+    def Lz(self) -> float:  # noqa: N802: Allow function name
+        """Length in z direction."""
+        pass
+
+    @property
+    @abc.abstractmethod
+    def xy(self) -> float:
+        """Tilt factor in the xy plane."""
+        pass
+
+    @property
+    @abc.abstractmethod
+    def xz(self) -> float:
+        """Tilt factor in the xy plane."""
+        pass
+
+    @property
+    @abc.abstractmethod
+    def yz(self) -> float:
+        """Tilt factor in the xy plane."""
+        pass
+
+
+box_like = typing.Union[Box, BoxInterface, typing.Sequence[float],
+                        typing.Mapping[str, float], np.ndarray]
+"""Objects that are or can be converted to `Box`.
+
+This includes
+
+* `hoomd.Box` objects
+* objects with attributes ``Lx, Ly, Lz xy, xz, yz``
+* lists like ``[Lx, Ly, Lz, xy, xz, yz]``
+* dictionaries with keys ``'Lx', 'Ly', 'Lz', 'xy', 'xz', 'yz'``
+* 3x3 NumPy arrays or object convertible to a 3x3 array (see
+  `hoomd.Box.from_matrix`)
+
+Note:
+    If any of ``Lz, xy, xz, yz`` for these different types are not provided,
+    they are considered 0.
+"""

--- a/hoomd/box.py
+++ b/hoomd/box.py
@@ -558,12 +558,12 @@ box_like = typing.Union[Box, BoxInterface, typing.Sequence[float],
 
 This includes
 
-* `hoomd.Box` objects
-* objects with attributes ``Lx, Ly, Lz xy, xz, yz``
-* lists like ``[Lx, Ly, Lz, xy, xz, yz]``
-* dictionaries with keys ``'Lx', 'Ly', 'Lz', 'xy', 'xz', 'yz'``
-* 3x3 NumPy arrays or object convertible to a 3x3 array (see
-  `hoomd.Box.from_matrix`)
+* `hoomd.Box` objects.
+* Objects with attributes ``Lx, Ly, Lz, xy, xz, yz``.
+* Lists like ``[Lx, Ly, Lz, xy, xz, yz]``.
+* Dictionaries with keys ``'Lx', 'Ly', 'Lz', 'xy', 'xz', 'yz'``.
+* 3x3 NumPy arrays or objects convertible to a 3x3 array (see
+  `hoomd.Box.from_matrix`).
 
 Note:
     If any of ``Lz, xy, xz, yz`` for these different types are not provided,

--- a/hoomd/custom/custom_operation.py
+++ b/hoomd/custom/custom_operation.py
@@ -35,8 +35,8 @@ class CustomOperation(TriggeredOperation, metaclass=_AbstractLoggable):
         This object should not be instantiated or subclassed by an user.
 
     Attributes:
-        trigger (hoomd.trigger.Trigger): A trigger to determine when the wrapped
-            `hoomd.custom.Action` is run.
+        trigger (hoomd.trigger.trigger_like): A trigger to determine when the
+            wrapped `hoomd.custom.Action` is run.
     """
 
     _override_setattr = {'_action', "_export_dict"}

--- a/hoomd/custom/custom_operation.py
+++ b/hoomd/custom/custom_operation.py
@@ -35,7 +35,7 @@ class CustomOperation(TriggeredOperation, metaclass=_AbstractLoggable):
         This object should not be instantiated or subclassed by an user.
 
     Attributes:
-        trigger (hoomd.trigger.trigger_like): A trigger to determine when the
+        trigger (hoomd.trigger.Trigger): A trigger to determine when the
             wrapped `hoomd.custom.Action` is run.
     """
 

--- a/hoomd/data/typeconverter.py
+++ b/hoomd/data/typeconverter.py
@@ -45,8 +45,7 @@ def variant_preprocessing(variant):
         try:
             return Constant(float(variant))
         except Exception:
-            raise ValueError(
-                "Expected a hoomd.variant.Variant or float object.")
+            raise ValueError("Expected a hoomd.variant.variant_like object.")
 
 
 def box_preprocessing(box):

--- a/hoomd/data/typeconverter.py
+++ b/hoomd/data/typeconverter.py
@@ -31,7 +31,7 @@ def trigger_preprocessing(trigger):
         try:
             return Periodic(period=int(trigger), phase=0)
         except Exception:
-            raise ValueError("Expected a hoomd.trigger.Trigger or int object.")
+            raise ValueError("Expected a hoomd.trigger.trigger_like object.")
 
 
 def variant_preprocessing(variant):

--- a/hoomd/filter/__init__.py
+++ b/hoomd/filter/__init__.py
@@ -25,6 +25,8 @@ themselves to compute the kinetic temperature. See
 count.
 """
 
+import typing
+
 from hoomd.filter.filter_ import ParticleFilter
 from hoomd.filter.all_ import All
 from hoomd.filter.null import Null
@@ -33,3 +35,10 @@ from hoomd.filter.set_ import Intersection, SetDifference, Union
 from hoomd.filter.tags import Tags
 from hoomd.filter.type_ import Type
 from hoomd.filter.custom import CustomFilter
+
+filter_like = typing.Union[ParticleFilter, CustomFilter]
+"""
+An object that acts like a particle filter.
+
+Either a subclass of `ParticleFilter` or `CustomFilter`.
+"""

--- a/hoomd/hpmc/external/field.py
+++ b/hoomd/hpmc/external/field.py
@@ -34,11 +34,10 @@ class Harmonic(ExternalField):
         reference_orientations ((*N_particles*, 4) `numpy.ndarray` of `float`):
             the reference orientations to which particles are restrained
             :math:`[\mathrm{dimensionless}]`.
-        k_translational (`hoomd.variant.Variant` or `float`): translational
-            spring constant :math:`[\mathrm{energy} \cdot
-            \mathrm{length}^{-2}]`.
-        k_rotational (`hoomd.variant.Variant` or `float`): rotational spring
-            constant :math:`[\mathrm{energy}]`.
+        k_translational (hoomd.variant.variant_like): translational spring
+            constant :math:`[\mathrm{energy} \cdot \mathrm{length}^{-2}]`.
+        k_rotational (hoomd.variant.variant_like): rotational spring constant
+            :math:`[\mathrm{energy}]`.
         symmetries ((*N_symmetries*, 4) `numpy.ndarray` of `float`): the
             orientations that are equivalent through symmetry, i.e., the
             rotation quaternions that leave the particles unchanged. At a

--- a/hoomd/hpmc/nec/tune.py
+++ b/hoomd/hpmc/nec/tune.py
@@ -191,8 +191,8 @@ class ChainTime(_InternalCustomTuner):
         `ChainTime.secant_solver` and `ChainTime.scale_solver` respectively.
 
     Args:
-        trigger (hoomd.trigger.Trigger): ``Trigger`` to determine when to run
-            the tuner.
+        trigger (hoomd.trigger.trigger_like): ``Trigger`` to determine when to
+            run the tuner.
         target (float): The acceptance rate for trial moves that is desired. The
             value should be between 0 and 1.
         solver (`hoomd.tune.RootSolver`): A solver that tunes chain times to
@@ -221,8 +221,8 @@ class ChainTime(_InternalCustomTuner):
         """Create a `ChainTime` tuner with a `hoomd.tune.ScaleSolver`.
 
         Args:
-            trigger (hoomd.trigger.Trigger): ``Trigger`` to determine when to
-                run the tuner.
+            trigger (hoomd.trigger.trigger_like): ``Trigger`` to determine when
+                to run the tuner.
             target (float): The number of collisions in a chain that is
                 desired.
             max_chain_time (float): The maximum value of chain time to attempt.
@@ -255,8 +255,8 @@ class ChainTime(_InternalCustomTuner):
         of gamma this should not be a problem.
 
         Args:
-            trigger (hoomd.trigger.Trigger): ``Trigger`` to determine when to
-                run the tuner.
+            trigger (hoomd.trigger.trigger_like): ``Trigger`` to determine when
+                to run the tuner.
             target (float): The number of collisions in a chain that is desired.
             max_chain_time (float): The maximum value of chain time to attempt,
                 defaults to ``None`` which represents no maximum chain time.

--- a/hoomd/hpmc/shape_move.py
+++ b/hoomd/hpmc/shape_move.py
@@ -89,7 +89,7 @@ class Elastic(ShapeMove):
     and :math:`V` is the particle volume.
 
     Args:
-        stiffness (`hoomd.variant.Variant`): Shape stiffness against
+        stiffness (hoomd.variant.variant_like): Shape stiffness against
             deformations.
 
         mc (`type` or `hoomd.hpmc.integrate.HPMCIntegrator`): The class of
@@ -124,7 +124,7 @@ class Elastic(ShapeMove):
         elastic_move.reference_shape["A"] = verts
 
     Attributes:
-        stiffness (:py:mod:`hoomd.variant.Variant`): Shape stiffness against
+        stiffness (hoomd.variant.Variant): Shape stiffness against
             deformations.
 
         step_size (`TypeParameter` [``particle type``, `float`]): Maximum size

--- a/hoomd/hpmc/tune/boxmc_move_size.py
+++ b/hoomd/hpmc/tune/boxmc_move_size.py
@@ -190,8 +190,8 @@ class BoxMCMoveSize(_InternalCustomTuner):
         invalid results due to the breaking of balance.
 
     Args:
-        trigger (hoomd.trigger.Trigger): ``Trigger`` to determine when to run
-            the tuner.
+        trigger (hoomd.trigger.trigger_like): ``Trigger`` to determine when to
+            run the tuner.
         boxmc (hoomd.hpmc.update.BoxMC): The `hoomd.hpmc.update.BoxMC` object to
             tune.
         moves (list[str]): A list of types of moves to tune. Available options
@@ -249,8 +249,8 @@ class BoxMCMoveSize(_InternalCustomTuner):
         """Create a `BoxMCMoveSize` tuner with a `hoomd.tune.ScaleSolver`.
 
         Args:
-            trigger (hoomd.trigger.Trigger): ``Trigger`` to determine when to
-                run the tuner.
+            trigger (hoomd.trigger.trigger_like): ``Trigger`` to determine when
+                to run the tuner.
             boxmc (hoomd.hpmc.update.BoxMC): The `hoomd.hpmc.update.BoxMC`
                 object to tune.
             moves (list[str]): A list of types of moves to tune. Available
@@ -289,8 +289,8 @@ class BoxMCMoveSize(_InternalCustomTuner):
         of gamma this should not be a problem.
 
         Args:
-            trigger (hoomd.trigger.Trigger): ``Trigger`` to determine when to
-                run the tuner.
+            trigger (hoomd.trigger.trigger_like): ``Trigger`` to determine when
+                to run the tuner.
             boxmc (hoomd.hpmc.update.BoxMC): The `hoomd.hpmc.update.BoxMC`
                 object to tune.
             moves (list[str]): A list of types of moves to tune. Available

--- a/hoomd/hpmc/tune/move_size.py
+++ b/hoomd/hpmc/tune/move_size.py
@@ -209,7 +209,7 @@ class MoveSize(_InternalCustomTuner):
             to attempt.
 
     Attributes:
-        trigger (hoomd.trigger.trigger_like): ``Trigger`` to determine when to
+        trigger (hoomd.trigger.Trigger): ``Trigger`` to determine when to
             run the tuner.
         moves (list[str]): A list of types of moves to tune. Available options
             are ``'a'`` and ``'d'``.

--- a/hoomd/hpmc/tune/move_size.py
+++ b/hoomd/hpmc/tune/move_size.py
@@ -192,8 +192,8 @@ class MoveSize(_InternalCustomTuner):
         `MoveSize.secant_solver` and `MoveSize.scale_solver`.
 
     Args:
-        trigger (hoomd.trigger.Trigger): ``Trigger`` to determine when to run
-            the tuner.
+        trigger (hoomd.trigger.trigger_like): ``Trigger`` to determine when to
+            run the tuner.
         moves (list[str]): A list of types of moves to tune. Available options
             are ``'a'`` and ``'d'``.
         target (float): The acceptance rate for trial moves that is desired. The
@@ -209,8 +209,8 @@ class MoveSize(_InternalCustomTuner):
             to attempt.
 
     Attributes:
-        trigger (hoomd.trigger.Trigger): ``Trigger`` to determine when to run
-            the tuner.
+        trigger (hoomd.trigger.trigger_like): ``Trigger`` to determine when to
+            run the tuner.
         moves (list[str]): A list of types of moves to tune. Available options
             are ``'a'`` and ``'d'``.
         target (float): The acceptance rate for trial moves that is desired. The
@@ -264,8 +264,8 @@ class MoveSize(_InternalCustomTuner):
         """Create a `MoveSize` tuner with a `hoomd.tune.ScaleSolver`.
 
         Args:
-            trigger (hoomd.trigger.Trigger): ``Trigger`` to determine when to
-                run the tuner.
+            trigger (hoomd.trigger.trigger_like): ``Trigger`` to determine when
+                to run the tuner.
             moves (list[str]): A list of types of moves to tune. Available
                 options are ``'a'`` and ``'d'``.
             target (float): The acceptance rate for trial moves that is desired.
@@ -309,8 +309,8 @@ class MoveSize(_InternalCustomTuner):
         of gamma this should not be a problem.
 
         Args:
-            trigger (hoomd.trigger.Trigger): ``Trigger`` to determine when to
-                run the tuner.
+            trigger (hoomd.trigger.trigger_like): ``Trigger`` to determine when
+                to run the tuner.
             moves (list[str]): A list of types of moves to tune. Available
                 options are ``'a'`` and ``'d'``.
             target (float): The acceptance rate for trial moves that is desired.

--- a/hoomd/hpmc/update.py
+++ b/hoomd/hpmc/update.py
@@ -789,7 +789,7 @@ class QuickCompress(Updater):
         trigger (hoomd.trigger.trigger_like): Update the box dimensions on
             triggered time steps.
 
-        target_box (Box): Dimensions of the target box.
+        target_box (hoomd.box.box_like): Dimensions of the target box.
 
         max_overlaps_per_particle (float): The maximum number of overlaps to
             allow per particle (may be less than 1 - e.g.

--- a/hoomd/hpmc/update.py
+++ b/hoomd/hpmc/update.py
@@ -25,11 +25,11 @@ class BoxMC(Updater):
     r"""Apply box updates to sample isobaric and related ensembles.
 
     Args:
-        betaP (`float` or :py:mod:`hoomd.variant.Variant`):
-            :math:`\frac{p}{k_{\mathrm{B}}T}` :math:`[\mathrm{length}^{-2}]`
-            in 2D or :math:`[\mathrm{length}^{-3}]` in 3D.
-        trigger (hoomd.trigger.Trigger): Select the timesteps to perform box
-            trial moves.
+        betaP (hoomd.variant.variant_like): :math:`\frac{p}{k_{\mathrm{B}}T}`
+            :math:`[\mathrm{length}^{-2}]` in 2D or
+            :math:`[\mathrm{length}^{-3}]` in 3D.
+        trigger (hoomd.trigger.trigger_like): Select the timesteps to perform
+            box trial moves.
 
     Use `BoxMC` in conjunction with an HPMC integrator to allow the simulation
     box to undergo random fluctuations at constant pressure, or random
@@ -519,7 +519,8 @@ class Shape(Updater):
         `hoomd.hpmc.shape_move` describes the shape alchemy algorithm.
 
     Args:
-        trigger (Trigger): Call the updater on triggered time steps.
+        trigger (hoomd.trigger.trigger_like): Call the updater on triggered time
+            steps.
 
         shape_move (ShapeMove): Type of shape move to apply when updating shape
             definitions
@@ -685,8 +686,8 @@ class Clusters(Updater):
                                         pivot move.
         flip_probability (float): Set the probability for transforming an
                                  individual cluster.
-        trigger (Trigger): Select the timesteps on which to perform cluster
-            moves.
+        trigger (hoomd.trigger.trigger_like): Select the timesteps on which to
+            perform cluster moves.
 
     The GCA as described in Liu and Lujten (2004),
     http://doi.org/10.1103/PhysRevLett.92.035504 is used for hard shape, patch
@@ -785,7 +786,8 @@ class QuickCompress(Updater):
     r"""Quickly compress a hard particle system to a target box.
 
     Args:
-        trigger (Trigger): Update the box dimensions on triggered time steps.
+        trigger (hoomd.trigger.trigger_like): Update the box dimensions on
+            triggered time steps.
 
         target_box (Box): Dimensions of the target box.
 

--- a/hoomd/md/alchemy/methods.py
+++ b/hoomd/md/alchemy/methods.py
@@ -56,7 +56,7 @@ class NVT(Alchemostat):
     particle attributes as thermodynamic variables.
 
     Args:
-        alchemical_kT (`hoomd.variant.Variant` or `float`): Temperature set
+        alchemical_kT (hoomd.variant.variant_like): Temperature set
             point for the alchemostat :math:`[\mathrm{energy}]`.
 
         alchemical_dof (`list` [`hoomd.md.alchemy.pair.AlchemicalDOF`]): List

--- a/hoomd/md/compute.py
+++ b/hoomd/md/compute.py
@@ -292,8 +292,8 @@ class HarmonicAveragedThermodynamicQuantities(Compute):
     """Compute harmonic averaged thermodynamic properties of particles.
 
     Args:
-        filter (`hoomd.filter`): Particle filter to compute thermodynamic
-            properties for.
+        filter (hoomd.filter.filter_like): Particle filter to compute
+            thermodynamic properties for.
         kT (float): Temperature of the system :math:`[\\mathrm{energy}]`.
         harmonic_pressure (float): Harmonic contribution to the pressure
             :math:`[\\mathrm{pressure}]`. If omitted, the HMA pressure can
@@ -323,10 +323,10 @@ class HarmonicAveragedThermodynamicQuantities(Compute):
 
 
     Attributes:
-        filter (hoomd.filter.ParticleFilter): Subset of particles compute
+        filter (hoomd.filter.filter_like): Subset of particles compute
             thermodynamic properties for.
 
-        kT (hoomd.variant.Variant): Temperature of the system
+        kT (float): Temperature of the system
             :math:`[\\mathrm{energy}]`.
 
         harmonic_pressure (float): Harmonic contribution to the pressure

--- a/hoomd/md/force.py
+++ b/hoomd/md/force.py
@@ -427,7 +427,7 @@ class Active(Force):
         Args:
             trigger (hoomd.trigger.Trigger): Select the timesteps to update
                 rotational diffusion.
-            rotational_diffusion (hoomd.variant.Variant or float): The
+            rotational_diffusion (hoomd.variant.variant_like): The
                 rotational diffusion as a function of time or a constant.
 
         Returns:

--- a/hoomd/md/force.py
+++ b/hoomd/md/force.py
@@ -425,7 +425,7 @@ class Active(Force):
         """Create a rotational diffusion updater for this active force.
 
         Args:
-            trigger (hoomd.trigger.Trigger): Select the timesteps to update
+            trigger (hoomd.trigger.trigger_like): Select the timesteps to update
                 rotational diffusion.
             rotational_diffusion (hoomd.variant.variant_like): The
                 rotational diffusion as a function of time or a constant.

--- a/hoomd/md/methods/methods.py
+++ b/hoomd/md/methods/methods.py
@@ -36,10 +36,10 @@ class NVT(Method):
     r"""Constant volume, constant temperature dynamics.
 
     Args:
-        filter (hoomd.filter.ParticleFilter): Subset of particles on which
-            to apply this method.
+        filter (hoomd.filter.filter_like): Subset of particles on which to apply
+            this method.
 
-        kT (`hoomd.variant.Variant` or `float`): Temperature set point
+        kT (hoomd.variant.variant_like): Temperature set point
             for the Nosé-Hoover thermostat :math:`[\mathrm{energy}]`.
 
         tau (float): Coupling constant for the Nosé-Hoover thermostat
@@ -80,8 +80,8 @@ class NVT(Method):
         integrator = hoomd.md.Integrator(dt=0.005, methods=[nvt], forces=[lj])
 
     Attributes:
-        filter (hoomd.filter.ParticleFilter): Subset of particles on which to
-            apply this method.
+        filter (hoomd.filter.filter_like): Subset of particles on which to apply
+            this method.
 
         kT (hoomd.variant.Variant): Temperature set point
             for the Nosé-Hoover thermostat :math:`[\mathrm{energy}]`.
@@ -160,28 +160,29 @@ class NVT(Method):
 
 
 class NPT(Method):
-    r"""Constant pressure, constant temperature dynamics.
+    """Constant pressure, constant temperature dynamics.
 
     Args:
-        filter (hoomd.filter.ParticleFilter): Subset of particles on which to
-            apply this method.
+        filter (hoomd.filter.filter_like): Subset of particles on which to apply
+            this method.
 
-        kT (`hoomd.variant.Variant` or `float`): Temperature set point for the
-            thermostat :math:`[\mathrm{energy}]`.
+        kT (hoomd.variant.variant_like): Temperature set point for the
+            thermostat :math:`[\\mathrm{energy}]`.
 
         tau (float): Coupling constant for the thermostat
-            :math:`[\mathrm{time}]`.
+            :math:`[\\mathrm{time}]`.
 
-        S: Stress components set point for the barostat.
-           In Voigt notation:
-           :math:`[S_{xx}, S_{yy}, S_{zz}, S_{yz}, S_{xz}, S_{xy}]`
-           :math:`[\mathrm{pressure}]`. In case of isotropic
-           pressure P (:math:`[p, p, p, 0, 0, 0]`), use ``S = p``.
-           Accepts: `tuple` [ `hoomd.variant.Variant` or `float`, ... ] or
-           `hoomd.variant.Variant` or `float`.
+        S (tuple[hoomd.variant.variant_like, ...] or \
+                hoomd.variant.variant_like): Stress components set point for the
+            barostat.
+
+            In Voigt notation:
+            :math:`[S_{xx}, S_{yy}, S_{zz}, S_{yz}, S_{xz}, S_{xy}]`
+            :math:`[\\mathrm{pressure}]`. In case of isotropic
+            pressure P (:math:`[p, p, p, 0, 0, 0]`), use ``S = p``.
 
         tauS (float): Coupling constant for the barostat
-           :math:`[\mathrm{time}]`.
+           :math:`[\\mathrm{time}]`.
 
         couple (str): Couplings of diagonal elements of the stress tensor,
             can be "none", "xy", "xz","yz", or "xyz".
@@ -203,11 +204,11 @@ class NPT(Method):
     degrees of freedom in the Hamiltonian that couple with the particle
     velocities and angular momenta and the box parameters.
 
-    The translational thermostat has a momentum :math:`\xi` and position
-    :math:`\eta`. The rotational thermostat has momentum
-    :math:`\xi_{\mathrm{rot}}` and position :math:`\eta_\mathrm{rot}`. The
-    barostat tensor is :math:`\nu_{\mathrm{ij}}`. Access these quantities using
-    `translational_thermostat_dof`, `rotational_thermostat_dof`, and
+    The translational thermostat has a momentum :math:`\\xi` and position
+    :math:`\\eta`. The rotational thermostat has momentum
+    :math:`\\xi_{\\mathrm{rot}}` and position :math:`\\eta_\\mathrm{rot}`. The
+    barostat tensor is :math:`\\nu_{\\mathrm{ij}}`. Access these quantities
+    using `translational_thermostat_dof`, `rotational_thermostat_dof`, and
     `barostat_dof`.
 
     By default, `NPT` performs integration in a cubic box under hydrostatic
@@ -217,8 +218,8 @@ class NPT(Method):
     The integration mode is defined by a set of couplings and by specifying
     the box degrees of freedom that are put under barostat control. Couplings
     define which diagonal elements of the pressure tensor
-    :math:`P_{\alpha,\beta}` should be averaged over, so that the corresponding
-    box lengths are rescaled by the same amount.
+    :math:`P_{\\alpha,\\beta}` should be averaged over, so that the
+    corresponding box lengths are rescaled by the same amount.
 
     Valid couplings are:
 
@@ -271,13 +272,13 @@ class NPT(Method):
         The coupling constant `tau` should be set within a
         reasonable range to avoid abrupt fluctuations in the kinetic temperature
         and to avoid long time to equilibration. The recommended value for most
-        systems is :math:`\tau = 100 \delta t`.
+        systems is :math:`\\tau = 100 \\delta t`.
 
     Note:
         The barostat coupling constant `tauS` should be set within a reasonable
         range to avoid abrupt fluctuations in the box volume and to avoid long
         time to equilibration. The recommend value for most systems is
-        :math:`\tau_S = 1000 \delta t`.
+        :math:`\\tau_S = 1000 \\delta t`.
 
     Important:
         Ensure that your initial condition includes non-zero particle velocities
@@ -302,25 +303,25 @@ class NPT(Method):
         integrator = hoomd.md.Integrator(dt=0.005, methods=[npt], forces=[lj])
 
     Attributes:
-        filter (hoomd.filter.ParticleFilter): Subset of particles on which to
-            apply this method.
+        filter (hoomd.filter.filter_like): Subset of particles on which to apply
+            this method.
 
         kT (hoomd.variant.Variant): Temperature set point for the
-            thermostat :math:`[\mathrm{energy}]`.
+            thermostat :math:`[\\mathrm{energy}]`.
 
         tau (float): Coupling constant for the thermostat
-            :math:`[\mathrm{time}]`.
+            :math:`[\\mathrm{time}]`.
 
-        S (list[hoomd.variant.Variant]): Stress components set
-            point for the barostat.
+        S (tuple[hoomd.variant.Variant]): Stress components set point for the
+            barostat.
             In Voigt notation,
             :math:`[S_{xx}, S_{yy}, S_{zz}, S_{yz}, S_{xz}, S_{xy}]`
-            :math:`[\mathrm{pressure}]`. Stress can be reset after the method
+            :math:`[\\mathrm{pressure}]`. Stress can be reset after the method
             object is created. For example, an isotropic pressure can be set by
             ``npt.S = 4.``
 
         tauS (float): Coupling constant for the barostat
-            :math:`[\mathrm{time}]`.
+            :math:`[\\mathrm{time}]`.
 
         couple (str): Couplings of diagonal elements of the stress tensor,
             can be "none", "xy", "xz","yz", or "xyz".
@@ -335,17 +336,17 @@ class NPT(Method):
             freedom.
 
         translational_thermostat_dof (tuple[float, float]): Additional degrees
-            of freedom for the translational thermostat (:math:`\xi`,
-            :math:`\eta`)
+            of freedom for the translational thermostat (:math:`\\xi`,
+            :math:`\\eta`)
 
         rotational_thermostat_dof (tuple[float, float]): Additional degrees
-            of freedom for the rotational thermostat (:math:`\xi_\mathrm{rot}`,
-            :math:`\eta_\mathrm{rot}`)
+            of freedom for the rotational thermostat
+            (:math:`\\xi_\\mathrm{rot}`, :math:`\\eta_\\mathrm{rot}`)
 
         barostat_dof (tuple[float, float, float, float, float, float]):
-            Additional degrees of freedom for the barostat (:math:`\nu_{xx}`,
-            :math:`\nu_{xy}`, :math:`\nu_{xz}`, :math:`\nu_{yy}`,
-            :math:`\nu_{yz}`, :math:`\nu_{zz}`)
+            Additional degrees of freedom for the barostat (:math:`\\nu_{xx}`,
+            :math:`\\nu_{xy}`, :math:`\\nu_{xz}`, :math:`\\nu_{yy}`,
+            :math:`\\nu_{yz}`, :math:`\\nu_{zz}`)
     """
 
     def __init__(self,
@@ -460,22 +461,23 @@ class NPT(Method):
 
 
 class NPH(Method):
-    r"""Constant pressure, constant enthalpy dynamics.
+    """Constant pressure, constant enthalpy dynamics.
 
     Args:
-        filter (hoomd.filter.ParticleFilter): Subset of particles on which to
-            apply this method.
+        filter (hoomd.filter.filter_like): Subset of particles on which to apply
+            this method.
 
-        S: Stress components set point for the barostat.
-           In Voigt notation:
-           :math:`[S_{xx}, S_{yy}, S_{zz}, S_{yz}, S_{xz}, S_{xy}]`
-           :math:`[\mathrm{pressure}]`. In case of isotropic pressure P
-           (:math:`[p, p, p, 0, 0, 0]`), use ``S = p``.
-           Accepts: `tuple` [ `hoomd.variant.Variant` or `float`, ... ] or
-           `hoomd.variant.Variant` or `float`.
+        S (tuple[hoomd.variant.variant_like] or \
+                hoomd.variant.variant_like): Stress components set point for
+            the barostat.
+
+            In Voigt notation:
+            :math:`[S_{xx}, S_{yy}, S_{zz}, S_{yz}, S_{xz}, S_{xy}]`
+            :math:`[\\mathrm{pressure}]`. In case of isotropic
+            pressure P (:math:`[p, p, p, 0, 0, 0]`), use ``S = p``.
 
         tauS (float): Coupling constant for the barostat
-           :math:`[\mathrm{time}]`.
+           :math:`[\\mathrm{time}]`.
 
         couple (str): Couplings of diagonal elements of the stress tensor,
             can be "none", "xy", "xz","yz", or "all", default to "all".
@@ -496,7 +498,7 @@ class NPH(Method):
     ensemble. The barostat is introduced as additional degrees of freedom in the
     Hamiltonian that couple with the box parameters.
 
-    The barostat tensor is :math:`\nu_{\mathrm{ij}}`. Access these quantities
+    The barostat tensor is :math:`\\nu_{\\mathrm{ij}}`. Access these quantities
     `barostat_dof`.
 
     See Also:
@@ -520,19 +522,19 @@ class NPH(Method):
         integrator = hoomd.md.Integrator(dt=dt, methods=[nph], forces=[lj])
 
     Attributes:
-        filter (hoomd.filter.ParticleFilter): Subset of particles on which to
-            apply this method.
+        filter (hoomd.filter.filter_like): Subset of particles on which to apply
+            this method.
 
-        S (`tuple` [`hoomd.variant.Variant`, ...]): Stress components set
+        S (tuple[hoomd.variant.Variant, ...]): Stress components set
             point for the barostat totalling 6 components.
             In Voigt notation,
             :math:`[S_{xx}, S_{yy}, S_{zz}, S_{yz}, S_{xz}, S_{xy}]`
-            :math:`[\mathrm{pressure}]`. Stress can be reset after
+            :math:`[\\mathrm{pressure}]`. Stress can be reset after
             method object is created. For example, an isotopic
             pressure can be set by ``nph.S = 4.``
 
         tauS (float): Coupling constant for the barostat
-            :math:`[\mathrm{time}]`.
+            :math:`[\\mathrm{time}]`.
 
         couple (str): Couplings of diagonal elements of the stress tensor,
             can be "none", "xy", "xz","yz", or "all".
@@ -548,9 +550,9 @@ class NPH(Method):
             freedom.
 
         barostat_dof (tuple[float, float, float, float, float, float]):
-            Additional degrees of freedom for the barostat (:math:`\nu_{xx}`,
-            :math:`\nu_{xy}`, :math:`\nu_{xz}`, :math:`\nu_{yy}`,
-            :math:`\nu_{yz}`, :math:`\nu_{zz}`)
+            Additional degrees of freedom for the barostat (:math:`\\nu_{xx}`,
+            :math:`\\nu_{xy}`, :math:`\\nu_{xz}`, :math:`\\nu_{yy}`,
+            :math:`\\nu_{yz}`, :math:`\\nu_{zz}`)
     """
 
     def __init__(self,
@@ -654,7 +656,7 @@ class NVE(Method):
     r"""Constant volume, constant energy dynamics.
 
     Args:
-        filter (hoomd.filter.ParticleFilter): Subset of particles on which to
+        filter (hoomd.filter.filter_like): Subset of particles on which to
             apply this method.
 
     `NVE` integrates particles forward in time in the microcanonical ensemble.
@@ -676,7 +678,7 @@ class NVE(Method):
     .. _Kamberaj 2005: http://dx.doi.org/10.1063/1.1906216
 
     Attributes:
-        filter (hoomd.filter.ParticleFilter): Subset of particles on which to
+        filter (hoomd.filter.filter_like): Subset of particles on which to
             apply this method.
     """
 
@@ -708,11 +710,11 @@ class Langevin(Method):
     r"""Langevin dynamics.
 
     Args:
-        filter (hoomd.filter.ParticleFilter): Subset of particles to
+        filter (hoomd.filter.filter_like): Subset of particles to
             apply this method to.
 
-        kT (`hoomd.variant.Variant` or `float`): Temperature of the
-            simulation :math:`[\mathrm{energy}]`.
+        kT (hoomd.variant.variant_like): Temperature of the simulation
+            :math:`[\mathrm{energy}]`.
 
         alpha (float): When set, use :math:`\alpha d_i` for the drag
             coefficient where :math:`d_i` is particle diameter
@@ -805,7 +807,7 @@ class Langevin(Method):
     .. _Kamberaj 2005: http://dx.doi.org/10.1063/1.1906216
 
     Attributes:
-        filter (hoomd.filter.ParticleFilter): Subset of particles to
+        filter (hoomd.filter.filter_like): Subset of particles to
             apply this method to.
 
         kT (hoomd.variant.Variant): Temperature of the
@@ -883,11 +885,11 @@ class Brownian(Method):
     r"""Brownian dynamics.
 
     Args:
-        filter (hoomd.filter.ParticleFilter): Subset of particles to
+        filter (hoomd.filter.filter_like): Subset of particles to
             apply this method to.
 
-        kT (`hoomd.variant.Variant` or `float`): Temperature of the
-            simulation :math:`[\mathrm{energy}]`.
+        kT (hoomd.variant.variant_like): Temperature of the simulation
+            :math:`[\mathrm{energy}]`.
 
         alpha (float): When set, use :math:`\alpha d_i` for the
             drag coefficient where :math:`d_i` is particle diameter
@@ -990,7 +992,7 @@ class Brownian(Method):
         brownian.gamma_r.default = [1.0, 2.0, 3.0]
 
     Attributes:
-        filter (hoomd.filter.ParticleFilter): Subset of particles to
+        filter (hoomd.filter.filter_like): Subset of particles to
             apply this method to.
 
         kT (hoomd.variant.Variant): Temperature of the
@@ -1068,11 +1070,11 @@ class Berendsen(Method):
     r"""Applies the Berendsen thermostat.
 
     Args:
-        filter (hoomd.filter.ParticleFilter): Subset of particles to
-            apply this method to.
+        filter (hoomd.filter.filter_like): Subset of particles to apply this
+            method to.
 
-        kT (`hoomd.variant.Variant` or `float`): Temperature of the
-            simulation. :math:`[energy]`
+        kT (hoomd.variant.variant_like): Temperature of the simulation.
+            :math:`[energy]`
 
         tau (float): Time constant of thermostat. :math:`[time]`
 
@@ -1100,8 +1102,8 @@ class Berendsen(Method):
 
 
     Attributes:
-        filter (hoomd.filter.ParticleFilter): Subset of particles to
-            apply this method to.
+        filter (hoomd.filter.filter_like): Subset of particles to apply this
+            method to.
 
         kT (hoomd.variant.Variant): Temperature of the
             simulation. :math:`[energy]`
@@ -1145,8 +1147,8 @@ class OverdampedViscous(Method):
     r"""Overdamped viscous dynamics.
 
     Args:
-        filter (hoomd.filter.ParticleFilter): Subset of particles to
-            apply this method to.
+        filter (hoomd.filter.filter_like): Subset of particles to apply this
+            method to.
 
         alpha (float): When set, use :math:`\alpha d_i` for the
             drag coefficient where :math:`d_i` is particle diameter
@@ -1198,8 +1200,8 @@ class OverdampedViscous(Method):
         odv.gamma_r.default = [1.0, 2.0, 3.0]
 
     Attributes:
-        filter (hoomd.filter.ParticleFilter): Subset of particles to
-            apply this method to.
+        filter (hoomd.filter.filter_like): Subset of particles to apply this
+            method to.
 
         alpha (float): When set, use :math:`\alpha d_i` for the drag
             coefficient where :math:`d_i` is particle diameter

--- a/hoomd/md/methods/methods.py
+++ b/hoomd/md/methods/methods.py
@@ -312,8 +312,8 @@ class NPT(Method):
         tau (float): Coupling constant for the thermostat
             :math:`[\\mathrm{time}]`.
 
-        S (tuple[hoomd.variant.Variant]): Stress components set point for the
-            barostat.
+        S (tuple[hoomd.variant.Variant,...]): Stress components set point for
+            the barostat.
             In Voigt notation,
             :math:`[S_{xx}, S_{yy}, S_{zz}, S_{yz}, S_{xz}, S_{xy}]`
             :math:`[\\mathrm{pressure}]`. Stress can be reset after the method
@@ -417,7 +417,7 @@ class NPT(Method):
         if isinstance(value, Sequence):
             if len(value) != 6:
                 raise ValueError(
-                    "Expected a single hoomd.variant.Variant / float or six.")
+                    "Expected a single hoomd.variant.variant_like or six.")
             return tuple(value)
         else:
             return (value, value, value, 0, 0, 0)
@@ -467,7 +467,7 @@ class NPH(Method):
         filter (hoomd.filter.filter_like): Subset of particles on which to apply
             this method.
 
-        S (tuple[hoomd.variant.variant_like] or \
+        S (tuple[hoomd.variant.variant_like, ...] or \
                 hoomd.variant.variant_like): Stress components set point for
             the barostat.
 
@@ -618,7 +618,7 @@ class NPH(Method):
         if isinstance(value, Sequence):
             if len(value) != 6:
                 raise ValueError(
-                    "Expected a single hoomd.variant.Variant / float or six.")
+                    "Expected a single hoomd.variant.variant_like or six.")
             return tuple(value)
         else:
             return (value, value, value, 0, 0, 0)

--- a/hoomd/md/methods/rattle.py
+++ b/hoomd/md/methods/rattle.py
@@ -62,8 +62,8 @@ class NVE(MethodRATTLE):
     r"""NVE Integration via Velocity-Verlet with RATTLE constraint.
 
     Args:
-        filter (hoomd.filter.ParticleFilter): Subset of particles on which to
-         apply this method.
+        filter (hoomd.filter.filter_like): Subset of particles on which to apply
+            this method.
 
         manifold_constraint (hoomd.md.manifold.Manifold): Manifold
             constraint.
@@ -87,8 +87,8 @@ class NVE(MethodRATTLE):
 
 
     Attributes:
-        filter (hoomd.filter.ParticleFilter): Subset of particles on which to
-            apply this method.
+        filter (hoomd.filter.filter_like): Subset of particles on which to apply
+            this method.
 
         manifold_constraint (hoomd.md.manifold.Manifold): Manifold constraint
             which is used by and as a trigger for the RATTLE algorithm of this
@@ -142,11 +142,11 @@ class Langevin(MethodRATTLE):
     r"""Langevin dynamics with RATTLE constraint.
 
     Args:
-        filter (hoomd.filter.ParticleFilter): Subset of particles to
-            apply this method to.
+        filter (hoomd.filter.filter_like): Subset of particles to apply this
+            method to.
 
-        kT (`hoomd.variant.Variant` or `float`): Temperature of the
-            simulation :math:`[\mathrm{energy}]`.
+        kT (hoomd.variant.variant_like): Temperature of the simulation
+            :math:`[\mathrm{energy}]`.
 
         manifold_constraint (hoomd.md.manifold.Manifold): Manifold
             constraint.
@@ -194,8 +194,8 @@ class Langevin(MethodRATTLE):
         manifold_constraint = sphere, seed=1, alpha=1.0)
 
     Attributes:
-        filter (hoomd.filter.ParticleFilter): Subset of particles to
-            apply this method to.
+        filter (hoomd.filter.filter_like): Subset of particles to apply this
+            method to.
 
         kT (hoomd.variant.Variant): Temperature of the
             simulation :math:`[\mathrm{energy}]`.
@@ -297,11 +297,11 @@ class Brownian(MethodRATTLE):
     r"""Brownian dynamics with RATTLE constraint.
 
     Args:
-        filter (hoomd.filter.ParticleFilter): Subset of particles to
-            apply this method to.
+        filter (hoomd.filter.filter_like): Subset of particles to apply this
+            method to.
 
-        kT (`hoomd.variant.Variant` or `float`): Temperature of the
-            simulation :math:`[\mathrm{energy}]`.
+        kT (hoomd.variant.variant_like): Temperature of the simulation
+            :math:`[\mathrm{energy}]`.
 
         manifold_constraint (hoomd.md.manifold.Manifold): Manifold
             constraint.
@@ -335,8 +335,8 @@ class Brownian(MethodRATTLE):
         forces=[lj])
 
     Attributes:
-        filter (hoomd.filter.ParticleFilter): Subset of particles to
-            apply this method to.
+        filter (hoomd.filter.filter_like): Subset of particles to apply this
+            method to.
 
         kT (hoomd.variant.Variant): Temperature of the
             simulation :math:`[\mathrm{energy}]`.
@@ -436,7 +436,7 @@ class OverdampedViscous(MethodRATTLE):
     r"""Overdamped viscous dynamics with RATTLE constraint.
 
     Args:
-        filter (hoomd.filter.ParticleFilter): Subset of particles to apply this
+        filter (hoomd.filter.filter_like): Subset of particles to apply this
             method to.
 
         manifold_constraint (hoomd.md.manifold.Manifold): Manifold constraint.
@@ -470,7 +470,7 @@ class OverdampedViscous(MethodRATTLE):
 
 
     Attributes:
-        filter (hoomd.filter.ParticleFilter): Subset of particles to apply this
+        filter (hoomd.filter.filter_like): Subset of particles to apply this
             method to.
 
         manifold_constraint (hoomd.md.manifold.Manifold): Manifold constraint

--- a/hoomd/md/tune/nlist_buffer.py
+++ b/hoomd/md/tune/nlist_buffer.py
@@ -206,8 +206,8 @@ class NeighborListBuffer(hoomd.tune.custom_tuner._InternalCustomTuner):
         `NeighborListBuffer.with_gradient_descent`.
 
     Args:
-        trigger (hoomd.trigger.Trigger): ``Trigger`` to determine when to run
-            the tuner.
+        trigger (hoomd.trigger.trigger_like): ``Trigger`` to determine when to
+            run the tuner.
         nlist (hoomd.md.nlist.NeighborList): Neighbor list instance to tune.
         solver (`hoomd.tune.solve.Optimizer`): A solver that tunes the
             neighbor list buffer to maximize TPS.
@@ -241,11 +241,11 @@ class NeighborListBuffer(hoomd.tune.custom_tuner._InternalCustomTuner):
     @classmethod
     def with_gradient_descent(
         cls,
-        trigger: hoomd.trigger.Trigger,
+        trigger: hoomd.trigger.trigger_like,
         nlist: NeighborList,
         maximum_buffer: float,
         minimum_buffer: float = 0.0,
-        alpha: "hoomd.variant.Variant | float" = hoomd.variant.Ramp(
+        alpha: hoomd.variant.variant_like = hoomd.variant.Ramp(
             1e-5, 1e-6, 0, 30),
         kappa: typing.Optional[np.ndarray] = (0.33, 0.165),
         tol: float = 1e-5,
@@ -257,14 +257,14 @@ class NeighborListBuffer(hoomd.tune.custom_tuner._InternalCustomTuner):
         solver.
 
         Args:
-            trigger (hoomd.trigger.Trigger): ``Trigger`` to determine when to
-                run the tuner.
+            trigger (hoomd.trigger.trigger_like): ``Trigger`` to determine when
+                to run the tuner.
             nlist (hoomd.md.nlist.NeighborList): Neighbor list buffer to
                 maximize TPS.
             maximum_buffer (float): The largest buffer value to allow.
             minimum_buffer (`float`, optional): The smallest buffer value to
                 allow (defaults to 0).
-            alpha (`float` or `hoomd.variant.Variant`, optional): Number
+            alpha (`hoomd.variant.variant_like`, optional): Number
                 between 0 and 1 or variant used to dampen the rate of change in
                 x (defaults to ``hoomd.variant.Ramp(1e-5, 1e-6, 0, 30)``).
                 ``alpha`` scales the corrections to x each iteration.  Larger
@@ -306,7 +306,7 @@ class NeighborListBuffer(hoomd.tune.custom_tuner._InternalCustomTuner):
     @classmethod
     def with_grid(
         cls,
-        trigger: hoomd.trigger.Trigger,
+        trigger: hoomd.trigger.trigger_like,
         nlist: NeighborList,
         maximum_buffer: float,
         minimum_buffer: float = 0.0,
@@ -316,8 +316,8 @@ class NeighborListBuffer(hoomd.tune.custom_tuner._InternalCustomTuner):
         """Create a `NeighborListBuffer` with a `hoomd.tune.GridOptimizer`.
 
         Args:
-            trigger (hoomd.trigger.Trigger): ``Trigger`` to determine when to
-                run the tuner.
+            trigger (hoomd.trigger.trigger_like): ``Trigger`` to determine when
+                to run the tuner.
             nlist (hoomd.md.nlist.NeighborList): Neighbor list buffer to
                 maximize TPS.
             maximum_buffer (float): The largest buffer value to allow.

--- a/hoomd/md/update.py
+++ b/hoomd/md/update.py
@@ -16,7 +16,8 @@ class ZeroMomentum(Updater):
     r"""Zeroes system momentum.
 
     Args:
-        trigger (hoomd.trigger.Trigger): Select the timesteps to zero momentum.
+        trigger (hoomd.trigger.trigger_like): Select the timesteps to zero
+            momentum.
 
     `ZeroMomentum` computes the center of mass linear momentum of the system:
 
@@ -74,10 +75,10 @@ class ReversePerturbationFlow(Updater):
     "max" and "min" slab might be swapped.
 
     Args:
-        filter (hoomd.filter.ParticleFilter): Subset of particles on which to
+        filter (hoomd.filter.filter_like): Subset of particles on which to
             apply this updater.
 
-        flow_target (hoomd.variant.Variant): Target value of the
+        flow_target (hoomd.variant.variant_like): Target value of the
             time-integrated momentum flux.
             :math:`[\\delta t \\cdot \\mathrm{mass} \\cdot \\mathrm{length}
             \\cdot \\mathrm{time}^{-1}]` - where :math:`\\delta t` is the
@@ -123,7 +124,7 @@ class ReversePerturbationFlow(Updater):
                                                       n_slabs=20)
 
     Attributes:
-        filter (hoomd.filter.ParticleFilter): Subset of particles on which to
+        filter (hoomd.filter.filter_like): Subset of particles on which to
             apply this updater.
 
         flow_target (hoomd.variant.Variant): Target value of the
@@ -229,13 +230,13 @@ class ActiveRotationalDiffusion(Updater):
     r"""Updater to introduce rotational diffusion with an active force.
 
     Args:
-        trigger (hoomd.trigger.Trigger): Select the timesteps to update
+        trigger (hoomd.trigger.trigger_like): Select the timesteps to update
             rotational diffusion.
         active_force (hoomd.md.force.Active): The active force associated with
             the updater can be any subclass of the class
             `hoomd.md.force.Active`.
-        rotational_diffusion (hoomd.variant.Variant): The rotational diffusion
-            as a function of time.
+        rotational_diffusion (hoomd.variant.variant_like): The rotational
+            diffusion as a function of time.
 
     `ActiveRotationalDiffusion` works directly with `hoomd.md.force.Active` or
     `hoomd.md.force.ActiveOnManifold` to apply rotational diffusion to the

--- a/hoomd/state.py
+++ b/hoomd/state.py
@@ -626,7 +626,7 @@ class State:
         """Assign random values to particle momenta.
 
         Args:
-            filter (hoomd.filter.ParticleFilter): Particles to modify
+            filter (hoomd.filter.filter_like): Particles to modify
             kT (float): Thermal energy to set :math:`[\\mathrm{energy}]`
 
         `thermalize_particle_momenta` assigns the selected particle's velocities

--- a/hoomd/state.py
+++ b/hoomd/state.py
@@ -440,7 +440,7 @@ class State:
         """Set a new simulation box.
 
         Args:
-            box (Box): New simulation box.
+            box (hoomd.box.box_like): New simulation box.
 
         Note:
             All particles must be inside the new box. `set_box` does not change

--- a/hoomd/trigger.py
+++ b/hoomd/trigger.py
@@ -382,9 +382,9 @@ trigger_like = typing.Union[Trigger, int]
 """
 An object that can serve as a trigger for an operation.
 
-Any instance of a `Trigger` subclass is allowed, as well as an int instance. The
-integer is converted to a `Periodic` trigger via ``Periodic(period=a)`` where
-``a`` is the passed integer.
+Any instance of a `Trigger` subclass is allowed, as well as an int instance or
+any object convertible to an int. The integer is converted to a `Periodic`
+trigger via ``Periodic(period=int(a))`` where ``a`` is the passed integer.
 
 Note:
     Attributes that are `Trigger` objects can be set via a `trigger_like`

--- a/hoomd/trigger.py
+++ b/hoomd/trigger.py
@@ -25,6 +25,8 @@ Example:
                 return (timestep**(1 / 2)).is_integer()
 """
 
+import typing
+
 from hoomd import _hoomd
 
 # Note: We use pybind11's pickling infrastructure for simple triggers like
@@ -374,3 +376,13 @@ class Or(_hoomd.OrTrigger, Trigger):
     def __eq__(self, other):
         """Test for equivalent triggers."""
         return isinstance(other, Or) and self.triggers == other.triggers
+
+
+trigger_like = typing.Union[Trigger, int]
+"""
+An object that can serve as a trigger for an operation.
+
+Any instance of a `Trigger` subclass is allowed, as well as an int instance. The
+integer is converted to a `Periodic` trigger via ``Periodic(period=a)`` where
+``a`` is the passed integer.
+"""

--- a/hoomd/trigger.py
+++ b/hoomd/trigger.py
@@ -385,4 +385,8 @@ An object that can serve as a trigger for an operation.
 Any instance of a `Trigger` subclass is allowed, as well as an int instance. The
 integer is converted to a `Periodic` trigger via ``Periodic(period=a)`` where
 ``a`` is the passed integer.
+
+Note:
+    Attributes that are `Trigger` objects can be set via a `trigger_like`
+    object.
 """

--- a/hoomd/tune/balance.py
+++ b/hoomd/tune/balance.py
@@ -13,7 +13,7 @@ class LoadBalancer(Tuner):
     r"""Adjusts the boundaries of the domain decomposition.
 
     Args:
-        trigger (hoomd.trigger.Trigger): Select the timesteps on which to
+        trigger (hoomd.trigger.trigger_like): Select the timesteps on which to
             perform load balancing.
         x (bool): Balance the **x** direction when `True`.
         y (bool): Balance the **y** direction when `True`.

--- a/hoomd/tune/custom_tuner.py
+++ b/hoomd/tune/custom_tuner.py
@@ -29,7 +29,7 @@ class CustomTuner(CustomOperation, _TunerProperty, Tuner):
 
     Args:
         action (hoomd.custom.Action): The action to call.
-        trigger (hoomd.trigger.Trigger): Select the timesteps to call the
+        trigger (hoomd.trigger.trigger_like): Select the timesteps to call the
           action.
 
     `CustomTuner` is a `hoomd.operation.Tuner` that wraps a user-defined

--- a/hoomd/tune/solve.py
+++ b/hoomd/tune/solve.py
@@ -339,13 +339,13 @@ class GradientDescent(Optimizer, _GradientHelper):
     is smaller than ``tol``).
 
     Args:
-        alpha (`float` or `hoomd.variant.Variant`, optional): Either a number
-            between 0 and 1 used to dampen the rate of change in x or a variant
-            that varies not by timestep but by the number of times `solve` has
-            been called (i.e. the number of steps taken) (defaults to
-            0.1). ``alpha`` scales the corrections to x each iteration.  Larger
-            values of ``alpha`` lead to larger changes while a ``alpha`` of 0
-            leads to no change in x at all.
+        alpha (`hoomd.variant.variant_like`, optional): Either a number between
+            0 and 1 used to dampen the rate of change in x or a variant that
+            varies not by timestep but by the number of times `solve` has been
+            called (i.e. the number of steps taken) (defaults to 0.1). ``alpha``
+            scales the corrections to x each iteration.  Larger values of
+            ``alpha`` lead to larger changes while a ``alpha`` of 0 leads to no
+            change in x at all.
         kappa (`numpy.ndarray`, optional): Real number array that determines how
             much of the previous steps' directions to use (defaults to ``None``
             which does no averaging over past step directions). The array values
@@ -420,14 +420,14 @@ class GradientDescent(Optimizer, _GradientHelper):
         return self._alpha(self._cnt)
 
     @alpha.setter
-    def alpha(self, new_alpha: typing.Union[float, hoomd.variant.Variant]):
+    def alpha(self, new_alpha: hoomd.variant.variant_like):
         if isinstance(new_alpha, float):
             self._alpha = hoomd.variant.Constant(new_alpha)
         elif isinstance(new_alpha, hoomd.variant.Variant):
             self._alpha = new_alpha
         else:
             raise TypeError(
-                "Expected either a float or hoomd.variant.Variant object.")
+                "Expected either a hoomd.variant.variant_like object.")
 
     def solve_one(self, tunable):
         """Solve one step."""

--- a/hoomd/tune/sorter.py
+++ b/hoomd/tune/sorter.py
@@ -15,8 +15,8 @@ class ParticleSorter(Tuner):
     """Order particles in memory to improve performance.
 
     Args:
-        trigger (hoomd.trigger.Trigger): Select the timesteps on which to sort.
-            Defaults to a ``hoomd.trigger.Periodic(200)`` trigger.
+        trigger (hoomd.trigger.trigger_like): Select the timesteps on which to
+            sort. Defaults to a ``hoomd.trigger.Periodic(200)`` trigger.
 
         grid (int): Resolution of the grid to use when sorting. The default
             value of `None` sets ``grid=4096`` in 2D simulations and

--- a/hoomd/update/box_resize.py
+++ b/hoomd/update/box_resize.py
@@ -79,14 +79,15 @@ class BoxResize(Updater):
         resets the constituent particle positions before computing forces.
 
     Args:
-        trigger (hoomd.trigger.Trigger): The trigger to activate this updater.
+        trigger (hoomd.trigger.trigger_like): The trigger to activate this
+            updater.
         box1 (hoomd.Box): The box associated with the minimum of the
             passed variant.
         box2 (hoomd.Box): The box associated with the maximum of the
             passed variant.
-        variant (hoomd.variant.Variant): A variant used to interpolate between
-            the two boxes.
-        filter (hoomd.filter.ParticleFilter): The subset of particle positions
+        variant (hoomd.variant.variant_like): A variant used to interpolate
+            between the two boxes.
+        filter (hoomd.filter.filter_like): The subset of particle positions
             to update.
 
     Attributes:
@@ -97,7 +98,7 @@ class BoxResize(Updater):
         variant (hoomd.variant.Variant): A variant used to interpolate between
             the two boxes.
         trigger (hoomd.trigger.Trigger): The trigger to activate this updater.
-        filter (hoomd.filter.ParticleFilter): The subset of particles to
+        filter (hoomd.filter.filter_like): The subset of particles to
             update.
     """
 
@@ -147,7 +148,7 @@ class BoxResize(Updater):
         Args:
             state (State): System state to scale.
             box (Box): New box.
-            filter (hoomd.filter.ParticleFilter): The subset of particles to
+            filter (hoomd.filter.filter_like): The subset of particles to
                 update.
         """
         group = state._get_group(filter)

--- a/hoomd/update/box_resize.py
+++ b/hoomd/update/box_resize.py
@@ -81,9 +81,9 @@ class BoxResize(Updater):
     Args:
         trigger (hoomd.trigger.trigger_like): The trigger to activate this
             updater.
-        box1 (hoomd.Box): The box associated with the minimum of the
+        box1 (hoomd.box.box_like): The box associated with the minimum of the
             passed variant.
-        box2 (hoomd.Box): The box associated with the maximum of the
+        box2 (hoomd.box.box_like): The box associated with the maximum of the
             passed variant.
         variant (hoomd.variant.variant_like): A variant used to interpolate
             between the two boxes.
@@ -147,7 +147,7 @@ class BoxResize(Updater):
 
         Args:
             state (State): System state to scale.
-            box (Box): New box.
+            box (hoomd.box.box_like): New box.
             filter (hoomd.filter.filter_like): The subset of particles to
                 update.
         """

--- a/hoomd/update/custom_updater.py
+++ b/hoomd/update/custom_updater.py
@@ -27,7 +27,7 @@ class CustomUpdater(CustomOperation, _UpdaterProperty, Updater):
 
     Args:
         action (hoomd.custom.Action): The action to call.
-        trigger (hoomd.trigger.Trigger): Select the timesteps to call the
+        trigger (hoomd.trigger.trigger_like): Select the timesteps to call the
           action.
 
     `CustomUpdater` is a `hoomd.operation.Updater` that wraps a user-defined

--- a/hoomd/update/particle_filter.py
+++ b/hoomd/update/particle_filter.py
@@ -37,7 +37,7 @@ class FilterUpdater(hoomd.operation.Updater):
     """Update sets of particles associated with a filter.
 
     `hoomd.Simulation` caches the particles selected by
-    `hoomd.filter.ParticleFilter` instances to avoid the cost of re-running the
+    `hoomd.filter.filter_like` objects to avoid the cost of re-running the
     filter on every time step. The particles selected by a filter will remain
     static until recomputed. This class provides a mechanism to update the
     cached list of particles. For example, periodically update a MD integration
@@ -54,11 +54,10 @@ class FilterUpdater(hoomd.operation.Updater):
         or removing particles to the `hoomd.Simulation.state`.
 
     Args:
-        trigger (hoomd.trigger.Trigger or int):
-            A trigger to use for determining when to update particles associated
-            with a filter.
-        filters (list[hoomd.filter.ParticleFilter]):
-            A list of `hoomd.filter.ParticleFilter` instances to update.
+        trigger (hoomd.trigger.trigger_like): A trigger to use for determining
+            when to update particles associated with a filter.
+        filters (list[hoomd.filter.filter_like]): A list of
+            `hoomd.filter.filter_like` objects to update.
 
     Attributes:
         trigger (hoomd.trigger.Trigger):
@@ -75,7 +74,7 @@ class FilterUpdater(hoomd.operation.Updater):
 
     @property
     def filters(self):
-        """list[hoomd.filter.ParticleFilter]: filters to update select \
+        """list[hoomd.filter.filter_like]: filters to update select \
                 particles."""
         return self._filters
 

--- a/hoomd/update/remove_drift.py
+++ b/hoomd/update/remove_drift.py
@@ -17,7 +17,8 @@ class RemoveDrift(Updater):
     Args:
         reference_positions ((*N_particles*, 3) `numpy.ndarray` of `float`):
             the reference positions :math:`[\mathrm{length}]`.
-        trigger (hoomd.trigger.Trigger): Select the timesteps to remove drift.
+        trigger (hoomd.trigger.trigger_like): Select the timesteps to remove
+            drift.
 
     `RemoveDrift` computes the mean drift :math:`\vec{D}` from the
     given `reference_positions` (:math:`\vec{r}_{ref, i}`):

--- a/hoomd/variant.py
+++ b/hoomd/variant.py
@@ -29,6 +29,7 @@ Note:
     Provide the minimum and maximum values in the ``_min`` and ``_max``
     methods respectively.
 """
+import typing
 
 from hoomd import _hoomd
 
@@ -202,3 +203,12 @@ class Power(_hoomd.VariantPower, Variant):
         _hoomd.VariantPower.__init__(self, A, B, power, t_start, t_ramp)
 
     __eq__ = Variant._private_eq
+
+
+variant_like = typing.Union[Variant, float]
+"""
+Objects that are like a variant.
+
+Any subclass of `Variant` is accepted, but float instances are also valid. They
+are internally converted to variants of type `Constant`.
+"""

--- a/hoomd/variant.py
+++ b/hoomd/variant.py
@@ -211,4 +211,8 @@ Objects that are like a variant.
 
 Any subclass of `Variant` is accepted, but float instances are also valid. They
 are internally converted to variants of type `Constant`.
+
+Note:
+    Attributes that are `Variant` objects can be set via a `variant_like`
+    object.
 """

--- a/hoomd/variant.py
+++ b/hoomd/variant.py
@@ -209,8 +209,10 @@ variant_like = typing.Union[Variant, float]
 """
 Objects that are like a variant.
 
-Any subclass of `Variant` is accepted, but float instances are also valid. They
-are internally converted to variants of type `Constant`.
+Any subclass of `Variant` is accepted along with float instances and objects
+convertible to float. They are internally converted to variants of type
+`Constant` via ``Constant(float(a))`` where ``a`` is the float or float
+convertible object.
 
 Note:
     Attributes that are `Variant` objects can be set via a `variant_like`

--- a/hoomd/write/custom_writer.py
+++ b/hoomd/write/custom_writer.py
@@ -27,7 +27,7 @@ class CustomWriter(CustomOperation, _WriterProperty, Writer):
 
     Args:
         action (hoomd.custom.Action): The action to call.
-        trigger (hoomd.trigger.Trigger): Select the timesteps to call the
+        trigger (hoomd.trigger.trigger_like): Select the timesteps to call the
           action.
 
     `CustomWriter` is a `hoomd.operation.Writer` that wraps a user-defined

--- a/hoomd/write/dcd.py
+++ b/hoomd/write/dcd.py
@@ -15,7 +15,7 @@ class DCD(Writer):
     Args:
         trigger (hoomd.trigger.Periodic): Select the timesteps to write.
         filename (str): File name to write.
-        filter (hoomd.filter.ParticleFilter): Select the particles to write.
+        filter (hoomd.filter.filter_like): Select the particles to write.
             Defaults to `hoomd.filter.All`.
         overwrite (bool): When False, (the default) an existing DCD file will be
             appended to. When True, an existing DCD file *filename* will be
@@ -56,7 +56,7 @@ class DCD(Writer):
     Attributes:
         filename (str): File name to write.
         trigger (hoomd.trigger.Periodic): Select the timesteps to write.
-        filter (hoomd.filter.ParticleFilter): Select the particles to write.
+        filter (hoomd.filter.filter_like): Select the particles to write.
         overwrite (bool): When False, an existing DCD file will be appended to.
             When True, an existing DCD file *filename* will be overwritten.
         unwrap_full (bool): When False, particle coordinates are always written

--- a/hoomd/write/gsd.py
+++ b/hoomd/write/gsd.py
@@ -32,9 +32,9 @@ class GSD(Writer):
     r"""Write simulation trajectories in the GSD format.
 
     Args:
-        trigger (hoomd.trigger.Trigger): Select the timesteps to write.
+        trigger (hoomd.trigger.trigger_like): Select the timesteps to write.
         filename (str): File name to write.
-        filter (hoomd.filter.ParticleFilter): Select the particles to write.
+        filter (hoomd.filter.filter_like): Select the particles to write.
             Defaults to `hoomd.filter.All`.
         mode (str): The file open mode. Defaults to ``'ab'``.
         truncate (bool): When `True`, truncate the file and write a new frame 0
@@ -136,7 +136,7 @@ class GSD(Writer):
     Attributes:
         filename (str): File name to write.
         trigger (hoomd.trigger.Trigger): Select the timesteps to write.
-        filter (hoomd.filter.ParticleFilter): Select the particles to write.
+        filter (hoomd.filter.filter_like): Select the particles to write.
         mode (str): The file open mode.
         truncate (bool): When `True`, truncate the file and write a new frame 0
             each time this operation triggers.
@@ -201,7 +201,7 @@ class GSD(Writer):
         Args:
             state (State): Simulation state.
             filename (str): File name to write.
-            filter (hoomd.filter.ParticleFilter): Select the particles to write.
+            filter (hoomd.filter.filter_like): Select the particles to write.
             mode (str): The file open mode. Defaults to ``'wb'``.
             log (hoomd.logging.Logger): Provide log quantities to write.
 

--- a/hoomd/write/table.py
+++ b/hoomd/write/table.py
@@ -342,8 +342,8 @@ class Table(_InternalCustomWriter):
         values once created.
 
     Args:
-        trigger (hoomd.trigger.Trigger): The trigger to determine when to run
-            the Table backend.
+        trigger (hoomd.trigger.trigger_like): The trigger to determine when to
+            run the Table backend.
         logger (hoomd.logging.Logger): The logger to query for output. The
             'scalar' categories must be set on the logger, and the 'string'
             categories is optional.

--- a/sphinx-doc/conf.py
+++ b/sphinx-doc/conf.py
@@ -8,6 +8,13 @@ import os
 import sphinx
 import datetime
 
+from sphinx.domains.python import PythonDomain
+
+# allows typing objects like variant_like to be documented correctly.
+# See: https://github.com/sphinx-doc/sphinx/issues/9560
+PythonDomain.object_types['class'].roles = ('class', 'exc', 'data', 'obj')
+PythonDomain.object_types['data'].roles = ('data', 'class', 'obj')
+
 sphinx_ver = tuple(map(int, sphinx.__version__.split('.')))
 
 # If extensions (or modules to document with autodoc) are in another directory,

--- a/sphinx-doc/module-hoomd-box.rst
+++ b/sphinx-doc/module-hoomd-box.rst
@@ -1,0 +1,27 @@
+.. Copyright (c) 2009-2022 The Regents of the University of Michigan.
+.. Part of HOOMD-blue, released under the BSD 3-Clause License.
+
+.. Copyright (c) 2009-2022 The Regents of the University of Michigan.
+.. Part of HOOMD-blue, released under the BSD 3-Clause License.
+
+hoomd.box
+---------
+
+.. rubric:: Overview
+
+.. py:currentmodule:: hoomd.box
+
+.. autosummary::
+    :nosignatures:
+
+    BoxInterface
+    box_like
+
+.. rubric:: Details
+
+.. automodule:: hoomd.box
+    :synopsis: Defines HOOMD's concept and Python implementation of a simulation box.
+    :no-members:
+
+    .. autoclass:: BoxInterface
+    .. autodata:: box_like

--- a/sphinx-doc/module-hoomd-filter.rst
+++ b/sphinx-doc/module-hoomd-filter.rst
@@ -21,6 +21,7 @@ hoomd.filter
     Tags
     Type
     Union
+    filter_like
 
 .. rubric:: Details
 
@@ -42,3 +43,4 @@ hoomd.filter
     .. autoclass:: Type(types)
         :members: types
     .. autoclass:: Union(f, g)
+    .. autodata:: filter_like

--- a/sphinx-doc/module-hoomd-triggers.rst
+++ b/sphinx-doc/module-hoomd-triggers.rst
@@ -19,6 +19,7 @@ hoomd.trigger
     Or
     Periodic
     Trigger
+    trigger_like
 
 .. rubric:: Details
 
@@ -41,3 +42,4 @@ hoomd.trigger
     .. autoclass:: Periodic(period, phase)
         :show-inheritance:
     .. autoclass:: Trigger()
+    .. autodata:: trigger_like

--- a/sphinx-doc/module-hoomd-variant.rst
+++ b/sphinx-doc/module-hoomd-variant.rst
@@ -16,6 +16,7 @@ hoomd.variant
     Power
     Ramp
     Variant
+    variant_like
 
 .. rubric:: Details
 
@@ -37,3 +38,4 @@ hoomd.variant
         :show-inheritance:
     .. autoclass:: Variant()
         :members: min, max, __getstate__, __setstate__
+    .. autodata:: variant_like

--- a/sphinx-doc/package-hoomd.rst
+++ b/sphinx-doc/package-hoomd.rst
@@ -34,6 +34,7 @@ hoomd
 .. toctree::
    :maxdepth: 3
 
+   module-hoomd-box
    module-hoomd-communicator
    module-hoomd-custom
    module-hoomd-data


### PR DESCRIPTION
## Description

Creates the 
- `variant_like`
- `trigger_like`
- `filter_like`
objects, and documents them. In addition, I modified existing documentation to use these. I attempted to use `grep` to get all instances of the previous documentation.

## Motivation and context

Resolves #1319

## How has this been tested?

Documentation builds.

## Change log

```
Added: New ``variant_like``, ``trigger_like``, and ``filter_like`` typing objects for documentation.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
