### PR TITLE
Raise an error when there are duplicate types.

### DIFF
--- a/hoomd/BondedGroupData.cc
+++ b/hoomd/BondedGroupData.cc
@@ -230,11 +230,9 @@ void BondedGroupData<group_size, Group, name, has_type_mapping>::initializeFromS
     const Snapshot& snapshot)
     {
     // check that all fields in the snapshot have correct length
-    if (m_exec_conf->getRank() == 0 && !snapshot.validate())
+    if (m_exec_conf->getRank() == 0)
         {
-        std::ostringstream s;
-        s << "Error initializing from " << name << " data snapshot.";
-        throw std::runtime_error(s.str());
+        snapshot.validate();
         }
 
     // re-initialize data structures

--- a/hoomd/BondedGroupData.h
+++ b/hoomd/BondedGroupData.h
@@ -189,13 +189,29 @@ class BondedGroupData
         //! Validate the snapshot
         /* \returns true if number of elements in snapshot is consistent
          */
-        bool validate() const
+        void validate() const
             {
             if (has_type_mapping && groups.size() != type_id.size())
-                return false;
+                {
+                throw std::runtime_error("All array sizes must match.");
+                }
+
             if (!has_type_mapping && groups.size() != val.size())
-                return false;
-            return true;
+                {
+                throw std::runtime_error("All array sizes must match.");
+                }
+
+            // Check that the user provided unique type names.
+            if (has_type_mapping)
+                {
+                std::vector<std::string> types_copy = type_mapping;
+                std::sort(types_copy.begin(), types_copy.end());
+                auto last = std::unique(types_copy.begin(), types_copy.end());
+                if (last - types_copy.begin() != type_mapping.size())
+                    {
+                    throw std::runtime_error("Type names must be unique.");
+                    }
+                }
             }
 
         //! Replicate this snapshot

--- a/hoomd/BondedGroupData.h
+++ b/hoomd/BondedGroupData.h
@@ -207,7 +207,7 @@ class BondedGroupData
                 std::vector<std::string> types_copy = type_mapping;
                 std::sort(types_copy.begin(), types_copy.end());
                 auto last = std::unique(types_copy.begin(), types_copy.end());
-                if (last - types_copy.begin() != type_mapping.size())
+                if (static_cast<size_t>(last - types_copy.begin()) != type_mapping.size())
                     {
                     throw std::runtime_error("Type names must be unique.");
                     }

--- a/hoomd/MeshGroupData.cc
+++ b/hoomd/MeshGroupData.cc
@@ -112,11 +112,9 @@ void MeshGroupData<group_size, Group, name, snap, bond>::initializeFromSnapshot(
     const TriangleData::Snapshot& snapshot)
     {
     // check that all fields in the snapshot have correct length
-    if (this->m_exec_conf->getRank() == 0 && !snapshot.validate())
+    if (this->m_exec_conf->getRank() == 0)
         {
-        std::ostringstream s;
-        s << "Error initializing from " << name << " data snapshot.";
-        throw std::runtime_error(s.str());
+        snapshot.validate();
         }
 
     // re-initialize data structures

--- a/hoomd/ParticleData.cc
+++ b/hoomd/ParticleData.cc
@@ -2887,7 +2887,7 @@ template<class Real> void SnapshotParticleData<Real>::validate() const
     std::vector<std::string> types_copy = type_mapping;
     std::sort(types_copy.begin(), types_copy.end());
     auto last = std::unique(types_copy.begin(), types_copy.end());
-    if (last - types_copy.begin() != type_mapping.size())
+    if (static_cast<size_t>(last - types_copy.begin()) != type_mapping.size())
         {
         throw std::runtime_error("Type names must be unique.");
         }

--- a/hoomd/ParticleData.h
+++ b/hoomd/ParticleData.h
@@ -178,9 +178,9 @@ template<class Real> struct PYBIND11_EXPORT SnapshotParticleData
     void insert(unsigned int i, unsigned int n);
 
     //! Validate the snapshot
-    /*! \returns true if the number of elements is consistent
+    /*! Throws an exception when the snapshot contains invalid data.
      */
-    bool validate() const;
+    void validate() const;
 
 #ifdef ENABLE_MPI
     //! Broadcast the snapshot using MPI

--- a/hoomd/pytest/test_snapshot.py
+++ b/hoomd/pytest/test_snapshot.py
@@ -462,15 +462,18 @@ def test_no_particle_types(simulation_factory, lattice_snapshot_factory):
         simulation_factory(snap)
 
 
+@pytest.mark.serial
 def test_no_duplicate_particle_types(simulation_factory,
                                      lattice_snapshot_factory):
     """Test that initialization fails when there are duplicate types."""
     snap = lattice_snapshot_factory(particle_types=['A', 'B', 'C', 'A'])
 
+    # Run test in serial as only rank 0 raises the runtime error.
     with pytest.raises(RuntimeError):
         simulation_factory(snap)
 
 
+@pytest.mark.serial
 @pytest.mark.parametrize('bond',
                          ['bonds', 'angles', 'dihedrals', 'impropers', 'pairs'])
 def test_no_duplicate_bond_types(simulation_factory, lattice_snapshot_factory,
@@ -480,6 +483,7 @@ def test_no_duplicate_bond_types(simulation_factory, lattice_snapshot_factory,
 
     getattr(snap, bond).types = ['A', 'B', 'B', 'C']
 
+    # Run test in serial as only rank 0 raises the runtime error.
     with pytest.raises(RuntimeError):
         simulation_factory(snap)
 

--- a/hoomd/pytest/test_snapshot.py
+++ b/hoomd/pytest/test_snapshot.py
@@ -462,6 +462,28 @@ def test_no_particle_types(simulation_factory, lattice_snapshot_factory):
         simulation_factory(snap)
 
 
+def test_no_duplicate_particle_types(simulation_factory,
+                                     lattice_snapshot_factory):
+    """Test that initialization fails when there are duplicate types."""
+    snap = lattice_snapshot_factory(particle_types=['A', 'B', 'C', 'A'])
+
+    with pytest.raises(RuntimeError):
+        simulation_factory(snap)
+
+
+@pytest.mark.parametrize('bond',
+                         ['bonds', 'angles', 'dihedrals', 'impropers', 'pairs'])
+def test_no_duplicate_bond_types(simulation_factory, lattice_snapshot_factory,
+                                 bond):
+    """Test that initialization fails when there are duplicate types."""
+    snap = lattice_snapshot_factory(particle_types=['A'])
+
+    getattr(snap, bond).types = ['A', 'B', 'B', 'C']
+
+    with pytest.raises(RuntimeError):
+        simulation_factory(snap)
+
+
 def test_zero_particle_system(simulation_factory, lattice_snapshot_factory):
     """Test that zero particle systems can be initialized with no types."""
     snap = lattice_snapshot_factory(particle_types=[], n=0)


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should be based on *trunk-patch*. -->
<!-- Backwards compatible new features should be based on *trunk-minor*. -->
<!-- Incompatible API changes should be based on *trunk-major*. -->

## Description

<!-- Describe your changes in detail. -->
Raise an error when there are duplicate types.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
When the user provides duplicate types, for example ['A', 'B', 'A'], the first shadows the 2nd. Users can create particles with typeid 2, but cannot set type parameters for 2 as the 'A' lookup will return typeid 0.

This fix gives the user a more understandable error.

<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves #1368

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
Added unit tests.

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
Changed:

* Raise an error when initializing with duplicate types.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
