### PR TITLE
Fix fugacity documentation

### DIFF
--- a/hoomd/hpmc/integrate.py
+++ b/hoomd/hpmc/integrate.py
@@ -319,7 +319,7 @@ class HPMCIntegrator(Integrator):
 
         depletant_fugacity (`TypeParameter` [ ``particle type``, `float`]):
             Depletant fugacity
-            :math:`[\\mathrm{volume}^{-1}]` (**default:** ``0``)
+            :math:`[\\mathrm{volume}^{-1}]` (**default:** 0)
 
             Allows setting the fugacity per particle type, e.g. ``'A'``
             refers to a depletant of type **A**.

--- a/hoomd/hpmc/integrate.py
+++ b/hoomd/hpmc/integrate.py
@@ -252,11 +252,6 @@ Set `HPMCIntegrator.depletant_fugacity` to activate the implicit depletant code
 path. This inerts depletant particles during every trial move and modifies the
 acceptance criterion accordingly. See `Glaser 2015
 <https://dx.doi.org/10.1063/1.4935175>`_ for details.
-
-Warning:
-    The algorithm and API for implicit depletants is **experimental** and will
-    change in a future minor releases. Specifically, it will switch to accepting
-    a single type parameter: ``fugacity['A', 'A']`` -> ``fugacity['A']``
 """
 
 from hoomd import _hoomd
@@ -328,12 +323,6 @@ class HPMCIntegrator(Integrator):
 
             Allows setting the fugacity per particle type, e.g. ``'A'``
             refers to a depletant of type **A**.
-
-            Warning:
-                The algorithm and API for implicit depletants is
-                **experimental** and will change in a future minor releases.
-                Specifically, it will switch to accepting a single type
-                parameter: ``fugacity['A', 'A']`` -> ``fugacity['A']``
 
         depletant_ntrial (`TypeParameter` [``particle type``, `int`]):
             Multiplicative factor for the number of times a depletant is

--- a/hoomd/hpmc/update.py
+++ b/hoomd/hpmc/update.py
@@ -418,6 +418,9 @@ class MuVT(Updater):
           (applies to Gibbs ensemble)
         ntrial (float): (**default**: 1) Number of configurational bias attempts
           to swap depletants
+        fugacity (`TypeParameter` [ ``particle type``, `float`]):
+            Particle fugacity
+            :math:`[\mathrm{volume}^{-1}]` (**default:** ``0``).
     """
 
     def __init__(self,

--- a/hoomd/hpmc/update.py
+++ b/hoomd/hpmc/update.py
@@ -420,7 +420,7 @@ class MuVT(Updater):
           to swap depletants
         fugacity (`TypeParameter` [ ``particle type``, `float`]):
             Particle fugacity
-            :math:`[\mathrm{volume}^{-1}]` (**default:** ``0``).
+            :math:`[\mathrm{volume}^{-1}]` (**default:** 0).
     """
 
     def __init__(self,


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should be based on *trunk-patch*. -->
<!-- Backwards compatible new features should be based on *trunk-minor*. -->
<!-- Incompatible API changes should be based on *trunk-major*. -->

## Description

<!-- Describe your changes in detail. -->
* Add `fugacity` to `hpmc.update.MuVT` documentation.
* Remove outdated warning boxes on per type pair fugacity in `HPMCIntegrator`.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
* The `fugacity` parameter was not documented. Users need to know how to set it in order to use `MuVT` effectively.
* We removed per type pair fugacities in v3.1.0 and forgot to remove the warning boxes.

<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves #1349 
Resolves #1348

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
I rendered the documentation locally and inspected it.

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
* Improved documentation.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
