### PR TITLE
Allow the seed constructor argument to be out of range.

### DIFF
--- a/hoomd/pytest/test_simulation.py
+++ b/hoomd/pytest/test_simulation.py
@@ -428,6 +428,13 @@ def test_seed(device, lattice_snapshot_factory):
     assert sim.seed == 20
 
 
+def test_seed_constructor_out_of_range(device, lattice_snapshot_factory):
+    sim = hoomd.Simulation(device, seed=0x123456789abcdef)
+
+    sim.create_state_from_snapshot(lattice_snapshot_factory())
+    assert sim.seed == 0xcdef
+
+
 def test_operations_setting(simulation_factory, lattice_snapshot_factory):
     sim = simulation_factory()
     sim.create_state_from_snapshot(lattice_snapshot_factory())

--- a/hoomd/simulation.py
+++ b/hoomd/simulation.py
@@ -40,7 +40,9 @@ class Simulation(metaclass=Loggable):
         self._operations = Operations()
         self._operations._simulation = self
         self._timestep = None
-        self._seed = seed
+        self._seed = None
+        if seed is not None:
+            self.seed = seed
 
     @property
     def device(self):


### PR DESCRIPTION
Emit the same warning when setting the property to an out of range value.

<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should be based on *trunk-patch*. -->
<!-- Backwards compatible new features should be based on *trunk-minor*. -->
<!-- Incompatible API changes should be based on *trunk-major*. -->

## Description

<!-- Describe your changes in detail. -->
Normalize the behavior between the seed constructor argument and the seed property.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Passing an out of range seed value to the constructor produces a pybind11 error when the state is created.

<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves #1364 

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
Added unit test.

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
* Provide a warning instead of an error when passing an out of range seed to the `Simulation` constructor.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
