### PR TITLE
Document NeighborList properties in sphinx

### DIFF
--- a/sphinx-doc/module-md-nlist.rst
+++ b/sphinx-doc/module-md-nlist.rst
@@ -25,3 +25,4 @@ md.nlist
     :show-inheritance:
 
     .. autoclass:: NeighborList
+        :members:


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should be based on *trunk-patch*. -->
<!-- Backwards compatible new features should be based on *trunk-minor*. -->
<!-- Incompatible API changes should be based on *trunk-major*. -->

## Description

Adds `NeighborList`'s properties to the html docs. 

## Motivation and context

`num_builds` and `shortest_rebuild` are not currently rendered in the html documentation, but they should be.

<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves #1385 

## How has this been tested?

I built the html docs locally and these properties show up.

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
- Render `md.NeighborList` properties in sphinx-docs
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
