### PR TITLE
Reexport `Integrator`'s `setHalfStepHook` and `removeHalfStepHook`

### DIFF
--- a/hoomd/Integrator.cc
+++ b/hoomd/Integrator.cc
@@ -914,7 +914,9 @@ void export_Integrator(pybind11::module& m)
         .def_property("dt", &Integrator::getDeltaT, &Integrator::setDeltaT)
         .def_property_readonly("forces", &Integrator::getForces)
         .def_property_readonly("constraints", &Integrator::getConstraintForces)
-        .def("computeLinearMomentum", &Integrator::computeLinearMomentum);
+        .def("computeLinearMomentum", &Integrator::computeLinearMomentum)
+        .def("setHalfStepHook", &Integrator::setHalfStepHook)
+        .def("removeHalfStepHook", &Integrator::removeHalfStepHook);
     }
 
     } // end namespace detail

--- a/hoomd/md/HalfStepHook.cc
+++ b/hoomd/md/HalfStepHook.cc
@@ -1,0 +1,48 @@
+// Copyright (c) 2009-2022 The Regents of the University of Michigan.
+// Part of HOOMD-blue, released under the BSD 3-Clause License.
+
+#include "hoomd/HalfStepHook.h"
+
+namespace hoomd
+    {
+namespace md
+    {
+//! Trampoline for HalfStepHook classes inherited in python
+class HalfStepHookPy : public HalfStepHook
+    {
+    public:
+    // Inherit the constructor
+    using HalfStepHook::HalfStepHook;
+
+    // Trampoline methods
+    void setSystemDefinition(SystemDefinitionSPtr sysdef) override
+        {
+        PYBIND11_OVERLOAD_PURE(void, HalfStepHook, setSystemDefinition, sysdef);
+        }
+
+    void update(uint64_t timestep) override
+        {
+        PYBIND11_OVERLOAD_PURE(void, HalfStepHook, update, timestep);
+        }
+    };
+
+namespace detail
+    {
+// Method to enable unit testing of C++ HalfStepHook::update from pytest
+void testHalfStepHookUpdate(std::shared_ptr<HalfStepHook> hook, uint64_t step)
+    {
+    return hook->update(step);
+    }
+
+void export_HalfStepHook(pybind11::module& m)
+    {
+    pybind11::class_<HalfStepHook, HalfStepHookPy, std::shared_ptr<HalfStepHook>>(m, "HalfStepHook")
+        .def(pybind11::init<>())
+        .def("update", &HalfStepHook::update);
+    }
+
+    } // end namespace detail
+
+    } // end namespace md
+
+    } // end namespace hoomd

--- a/hoomd/md/module-md.cc
+++ b/hoomd/md/module-md.cc
@@ -110,6 +110,7 @@ void export_TwoStepNVTAlchemy(pybind11::module& m);
 void export_FIREEnergyMinimizer(pybind11::module& m);
 void export_MuellerPlatheFlow(pybind11::module& m);
 void export_AlchemostatTwoStep(pybind11::module& m);
+void export_HalfStepHook(pybind11::module& m);
 
 void export_TwoStepRATTLEBDCylinder(pybind11::module& m);
 void export_TwoStepRATTLEBDDiamond(pybind11::module& m);
@@ -466,6 +467,7 @@ PYBIND11_MODULE(_md, m)
     export_MuellerPlatheFlow(m);
     export_AlchemostatTwoStep(m);
     export_TwoStepNVTAlchemy(m);
+    export_HalfStepHook(m);
 
     // RATTLE
     export_TwoStepRATTLEBDCylinder(m);


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should be based on *trunk-patch*. -->
<!-- Backwards compatible new features should be based on *trunk-minor*. -->
<!-- Incompatible API changes should be based on *trunk-major*. -->

## Description

Expose `setHalfStepHook` and `removeHalfStepHook` as part of python-side `Integrator` interface for HOOMD-blue 3.

## Motivation and context

In https://github.com/glotzerlab/hoomd-blue/commit/4f91146843be1e47443a152bf3fe536f585f0c90 `setHalfStepHook` and `removeHalfStepHook` were dropped from the python interface for `Integrator`. We rely on these in https://github.com/SSAGESLabs/PySAGES

## How has this been tested?

Not sure what's the best way to test directly here.

## Change log

<!-- Propose a change log entry. -->
```
*- Expose `setHalfStepHook` and `removeHalfStepHook` as part of python-side `Integrator` interface.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [ ] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
