### PR TITLE
Feature/notice API

### DIFF
--- a/hoomd/device.py
+++ b/hoomd/device.py
@@ -28,7 +28,10 @@ from hoomd import _hoomd
 class Device:
     """Base class device object.
 
-    Provides methods and properties common to `CPU` and `GPU`.
+    Provides methods and properties common to `CPU` and `GPU`, including those
+    that control where status messages are stored (`msg_file`) how many status
+    messages HOOMD-blue prints (`notice_level`) and a method for user provided
+    status messages (`notice`).
 
     Warning:
         `Device` cannot be used directly. Instantate a `CPU` or `GPU` object.

--- a/hoomd/device.py
+++ b/hoomd/device.py
@@ -140,6 +140,15 @@ class Device:
         else:
             self._cpp_exec_conf.setNumThreads(int(num_cpu_threads))
 
+    #Want to add a function here for print
+    def notice_print(self, mpi_config, notice_level, msg_file):
+        msg = _hoomd.Messenger(mpi_config)
+        if not hoomd.version.tbb_enabled:
+            msg.notice(notice_level)
+        
+        # This will open the given msg_file if not None
+        if msg_file is not None:
+            msg.openFile(msg_file)
 
 def _create_messenger(mpi_config, notice_level, msg_file):
     msg = _hoomd.Messenger(mpi_config)

--- a/hoomd/device.py
+++ b/hoomd/device.py
@@ -144,7 +144,9 @@ class Device:
     def notice_print(self, mpi_config, notice_level, msg_file):
         msg = _hoomd.Messenger(mpi_config)
         if not hoomd.version.tbb_enabled:
-            msg.notice(notice_level)
+            self._cpp_msg.notice(
+                "Input a message here"
+            )
         
         # This will open the given msg_file if not None
         if msg_file is not None:

--- a/hoomd/device.py
+++ b/hoomd/device.py
@@ -146,11 +146,12 @@ class Device:
         if notice_level > self.notice_level:
             return
         else:
-            return self._cpp_msg.noticeStr(notice_level, str(msg) + "\n")
+            return self._cpp_msg.notice(notice_level, str(msg) + "\n")
 
     def print(self, msg):
-        """Easily directed to msg_file"""
-        return self._cpp_msg.notice(str(msg) + "\n")
+        """Easily directed to msg_file regardless of notice level"""
+        return self._cpp_msg.notice(5, str(msg) + "\n")
+        # Only works if notice_level is > 3?
 
 
 def _create_messenger(mpi_config, notice_level, msg_file):

--- a/hoomd/device.py
+++ b/hoomd/device.py
@@ -140,17 +140,12 @@ class Device:
         else:
             self._cpp_exec_conf.setNumThreads(int(num_cpu_threads))
 
-    #Want to add a function here for print
-    def notice_print(self, mpi_config, notice_level, msg_file):
-        msg = _hoomd.Messenger(mpi_config)
-        if not hoomd.version.tbb_enabled:
-            self._cpp_msg.notice(
-                "Input a message here"
-            )
-        
-        # This will open the given msg_file if not None
-        if msg_file is not None:
-            msg.openFile(msg_file)
+    def notice(self, notice_level, msg):
+        return self._cpp_msg.noticeStr(notice_level, msg)
+
+    def print(self, msg):
+        # How to return it to the self.msg_file?
+        return self._cpp_msg.notice(msg)
 
 def _create_messenger(mpi_config, notice_level, msg_file):
     msg = _hoomd.Messenger(mpi_config)

--- a/hoomd/device.py
+++ b/hoomd/device.py
@@ -143,15 +143,14 @@ class Device:
     def notice(self, notice_level, msg):
         """If the devices notice level is less than given notice level
            there is no output"""
-        if notice_level > self.notice_level:
-            return
-        else:
-            return self._cpp_msg.notice(notice_level, str(msg) + "\n")
+        if notice_level <= self.notice_level:
+            self._cpp_msg.notice(notice_level, str(msg) + "\n")
+        #For debugging purposes?
 
     def print(self, msg):
         """Easily directed to msg_file regardless of notice level"""
-        return self._cpp_msg.notice(5, str(msg) + "\n")
-        # Only works if notice_level is > 3?
+        self._cpp_msg.notice(self.notice_level + 1, str(msg) + "\n")
+        # Only works if notice_level is greater than the devices notice level
 
 
 def _create_messenger(mpi_config, notice_level, msg_file):

--- a/hoomd/device.py
+++ b/hoomd/device.py
@@ -140,17 +140,10 @@ class Device:
         else:
             self._cpp_exec_conf.setNumThreads(int(num_cpu_threads))
 
-    def notice(self, notice_level, msg):
-        """If the devices notice level is less than given notice level
-           there is no output"""
-        if notice_level <= self.notice_level:
-            self._cpp_msg.notice(notice_level, str(msg) + "\n")
-        #For debugging purposes?
-
-    def print(self, msg):
-        """Easily directed to msg_file regardless of notice level"""
-        self._cpp_msg.notice(self.notice_level + 1, str(msg) + "\n")
-        # Only works if notice_level is greater than the devices notice level
+    def notice(self, msg, notice_level=1):
+        """If msg_file is specified then msg will output in msg_file,
+           else msg will output to stdout"""
+        self._cpp_msg.notice(notice_level, str(msg) + "\n")
 
 
 def _create_messenger(mpi_config, notice_level, msg_file):

--- a/hoomd/device.py
+++ b/hoomd/device.py
@@ -140,10 +140,21 @@ class Device:
         else:
             self._cpp_exec_conf.setNumThreads(int(num_cpu_threads))
 
-    def notice(self, msg, notice_level=1):
-        """If msg_file is specified then msg will output in msg_file,
-           else msg will output to stdout"""
-        self._cpp_msg.notice(notice_level, str(msg) + "\n")
+    def notice(self, message, notice_level=1):
+        """Write a notice message.
+
+        Args:
+            message (str): Message to write.
+
+        Write the given message string to the output defined by `msg_file`.
+
+        Hint:
+            Use `notice` instead of `print` to write status messages and your
+            scripts will work well in parallel MPI jobs. `notice` writes message
+            only on rank 0. Use with a rank-specific `msg_file` to troubleshoot
+            issues with specific partitions.
+        """
+        self._cpp_msg.notice(notice_level, str(message) + "\n")
 
 
 def _create_messenger(mpi_config, notice_level, msg_file):

--- a/hoomd/device.py
+++ b/hoomd/device.py
@@ -140,13 +140,15 @@ class Device:
         else:
             self._cpp_exec_conf.setNumThreads(int(num_cpu_threads))
 
-    def notice(self, message, notice_level=1):
+    def notice(self, message, level=1):
         """Write a notice message.
 
         Args:
             message (str): Message to write.
+            level (int): Message notice level.
 
-        Write the given message string to the output defined by `msg_file`.
+        Write the given message string to the output defined by `msg_file`
+        on MPI rank 0 when `notice_level` >= ``level``.
 
         Hint:
             Use `notice` instead of `print` to write status messages and your
@@ -154,7 +156,7 @@ class Device:
             only on rank 0. Use with a rank-specific `msg_file` to troubleshoot
             issues with specific partitions.
         """
-        self._cpp_msg.notice(notice_level, str(message) + "\n")
+        self._cpp_msg.notice(level, str(message) + "\n")
 
 
 def _create_messenger(mpi_config, notice_level, msg_file):

--- a/hoomd/device.py
+++ b/hoomd/device.py
@@ -141,11 +141,17 @@ class Device:
             self._cpp_exec_conf.setNumThreads(int(num_cpu_threads))
 
     def notice(self, notice_level, msg):
-        return self._cpp_msg.noticeStr(notice_level, msg)
+        """If the devices notice level is less than given notice level
+           there is no output"""
+        if notice_level > self.notice_level:
+            return
+        else:
+            return self._cpp_msg.noticeStr(notice_level, str(msg) + "\n")
 
     def print(self, msg):
-        # How to return it to the self.msg_file?
-        return self._cpp_msg.notice(msg)
+        """Easily directed to msg_file"""
+        return self._cpp_msg.notice(str(msg) + "\n")
+
 
 def _create_messenger(mpi_config, notice_level, msg_file):
     msg = _hoomd.Messenger(mpi_config)

--- a/hoomd/pytest/test_device.py
+++ b/hoomd/pytest/test_device.py
@@ -3,7 +3,6 @@
 
 import hoomd
 import pytest
-import gsd.hoomd
 
 @pytest.mark.gpu
 def test_gpu_profile(device):
@@ -114,20 +113,14 @@ def test_device_notice(device, tmp_path):
     # Message file declared. Should output in specified file
     device.notice_level = 4
     device.msg_file = str(tmp_path / "example.txt")
-    device.notice("This message should output.")
-    file = open(device.msg_file)
-    # Check the msg file if the output is correctly placed
-    assert file.read() == "This message should output.\n"
-
-    file.close()
-
-    snapshot = gsd.hoomd.Snapshot()
-    snapshot.particles.N = 4
-
+    msg = "This message should output."
+    device.notice(msg)
+    with open(device.msg_file) as fh:
+        # Check the msg file if the output is correctly placed
+        assert fh.read() == msg + "\n"
     device.msg_file = str(tmp_path/"example2.txt")
     # Test notice with a message that is not a string
-    device.notice(snapshot.particles.N)
-    file = open(device.msg_file)
-    assert file.read() == "4\n"
-
-    file.close()
+    msg = 123456
+    device.notice(msg)
+    with open(device.msg_file) as fh:
+        assert fh.read() == str(msg) + "\n"

--- a/hoomd/pytest/test_device.py
+++ b/hoomd/pytest/test_device.py
@@ -110,38 +110,14 @@ def test_cpu_build_specifics():
     assert type(hoomd.device.auto_select()) == hoomd.device.CPU
 
 
-# def test_device_notice(device, capsys, tmp_path):
-#     # Test when notice level is higher
-#     device.notice_level = 3
-#     device.notice(2, "This message should output.")
-#     captured = capsys.readouterr()
-#     assert captured.out == "This message should output.\n"
+def test_device_notice(device, tmp_path):
+    device.notice_level = 4
 
-#     # Test when notice level is lower
-#     device.notice(4, "This message should not output.")
-#     captured = capsys.readouterr()
-#     assert captured.out == None
+    # Message file declared. Should output in specified file
+    device.msg_file = str(tmp_path / "example.txt")
+    device.notice("This message should output.")
+    file = open(device.msg_file)
+    #Check the msg file if the output is correctly placed
+    assert file.read() == "This message should output.\n"
 
-#     #Test message file notice
-#     device.msg_file = str(tmp_path / "example.txt")
-#     device.notice(2, "This message should output.")
-#     # assert example.txt has the msg
-
-
-def test_device_print(device, capsys, tmp_path):
-    # No message file declared. Should output to sys.stdout
-    device.notice_level = 2
-    device.msg_file = None
-    _assert_common_properties(device, 2, None)
-
-    device.print("This message should output.")
-    # Print is not outputting to stdout or anywhere really.
-    captured = capsys.readouterr()
-    assert captured.out == 'This message should output.\n'
-
-    # Message file declared. Should output in the file
-    # device.msg_file = str(tmp_path / "example.txt")
-    # device.print("This message should output.")
-    # file = open(device.msg_file)
-    # assert file.read() == "This message should output."
-    # Check the msg file if the output is correctly placed
+    file.close()

--- a/hoomd/pytest/test_device.py
+++ b/hoomd/pytest/test_device.py
@@ -3,7 +3,7 @@
 
 import hoomd
 import pytest
-
+import gsd.hoomd
 
 @pytest.mark.gpu
 def test_gpu_profile(device):
@@ -119,5 +119,16 @@ def test_device_notice(device, tmp_path):
     file = open(device.msg_file)
     #Check the msg file if the output is correctly placed
     assert file.read() == "This message should output.\n"
+
+    file.close()
+
+    snapshot = gsd.hoomd.Snapshot()
+    snapshot.particles.N = 4
+
+    device.msg_file = str(tmp_path/"example2.txt")
+    #Test notice with a message that is not a string
+    device.notice(snapshot.particles.N)
+    file = open(device.msg_file)
+    assert file.read() == "4\n"
 
     file.close()

--- a/hoomd/pytest/test_device.py
+++ b/hoomd/pytest/test_device.py
@@ -108,3 +108,28 @@ def test_cpu_build_specifics():
         pytest.skip("Don't run CPU-build specific tests when GPU is available")
     assert not hoomd.device.GPU.is_available()
     assert type(hoomd.device.auto_select()) == hoomd.device.CPU
+
+
+def test_api_notice(device, tmp_path):
+    # Test notice and print
+    # test default params, don't assert default tbb threads b/c it depends on
+    # hardware
+    _assert_common_properties(device, 2, None)
+
+    # make sure we can set those properties
+    device.notice_level = 3
+    device.msg_file = str(tmp_path / "example.txt")
+    # Returns ostream
+    device.notice(device.notice_level, "Message")
+
+    _assert_common_properties(device, 3, str(tmp_path / "example.txt"))
+
+    # now make a device with non-default arguments
+    device_type = type(device)
+    dev = device_type(msg_file=str(tmp_path / "example2.txt"),
+                      notice_level=10,
+                      num_cpu_threads=10)
+    _assert_common_properties(dev,
+                              notice_level=10,
+                              msg_file=str(tmp_path / "example2.txt"),
+                              num_cpu_threads=10)

--- a/hoomd/pytest/test_device.py
+++ b/hoomd/pytest/test_device.py
@@ -111,13 +111,12 @@ def test_cpu_build_specifics():
 
 
 def test_device_notice(device, tmp_path):
-    device.notice_level = 4
-
     # Message file declared. Should output in specified file
+    device.notice_level = 4
     device.msg_file = str(tmp_path / "example.txt")
     device.notice("This message should output.")
     file = open(device.msg_file)
-    #Check the msg file if the output is correctly placed
+    # Check the msg file if the output is correctly placed
     assert file.read() == "This message should output.\n"
 
     file.close()
@@ -126,7 +125,7 @@ def test_device_notice(device, tmp_path):
     snapshot.particles.N = 4
 
     device.msg_file = str(tmp_path/"example2.txt")
-    #Test notice with a message that is not a string
+    # Test notice with a message that is not a string
     device.notice(snapshot.particles.N)
     file = open(device.msg_file)
     assert file.read() == "4\n"

--- a/hoomd/pytest/test_device.py
+++ b/hoomd/pytest/test_device.py
@@ -4,6 +4,7 @@
 import hoomd
 import pytest
 
+
 @pytest.mark.gpu
 def test_gpu_profile(device):
 
@@ -110,17 +111,30 @@ def test_cpu_build_specifics():
 
 
 def test_device_notice(device, tmp_path):
-    # Message file declared. Should output in specified file
+    # Message file declared. Should output in specified file.
     device.notice_level = 4
-    device.msg_file = str(tmp_path / "example.txt")
+    device.msg_file = str(tmp_path / "str_message")
     msg = "This message should output."
     device.notice(msg)
-    with open(device.msg_file) as fh:
-        # Check the msg file if the output is correctly placed
-        assert fh.read() == msg + "\n"
-    device.msg_file = str(tmp_path/"example2.txt")
-    # Test notice with a message that is not a string
+
+    if device.communicator.rank == 0:
+        with open(device.msg_file) as fh:
+            assert fh.read() == msg + "\n"
+
+    # Test notice with a message that is not a string.
+    device.msg_file = str(tmp_path / "int_message")
     msg = 123456
     device.notice(msg)
-    with open(device.msg_file) as fh:
-        assert fh.read() == str(msg) + "\n"
+
+    if device.communicator.rank == 0:
+        with open(device.msg_file) as fh:
+            assert fh.read() == str(msg) + "\n"
+
+    # Test the level argument.
+    device.msg_file = str(tmp_path / "empty_notice")
+    msg = "This message should not output."
+    device.notice(msg, level=5)
+
+    if device.communicator.rank == 0:
+        with open(device.msg_file) as fh:
+            assert fh.read() == ""

--- a/hoomd/pytest/test_device.py
+++ b/hoomd/pytest/test_device.py
@@ -110,23 +110,38 @@ def test_cpu_build_specifics():
     assert type(hoomd.device.auto_select()) == hoomd.device.CPU
 
 
-# def test_api_notice(device, tmp_path):
-#     # Test when notice level is lower, and when msg file is given or not
+# def test_device_notice(device, capsys, tmp_path):
+#     # Test when notice level is higher
+#     device.notice_level = 3
+#     device.notice(2, "This message should output.")
+#     captured = capsys.readouterr()
+#     assert captured.out == "This message should output.\n"
+
+#     # Test when notice level is lower
+#     device.notice(4, "This message should not output.")
+#     captured = capsys.readouterr()
+#     assert captured.out == None
+
+#     #Test message file notice
+#     device.msg_file = str(tmp_path / "example.txt")
+#     device.notice(2, "This message should output.")
+#     # assert example.txt has the msg
 
 
 def test_device_print(device, capsys, tmp_path):
     # No message file declared. Should output to sys.stdout
-    device.notice_level = 3
+    device.notice_level = 2
     device.msg_file = None
-    _assert_common_properties(device, 3, None)
+    _assert_common_properties(device, 2, None)
 
     device.print("This message should output.")
-    # Print is not outputting to stdout
+    # Print is not outputting to stdout or anywhere really.
     captured = capsys.readouterr()
     assert captured.out == 'This message should output.\n'
 
-    #Message file declared. Should output in the file
-    device.msg_file = str(tmp_path / "example.txt")
-    device.print("This message should output.")
-    
+    # Message file declared. Should output in the file
+    # device.msg_file = str(tmp_path / "example.txt")
+    # device.print("This message should output.")
+    # file = open(device.msg_file)
+    # assert file.read() == "This message should output."
     # Check the msg file if the output is correctly placed

--- a/hoomd/pytest/test_device.py
+++ b/hoomd/pytest/test_device.py
@@ -110,26 +110,23 @@ def test_cpu_build_specifics():
     assert type(hoomd.device.auto_select()) == hoomd.device.CPU
 
 
-def test_api_notice(device, tmp_path):
-    # Test notice and print
-    # test default params, don't assert default tbb threads b/c it depends on
-    # hardware
-    _assert_common_properties(device, 2, None)
+# def test_api_notice(device, tmp_path):
+#     # Test when notice level is lower, and when msg file is given or not
 
-    # make sure we can set those properties
+
+def test_device_print(device, capsys, tmp_path):
+    # No message file declared. Should output to sys.stdout
     device.notice_level = 3
+    device.msg_file = None
+    _assert_common_properties(device, 3, None)
+
+    device.print("This message should output.")
+    # Print is not outputting to stdout
+    captured = capsys.readouterr()
+    assert captured.out == 'This message should output.\n'
+
+    #Message file declared. Should output in the file
     device.msg_file = str(tmp_path / "example.txt")
-    # Returns ostream
-    device.notice(device.notice_level, "Message")
-
-    _assert_common_properties(device, 3, str(tmp_path / "example.txt"))
-
-    # now make a device with non-default arguments
-    device_type = type(device)
-    dev = device_type(msg_file=str(tmp_path / "example2.txt"),
-                      notice_level=10,
-                      num_cpu_threads=10)
-    _assert_common_properties(dev,
-                              notice_level=10,
-                              msg_file=str(tmp_path / "example2.txt"),
-                              num_cpu_threads=10)
+    device.print("This message should output.")
+    
+    # Check the msg file if the output is correctly placed


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should be based on *trunk-patch*. -->
<!-- Backwards compatible new features should be based on *trunk-minor*. -->
<!-- Incompatible API changes should be based on *trunk-major*. -->

## Description

Adds a print API for `Messenger.notice` to `hoomd.device` denoted as `device.notice("Message")`.

## Motivation and context
Easily allows users to output information to a directed `msg_file` or stdout.
Resolves #1329.

## How has this been tested?

I added a unit test to check whether `"Message"` is properly outputted to a `msg_file` when explicitly declared.

## Change log

<!-- Propose a change log entry. -->
```
Added: An user-facing API for `Messenger.notice` 
```

## Checklist:

- [X] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
