### PR TITLE
Add missing Autotuned.h to _hoomd_headers

### DIFF
--- a/hoomd/CMakeLists.txt
+++ b/hoomd/CMakeLists.txt
@@ -116,6 +116,7 @@ set(_hoomd_headers
     Action.h
     Analyzer.h
     ArrayView.h
+    Autotuned.h
     Autotuner.h
     BondedGroupData.cuh
     BondedGroupData.h


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should be based on *trunk-patch*. -->
<!-- Backwards compatible new features should be based on *trunk-minor*. -->
<!-- Incompatible API changes should be based on *trunk-major*. -->

## Description

This adds `Autotuned.h` to the set `_hoomd_headers` in `hoomd/CMakeLists.txt`.

## Motivation and context

I suspect this should have been part of #1351. Now external plugins that depend on `System.h` won't work as `Autotuned.h` will be missing from the set of header files in the `include` directory of any hoomd installation.

<!-- Replace ??? with the issue number that this pull request resolves. -->

## How has this been tested?

By building https://github.com/SSAGESLabs/hoomd-dlext/pull/15 against the changes in this PR.

## Change log

<!-- Propose a change log entry. -->
```
*- Allow external plugins to depend again on `System.h`.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
