### PR TITLE
doc: Fix documentation of BoxMCMoveSize factory methods

### DIFF
--- a/hoomd/hpmc/tune/boxmc_move_size.py
+++ b/hoomd/hpmc/tune/boxmc_move_size.py
@@ -252,7 +252,9 @@ class BoxMCMoveSize(_InternalCustomTuner):
             boxmc (hoomd.hpmc.update.BoxMC): The `hoomd.hpmc.update.BoxMC`
                 object to tune.
             moves (list[str]): A list of types of moves to tune. Available
-                options are 'a' and 'd'.
+                options are 'volume', 'aspect', 'shear_{x,y,z}', and
+                'length_{x,y,z}' where brackets denote multiple options. For
+                shear and length moves each dimension is tuned independently.
             target (float): The acceptance rate for trial moves that is desired.
                 The value should be between 0 and 1.
             max_move_size (float): The maximum value of a volume
@@ -292,7 +294,9 @@ class BoxMCMoveSize(_InternalCustomTuner):
             boxmc (hoomd.hpmc.update.BoxMC): The `hoomd.hpmc.update.BoxMC`
                 object to tune.
             moves (list[str]): A list of types of moves to tune. Available
-                options are 'a' and 'd'.
+                options are 'volume', 'aspect', 'shear_{x,y,z}', and
+                'length_{x,y,z}' where brackets denote multiple options. For
+                shear and length moves each dimension is tuned independently.
             target (float): The acceptance rate for trial moves that is desired.
                 The value should be between 0 and 1.
             max_move_size (float): The maximum value of a volume


### PR DESCRIPTION

## Description

Corrects documentation copied from hoomd.hpmc.tune.MoveSize

## Motivation and context

Resolves #1326

## How has this been tested?

NA

## Change log

NA

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
