### PR TITLE
Fix/filter updater

### DIFF
--- a/hoomd/data/syncedlist.py
+++ b/hoomd/data/syncedlist.py
@@ -9,20 +9,6 @@ from copy import copy
 from hoomd.data.typeconverter import _BaseConverter, TypeConverter
 
 
-class _PartialIsInstance:
-    """Allows partial function application of isinstance over classes.
-
-    This is a solution to avoid lambdas to enable pickling. We cannot use
-    functools.partial since we need to partially apply the second argument.
-    """
-
-    def __init__(self, classes):
-        self.classes = classes
-
-    def __call__(self, instance):
-        return isinstance(instance, self.classes)
-
-
 class _PartialGetAttr:
     """Allows partial function application of isinstance over attributes.
 

--- a/hoomd/pytest/test_filter_updater.py
+++ b/hoomd/pytest/test_filter_updater.py
@@ -10,10 +10,23 @@ import hoomd.conftest
 
 @pytest.fixture
 def filter_list():
+
+    class NewFilter(hoomd.filter.CustomFilter):
+
+        def __call__(self, state):
+            return np.array([])
+
+        def __hash__(self):
+            return hash(self.__class__.__name__)
+
+        def __eq__(self, other):
+            return isinstance(self, other.__class__)
+
     return [
         hoomd.filter.All(),
         hoomd.filter.Tags([1, 2, 3]),
-        hoomd.filter.Type(["A"])
+        hoomd.filter.Type(["A"]),
+        NewFilter()
     ]
 
 
@@ -22,12 +35,12 @@ def test_initialization_setting(filter_list):
     assert filter_updater.trigger == hoomd.trigger.Periodic(1)
     assert filter_updater.filters == []
     filter_updater.filters.extend(filter_list)
-    assert len(filter_updater.filters) == 3
+    assert len(filter_updater.filters) == 4
     assert filter_list == filter_updater.filters
 
     filter_updater = hoomd.update.FilterUpdater(5, filter_list)
     assert filter_updater.trigger == hoomd.trigger.Periodic(5)
-    assert len(filter_updater.filters) == 3
+    assert len(filter_updater.filters) == 4
     assert filter_list == filter_updater.filters
     filter_updater.trigger = hoomd.trigger.After(100)
     assert filter_updater.trigger == hoomd.trigger.After(100)
@@ -94,5 +107,8 @@ def test_updating(simulation, filter_updater, filter_list):
             assert_group_match(filter_, simulation.state)
 
 
-def test_pickling(simulation, filter_updater):
-    hoomd.conftest.operation_pickling_check(filter_updater, simulation)
+def test_pickling(simulation, filter_list):
+    # Remove local custom filter
+    filter_list.pop()
+    hoomd.conftest.operation_pickling_check(
+        hoomd.update.FilterUpdater(1, filter_list), simulation)

--- a/hoomd/pytest/test_filter_updater.py
+++ b/hoomd/pytest/test_filter_updater.py
@@ -107,8 +107,12 @@ def test_updating(simulation, filter_updater, filter_list):
             assert_group_match(filter_, simulation.state)
 
 
-def test_pickling(simulation, filter_list):
-    # Remove local custom filter
-    filter_list.pop()
+def test_pickling(simulation):
+    # Don't use filter_list fixture since NewFilter is not picklable.
+    filters = [
+        hoomd.filter.All(),
+        hoomd.filter.Tags([1, 2, 3]),
+        hoomd.filter.Type(["A"]),
+    ]
     hoomd.conftest.operation_pickling_check(
-        hoomd.update.FilterUpdater(1, filter_list), simulation)
+        hoomd.update.FilterUpdater(1, filters), simulation)


### PR DESCRIPTION
## Description

This modifies `SyncedList` to behave like other HOOMD objects in its type validation/processing.

## Motivation and context
Resolves #1359

## How has this been tested?
Added new tests that checks for correct behavior.

## Change log

<!-- Propose a change log entry. -->
```
Fixed: ``hoomd.update.FilterUpdater`` now accepts ``hoomd.filter.CustomFilter`` subclasses.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
