### PR TITLE
Replace deprecated usage of cusparse.

### DIFF
--- a/CMake/hoomd/HOOMDCUDASetup.cmake
+++ b/CMake/hoomd/HOOMDCUDASetup.cmake
@@ -18,6 +18,11 @@ if (ENABLE_HIP)
             set(CUDA_ARCH_LIST 60 CACHE STRING "List of target sm_ architectures to compile CUDA code for. Separate with semicolons.")
         endif()
 
+        if (CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL 11.2)
+          set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DCUSPARSE_NEW_API")
+          set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -DCUSPARSE_NEW_API")
+        endif()
+
         # need to know the minimum supported CUDA_ARCH
         set(_cuda_arch_list_sorted ${CUDA_ARCH_LIST})
         list(SORT _cuda_arch_list_sorted)

--- a/hoomd/md/ForceDistanceConstraintGPU.cc
+++ b/hoomd/md/ForceDistanceConstraintGPU.cc
@@ -238,7 +238,7 @@ void ForceDistanceConstraintGPU::solveConstraints(uint64_t timestep)
         m_condition.resetFlags(0);
 
         m_csr_rowptr.resize(n_constraint + 1);
-
+#ifdef CUSPARSE_NEW_API
             {
             ArrayHandle<int> d_csr_rowptr(m_csr_rowptr,
                                           access_location::device,
@@ -301,7 +301,62 @@ void ForceDistanceConstraintGPU::solveConstraints(uint64_t timestep)
             cusparseDestroySpMat(csr_descr);
             cudaFree(d_buffer);
             }
+#else
+            {
+            // access matrix and vector
+            ArrayHandle<double> d_cmatrix(m_cmatrix, access_location::device, access_mode::read);
+            ArrayHandle<double> d_cvec(m_cvec, access_location::device, access_mode::read);
 
+            // access sparse matrix structural data
+            ArrayHandle<int> d_nnz(m_nnz, access_location::device, access_mode::overwrite);
+
+            m_nnz_tot = 0;
+
+            // count non zeros
+            kernel::gpu_count_nnz(n_constraint,
+                                  d_cmatrix.data,
+                                  d_nnz.data,
+                                  m_nnz_tot,
+                                  m_cusparse_handle,
+                                  m_cusparse_mat_descr);
+
+            if (m_exec_conf->isCUDAErrorCheckingEnabled())
+                CHECK_CUDA_ERROR();
+            }
+        m_csr_colind.resize(m_nnz_tot);
+        m_sparse_val.resize(m_nnz_tot);
+            {
+            // access matrix and vector
+            ArrayHandle<double> d_cmatrix(m_cmatrix, access_location::device, access_mode::read);
+            ArrayHandle<double> d_cvec(m_cvec, access_location::device, access_mode::read);
+
+            // access sparse matrix structural data
+            ArrayHandle<int> d_nnz(m_nnz, access_location::device, access_mode::overwrite);
+            ArrayHandle<int> d_csr_colind(m_csr_colind,
+                                          access_location::device,
+                                          access_mode::overwrite);
+            ArrayHandle<int> d_csr_rowptr(m_csr_rowptr,
+                                          access_location::device,
+                                          access_mode::overwrite);
+            ArrayHandle<double> d_sparse_val(m_sparse_val,
+                                             access_location::device,
+                                             access_mode::overwrite);
+
+            // count zeros and convert matrix
+            kernel::gpu_dense2sparse(n_constraint,
+                                     d_cmatrix.data,
+                                     d_nnz.data,
+                                     m_cusparse_handle,
+                                     m_cusparse_mat_descr,
+                                     d_csr_rowptr.data,
+                                     d_csr_colind.data,
+                                     d_sparse_val.data);
+
+            if (m_exec_conf->isCUDAErrorCheckingEnabled())
+                CHECK_CUDA_ERROR();
+            }
+
+#endif
             {
             ArrayHandle<int> h_sparse_idxlookup(m_sparse_idxlookup,
                                                 access_location::host,

--- a/hoomd/md/ForceDistanceConstraintGPU.cc
+++ b/hoomd/md/ForceDistanceConstraintGPU.cc
@@ -237,61 +237,58 @@ void ForceDistanceConstraintGPU::solveConstraints(uint64_t timestep)
         // reset flags
         m_condition.resetFlags(0);
 
-            {
-            // access matrix and vector
-            ArrayHandle<double> d_cmatrix(m_cmatrix, access_location::device, access_mode::read);
-            ArrayHandle<double> d_cvec(m_cvec, access_location::device, access_mode::read);
-
-            // access sparse matrix structural data
-            ArrayHandle<int> d_nnz(m_nnz, access_location::device, access_mode::overwrite);
-
-            m_nnz_tot = 0;
-
-            // count non zeros
-            kernel::gpu_count_nnz(n_constraint,
-                                  d_cmatrix.data,
-                                  d_nnz.data,
-                                  m_nnz_tot,
-                                  m_cusparse_handle,
-                                  m_cusparse_mat_descr);
-
-            if (m_exec_conf->isCUDAErrorCheckingEnabled())
-                CHECK_CUDA_ERROR();
-            }
-
         m_csr_rowptr.resize(n_constraint + 1);
+
+            {
+          ArrayHandle<int> d_csr_rowptr(m_csr_rowptr,
+                                        access_location::device,
+                                        access_mode::overwrite);
+            ArrayHandle<double> d_cmatrix(m_cmatrix, access_location::device, access_mode::read);
+          cusparseDnMatDescr_t cmatrix_descr;
+          cusparseSpMatDescr_t csr_descr;
+          cusparseCreateDnMat(&cmatrix_descr, n_constraint, n_constraint, n_constraint, d_cmatrix.data,
+                              CUDA_R_64F, CUSPARSE_ORDER_COL);
+          cusparseCreateCsr(&csr_descr, n_constraint, n_constraint, 0,
+                            d_csr_rowptr.data, NULL, NULL,
+                            CUSPARSE_INDEX_32I, CUSPARSE_INDEX_32I,
+                            CUSPARSE_INDEX_BASE_ZERO, CUDA_R_64F);
+          size_t bufferSize = 0;
+          cusparseDenseToSparse_bufferSize(m_cusparse_handle,
+                                           cmatrix_descr,
+                                           csr_descr,
+                                           CUSPARSE_DENSETOSPARSE_ALG_DEFAULT,
+                                           &bufferSize);
+          void* d_buffer    = NULL;
+          cudaMalloc(&d_buffer, bufferSize);
+          cusparseDenseToSparse_analysis(m_cusparse_handle,
+                                         cmatrix_descr,
+                                         csr_descr,
+                                         CUSPARSE_DENSETOSPARSE_ALG_DEFAULT,
+                                         d_buffer);
+          int64_t nrows, ncols, nnz;
+          cusparseSpMatGetSize(csr_descr, &nrows, &ncols, &nnz);
+          m_nnz_tot = static_cast<int>(nnz);
         m_csr_colind.resize(m_nnz_tot);
         m_sparse_val.resize(m_nnz_tot);
-
-            {
-            // access matrix and vector
-            ArrayHandle<double> d_cmatrix(m_cmatrix, access_location::device, access_mode::read);
-            ArrayHandle<double> d_cvec(m_cvec, access_location::device, access_mode::read);
-
-            // access sparse matrix structural data
-            ArrayHandle<int> d_nnz(m_nnz, access_location::device, access_mode::overwrite);
             ArrayHandle<int> d_csr_colind(m_csr_colind,
-                                          access_location::device,
-                                          access_mode::overwrite);
-            ArrayHandle<int> d_csr_rowptr(m_csr_rowptr,
                                           access_location::device,
                                           access_mode::overwrite);
             ArrayHandle<double> d_sparse_val(m_sparse_val,
                                              access_location::device,
                                              access_mode::overwrite);
-
-            // count zeros and convert matrix
-            kernel::gpu_dense2sparse(n_constraint,
-                                     d_cmatrix.data,
-                                     d_nnz.data,
-                                     m_cusparse_handle,
-                                     m_cusparse_mat_descr,
+          cusparseCsrSetPointers(csr_descr,
                                      d_csr_rowptr.data,
                                      d_csr_colind.data,
                                      d_sparse_val.data);
+          cusparseDenseToSparse_convert(m_cusparse_handle,
+                                        cmatrix_descr,
+                                        csr_descr,
+                                        CUSPARSE_DENSETOSPARSE_ALG_DEFAULT,
+                                        d_buffer);
+          cusparseDestroyDnMat(cmatrix_descr);
+          cusparseDestroySpMat(csr_descr);
+          cudaFree(d_buffer);
 
-            if (m_exec_conf->isCUDAErrorCheckingEnabled())
-                CHECK_CUDA_ERROR();
             }
 
             {

--- a/hoomd/md/ForceDistanceConstraintGPU.cc
+++ b/hoomd/md/ForceDistanceConstraintGPU.cc
@@ -240,55 +240,66 @@ void ForceDistanceConstraintGPU::solveConstraints(uint64_t timestep)
         m_csr_rowptr.resize(n_constraint + 1);
 
             {
-          ArrayHandle<int> d_csr_rowptr(m_csr_rowptr,
-                                        access_location::device,
-                                        access_mode::overwrite);
+            ArrayHandle<int> d_csr_rowptr(m_csr_rowptr,
+                                          access_location::device,
+                                          access_mode::overwrite);
             ArrayHandle<double> d_cmatrix(m_cmatrix, access_location::device, access_mode::read);
-          cusparseDnMatDescr_t cmatrix_descr;
-          cusparseSpMatDescr_t csr_descr;
-          cusparseCreateDnMat(&cmatrix_descr, n_constraint, n_constraint, n_constraint, d_cmatrix.data,
-                              CUDA_R_64F, CUSPARSE_ORDER_COL);
-          cusparseCreateCsr(&csr_descr, n_constraint, n_constraint, 0,
-                            d_csr_rowptr.data, NULL, NULL,
-                            CUSPARSE_INDEX_32I, CUSPARSE_INDEX_32I,
-                            CUSPARSE_INDEX_BASE_ZERO, CUDA_R_64F);
-          size_t bufferSize = 0;
-          cusparseDenseToSparse_bufferSize(m_cusparse_handle,
+            cusparseDnMatDescr_t cmatrix_descr;
+            cusparseSpMatDescr_t csr_descr;
+            cusparseCreateDnMat(&cmatrix_descr,
+                                n_constraint,
+                                n_constraint,
+                                n_constraint,
+                                d_cmatrix.data,
+                                CUDA_R_64F,
+                                CUSPARSE_ORDER_COL);
+            cusparseCreateCsr(&csr_descr,
+                              n_constraint,
+                              n_constraint,
+                              0,
+                              d_csr_rowptr.data,
+                              NULL,
+                              NULL,
+                              CUSPARSE_INDEX_32I,
+                              CUSPARSE_INDEX_32I,
+                              CUSPARSE_INDEX_BASE_ZERO,
+                              CUDA_R_64F);
+            size_t bufferSize = 0;
+            cusparseDenseToSparse_bufferSize(m_cusparse_handle,
+                                             cmatrix_descr,
+                                             csr_descr,
+                                             CUSPARSE_DENSETOSPARSE_ALG_DEFAULT,
+                                             &bufferSize);
+            void* d_buffer = NULL;
+            cudaMalloc(&d_buffer, bufferSize);
+            cusparseDenseToSparse_analysis(m_cusparse_handle,
                                            cmatrix_descr,
                                            csr_descr,
                                            CUSPARSE_DENSETOSPARSE_ALG_DEFAULT,
-                                           &bufferSize);
-          void* d_buffer    = NULL;
-          cudaMalloc(&d_buffer, bufferSize);
-          cusparseDenseToSparse_analysis(m_cusparse_handle,
-                                         cmatrix_descr,
-                                         csr_descr,
-                                         CUSPARSE_DENSETOSPARSE_ALG_DEFAULT,
-                                         d_buffer);
-          int64_t nrows, ncols, nnz;
-          cusparseSpMatGetSize(csr_descr, &nrows, &ncols, &nnz);
-          m_nnz_tot = static_cast<int>(nnz);
-        m_csr_colind.resize(m_nnz_tot);
-        m_sparse_val.resize(m_nnz_tot);
+                                           d_buffer);
+            int64_t nrows, ncols, nnz;
+            cusparseSpMatGetSize(csr_descr, &nrows, &ncols, &nnz);
+            m_nnz_tot = static_cast<int>(nnz);
+            m_csr_colind.resize(m_nnz_tot);
+            m_sparse_val.resize(m_nnz_tot);
             ArrayHandle<int> d_csr_colind(m_csr_colind,
                                           access_location::device,
                                           access_mode::overwrite);
             ArrayHandle<double> d_sparse_val(m_sparse_val,
                                              access_location::device,
                                              access_mode::overwrite);
-          cusparseCsrSetPointers(csr_descr,
-                                     d_csr_rowptr.data,
-                                     d_csr_colind.data,
-                                     d_sparse_val.data);
-          cusparseDenseToSparse_convert(m_cusparse_handle,
-                                        cmatrix_descr,
-                                        csr_descr,
-                                        CUSPARSE_DENSETOSPARSE_ALG_DEFAULT,
-                                        d_buffer);
-          cusparseDestroyDnMat(cmatrix_descr);
-          cusparseDestroySpMat(csr_descr);
-          cudaFree(d_buffer);
-
+            cusparseCsrSetPointers(csr_descr,
+                                   d_csr_rowptr.data,
+                                   d_csr_colind.data,
+                                   d_sparse_val.data);
+            cusparseDenseToSparse_convert(m_cusparse_handle,
+                                          cmatrix_descr,
+                                          csr_descr,
+                                          CUSPARSE_DENSETOSPARSE_ALG_DEFAULT,
+                                          d_buffer);
+            cusparseDestroyDnMat(cmatrix_descr);
+            cusparseDestroySpMat(csr_descr);
+            cudaFree(d_buffer);
             }
 
             {

--- a/hoomd/md/ForceDistanceConstraintGPU.cu
+++ b/hoomd/md/ForceDistanceConstraintGPU.cu
@@ -349,6 +349,34 @@ hipError_t gpu_count_nnz(unsigned int n_constraint,
     }
 #endif
 
+#ifndef CUSPARSE_NEW_API
+hipError_t gpu_dense2sparse(unsigned int n_constraint,
+                            double* d_matrix,
+                            int* d_nnz,
+                            cusparseHandle_t cusparse_handle,
+                            cusparseMatDescr_t cusparse_mat_descr,
+                            int* d_csr_rowptr,
+                            int* d_csr_colind,
+                            double* d_csr_val)
+    {
+    // convert dense matrix to compressed sparse row
+
+    // update values in CSR format
+    cusparseDdense2csr(cusparse_handle,
+                       n_constraint,
+                       n_constraint,
+                       cusparse_mat_descr,
+                       d_matrix,
+                       n_constraint,
+                       d_nnz,
+                       d_csr_val,
+                       d_csr_rowptr,
+                       d_csr_colind);
+
+    return hipSuccess;
+    }
+#endif
+
 hipError_t gpu_compute_constraint_forces(const Scalar4* d_pos,
                                          const group_storage<2>* d_gpu_clist,
                                          const Index2D& gpu_clist_indexer,

--- a/hoomd/md/ForceDistanceConstraintGPU.cu
+++ b/hoomd/md/ForceDistanceConstraintGPU.cu
@@ -335,7 +335,6 @@ hipError_t gpu_count_nnz(unsigned int n_constraint,
                          cusparseHandle_t cusparse_handle,
                          cusparseMatDescr_t cusparse_mat_descr)
     {
-#ifdef CUSOLVER_AVAILABLE
     // count zeros
     cusparseDnnz(cusparse_handle,
                  CUSPARSE_DIRECTION_ROW,
@@ -346,33 +345,6 @@ hipError_t gpu_count_nnz(unsigned int n_constraint,
                  n_constraint,
                  d_nnz,
                  &nnz);
-#endif
-    return hipSuccess;
-    }
-
-hipError_t gpu_dense2sparse(unsigned int n_constraint,
-                            double* d_matrix,
-                            int* d_nnz,
-                            cusparseHandle_t cusparse_handle,
-                            cusparseMatDescr_t cusparse_mat_descr,
-                            int* d_csr_rowptr,
-                            int* d_csr_colind,
-                            double* d_csr_val)
-    {
-    // convert dense matrix to compressed sparse row
-
-    // update values in CSR format
-    cusparseDdense2csr(cusparse_handle,
-                       n_constraint,
-                       n_constraint,
-                       cusparse_mat_descr,
-                       d_matrix,
-                       n_constraint,
-                       d_nnz,
-                       d_csr_val,
-                       d_csr_rowptr,
-                       d_csr_colind);
-
     return hipSuccess;
     }
 #endif

--- a/hoomd/md/ForceDistanceConstraintGPU.cuh
+++ b/hoomd/md/ForceDistanceConstraintGPU.cuh
@@ -49,14 +49,6 @@ hipError_t gpu_count_nnz(unsigned int n_constraint,
                          cusparseHandle_t cusparse_handle,
                          cusparseMatDescr_t cusparse_mat_descr);
 
-hipError_t gpu_dense2sparse(unsigned int n_constraint,
-                            double* d_matrix,
-                            int* d_nnz,
-                            cusparseHandle_t cusparse_handle,
-                            cusparseMatDescr_t cusparse_mat_descr,
-                            int* d_csr_rowptr,
-                            int* d_csr_colind,
-                            double* d_csr_val);
 #endif
 
 hipError_t gpu_compute_constraint_forces(const Scalar4* d_pos,

--- a/hoomd/md/ForceDistanceConstraintGPU.cuh
+++ b/hoomd/md/ForceDistanceConstraintGPU.cuh
@@ -48,7 +48,16 @@ hipError_t gpu_count_nnz(unsigned int n_constraint,
                          int& nnz,
                          cusparseHandle_t cusparse_handle,
                          cusparseMatDescr_t cusparse_mat_descr);
-
+#ifndef CUSPARSE_NEW_API
+hipError_t gpu_dense2sparse(unsigned int n_constraint,
+                            double* d_matrix,
+                            int* d_nnz,
+                            cusparseHandle_t cusparse_handle,
+                            cusparseMatDescr_t cusparse_mat_descr,
+                            int* d_csr_rowptr,
+                            int* d_csr_colind,
+                            double* d_csr_val);
+#endif
 #endif
 
 hipError_t gpu_compute_constraint_forces(const Scalar4* d_pos,


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should be based on *trunk-patch*. -->
<!-- Backwards compatible new features should be based on *trunk-minor*. -->
<!-- Incompatible API changes should be based on *trunk-major*. -->

## Description

<!-- Describe your changes in detail. -->
Replace the deprecated usage of cusparse with current APIs. Thanks to Peng Wang at NVIDIA for providing this patch.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
The deprecated APIs will be removed in CUDA 12.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
The existing `test_constrain_distance.py` test passes.

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
* Compile with CUDA 12.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
