### PR TITLE
Fix/ndarray validation

### DIFF
--- a/hoomd/data/collections.py
+++ b/hoomd/data/collections.py
@@ -7,6 +7,8 @@ from abc import abstractmethod
 from collections import abc
 import warnings
 
+import numpy as np
+
 import hoomd
 import hoomd.data.typeconverter as _typeconverter
 
@@ -562,6 +564,13 @@ class _HOOMDTuple(_HOOMDSyncedCollection, abc.Sequence):
 def _to_hoomd_data(root, schema, parent=None, identity=None, data=None):
     _exclude_classes = (hoomd.logging.Logger,)
     if isinstance(data, _exclude_classes):
+        return data
+    # Even though a ndarray is a MutableSequence we need to ensure that it
+    # remains a ndarray and not a list when the validation is for an array. In
+    # addition, this would error if we allowed the MutableSequence conditional
+    # to execute.
+    if (isinstance(data, np.ndarray)
+            and isinstance(schema, _typeconverter.NDArrayValidator)):
         return data
     if isinstance(data, abc.MutableMapping):
         spec = _find_structural_validator(schema,

--- a/hoomd/pytest/test_collections.py
+++ b/hoomd/pytest/test_collections.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2009-2022 The Regents of the University of Michigan.
 # Part of HOOMD-blue, released under the BSD 3-Clause License.
 
+import numpy as np
 import pytest
 
 from hoomd.conftest import BaseListTest, BaseMappingTest, BaseSequenceTest
@@ -115,11 +116,15 @@ class TestHoomdTuple(BaseSequenceTest):
 
         def generate(n):
             strings = [self.str() for _ in range(self.int(10))]
-            return (self.int(), strings, self.float())
+            return (self.int(), strings, self.float(), self.ndarray((None, 3)))
 
         return generate
 
     def is_equal(self, a, b):
+        if isinstance(a, np.ndarray):
+            return np.array_equal(a, b)
+        if isinstance(b, np.ndarray):
+            return False
         return a == b
 
     def final_check(self, test_tuple):
@@ -133,8 +138,11 @@ class TestHoomdTuple(BaseSequenceTest):
     @pytest.fixture
     def populated_collection(self, plain_collection):
 
-        self._data = MockRoot({"tuple": (int, [str], float)},
-                              {"tuple": plain_collection})
+        self._data = MockRoot(
+            {
+                "tuple": (int, [str], float,
+                          typeconverter.NDArrayValidator("float64", (None, 3)))
+            }, {"tuple": plain_collection})
         return self._data._sync_data["tuple"], plain_collection
 
 

--- a/hoomd/pytest/test_collections.py
+++ b/hoomd/pytest/test_collections.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2009-2022 The Regents of the University of Michigan.
 # Part of HOOMD-blue, released under the BSD 3-Clause License.
 
+import warnings
+
 import numpy as np
 import pytest
 
@@ -227,7 +229,7 @@ class TestHoomdDict(BaseMappingTest):
             with pytest.warns(IsolationWarning):
                 obj[0] = obj._data[0]
 
-            with pytest.warns(None) as warning_record:
+            with warnings.catch_warnings(record=True) as warning_record:
                 obj.to_base()
             assert len(warning_record) == 0
 
@@ -240,7 +242,7 @@ class TestHoomdDict(BaseMappingTest):
             with pytest.warns(IsolationWarning):
                 list(obj._data[0])
 
-            with pytest.warns(None) as warning_record:
+            with warnings.catch_warnings(record=True) as warning_record:
                 obj._data[0].to_base()
             assert len(warning_record) == 0
 
@@ -256,7 +258,7 @@ class TestHoomdDict(BaseMappingTest):
             with pytest.warns(IsolationWarning):
                 obj._data[0][1][0] = obj._data[0][1]._data[0]
 
-            with pytest.warns(None) as warning_record:
+            with warnings.catch_warnings(record=True) as warning_record:
                 obj._data[0]._data[1].to_base()
             assert len(warning_record) == 0
 


### PR DESCRIPTION
## Description
- test: Refactor tests to remove pytest 8 deprecation warnings
- test: Test NumPy arrays in collections tests
- fix: _HOOMDSyncedCollection.__contains__ with ndarray elements.
  Since numpy.ndarray objects overwrite == to be element-wise, this leads
  to errors when having structures that contain array elements. This fixes
  this for __contains__. Other tests pass without this change and arrays.
- fix: Use of NumPy arrays in _HOOMDSyncedCollections  
  Fixes error in treating ndarray objects as MutableSequences for purposes
  of synced collections.

## Motivation and context

Resolves an issue brought to my attention by @Charlottez112 where the `default` property of `hoomd.md.pair.Table.params` fails.

## How has this been tested?
- Tests have been modified to look at NumPy array behavior.

## Change log
NA

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
