### PR TITLE
Remove fix_cudart_rpath.

### DIFF
--- a/CMake/hoomd/hoomd-macros.cmake
+++ b/CMake/hoomd/hoomd-macros.cmake
@@ -1,13 +1,5 @@
 ###############################
 # Helper macros
-macro(fix_cudart_rpath target)
-if (ENABLE_HIP AND APPLE)
-add_custom_command(TARGET $<TARGET_FILE:${target}> POST_BUILD
-                          COMMAND install_name_tool ARGS -change @rpath/libcudart.dylib ${CUDA_CUDART_LIBRARY} ${_target_exe})
-add_custom_command(TARGET $<TARGET_FILE:${target}> POST_BUILD
-                          COMMAND install_name_tool ARGS -change @rpath/libcufft.dylib ${CUDA_cufft_LIBRARY} ${_target_exe})
-endif (ENABLE_HIP AND APPLE)
-endmacro(fix_cudart_rpath)
 
 # copy all given files from the current source directory to the current build directory
 # files must be specified by relative path

--- a/example_plugins/pair_plugin/CMakeLists.txt
+++ b/example_plugins/pair_plugin/CMakeLists.txt
@@ -40,8 +40,6 @@ target_link_libraries(_${COMPONENT_NAME}
                       PUBLIC HOOMD::_md
                       )
 
-fix_cudart_rpath(_${COMPONENT_NAME})
-
 # Install the library.
 install(TARGETS _${COMPONENT_NAME}
         LIBRARY DESTINATION ${PYTHON_SITE_INSTALL_DIR}/${COMPONENT_NAME}

--- a/example_plugins/updater_plugin/CMakeLists.txt
+++ b/example_plugins/updater_plugin/CMakeLists.txt
@@ -31,8 +31,6 @@ endif()
 # libraries) as needed.
 target_link_libraries(_${COMPONENT_NAME} PUBLIC HOOMD::_hoomd)
 
-fix_cudart_rpath(_${COMPONENT_NAME})
-
 # Install the library.
 install(TARGETS _${COMPONENT_NAME}
         LIBRARY DESTINATION ${PYTHON_SITE_INSTALL_DIR}/${COMPONENT_NAME}

--- a/hoomd/CMakeLists.txt
+++ b/hoomd/CMakeLists.txt
@@ -333,8 +333,6 @@ else()
 set_target_properties(_hoomd PROPERTIES INSTALL_RPATH "\$ORIGIN")
 endif()
 
-fix_cudart_rpath(_hoomd)
-
 # install the library
 install(TARGETS _hoomd quickhull EXPORT HOOMDTargets
         LIBRARY DESTINATION ${PYTHON_SITE_INSTALL_DIR}

--- a/hoomd/hpmc/CMakeLists.txt
+++ b/hoomd/hpmc/CMakeLists.txt
@@ -160,8 +160,6 @@ if (ENABLE_HIP AND HIP_PLATFORM STREQUAL "nvcc")
 target_link_libraries(_hpmc PUBLIC CUDA::cusparse )
 endif()
 
-fix_cudart_rpath(_hpmc)
-
 # install the library
 install(TARGETS _hpmc EXPORT HOOMDTargets
         LIBRARY DESTINATION ${PYTHON_SITE_INSTALL_DIR}/hpmc
@@ -264,8 +262,6 @@ if (ENABLE_LLVM)
     else()
     set_target_properties(_${PACKAGE_NAME} PROPERTIES INSTALL_RPATH "\$ORIGIN/..;\$ORIGIN")
     endif()
-
-    fix_cudart_rpath(_${PACKAGE_NAME})
 
     # install the library
     install(TARGETS _${PACKAGE_NAME}

--- a/hoomd/hpmc/test/CMakeLists.txt
+++ b/hoomd/hpmc/test/CMakeLists.txt
@@ -30,7 +30,6 @@ foreach (CUR_TEST ${TEST_LIST})
     add_dependencies(test_all ${CUR_TEST})
 
     target_link_libraries(${CUR_TEST} _hpmc ${PYTHON_LIBRARIES})
-    fix_cudart_rpath(${CUR_TEST})
 
 endforeach (CUR_TEST)
 

--- a/hoomd/md/CMakeLists.txt
+++ b/hoomd/md/CMakeLists.txt
@@ -577,8 +577,6 @@ if (ENABLE_HIP)
     target_link_libraries(_md PRIVATE neighbor)
 endif()
 
-fix_cudart_rpath(_md)
-
 # install the library
 install(TARGETS _md EXPORT HOOMDTargets
         LIBRARY DESTINATION ${PYTHON_SITE_INSTALL_DIR}/md

--- a/hoomd/md/test/CMakeLists.txt
+++ b/hoomd/md/test/CMakeLists.txt
@@ -60,8 +60,6 @@ foreach (CUR_TEST ${TEST_LIST} ${MPI_TEST_LIST})
     endif()
     target_link_libraries(${CUR_TEST} _md ${additional_link_options} ${PYTHON_LIBRARIES})
 
-    fix_cudart_rpath(${CUR_TEST})
-
 endforeach (CUR_TEST)
 
 # add non-MPI tests to test list first

--- a/hoomd/metal/CMakeLists.txt
+++ b/hoomd/metal/CMakeLists.txt
@@ -36,8 +36,6 @@ endif()
 # link the library to its dependencies
 target_link_libraries(_${PACKAGE_NAME} PUBLIC _md)
 
-fix_cudart_rpath(_${PACKAGE_NAME})
-
 # install the library
 install(TARGETS _${PACKAGE_NAME}
         LIBRARY DESTINATION ${PYTHON_SITE_INSTALL_DIR}/${PACKAGE_NAME}

--- a/hoomd/mpcd/CMakeLists.txt
+++ b/hoomd/mpcd/CMakeLists.txt
@@ -134,8 +134,6 @@ if (ENABLE_HIP)
     target_link_libraries(_mpcd PUBLIC CUDA::cudadevrt)
 endif (ENABLE_HIP)
 
-fix_cudart_rpath(_mpcd)
-
 # install the library
 install(TARGETS _mpcd EXPORT HOOMDTargets
         LIBRARY DESTINATION ${PYTHON_SITE_INSTALL_DIR}/mpcd

--- a/hoomd/mpcd/test/CMakeLists.txt
+++ b/hoomd/mpcd/test/CMakeLists.txt
@@ -54,7 +54,6 @@ macro(compile_test TEST_EXE TEST_SRC)
     target_include_directories(${TEST_EXE} PRIVATE ${PYTHON_INCLUDE_DIR})
     add_dependencies(test_all ${TEST_EXE})
     target_link_libraries(${TEST_EXE} _mpcd ${PYTHON_LIBRARIES})
-    fix_cudart_rpath(${TEST_EXE})
 
 endmacro(compile_test)
 

--- a/hoomd/test/CMakeLists.txt
+++ b/hoomd/test/CMakeLists.txt
@@ -61,8 +61,6 @@ foreach (CUR_TEST ${TEST_LIST} ${MPI_TEST_LIST})
     add_dependencies(test_all ${CUR_TEST})
     target_link_libraries(${CUR_TEST} _hoomd ${PYTHON_LIBRARIES})
 
-    fix_cudart_rpath(${CUR_TEST})
-
 endforeach (CUR_TEST)
 
 # add non-MPI tests to test list first

--- a/sphinx-doc/migrating.rst
+++ b/sphinx-doc/migrating.rst
@@ -1,15 +1,36 @@
 .. Copyright (c) 2009-2022 The Regents of the University of Michigan.
 .. Part of HOOMD-blue, released under the BSD 3-Clause License.
 
+Migrating to the latest version
+===============================
+
+Migrating to HOOMD v4
+---------------------
+
+Removed functionality
+^^^^^^^^^^^^^^^^^^^^^
+
+HOOMD v4 removes functionality deprecated in v3.x releases.
+
+Compiling
+^^^^^^^^^
+
+* HOOMD v4 no longer builds on macOS with ``ENABLE_GPU=on``.
+
+Components
+^^^^^^^^^^
+
+* Remove ``fix_cudart_rpath(_${COMPONENT_NAME})`` from your components ``CMakeLists.txt``
+
 Migrating to HOOMD v3
-=====================
+---------------------
 
 HOOMD v3 introduces many breaking changes for both users and developers
 in order to provide a cleaner Python interface, enable new functionalities, and
 move away from unsupported tools. This guide highlights those changes.
 
 Overview of API changes
------------------------
+^^^^^^^^^^^^^^^^^^^^^^^
 
 HOOMD v3 introduces a completely new API. All classes have been renamed to match
 PEP8 naming guidelines and have new or renamed parameters, methods, and
@@ -75,7 +96,7 @@ Here is a module level overview of features that have been moved or removed:
      - `hoomd.hpmc.external.user`
 
 Removed functionality
----------------------
+^^^^^^^^^^^^^^^^^^^^^
 
 HOOMD v3 removes old APIs, unused functionality, and features better served by other codes:
 

--- a/sphinx-doc/migrating.rst
+++ b/sphinx-doc/migrating.rst
@@ -203,7 +203,7 @@ HOOMD v3 removes old APIs, unused functionality, and features better served by o
      - ALJ pair potential in `hoomd.md.pair.aniso`.
 
 Not yet ported
---------------
+^^^^^^^^^^^^^^
 
 The following v2 functionalities have not yet been ported to the v3 API. They may be added in a
 future 3.x release:
@@ -219,7 +219,7 @@ contact the developers if you have an interest in porting these in a future rele
 
 
 Compiling
----------
+^^^^^^^^^
 
 * CMake 3.8 or newer is required to build HOOMD v3.0.
 * To compile with GPU support, use the option ``ENABLE_GPU=ON``.
@@ -234,7 +234,7 @@ Compiling
 * ``BUILD_JIT`` is replaced with ``ENABLE_LLVM``.
 
 Components
-----------
+^^^^^^^^^^
 
 * HOOMD now uses native CUDA support in CMake. Use ``CMAKE_CUDA_COMPILER`` to
   specify a specific ``nvcc`` or ``hipcc``. Plugins will require updates to


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should be based on *trunk-patch*. -->
<!-- Backwards compatible new features should be based on *trunk-minor*. -->
<!-- Incompatible API changes should be based on *trunk-major*. -->

## Description

<!-- Describe your changes in detail. -->
Remove the CMake macro `fix_cudart_rpath`.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
This macro is no longer needed. The last CUDA release with support for macOS is CUDA 10.2 which is quite old at this time. I do not have access to any macOS machines with NVIDIA GPUs.

<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves #1383

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
Successfully built locally with `ENABLE_GPU=on`.

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
* Remove `fix_cudart_rpath` macro.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
