### PR TITLE
Use compute-sanitizer.

### DIFF
--- a/CMake/hoomd/FindCUDALibs.cmake
+++ b/CMake/hoomd/FindCUDALibs.cmake
@@ -334,9 +334,9 @@ endif()
 #endif()
 
 if (HIP_PLATFORM STREQUAL "nvcc")
-    # find cuda-memcheck
+    # find compute-sanitizer
     find_program(CUDA_MEMCHECK_EXECUTABLE
-      NAMES cuda-memcheck
+      NAMES compute-sanitizer
       HINTS "${CUDA_BIN_PATH}"
       NO_DEFAULT_PATH)
     mark_as_advanced(CUDA_MEMCHECK_EXECUTABLE)


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should be based on *trunk-patch*. -->
<!-- Backwards compatible new features should be based on *trunk-minor*. -->
<!-- Incompatible API changes should be based on *trunk-major*. -->

## Description

<!-- Describe your changes in detail. -->
Switch from `cuda-memcheck` to `compute-sanitizer`.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
`cuda-memcheck` has been deprecated for some time and is no longer supported on H100.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
I tested this locally. The ctest invocations on CI will also test the change.

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
