### PR TITLE
Document installation procedure to enable run time compilation on macos.

### DIFF
--- a/INSTALLING.rst
+++ b/INSTALLING.rst
@@ -31,10 +31,20 @@ package. Override this and force GPU package installation with::
 
     $ conda install -c conda-forge "hoomd=*=*gpu*"
 
+.. note::
+
+    To use :ref:`run time compilation` on **macOS**, install the ``compilers`` package::
+
+        $ conda install -c conda-forge compilers
+
+    Without this package you will get *file not found* errors when HOOMD-blue performs the run time
+    compilation.
+
 .. tip::
 
-    Use miniforge_ or miniconda_ instead of the full Anaconda distribution to avoid package
-    conflicts with conda-forge_ packages.
+    Use mambaforge_, miniforge_ or miniconda_ instead of the full Anaconda distribution to avoid
+    package conflicts with conda-forge_ packages.
 
+.. _mambaforge: https://github.com/conda-forge/miniforge
 .. _miniforge: https://github.com/conda-forge/miniforge
 .. _miniconda: http://conda.pydata.org/miniconda.html

--- a/sphinx-doc/features.rst
+++ b/sphinx-doc/features.rst
@@ -100,6 +100,8 @@ very limited and only applies to implicit depletants in `hpmc.integrate.HPMCInte
 ``ENABLE_TBB`` CMake option (see :doc:`building`). At runtime, `hoomd.version.tbb_enabled` indicates
 whether the build supports threaded execution.
 
+.. _Run time compilation:
+
 Run time compilation
 --------------------
 


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should be based on *trunk-patch*. -->
<!-- Backwards compatible new features should be based on *trunk-minor*. -->
<!-- Incompatible API changes should be based on *trunk-major*. -->

## Description

<!-- Describe your changes in detail. -->
Instruct users to install the `compilers` package to use run time compilation on macOS.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
The `compilers` package provides a link to the macOS SDK which provides files needed to compile potentials at runtime, including `stdio.h`, and `math.h`. 

Without this package, users will get *file not found* errors. `compilers` cannot be made a dependency of `hoomd` on `conda-forge` due to technical limitations.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
I installed `hoomd 3.3.0 cpu_py310hb920e00_2` with `mambaforge` and checked that I got the file not found error when running HPMC unit tests. Then I installed `compilers` and all HPMC unit tests pass.

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
* Document installation procedure that enables run time compilation on macOS.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
