### PR TITLE
Document that beta=1 in HPMC.

### DIFF
--- a/hoomd/hpmc/integrate.py
+++ b/hoomd/hpmc/integrate.py
@@ -26,6 +26,14 @@ When the trial move is accepted, the system state is set to the the trial
 configuration. When it is not accepted, the move is rejected and the state is
 not modified.
 
+.. rubric:: Temperature
+
+HPMC assumes that :math:`\beta = \frac{1}{kT} = 1`. This is not relevant to
+systems of purely hard particles where :math:`\Delta U` is either 0 or
+:math:`\infty`. To adjust the effective temperature in systems with finite
+interactions (see *Energy evaluation* below), scale the magnitude of the
+energetic interactions accordingly.
+
 .. rubric:: Local trial moves
 
 `HPMCIntegrator` generates local trial moves for a single particle :math:`i` at


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should be based on *trunk-patch*. -->
<!-- Backwards compatible new features should be based on *trunk-minor*. -->
<!-- Incompatible API changes should be based on *trunk-major*. -->

## Description

<!-- Describe your changes in detail. -->
Document that `\beta=1` in the HPMC integrator overview.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
This is mentioned in `units.rst` but only briefly and out of context. This PR clarifies that `\beta=1` right after the move acceptance criterion to make it clear to users.

## How has this been tested?

I rendered the docs locally.

<!--- Please describe in detail how you tested your changes. -->

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
* Improved documentation.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
