### PR TITLE
Fix/sequence typeparameter error raising

### DIFF
--- a/hoomd/data/parameterdicts.py
+++ b/hoomd/data/parameterdicts.py
@@ -64,6 +64,9 @@ def _raise_if_required_arg(value, current_context=()):
     # _is_iterable is required over isinstance(value, Sequence) because a
     # str of 1 character is still a sequence and results in infinite recursion.
     elif _is_iterable(value):
+        # Special case where a sequence type spec was given no value.
+        if len(value) == 1 and value[0] is RequiredArg:
+            _raise_error_with_context(current_context)
         for index, item in enumerate(value):
             _raise_if_required_arg(item, current_context + (index,))
 

--- a/hoomd/data/parameterdicts.py
+++ b/hoomd/data/parameterdicts.py
@@ -26,7 +26,7 @@ def _has_str_elems(obj):
     return all([isinstance(elem, str) for elem in obj])
 
 
-def _is_good_iterable(obj):
+def _is_key_iterable(obj):
     """Returns True if object is iterable with respect to types."""
     return _is_iterable(obj) and _has_str_elems(obj)
 
@@ -61,9 +61,9 @@ def _raise_if_required_arg(value, current_context=()):
     if isinstance(value, Mapping):
         for key, item in value.items():
             _raise_if_required_arg(item, current_context + (key,))
-    # _is_good_iterable is required over isinstance(value, Sequence) because a
+    # _is_iterable is required over isinstance(value, Sequence) because a
     # str of 1 character is still a sequence and results in infinite recursion.
-    elif _is_good_iterable(value):
+    elif _is_iterable(value):
         for index, item in enumerate(value):
             _raise_if_required_arg(item, current_context + (index,))
 
@@ -131,7 +131,7 @@ class _SmartTypeIndexer:
         """
         if isinstance(key, tuple) and len(key) == self.len_key:
             if any([
-                    not _is_good_iterable(v) and not isinstance(v, str)
+                    not _is_key_iterable(v) and not isinstance(v, str)
                     for v in key
             ]):
                 raise KeyError("The key {} is not valid.".format(key))


### PR DESCRIPTION


## Description
Improves error message when required sequence is not provided.
<!-- Describe your changes in detail. -->

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves #1345

## How has this been tested?
Test was added that tests the fix.
<!--- Please describe in detail how you tested your changes. -->

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
Fixed: Correct error message is given when a sequence like parameter is not given to a type parameter.
```

## Checklist:

- [ ] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.md).
- [ ] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [ ] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
