### PR TITLE
Export HalfStepHook

### DIFF
--- a/hoomd/HalfStepHook.h
+++ b/hoomd/HalfStepHook.h
@@ -15,7 +15,7 @@
 
 namespace hoomd
     {
-class HalfStepHook
+class PYBIND11_EXPORT HalfStepHook
     {
     public:
     // Set SystemDefinition.

--- a/hoomd/md/CMakeLists.txt
+++ b/hoomd/md/CMakeLists.txt
@@ -593,6 +593,7 @@ set(files __init__.py
           constrain.py
           dihedral.py
           force.py
+          half_step_hook.py
           improper.py
           integrate.py
           manifold.py

--- a/hoomd/md/CMakeLists.txt
+++ b/hoomd/md/CMakeLists.txt
@@ -19,6 +19,7 @@ set(_md_sources module-md.cc
                    FIREEnergyMinimizer.cc
                    ForceComposite.cc
                    ForceDistanceConstraint.cc
+                   HalfStepHook.cc
                    HarmonicAngleForceCompute.cc
                    HarmonicDihedralForceCompute.cc
                    HarmonicImproperForceCompute.cc

--- a/hoomd/md/HalfStepHook.cc
+++ b/hoomd/md/HalfStepHook.cc
@@ -1,0 +1,50 @@
+// Copyright (c) 2009-2022 The Regents of the University of Michigan.
+// Part of HOOMD-blue, released under the BSD 3-Clause License.
+
+#include "hoomd/HalfStepHook.h"
+
+namespace hoomd
+    {
+namespace md
+    {
+
+//! Trampoline for HalfStepHook classes inherited in python
+class PYBIND11_EXPORT HalfStepHookPy : public HalfStepHook
+    {
+    public:
+    // Inherit the constructor
+    using HalfStepHook::HalfStepHook;
+
+    // Trampoline methods
+    void setSystemDefinition(std::shared_ptr<SystemDefinition> sysdef) override
+        {
+        PYBIND11_OVERLOAD_PURE(void, HalfStepHook, setSystemDefinition, sysdef);
+        }
+
+    void update(uint64_t timestep) override
+        {
+        PYBIND11_OVERLOAD_PURE(void, HalfStepHook, update, timestep);
+        }
+    };
+
+namespace detail
+    {
+
+// Method to enable unit testing of C++ HalfStepHook::update from pytest
+void testHalfStepHookUpdate(std::shared_ptr<HalfStepHook> hook, uint64_t step)
+    {
+    return hook->update(step);
+    }
+
+void export_HalfStepHook(pybind11::module& m)
+    {
+    pybind11::class_<HalfStepHook, HalfStepHookPy, std::shared_ptr<HalfStepHook>>(m, "HalfStepHook")
+        .def(pybind11::init_alias<>())
+        .def("setSystemDefinition", &HalfStepHook::setSystemDefinition)
+        .def("update", &HalfStepHook::update);
+    }
+
+    } // end namespace detail
+
+    } // end namespace md
+    } // end namespace hoomd

--- a/hoomd/md/IntegratorTwoStep.cc
+++ b/hoomd/md/IntegratorTwoStep.cc
@@ -375,7 +375,16 @@ void export_IntegratorTwoStep(pybind11::module& m)
         .def_property("rigid", &IntegratorTwoStep::getRigid, &IntegratorTwoStep::setRigid)
         .def_property("integrate_rotational_dof",
                       &IntegratorTwoStep::getIntegrateRotationalDOF,
-                      &IntegratorTwoStep::setIntegrateRotationalDOF);
+                      &IntegratorTwoStep::setIntegrateRotationalDOF)
+        .def_property("half_step_hook",
+                      nullptr,
+                      [](IntegratorTwoStep& self, std::shared_ptr<HalfStepHook> hook)
+                      {
+                          if (hook)
+                              self.setHalfStepHook(hook);
+                          else // `if hook is None` on the python side
+                              self.removeHalfStepHook();
+                      });
     }
 
     } // end namespace detail

--- a/hoomd/md/__init__.py
+++ b/hoomd/md/__init__.py
@@ -41,3 +41,4 @@ from hoomd.md import methods
 from hoomd.md import mesh
 from hoomd.md import many_body
 from hoomd.md import tune
+from hoomd.md.half_step_hook import HalfStepHook

--- a/hoomd/md/half_step_hook.py
+++ b/hoomd/md/half_step_hook.py
@@ -1,0 +1,31 @@
+# Copyright (c) 2009-2022 The Regents of the University of Michigan.
+# Part of HOOMD-blue, released under the BSD 3-Clause License.
+
+"""Perform user defined computations during the half-step of a \
+`hoomd.md.Integrator`.
+
+HalfStepHook can be subclassed to define custom operations at the middle of
+each integration step. Examples of use cases include evaluating collective
+variables or biasing the simulation.
+"""
+
+from hoomd.md import _md
+
+
+class HalfStepHook(_md.HalfStepHook):
+    """HalfStepHook base class.
+
+    HalfStepHook provides an interface to perform computations during the
+    half-step of a hoomd.md.Integrator.
+    """
+
+    def update(self, timestep):
+        """Called during the half-step of a `hoomd.md.Integrator`.
+
+        This method should provide the implementation of any computation that
+        the user wants to execute at each timestep in the middle of the
+        integration routine.
+        """
+        raise TypeError(
+            "Use a hoomd.md.HalfStepHook derived class implementing the "
+            "corresponding update method.")

--- a/hoomd/md/integrate.py
+++ b/hoomd/md/integrate.py
@@ -167,6 +167,9 @@ class Integrator(_DynamicIntegrator):
         rigid (hoomd.md.constrain.Rigid): An object defining the rigid bodies in
           the simulation.
 
+        half_step_hook (hoomd.md.HalfStepHook): Enables the user to perform
+            arbitrary computations during the half-step of the integration.
+
     `Integrator` is the top level class that orchestrates the time integration
     step in molecular dynamics simulations. The integration `methods` define
     the equations of motion to integrate under the influence of the given
@@ -273,6 +276,9 @@ class Integrator(_DynamicIntegrator):
 
         rigid (hoomd.md.constrain.Rigid): The rigid body definition for the
             simulation associated with the integrator.
+
+        half_step_hook (hoomd.md.HalfStepHook): User defined implementation to
+            perform computations during the half-step of the integration.
     """
 
     def __init__(self,
@@ -281,14 +287,19 @@ class Integrator(_DynamicIntegrator):
                  forces=None,
                  constraints=None,
                  methods=None,
-                 rigid=None):
+                 rigid=None,
+                 half_step_hook=None):
 
         super().__init__(forces, constraints, methods, rigid)
 
         self._param_dict.update(
             ParameterDict(
                 dt=float(dt),
-                integrate_rotational_dof=bool(integrate_rotational_dof)))
+                integrate_rotational_dof=bool(integrate_rotational_dof),
+                half_step_hook=OnlyTypes(hoomd.md.HalfStepHook,
+                                         allow_none=True)))
+
+        self.half_step_hook = half_step_hook
 
     def _attach(self):
         # initialize the reflected c++ class

--- a/hoomd/md/module-md.cc
+++ b/hoomd/md/module-md.cc
@@ -110,6 +110,7 @@ void export_TwoStepNVTAlchemy(pybind11::module& m);
 void export_FIREEnergyMinimizer(pybind11::module& m);
 void export_MuellerPlatheFlow(pybind11::module& m);
 void export_AlchemostatTwoStep(pybind11::module& m);
+void export_HalfStepHook(pybind11::module& m);
 
 void export_TwoStepRATTLEBDCylinder(pybind11::module& m);
 void export_TwoStepRATTLEBDDiamond(pybind11::module& m);
@@ -466,6 +467,7 @@ PYBIND11_MODULE(_md, m)
     export_MuellerPlatheFlow(m);
     export_AlchemostatTwoStep(m);
     export_TwoStepNVTAlchemy(m);
+    export_HalfStepHook(m);
 
     // RATTLE
     export_TwoStepRATTLEBDCylinder(m);

--- a/hoomd/md/pytest/CMakeLists.txt
+++ b/hoomd/md/pytest/CMakeLists.txt
@@ -12,6 +12,7 @@ set(files __init__.py
     test_custom_force.py
     test_external.py
     test_filter_md.py
+    test_half_step_hook.py
     test_improper.py
     test_integrate.py
     test_bond.py

--- a/hoomd/md/pytest/test_half_step_hook.py
+++ b/hoomd/md/pytest/test_half_step_hook.py
@@ -1,0 +1,66 @@
+# Copyright (c) 2009-2022 The Regents of the University of Michigan.
+# Part of HOOMD-blue, released under the BSD 3-Clause License.
+
+"""Test that `HalfStepHook` works."""
+
+import numpy as np
+import pytest
+import hoomd
+
+from hoomd import md
+
+
+class DistanceCV(md.HalfStepHook):
+
+    def __init__(self, sim):
+        md.HalfStepHook.__init__(self)
+        self.state = sim.state
+        self.time_series = []
+
+    def update(self, _):
+        snapshot = self.state.get_snapshot()
+        if snapshot.communicator.rank == 0:
+            r1, r2 = snapshot.particles.position
+            self.time_series.append(np.linalg.norm(r1 - r2))
+
+
+@pytest.fixture
+def make_simulation(simulation_factory, two_particle_snapshot_factory):
+
+    def sim_factory(particle_types=['A'], dimensions=3, d=1, L=20):
+        snap = two_particle_snapshot_factory()
+        if snap.communicator.rank == 0:
+            snap.constraints.N = 1
+            snap.constraints.value[0] = 1.0
+            snap.constraints.group[0] = [0, 1]
+        return simulation_factory(snap)
+
+    return sim_factory
+
+
+@pytest.fixture
+def integrator_elements():
+    nlist = md.nlist.Cell(buffer=0.4)
+    lj = md.pair.LJ(nlist=nlist, default_r_cut=2.5)
+    gauss = md.pair.Gauss(nlist, default_r_cut=3.0)
+    lj.params[("A", "A")] = {"epsilon": 1.0, "sigma": 1.0}
+    gauss.params[("A", "A")] = {"epsilon": 1.0, "sigma": 1.0}
+    return {
+        "methods": [md.methods.NVE(hoomd.filter.All())],
+        "forces": [lj, gauss],
+        "constraints": [md.constrain.Distance()]
+    }
+
+
+def test_half_step_hook(make_simulation, integrator_elements):
+    sim = make_simulation()
+    half_step_hook = DistanceCV(sim)
+    integrator = md.Integrator(0.005, **integrator_elements)
+    integrator.half_step_hook = half_step_hook
+    sim.operations.integrator = integrator
+    sim.run(1)
+    if sim.device.communicator.rank == 0:
+        assert len(half_step_hook.time_series) == 1
+    sim.run(9)
+    if sim.device.communicator.rank == 0:
+        assert len(half_step_hook.time_series) == 10

--- a/sphinx-doc/credits.rst
+++ b/sphinx-doc/credits.rst
@@ -78,6 +78,7 @@ The following people have contributed to the to HOOMD-blue:
 * Mike Henry, Boise State University
 * Nathan Horst
 * Nipuli Gunaratne, University of Michigan
+* Pablo Zubieta, PME, The University of Chicago
 * Patrick Lawton, University of Michigan
 * Paul Dodd, University of Michigan
 * Pavani Medapuram Lakshmi Narasimha, University of Minnesota

--- a/sphinx-doc/package-md.rst
+++ b/sphinx-doc/package-md.rst
@@ -8,7 +8,7 @@ hoomd.md
 
 .. automodule:: hoomd.md
     :synopsis: Molecular Dynamics.
-    :members: Integrator
+    :members: Integrator, HalfStepHook
 
 .. rubric:: Modules
 


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should be based on *trunk-patch*. -->
<!-- Backwards compatible new features should be based on *trunk-minor*. -->
<!-- Incompatible API changes should be based on *trunk-major*. -->

## Description

Add `HalfStepHook` and an `half_step_hook` property to `Integrator` as part of the interface for HOOMD-blue 3 (supersedes #1352). 

## Motivation and context

In https://github.com/glotzerlab/hoomd-blue/commit/4f91146843be1e47443a152bf3fe536f585f0c90 `setHalfStepHook` and `removeHalfStepHook` were dropped from the python interface for `Integrator`. We rely on these in https://github.com/SSAGESLabs/PySAGES

## How has this been tested?

Unit test included in the PR.

## Change log

<!-- Propose a change log entry. -->
```
*- `HalfStepHook` is now exposed as part of the interface for HOOMD-blue 3 and can be set as the property `half_step_hook` of a `hoomd.md.Integrator`.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
