### PR TITLE
Add the Modelling Rigid Bodies tutorial.

### DIFF
--- a/sphinx-doc/index.rst
+++ b/sphinx-doc/index.rst
@@ -143,6 +143,7 @@ Molecular dynamics:
     tutorial/03-Parallel-Simulations-With-MPI/00-index
     tutorial/04-Custom-Actions-In-Python/00-index
     tutorial/05-Organizing-and-Executing-Simulations/00-index
+    tutorial/06-Modelling-Rigid-Bodies/00-index
 
 .. toctree::
     :maxdepth: 1


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should be based on *trunk-patch*. -->
<!-- Backwards compatible new features should be based on *trunk-minor*. -->
<!-- Incompatible API changes should be based on *trunk-major*. -->

## Description

<!-- Describe your changes in detail. -->
Add the rigid body tutorial from https://github.com/glotzerlab/hoomd-examples/pull/61.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Make the rigid body tutorial visible in the readthedocs documentation so that users can access it.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
I rendered the Sphinx documentation locally.

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
Added:

* *Modelling Rigid Bodies* tutorial.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
