### PR TITLE
Fix cylinder walls.

### DIFF
--- a/hoomd/md/WallData.h
+++ b/hoomd/md/WallData.h
@@ -86,7 +86,7 @@ struct __attribute__((visibility("default"))) CylinderWall
             }
         quatAxisToZRot = quat<Scalar>(realPart, w);
         Scalar norm = fast::rsqrt(norm2(quatAxisToZRot));
-        quatAxisToZRot = norm * quatAxisToZRot;
+        quatAxisToZRot = conj(norm * quatAxisToZRot);
         }
     quat<Scalar>
         quatAxisToZRot; // need to order datatype in descending order of type size for Fermi

--- a/hoomd/md/pytest/test_wall_potential.py
+++ b/hoomd/md/pytest/test_wall_potential.py
@@ -202,7 +202,7 @@ def test_sphere(simulation, cls, params):
 @pytest.mark.parametrize("cls, params", zip(_potential_cls, _params(2.5, 0.0)))
 def test_cylinder(simulation, cls, params):
     """Test that particles stay within the pipe defined by a cylinder wall."""
-    n = np.array([1,1,1])
+    n = np.array([1, 1, 1])
     radius = 5
     wall_pot = cls([
         hoomd.wall.Cylinder(radius=radius,
@@ -217,7 +217,7 @@ def test_cylinder(simulation, cls, params):
         with simulation.state.cpu_local_snapshot as snap:
             for i in range(simulation.state.N_particles):
                 r = snap.particles.position[i]
-                assert np.linalg.norm(r-(np.dot(r,n)*n)) < radius
+                assert np.linalg.norm(r - (np.dot(r, n) * n)) < radius
 
 
 @pytest.mark.parametrize("cls, params", zip(_potential_cls, _params(2.5, 0.0)))

--- a/hoomd/md/pytest/test_wall_potential.py
+++ b/hoomd/md/pytest/test_wall_potential.py
@@ -215,7 +215,7 @@ def test_cylinder(simulation, cls, params):
     for _ in range(10):
         simulation.run(10)
         with simulation.state.cpu_local_snapshot as snap:
-            for i in range(simulation.state.N_particles):
+            for i in range(len(snap.particles.position)):
                 r = snap.particles.position[i]
                 assert np.linalg.norm(r - (np.dot(r, n) * n)) < radius
 

--- a/hoomd/md/pytest/test_wall_potential.py
+++ b/hoomd/md/pytest/test_wall_potential.py
@@ -202,11 +202,12 @@ def test_sphere(simulation, cls, params):
 @pytest.mark.parametrize("cls, params", zip(_potential_cls, _params(2.5, 0.0)))
 def test_cylinder(simulation, cls, params):
     """Test that particles stay within the pipe defined by a cylinder wall."""
+    n = np.array([1,1,1])
     radius = 5
     wall_pot = cls([
         hoomd.wall.Cylinder(radius=radius,
                             origin=(0, 0, 0),
-                            axis=(0, 0, 1),
+                            axis=n,
                             inside=True)
     ])
     simulation.operations.integrator.forces.append(wall_pot)
@@ -214,8 +215,9 @@ def test_cylinder(simulation, cls, params):
     for _ in range(10):
         simulation.run(10)
         with simulation.state.cpu_local_snapshot as snap:
-            assert np.all(
-                np.linalg.norm(snap.particles.position[:, :2], axis=1) < radius)
+            for i in range(simulation.state.N_particles):
+                r = snap.particles.position[i]
+                assert np.linalg.norm(r-(np.dot(r,n)*n)) < radius
 
 
 @pytest.mark.parametrize("cls, params", zip(_potential_cls, _params(2.5, 0.0)))


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should be based on *trunk-patch*. -->
<!-- Backwards compatible new features should be based on *trunk-minor*. -->
<!-- Incompatible API changes should be based on *trunk-major*. -->

## Description

<!-- Describe your changes in detail. -->
Fix the distance calculation for off-axis cylinder walls.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
The code that determined the rotation quaternion worked only for on-axis cylinders. The rotation was computed from the destination to the source rather than the other way around.

## How has this been tested?

Tested with a script provided by the bug reporter.

<!--- Please describe in detail how you tested your changes. -->

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
* Fix non-axis-aligned Cylinder walls in MD.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
