### PR TITLE
Feat/movement limited method

### DIFF
--- a/hoomd/md/TwoStepNVE.cc
+++ b/hoomd/md/TwoStepNVE.cc
@@ -359,7 +359,7 @@ void export_TwoStepNVE(pybind11::module& m)
         m,
         "TwoStepNVE")
         .def(pybind11::init<std::shared_ptr<SystemDefinition>, std::shared_ptr<ParticleGroup>>())
-        .def_property("limit", &TwoStepNVE::getLimit, &TwoStepNVE::setLimit)
+        .def_property("maximum_displacement", &TwoStepNVE::getLimit, &TwoStepNVE::setLimit)
         .def_property("zero_force", &TwoStepNVE::getZeroForce, &TwoStepNVE::setZeroForce);
     }
     } // end namespace detail

--- a/hoomd/md/TwoStepNVE.h
+++ b/hoomd/md/TwoStepNVE.h
@@ -2,6 +2,7 @@
 // Part of HOOMD-blue, released under the BSD 3-Clause License.
 
 #include "IntegrationMethodTwoStep.h"
+#include "hoomd/Variant.h"
 
 #ifndef __TWO_STEP_NVE_H__
 #define __TWO_STEP_NVE_H__
@@ -33,10 +34,10 @@ class PYBIND11_EXPORT TwoStepNVE : public IntegrationMethodTwoStep
     virtual ~TwoStepNVE();
 
     /// Get the movement limit
-    pybind11::object getLimit();
+    std::shared_ptr<Variant> getLimit();
 
     //! Sets the movement limit
-    void setLimit(pybind11::object limit);
+    void setLimit(std::shared_ptr<Variant>& limit);
 
     /// Get zero force
     bool getZeroForce();
@@ -54,9 +55,9 @@ class PYBIND11_EXPORT TwoStepNVE : public IntegrationMethodTwoStep
     virtual void integrateStepTwo(uint64_t timestep);
 
     protected:
-    bool m_limit;       //!< True if we should limit the distance a particle moves in one step
-    Scalar m_limit_val; //!< The maximum distance a particle is to move in one step
-    bool m_zero_force;  //!< True if the integration step should ignore computed forces
+    //!< The maximum distance a particle is to move in one step
+    std::shared_ptr<Variant> m_limit;
+    bool m_zero_force; //!< True if the integration step should ignore computed forces
     };
 
     } // end namespace md

--- a/hoomd/md/TwoStepNVEGPU.cc
+++ b/hoomd/md/TwoStepNVEGPU.cc
@@ -41,6 +41,21 @@ TwoStepNVEGPU::TwoStepNVEGPU(std::shared_ptr<SystemDefinition> sysdef,
         new Autotuner(valid_params, 5, 100000, "nve_angular_two", this->m_exec_conf));
     }
 
+std::pair<bool, Scalar> TwoStepNVEGPU::getKernelLimitValues(uint64_t timestep)
+    {
+    auto use_limit = this->m_limit == nullptr;
+    Scalar maximum_displacement;
+    if (use_limit)
+        {
+        maximum_displacement = this->m_limit->operator()(timestep);
+        }
+    else
+        {
+        maximum_displacement = 0.0;
+        }
+    return std::pair<bool, Scalar>(use_limit, maximum_displacement);
+    }
+
 /*! \param timestep Current time step
     \post Particle positions are moved forward to timestep+1 and velocities to timestep+1/2 per the
    velocity verlet method.
@@ -69,6 +84,7 @@ void TwoStepNVEGPU::integrateStepOne(uint64_t timestep)
     // perform the update on the GPU
     m_exec_conf->beginMultiGPU();
     m_tuner_one->begin();
+    auto limit_params = this->getKernelLimitValues(timestep);
     kernel::gpu_nve_step_one(d_pos.data,
                              d_vel.data,
                              d_accel.data,
@@ -77,8 +93,8 @@ void TwoStepNVEGPU::integrateStepOne(uint64_t timestep)
                              m_group->getGPUPartition(),
                              box,
                              m_deltaT,
-                             m_limit,
-                             m_limit_val,
+                             limit_params.first,
+                             limit_params.second,
                              m_zero_force,
                              m_tuner_one->getParam());
 
@@ -148,14 +164,15 @@ void TwoStepNVEGPU::integrateStepTwo(uint64_t timestep)
     m_exec_conf->beginMultiGPU();
     m_tuner_two->begin();
 
+    auto limit_params = this->getKernelLimitValues(timestep);
     kernel::gpu_nve_step_two(d_vel.data,
                              d_accel.data,
                              d_index_array.data,
                              m_group->getGPUPartition(),
                              d_net_force.data,
                              m_deltaT,
-                             m_limit,
-                             m_limit_val,
+                             limit_params.first,
+                             limit_params.second,
                              m_zero_force,
                              m_tuner_two->getParam());
 

--- a/hoomd/md/TwoStepNVEGPU.cc
+++ b/hoomd/md/TwoStepNVEGPU.cc
@@ -43,7 +43,7 @@ TwoStepNVEGPU::TwoStepNVEGPU(std::shared_ptr<SystemDefinition> sysdef,
 
 std::pair<bool, Scalar> TwoStepNVEGPU::getKernelLimitValues(uint64_t timestep)
     {
-    auto use_limit = this->m_limit == nullptr;
+    auto use_limit = !(this->m_limit == nullptr);
     Scalar maximum_displacement;
     if (use_limit)
         {

--- a/hoomd/md/TwoStepNVEGPU.h
+++ b/hoomd/md/TwoStepNVEGPU.h
@@ -41,6 +41,8 @@ class PYBIND11_EXPORT TwoStepNVEGPU : public TwoStepNVE
     //! Performs the second step of the integration
     virtual void integrateStepTwo(uint64_t timestep);
 
+    std::pair<bool, Scalar> getKernelLimitValues(uint64_t timestep);
+
     //! Set autotuner parameters
     /*! \param enable Enable/disable autotuning
         \param period period (approximate) in time steps when returning occurs

--- a/hoomd/md/TwoStepRATTLENVE.h
+++ b/hoomd/md/TwoStepRATTLENVE.h
@@ -632,7 +632,7 @@ template<class Manifold> void export_TwoStepRATTLENVE(pybind11::module& m, const
                             std::shared_ptr<ParticleGroup>,
                             Manifold,
                             Scalar>())
-        .def_property("limit",
+        .def_property("maximum_displacement",
                       &TwoStepRATTLENVE<Manifold>::getLimit,
                       &TwoStepRATTLENVE<Manifold>::setLimit)
         .def_property("zero_force",

--- a/hoomd/md/TwoStepRATTLENVE.h
+++ b/hoomd/md/TwoStepRATTLENVE.h
@@ -14,6 +14,7 @@
 #error This header cannot be compiled by nvcc
 #endif
 
+#include "hoomd/Variant.h"
 #include "hoomd/VectorMath.h"
 #include <pybind11/pybind11.h>
 
@@ -49,31 +50,14 @@ template<class Manifold> class PYBIND11_EXPORT TwoStepRATTLENVE : public Integra
     virtual ~TwoStepRATTLENVE();
 
     //! Sets the movement limit
-    void setLimit(pybind11::object limit)
+    void setLimit(std::shared_ptr<Variant>& limit)
         {
-        if (limit.is_none())
-            {
-            m_limit = false;
-            }
-        else
-            {
-            m_limit = true;
-            m_limit_val = pybind11::cast<Scalar>(limit);
-            }
+        m_limit = limit;
         }
 
-    pybind11::object getLimit()
+    std::shared_ptr<Variant> getLimit()
         {
-        pybind11::object result;
-        if (m_limit)
-            {
-            result = pybind11::cast(m_limit_val);
-            }
-        else
-            {
-            result = pybind11::none();
-            }
-        return result;
+        return m_limit;
         }
 
     void setZeroForce(bool zero_force)
@@ -125,11 +109,11 @@ template<class Manifold> class PYBIND11_EXPORT TwoStepRATTLENVE : public Integra
         }
 
     Manifold m_manifold; //!< The manifold used for the RATTLE constraint
-    bool m_limit;        //!< True if we should limit the distance a particle moves in one step
-    Scalar m_limit_val;  //!< The maximum distance a particle is to move in one step
-    Scalar m_tolerance;  //!< The tolerance value of the RATTLE algorithm, setting the tolerance to
-                         //!< the manifold
-    bool m_zero_force;   //!< True if the integration step should ignore computed forces
+    //!< The maximum distance a particle can move in one step
+    std::shared_ptr<Variant> m_limit;
+    Scalar m_tolerance; //!< The tolerance value of the RATTLE algorithm, setting the tolerance to
+                        //!< the manifold
+    bool m_zero_force;  //!< True if the integration step should ignore computed forces
     bool m_box_changed;
     };
 
@@ -147,8 +131,8 @@ TwoStepRATTLENVE<Manifold>::TwoStepRATTLENVE(std::shared_ptr<SystemDefinition> s
                                              std::shared_ptr<ParticleGroup> group,
                                              Manifold manifold,
                                              Scalar tolerance)
-    : IntegrationMethodTwoStep(sysdef, group), m_manifold(manifold), m_limit(false),
-      m_limit_val(1.0), m_tolerance(tolerance), m_zero_force(false), m_box_changed(false)
+    : IntegrationMethodTwoStep(sysdef, group), m_manifold(manifold), m_limit(),
+      m_tolerance(tolerance), m_zero_force(false), m_box_changed(false)
     {
     m_exec_conf->msg->notice(5) << "Constructing TwoStepRATTLENVE" << std::endl;
 
@@ -228,12 +212,13 @@ template<class Manifold> void TwoStepRATTLENVE<Manifold>::integrateStepOne(uint6
         // limit the movement of the particles
         if (m_limit)
             {
+            Scalar maximum_displacement = m_limit->operator()(timestep);
             Scalar len = sqrt(dx * dx + dy * dy + dz * dz);
-            if (len > m_limit_val)
+            if (len > maximum_displacement)
                 {
-                dx = dx / len * m_limit_val;
-                dy = dy / len * m_limit_val;
-                dz = dz / len * m_limit_val;
+                dx = dx / len * maximum_displacement;
+                dy = dy / len * maximum_displacement;
+                dz = dz / len * maximum_displacement;
                 }
             }
 
@@ -472,13 +457,14 @@ template<class Manifold> void TwoStepRATTLENVE<Manifold>::integrateStepTwo(uint6
         // limit the movement of the particles
         if (m_limit)
             {
+            Scalar maximum_displacement = m_limit->operator()(timestep);
             Scalar vel = sqrt(h_vel.data[j].x * h_vel.data[j].x + h_vel.data[j].y * h_vel.data[j].y
                               + h_vel.data[j].z * h_vel.data[j].z);
-            if ((vel * m_deltaT) > m_limit_val)
+            if ((vel * m_deltaT) > maximum_displacement)
                 {
-                h_vel.data[j].x = h_vel.data[j].x / vel * m_limit_val / m_deltaT;
-                h_vel.data[j].y = h_vel.data[j].y / vel * m_limit_val / m_deltaT;
-                h_vel.data[j].z = h_vel.data[j].z / vel * m_limit_val / m_deltaT;
+                h_vel.data[j].x = h_vel.data[j].x / vel * maximum_displacement / m_deltaT;
+                h_vel.data[j].y = h_vel.data[j].y / vel * maximum_displacement / m_deltaT;
+                h_vel.data[j].z = h_vel.data[j].z / vel * maximum_displacement / m_deltaT;
                 }
             }
         }

--- a/hoomd/md/TwoStepRATTLENVEGPU.h
+++ b/hoomd/md/TwoStepRATTLENVEGPU.h
@@ -57,7 +57,7 @@ class PYBIND11_EXPORT TwoStepRATTLENVEGPU : public TwoStepRATTLENVE<Manifold>
 
     std::pair<bool, Scalar> getKernelLimitValues(uint64_t timestep)
         {
-        auto use_limit = this->m_limit == nullptr;
+        auto use_limit = !(this->m_limit == nullptr);
         Scalar maximum_displacement;
         if (use_limit)
             {

--- a/hoomd/md/methods/__init__.py
+++ b/hoomd/md/methods/__init__.py
@@ -14,4 +14,4 @@ For methods that constrain motion to a manifold see `hoomd.md.methods.rattle`
 
 from . import rattle
 from .methods import (Method, NVT, NPT, NPH, NVE, Langevin, Brownian, Berendsen,
-                      OverdampedViscous)
+                      DisplacementCapped, OverdampedViscous)

--- a/hoomd/md/methods/methods.py
+++ b/hoomd/md/methods/methods.py
@@ -688,7 +688,7 @@ class NVE(Method):
 
         # store metadata
         param_dict = ParameterDict(filter=ParticleFilter,)
-        param_dict.update(dict(filter=filter, zero_force=False))
+        param_dict["filter"] = filter
 
         # set defaults
         self._param_dict.update(param_dict)
@@ -706,6 +706,48 @@ class NVE(Method):
 
         # Attach param_dict and typeparam_dict
         super()._attach()
+
+
+class DisplacementCapped(NVE):
+    r"""Modified constant volume, constant energy dynamics with a cap on motion.
+
+    The method employs a maximum displacement allowed each time step. This
+    method can be helpful to relax a system with too much overlaps without
+    "blowing up" the system.
+
+    Args:
+        filter (hoomd.filter.filter_like): Subset of particles on which to
+            apply this method.
+        maximum_displacement (hoomd.variant.variant_like): The maximum
+            displacement allowed for a particular timestep.
+
+    `MotionCapped` integrates integrates translational and rotational degrees of
+    freedom using modified microcanoncial dynamics. See `NVE` for the basis of
+    the algorithm.
+
+    Examples::
+
+        relaxer = hoomd.md.methods.MotionCapped(filter=hoomd.filter.All(), 1e-3)
+        integrator = hoomd.md.Integrator(
+            dt=0.005, methods=[relaxer], forces=[lj])
+
+    Attributes:
+        filter (hoomd.filter.filter_like): Subset of particles on which to
+            apply this method.
+        maximum_displacement (hoomd.variant.variant_like): The maximum
+            displacement allowed for a particular timestep.
+    """
+
+    def __init__(self, filter,
+                 maximum_displacement: hoomd.variant.variant_like):
+
+        # store metadata
+        super().__init__(filter)
+        param_dict = ParameterDict(maximum_displacement=hoomd.variant.Variant)
+        param_dict["maximum_displacement"] = maximum_displacement
+
+        # set defaults
+        self._param_dict.update(param_dict)
 
 
 class Langevin(Method):

--- a/hoomd/md/methods/methods.py
+++ b/hoomd/md/methods/methods.py
@@ -732,7 +732,7 @@ class DisplacementCapped(NVE):
     Examples::
 
         relaxer = hoomd.md.methods.DisplacementCapped(
-            filter=hoomd.filter.All(), 1e-3)
+            filter=hoomd.filter.All(), maximum_displacement=1e-3)
         integrator = hoomd.md.Integrator(
             dt=0.005, methods=[relaxer], forces=[lj])
 

--- a/hoomd/md/methods/methods.py
+++ b/hoomd/md/methods/methods.py
@@ -709,17 +709,21 @@ class NVE(Method):
 
 
 class DisplacementCapped(NVE):
-    r"""Modified constant volume, constant energy dynamics with a cap on motion.
+    r"""Newtonian dynamics with a cap on the maximum displacement per time step.
 
     The method employs a maximum displacement allowed each time step. This
     method can be helpful to relax a system with too much overlaps without
     "blowing up" the system.
 
+    Warning:
+        This method does not conserve energy or momentum.
+
     Args:
         filter (hoomd.filter.filter_like): Subset of particles on which to
             apply this method.
         maximum_displacement (hoomd.variant.variant_like): The maximum
-            displacement allowed for a particular timestep.
+            displacement allowed for a particular timestep
+            :math:`[\mathrm{length}]`.
 
     `MotionCapped` integrates integrates translational and rotational degrees of
     freedom using modified microcanoncial dynamics. See `NVE` for the basis of
@@ -735,7 +739,8 @@ class DisplacementCapped(NVE):
         filter (hoomd.filter.filter_like): Subset of particles on which to
             apply this method.
         maximum_displacement (hoomd.variant.variant_like): The maximum
-            displacement allowed for a particular timestep.
+            displacement allowed for a particular timestep
+            :math:`[\mathrm{length}]`.
     """
 
     def __init__(self, filter,

--- a/hoomd/md/methods/methods.py
+++ b/hoomd/md/methods/methods.py
@@ -725,13 +725,14 @@ class DisplacementCapped(NVE):
             displacement allowed for a particular timestep
             :math:`[\mathrm{length}]`.
 
-    `MotionCapped` integrates integrates translational and rotational degrees of
-    freedom using modified microcanoncial dynamics. See `NVE` for the basis of
-    the algorithm.
+    `DisplacementCapped` integrates integrates translational and rotational
+    degrees of freedom using modified microcanoncial dynamics. See `NVE` for the
+    basis of the algorithm.
 
     Examples::
 
-        relaxer = hoomd.md.methods.MotionCapped(filter=hoomd.filter.All(), 1e-3)
+        relaxer = hoomd.md.methods.DisplacementCapped(
+            filter=hoomd.filter.All(), 1e-3)
         integrator = hoomd.md.Integrator(
             dt=0.005, methods=[relaxer], forces=[lj])
 

--- a/hoomd/md/methods/rattle.py
+++ b/hoomd/md/methods/rattle.py
@@ -138,6 +138,67 @@ class NVE(MethodRATTLE):
         super()._attach()
 
 
+class DisplacementCapped(NVE):
+    r"""NVE-like integration with capped displacement.
+
+    Integration is via a maximum displacement capped Velocity-Verlet with
+    RATTLE constraint. This class is useful to relax a simulation on a manifold.
+
+    Args:
+        filter (hoomd.filter.filter_like): Subset of particles on which to apply
+            this method.
+        maximum_displacement (hoomd.variant.variant_like): The maximum
+            displacement allowed for a particular timestep.
+        manifold_constraint (hoomd.md.manifold.Manifold): Manifold
+            constraint.
+        tolerance (`float`, optional): Defines the tolerated error particles are
+            allowed to deviate from the manifold in terms of the implicit
+            function. The units of tolerance match that of the selected
+            manifold's implicit function. Defaults to 1e-6
+
+    `DisplacementCapped` performs constant volume simulations as described in
+    `hoomd.md.methods.DisplacementCapped`. In addition the particles are
+    constrained to a manifold by using the RATTLE algorithm.
+
+    Examples::
+
+        sphere = hoomd.md.manifold.Sphere(r=10)
+        relax_rattle = hoomd.md.methods.rattle.DisplacementCapped(
+            filter=hoomd.filter.All(),maifold=sphere)
+        integrator = hoomd.md.Integrator(
+            dt=0.005, methods=[relax_rattle], forces=[lj])
+
+
+    Attributes:
+        filter (hoomd.filter.filter_like): Subset of particles on which to apply
+            this method.
+        maximum_displacement (hoomd.variant.variant_like): The maximum
+            displacement allowed for a particular timestep.
+        manifold_constraint (hoomd.md.manifold.Manifold): Manifold constraint
+            which is used by and as a trigger for the RATTLE algorithm of this
+            method.
+        tolerance (float): Defines the tolerated error particles are allowed to
+            deviate from the manifold in terms of the implicit function. The
+            units of tolerance match that of the selected manifold's implicit
+            function. Defaults to 1e-6
+
+    """
+
+    def __init__(self,
+                 filter: hoomd.filter.filter_like,
+                 maximum_displacement: hoomd.variant.variant_like,
+                 manifold_constraint: "hoomd.md.manifold.Manifold",
+                 tolerance: float = 1e-6):
+
+        # store metadata
+        super().__init__(filter, manifold_constraint, tolerance)
+        param_dict = ParameterDict(maximum_displacement=hoomd.variant.Variant)
+        param_dict["maximum_displacement"] = maximum_displacement
+
+        # set defaults
+        self._param_dict.update(param_dict)
+
+
 class Langevin(MethodRATTLE):
     r"""Langevin dynamics with RATTLE constraint.
 

--- a/hoomd/md/methods/rattle.py
+++ b/hoomd/md/methods/rattle.py
@@ -168,7 +168,7 @@ class DisplacementCapped(NVE):
 
         sphere = hoomd.md.manifold.Sphere(r=10)
         relax_rattle = hoomd.md.methods.rattle.DisplacementCapped(
-            filter=hoomd.filter.All(),maifold=sphere)
+            filter=hoomd.filter.All(), maximum_displacement=0.01, manifold=sphere)
         integrator = hoomd.md.Integrator(
             dt=0.005, methods=[relax_rattle], forces=[lj])
 

--- a/hoomd/md/methods/rattle.py
+++ b/hoomd/md/methods/rattle.py
@@ -168,7 +168,8 @@ class DisplacementCapped(NVE):
 
         sphere = hoomd.md.manifold.Sphere(r=10)
         relax_rattle = hoomd.md.methods.rattle.DisplacementCapped(
-            filter=hoomd.filter.All(), maximum_displacement=0.01, manifold=sphere)
+            filter=hoomd.filter.All(), maximum_displacement=0.01,
+            manifold=sphere)
         integrator = hoomd.md.Integrator(
             dt=0.005, methods=[relax_rattle], forces=[lj])
 

--- a/hoomd/md/methods/rattle.py
+++ b/hoomd/md/methods/rattle.py
@@ -139,16 +139,20 @@ class NVE(MethodRATTLE):
 
 
 class DisplacementCapped(NVE):
-    r"""NVE-like integration with capped displacement.
+    r"""Newtonian dynamics with a cap on the maximum displacement per time step.
 
     Integration is via a maximum displacement capped Velocity-Verlet with
     RATTLE constraint. This class is useful to relax a simulation on a manifold.
+
+    Warning:
+        This method does not conserve energy or momentum.
 
     Args:
         filter (hoomd.filter.filter_like): Subset of particles on which to apply
             this method.
         maximum_displacement (hoomd.variant.variant_like): The maximum
-            displacement allowed for a particular timestep.
+            displacement allowed for a particular timestep
+            :math:`[\mathrm{length}]`.
         manifold_constraint (hoomd.md.manifold.Manifold): Manifold
             constraint.
         tolerance (`float`, optional): Defines the tolerated error particles are
@@ -173,7 +177,8 @@ class DisplacementCapped(NVE):
         filter (hoomd.filter.filter_like): Subset of particles on which to apply
             this method.
         maximum_displacement (hoomd.variant.variant_like): The maximum
-            displacement allowed for a particular timestep.
+            displacement allowed for a particular timestep
+            :math:`[\mathrm{length}]`.
         manifold_constraint (hoomd.md.manifold.Manifold): Manifold constraint
             which is used by and as a trigger for the RATTLE algorithm of this
             method.

--- a/hoomd/md/pytest/test_methods.py
+++ b/hoomd/md/pytest/test_methods.py
@@ -143,7 +143,8 @@ def _method_base_params():
     method_base_params_list.extend([
         paramtuple(displacement_capped_setup_params,
                    displacement_capped_extra_params,
-                   displacement_capped_changed_params, None,
+                   displacement_capped_changed_params,
+                   hoomd.md.methods.rattle.DisplacementCapped,
                    hoomd.md.methods.DisplacementCapped)
     ])
 

--- a/hoomd/md/pytest/test_methods.py
+++ b/hoomd/md/pytest/test_methods.py
@@ -131,6 +131,22 @@ def _method_base_params():
                    hoomd.md.methods.rattle.NVE, hoomd.md.methods.NVE)
     ])
 
+    displacement_capped_setup_params = {
+        "maximum_displacement": hoomd.variant.Ramp(1e-3, 1e-1, 0, 1_00)
+    }
+
+    displacement_capped_extra_params = {}
+    displacement_capped_changed_params = {
+        "maximum_displacement": hoomd.variant.Constant(1e-2)
+    }
+
+    method_base_params_list.extend([
+        paramtuple(displacement_capped_setup_params,
+                   displacement_capped_extra_params,
+                   displacement_capped_changed_params, None,
+                   hoomd.md.methods.DisplacementCapped)
+    ])
+
     return method_base_params_list
 
 

--- a/sphinx-doc/module-md-methods-rattle.rst
+++ b/sphinx-doc/module-md-methods-rattle.rst
@@ -13,6 +13,7 @@ md.methods.rattle
 
     MethodRATTLE
     Brownian
+    DisplacementCapped
     Langevin
     NVE
     OverdampedViscous
@@ -23,6 +24,7 @@ md.methods.rattle
     :synopsis: RATTLE integration methods.
     :members: MethodRATTLE,
         Brownian,
+        DisplacementCapped,
         Langevin,
         NVE,
         OverdampedViscous

--- a/sphinx-doc/module-md-methods.rst
+++ b/sphinx-doc/module-md-methods.rst
@@ -13,6 +13,7 @@ md.methods
 
     Method
     Brownian
+    DisplacementCapped
     Langevin
     NPH
     NPT
@@ -27,6 +28,7 @@ md.methods
     :synopsis: Integration methods.
     :members: Method,
               Brownian,
+              DisplacementCapped,
               Langevin,
               NPH,
               NPT,


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should be based on *trunk-patch*. -->
<!-- Backwards compatible new features should be based on *trunk-minor*. -->
<!-- Incompatible API changes should be based on *trunk-major*. -->

## Description

- Creates `hoomd.md.methods.DisplacementCapped` and `hoomd.md.methods.rattle.DisplacementCapped` methods
- Changes `TwoStepNVE` to use a `Variant` as its displacement limitation.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves #1261

## How has this been tested?

The two classes have been added to existing tests.
<!--- Please describe in detail how you tested your changes. -->

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
Added: ``hoomd.md.methods.DisplacementCapped`` class for relaxing configurations with overlaps.
Added: ``hoomd.md.methods.rattle.DisplacementCapped`` class for relaxing configurations with overlaps.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
