### PR TITLE
Fix/incorrect log category

### DIFF
--- a/hoomd/logging.py
+++ b/hoomd/logging.py
@@ -812,3 +812,32 @@ class Logger(_SafeNamespaceDict):
         return (self.categories == other.categories
                 and self.only_default == other.only_default
                 and self._dict == other._dict)
+
+
+def modify_namespace(cls, namespace=None):
+    """Modify a class's namespace to a manually assigned one.
+
+    Args:
+        cls (type or tuple[str]): The class to modify the namespace of or the
+            namespace itself. When passing a namespace (a tuple of strings), the
+            function can be used as a decorator.
+        namespace (`tuple`[`str`], optional): The namespace to change the
+            class's namespace to.
+
+    Warning:
+        This will only persist for the current class. All subclasses will have
+        the standard namespace assignment.
+    """
+    if namespace is None:
+        namespace = cls
+        cls = None
+
+    def modify(cls):
+        for entry in cls._export_dict.values():
+            entry.namespace = namespace
+        return cls
+
+    if cls is None:
+        return modify
+
+    return modify(cls)

--- a/hoomd/logging.py
+++ b/hoomd/logging.py
@@ -821,7 +821,7 @@ def modify_namespace(cls, namespace=None):
         cls (type or tuple[str]): The class to modify the namespace of or the
             namespace itself. When passing a namespace (a tuple of strings), the
             function can be used as a decorator.
-        namespace (`tuple`[`str`], optional): The namespace to change the
+        namespace (`tuple` [`str` ], optional): The namespace to change the
             class's namespace to.
 
     Warning:

--- a/hoomd/md/integrate.py
+++ b/hoomd/md/integrate.py
@@ -141,6 +141,7 @@ class _DynamicIntegrator(BaseIntegrator):
         self._param_dict["rigid"] = new_rigid
 
 
+@hoomd.logging.modify_namespace(("md", "Integrator"))
 class Integrator(_DynamicIntegrator):
     r"""Molecular dynamics time integration.
 

--- a/hoomd/md/integrate.py
+++ b/hoomd/md/integrate.py
@@ -304,7 +304,7 @@ class Integrator(_DynamicIntegrator):
                 and self._simulation.state is not None):
             self._simulation.state.update_group_dof()
 
-    @hoomd.logging.log(requires_run=True)
+    @hoomd.logging.log(category="sequence", requires_run=True)
     def linear_momentum(self):
         """tuple(float,float,float): The linear momentum vector of the system \
             :math:`[\\mathrm{mass} \\cdot \\mathrm{velocity}]`.

--- a/hoomd/md/pytest/test_integrate.py
+++ b/hoomd/md/pytest/test_integrate.py
@@ -92,3 +92,11 @@ def test_pickling(make_simulation, integrator_elements):
     sim = make_simulation()
     integrator = hoomd.md.Integrator(0.005, **integrator_elements)
     hoomd.conftest.operation_pickling_check(integrator, sim)
+
+
+def test_logging():
+    hoomd.conftest.logging_check(hoomd.md.Integrator, ("md",), {
+        "linear_momentum": {
+            "category": hoomd.logging.LoggerCategories.sequence
+        }
+    })

--- a/sphinx-doc/module-hoomd-logging.rst
+++ b/sphinx-doc/module-hoomd-logging.rst
@@ -12,6 +12,7 @@ hoomd.logging
     :nosignatures:
 
     log
+    modify_namespace
     Logger
     LoggerCategories
 
@@ -19,7 +20,7 @@ hoomd.logging
 
 .. automodule:: hoomd.logging
     :synopsis: Classes for logging data.
-    :members: log, Logger
+    :members: log, modify_namespace, Logger
     :undoc-members:
 
     .. autoclass:: LoggerCategories


### PR DESCRIPTION
## Description

Fixes a bug in the logging category of `hoomd.md.Integrate.linear_momentum`.
Adds a function `modify_namespace` that allows classes to have custom namespaces (irrespective of the auto namespacing mechanism).

## Motivation and context

In a simulation script the logging failed for this reason, and the new function is to enable `hoomd.md.Integrate` to be more consistent to our namespace approach, and is public to allow users ultimate flexibility in namespaces.

## How has this been tested?
`hoomd.md.Integrate` is tested for its loggables now.
`modify_namespace` is implicitly tested by `hoomd/md/pytest/test_integrate.py`

## Change log

<!-- Propose a change log entry. -->
```
- Added: A decorator for modifying the namespace of operation and custom action classes ``hoomd.logging.modify_namespace``
- Fixed: The logging category of ``hoomd.md.Integrate.linear_momentum``
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
