### PR TITLE
Fix pair table performance.

### DIFF
--- a/hoomd/md/AnisoPotentialPairGPU.cuh
+++ b/hoomd/md/AnisoPotentialPairGPU.cuh
@@ -302,7 +302,7 @@ gpu_compute_pair_aniso_forces_kernel(Scalar4* d_force,
                 unsigned int typpair
                     = typpair_idx(__scalar_as_int(postypei.w), __scalar_as_int(postypej.w));
                 Scalar rcutsq = s_rcutsq[typpair];
-                const typename evaluator::param_type param = s_params[typpair];
+                const typename evaluator::param_type& param = s_params[typpair];
 
                 // design specifies that energies are shifted if
                 // 1) shift mode is set to shift

--- a/hoomd/md/EvaluatorPairTable.h
+++ b/hoomd/md/EvaluatorPairTable.h
@@ -231,10 +231,10 @@ class EvaluatorPairTable
 #endif
 
     protected:
-    Scalar rsq;                   //!< distance squared
-    Scalar rcutsq;                //!< the potential cuttoff distance squared
-    size_t width;                 //!< the distance between table indices
-    Scalar rmin;                  //!< the distance of the first index of the table potential
+    Scalar rsq;                          //!< distance squared
+    Scalar rcutsq;                       //!< the potential cuttoff distance squared
+    size_t width;                        //!< the distance between table indices
+    Scalar rmin;                         //!< the distance of the first index of the table potential
     const ManagedArray<Scalar>& V_table; //!< the tabulated energy
     const ManagedArray<Scalar>& F_table; //!< the tabulated force specifically - (dV / dr)
     };

--- a/hoomd/md/EvaluatorPairTable.h
+++ b/hoomd/md/EvaluatorPairTable.h
@@ -235,8 +235,8 @@ class EvaluatorPairTable
     Scalar rcutsq;                //!< the potential cuttoff distance squared
     size_t width;                 //!< the distance between table indices
     Scalar rmin;                  //!< the distance of the first index of the table potential
-    ManagedArray<Scalar> V_table; //!< the tabulated energy
-    ManagedArray<Scalar> F_table; //!< the tabulated force specifically - (dV / dr)
+    const ManagedArray<Scalar>& V_table; //!< the tabulated energy
+    const ManagedArray<Scalar>& F_table; //!< the tabulated force specifically - (dV / dr)
     };
 
     } // end namespace md

--- a/hoomd/md/PotentialBondGPU.cuh
+++ b/hoomd/md/PotentialBondGPU.cuh
@@ -184,14 +184,14 @@ __global__ void gpu_compute_bond_forces_kernel(Scalar4* d_force,
         dx = box.minImage(dx);
 
         // get the bond parameters (MEM TRANSFER: 8 bytes)
-        typename evaluator::param_type param;
+        const typename evaluator::param_type* param;
         if (enable_shared_cache)
             {
-            param = s_params[cur_bond_type];
+            param = s_params + cur_bond_type;
             }
         else
             {
-            param = d_params[cur_bond_type];
+            param = d_params + cur_bond_type;
             }
 
         Scalar rsq = dot(dx, dx);
@@ -200,7 +200,7 @@ __global__ void gpu_compute_bond_forces_kernel(Scalar4* d_force,
         Scalar force_divr = Scalar(0.0);
         Scalar bond_eng = Scalar(0.0);
 
-        evaluator eval(rsq, param);
+        evaluator eval(rsq, *param);
 
         // get the bonded particle's diameter if needed
         if (evaluator::needsDiameter())

--- a/hoomd/md/PotentialPair.h
+++ b/hoomd/md/PotentialPair.h
@@ -712,7 +712,7 @@ template<class evaluator> void PotentialPair<evaluator>::computeForces(uint64_t 
 
             // get parameters for this type pair
             unsigned int typpair_idx = m_typpair_idx(typei, typej);
-            param_type param = m_params[typpair_idx];
+            const param_type& param = m_params[typpair_idx];
             Scalar rcutsq = h_rcutsq.data[typpair_idx];
             Scalar ronsq = Scalar(0.0);
             if (m_shift_mode == xplor)

--- a/hoomd/md/PotentialPairAlchemical.h
+++ b/hoomd/md/PotentialPairAlchemical.h
@@ -392,7 +392,7 @@ void PotentialPairAlchemical<evaluator, extra_pkg, alpha_particle_type>::compute
 
             // get parameters for this type pair
             unsigned int typpair_idx = m_typpair_idx(typei, typej);
-            auto param = m_params[typpair_idx];
+            const auto& param = m_params[typpair_idx];
             Scalar rcutsq = h_rcutsq.data[typpair_idx];
             Scalar ronsq = Scalar(0.0);
             if (m_shift_mode == xplor)

--- a/hoomd/md/PotentialPairDPDThermo.h
+++ b/hoomd/md/PotentialPairDPDThermo.h
@@ -194,7 +194,7 @@ template<class evaluator> void PotentialPairDPDThermo<evaluator>::computeForces(
 
             // get parameters for this type pair
             unsigned int typpair_idx = this->m_typpair_idx(typei, typej);
-            param_type param = this->m_params[typpair_idx];
+            const param_type& param = this->m_params[typpair_idx];
             Scalar rcutsq = h_rcutsq.data[typpair_idx];
 
             // design specifies that energies are shifted if

--- a/hoomd/md/PotentialPairDPDThermoGPU.cuh
+++ b/hoomd/md/PotentialPairDPDThermoGPU.cuh
@@ -262,7 +262,7 @@ __global__ void gpu_compute_dpd_forces_kernel(Scalar4* d_force,
                 unsigned int typpair
                     = typpair_idx(__scalar_as_int(postypei.w), __scalar_as_int(postypej.w));
                 Scalar rcutsq = s_rcutsq[typpair];
-                typename evaluator::param_type param = s_params[typpair];
+                typename evaluator::param_type& param = s_params[typpair];
 
                 // design specifies that energies are shifted if
                 // 1) shift mode is set to shift

--- a/hoomd/md/PotentialSpecialPair.h
+++ b/hoomd/md/PotentialSpecialPair.h
@@ -284,7 +284,7 @@ template<class evaluator> void PotentialSpecialPair<evaluator>::computeForces(ui
         Scalar rsq = dot(dx, dx);
 
         // get parameters for this bond type
-        param_type param = h_params.data[h_typeval.data[i].type];
+        const param_type& param = h_params.data[h_typeval.data[i].type];
 
         // compute the force and potential energy
         Scalar force_divr = Scalar(0.0);

--- a/hoomd/md/PotentialTersoff.h
+++ b/hoomd/md/PotentialTersoff.h
@@ -368,7 +368,7 @@ template<class evaluator> void PotentialTersoff<evaluator>::computeForces(uint64
 
                 // get parameters for this type pair
                 unsigned int typpair_idx = m_typpair_idx(typei, typej);
-                param_type param = h_params.data[typpair_idx];
+                const param_type& param = h_params.data[typpair_idx];
                 Scalar rcutsq = h_rcutsq.data[typpair_idx];
 
                 // evaluate the base repulsive and attractive terms
@@ -640,7 +640,7 @@ template<class evaluator> void PotentialTersoff<evaluator>::computeForces(uint64
 
                     // get parameters for this type pair
                     unsigned int typpair_idx = m_typpair_idx(typei, typej);
-                    param_type param = h_params.data[typpair_idx];
+                    const param_type& param = h_params.data[typpair_idx];
                     Scalar rcutsq = h_rcutsq.data[typpair_idx];
 
                     // evaluate the scalar per-neighbor contribution
@@ -652,7 +652,7 @@ template<class evaluator> void PotentialTersoff<evaluator>::computeForces(uint64
                 for (unsigned int typ_b = 0; typ_b < ntypes; ++typ_b)
                     {
                     unsigned int typpair_idx = m_typpair_idx(typei, typ_b);
-                    param_type param = h_params.data[typpair_idx];
+                    const param_type& param = h_params.data[typpair_idx];
                     Scalar rcutsq = h_rcutsq.data[typpair_idx];
                     evaluator eval(Scalar(0.0), rcutsq, param);
                     Scalar energy(0.0);
@@ -688,7 +688,7 @@ template<class evaluator> void PotentialTersoff<evaluator>::computeForces(uint64
 
                 // get parameters for this type pair
                 unsigned int typpair_idx = m_typpair_idx(typei, typej);
-                param_type param = h_params.data[typpair_idx];
+                const param_type& param = h_params.data[typpair_idx];
                 Scalar rcutsq = h_rcutsq.data[typpair_idx];
 
                 // evaluate the base repulsive and attractive terms
@@ -725,7 +725,7 @@ template<class evaluator> void PotentialTersoff<evaluator>::computeForces(uint64
 
                             // access the type pair parameters for i and k
                             typpair_idx = m_typpair_idx(typei, typek);
-                            param_type temp_param = h_params.data[typpair_idx];
+                            const param_type& temp_param = h_params.data[typpair_idx];
 
                             evaluator temp_eval(rij_sq, rcutsq, temp_param);
                             bool temp_evaluated = temp_eval.areInteractive();
@@ -812,7 +812,7 @@ template<class evaluator> void PotentialTersoff<evaluator>::computeForces(uint64
 
                             // access the type pair parameters for i and k
                             typpair_idx = m_typpair_idx(typei, typek);
-                            param_type temp_param = h_params.data[typpair_idx];
+                            const param_type& temp_param = h_params.data[typpair_idx];
 
                             evaluator temp_eval(rij_sq, rcutsq, temp_param);
                             bool temp_evaluated = temp_eval.areInteractive();

--- a/hoomd/md/PotentialTersoffGPU.cuh
+++ b/hoomd/md/PotentialTersoffGPU.cuh
@@ -277,7 +277,7 @@ __global__ void gpu_compute_triplet_forces_kernel(Scalar4* d_force,
             unsigned int typpair
                 = typpair_idx(__scalar_as_int(postypei.w), __scalar_as_int(postypej.w));
             Scalar rcutsq = s_rcutsq[typpair];
-            typename evaluator::param_type& param = s_params[typpair];
+            const typename evaluator::param_type& param = s_params[typpair];
 
             // compute the base repulsive and attractive terms of the potential
             Scalar invratio = 0.0;
@@ -496,7 +496,7 @@ __global__ void gpu_compute_triplet_forces_kernel(Scalar4* d_force,
                 unsigned int typpair
                     = typpair_idx(__scalar_as_int(postypei.w), __scalar_as_int(postypej.w));
                 Scalar rcutsq = s_rcutsq[typpair];
-                typename evaluator::param_type& param = s_params[typpair];
+                const typename evaluator::param_type& param = s_params[typpair];
 
                 evaluator eval(rij_sq, rcutsq, param);
                 eval.evalPhi(s_phi_ab[threadIdx.x * ntypes + __scalar_as_int(postypej.w)]);
@@ -518,7 +518,7 @@ __global__ void gpu_compute_triplet_forces_kernel(Scalar4* d_force,
                     {
                     unsigned int typpair = typpair_idx(__scalar_as_int(postypei.w), typ_b);
                     Scalar rcutsq = s_rcutsq[typpair];
-                    typename evaluator::param_type& param = s_params[typpair];
+                    const typename evaluator::param_type& param = s_params[typpair];
 
                     evaluator eval(Scalar(0.0), rcutsq, param);
                     Scalar energy(0.0);
@@ -575,7 +575,7 @@ __global__ void gpu_compute_triplet_forces_kernel(Scalar4* d_force,
             unsigned int typpair
                 = typpair_idx(__scalar_as_int(postypei.w), __scalar_as_int(postypej.w));
             Scalar rcutsq = s_rcutsq[typpair];
-            typename evaluator::param_type& param = s_params[typpair];
+            const typename evaluator::param_type& param = s_params[typpair];
 
             // compute the base repulsive and attractive terms of the potential
             Scalar fR = Scalar(0.0);

--- a/hoomd/md/PotentialTersoffGPU.cuh
+++ b/hoomd/md/PotentialTersoffGPU.cuh
@@ -277,7 +277,7 @@ __global__ void gpu_compute_triplet_forces_kernel(Scalar4* d_force,
             unsigned int typpair
                 = typpair_idx(__scalar_as_int(postypei.w), __scalar_as_int(postypej.w));
             Scalar rcutsq = s_rcutsq[typpair];
-            typename evaluator::param_type param = s_params[typpair];
+            typename evaluator::param_type& param = s_params[typpair];
 
             // compute the base repulsive and attractive terms of the potential
             Scalar invratio = 0.0;
@@ -496,7 +496,7 @@ __global__ void gpu_compute_triplet_forces_kernel(Scalar4* d_force,
                 unsigned int typpair
                     = typpair_idx(__scalar_as_int(postypei.w), __scalar_as_int(postypej.w));
                 Scalar rcutsq = s_rcutsq[typpair];
-                typename evaluator::param_type param = s_params[typpair];
+                typename evaluator::param_type& param = s_params[typpair];
 
                 evaluator eval(rij_sq, rcutsq, param);
                 eval.evalPhi(s_phi_ab[threadIdx.x * ntypes + __scalar_as_int(postypej.w)]);
@@ -518,7 +518,7 @@ __global__ void gpu_compute_triplet_forces_kernel(Scalar4* d_force,
                     {
                     unsigned int typpair = typpair_idx(__scalar_as_int(postypei.w), typ_b);
                     Scalar rcutsq = s_rcutsq[typpair];
-                    typename evaluator::param_type param = s_params[typpair];
+                    typename evaluator::param_type& param = s_params[typpair];
 
                     evaluator eval(Scalar(0.0), rcutsq, param);
                     Scalar energy(0.0);
@@ -575,7 +575,7 @@ __global__ void gpu_compute_triplet_forces_kernel(Scalar4* d_force,
             unsigned int typpair
                 = typpair_idx(__scalar_as_int(postypei.w), __scalar_as_int(postypej.w));
             Scalar rcutsq = s_rcutsq[typpair];
-            typename evaluator::param_type param = s_params[typpair];
+            typename evaluator::param_type& param = s_params[typpair];
 
             // compute the base repulsive and attractive terms of the potential
             Scalar fR = Scalar(0.0);
@@ -609,7 +609,7 @@ __global__ void gpu_compute_triplet_forces_kernel(Scalar4* d_force,
                         typpair
                             = typpair_idx(__scalar_as_int(postypei.w), __scalar_as_int(postypek.w));
                         Scalar temp_rcutsq = s_rcutsq[typpair];
-                        typename evaluator::param_type temp_param = s_params[typpair];
+                        typename evaluator::param_type& temp_param = s_params[typpair];
 
                         evaluator temp_eval(rij_sq, temp_rcutsq, temp_param);
                         bool temp_evaluated = temp_eval.areInteractive();
@@ -709,7 +709,7 @@ __global__ void gpu_compute_triplet_forces_kernel(Scalar4* d_force,
                         typpair
                             = typpair_idx(__scalar_as_int(postypei.w), __scalar_as_int(postypek.w));
                         Scalar temp_rcutsq = s_rcutsq[typpair];
-                        typename evaluator::param_type temp_param = s_params[typpair];
+                        typename evaluator::param_type& temp_param = s_params[typpair];
 
                         evaluator temp_eval(rij_sq, temp_rcutsq, temp_param);
                         bool temp_evaluated = temp_eval.areInteractive();


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should be based on *trunk-patch*. -->
<!-- Backwards compatible new features should be based on *trunk-minor*. -->
<!-- Incompatible API changes should be based on *trunk-major*. -->

## Description

<!-- Describe your changes in detail. -->
Store pair potential parameters by reference.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
This improves the performance of `md.pair.Table` in particular. Prior to this change, the copy constructors for the energy and force arrays were being called *twice* per pair interaction. After this change, `md.pair.Table` is 10-40x faster.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
I evaluated the performance increase with a new `hoomd-benchmarks` benchmark: https://github.com/glotzerlab/hoomd-benchmarks/pull/33

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
Fixed:

* Increased performance of `md.pair.Table` on the CPU.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
