### PR TITLE
Add default value for rounding_radii when using ALJ

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,10 +7,6 @@ Change Log
 v3.x
 ----
 
-*Added*
-* For the ALJ potential, ``shape.rounding_radii`` now defaults to 0.0.
-
-
 v3.5.0 (2022-09-14)
 ^^^^^^^^^^^^^^^^^^^
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,10 @@ Change Log
 v3.x
 ----
 
+*Added*
+* For the ALJ potential, ``shape.rounding_radii`` now defaults to 0.0.
+
+
 v3.5.0 (2022-09-14)
 ^^^^^^^^^^^^^^^^^^^
 

--- a/hoomd/md/pair/aniso.py
+++ b/hoomd/md/pair/aniso.py
@@ -444,6 +444,10 @@ class ALJ(AnisotropicPair):
         * ``rounding_radii`` (`tuple` [`float`, `float`, `float`] or `float`,
           **required**) - The semimajor axes of a rounding ellipsoid. If a
           single value is specified, the rounding ellipsoid is a sphere.
+
+          Warning:
+              ``rounding_radii`` was given a default value of 0.0 in version 3.5.1.
+
         * ``faces`` (`list` [`list` [`int`]], **required**) - The faces of the
           polyhedron specified as a list of list of integers.  The indices
           corresponding to the vertices must be ordered counterclockwise with
@@ -477,7 +481,8 @@ class ALJ(AnisotropicPair):
                               rounding_radii=OnlyIf(
                                   to_type_converter((float, float, float)),
                                   preprocess=self._to_three_tuple),
-                              len_keys=1))
+                              len_keys=1,
+                              _defaults = {'rounding_radii', 0.0}))
 
         self._extend_typeparam((params, shape))
 

--- a/hoomd/md/pair/aniso.py
+++ b/hoomd/md/pair/aniso.py
@@ -443,11 +443,7 @@ class ALJ(AnisotropicPair):
           dimensions. The third dimension in 2D is ignored.
         * ``rounding_radii`` (`tuple` [`float`, `float`, `float`] or `float`,
           **required**) - The semimajor axes of a rounding ellipsoid. If a
-          single value is specified, the rounding ellipsoid is a sphere.
-
-          Warning:
-              ``rounding_radii`` was given a default value of 0.0 in version 3.5.1.
-
+          single value is specified, the rounding ellipsoid is a sphere. Defaults to 0.0.
         * ``faces`` (`list` [`list` [`int`]], **required**) - The faces of the
           polyhedron specified as a list of list of integers.  The indices
           corresponding to the vertices must be ordered counterclockwise with

--- a/hoomd/md/pair/aniso.py
+++ b/hoomd/md/pair/aniso.py
@@ -479,7 +479,7 @@ class ALJ(AnisotropicPair):
                                   to_type_converter((float, float, float)),
                                   preprocess=self._to_three_tuple),
                               len_keys=1,
-                              _defaults = {'rounding_radii', (0.0, 0.0, 0.0)}))
+                              _defaults={'rounding_radii', (0.0, 0.0, 0.0)}))
 
         self._extend_typeparam((params, shape))
 

--- a/hoomd/md/pair/aniso.py
+++ b/hoomd/md/pair/aniso.py
@@ -443,7 +443,8 @@ class ALJ(AnisotropicPair):
           dimensions. The third dimension in 2D is ignored.
         * ``rounding_radii`` (`tuple` [`float`, `float`, `float`] or `float`,
           **required**) - The semimajor axes of a rounding ellipsoid. If a
-          single value is specified, the rounding ellipsoid is a sphere. Defaults to 0.0.
+          single value is specified, the rounding ellipsoid is a sphere. 
+          Defaults to (0.0, 0.0, 0.0).
         * ``faces`` (`list` [`list` [`int`]], **required**) - The faces of the
           polyhedron specified as a list of list of integers.  The indices
           corresponding to the vertices must be ordered counterclockwise with

--- a/hoomd/md/pair/aniso.py
+++ b/hoomd/md/pair/aniso.py
@@ -443,7 +443,7 @@ class ALJ(AnisotropicPair):
           dimensions. The third dimension in 2D is ignored.
         * ``rounding_radii`` (`tuple` [`float`, `float`, `float`] or `float`,
           **required**) - The semimajor axes of a rounding ellipsoid. If a
-          single value is specified, the rounding ellipsoid is a sphere. 
+          single value is specified, the rounding ellipsoid is a sphere.
           Defaults to (0.0, 0.0, 0.0).
         * ``faces`` (`list` [`list` [`int`]], **required**) - The faces of the
           polyhedron specified as a list of list of integers.  The indices

--- a/hoomd/md/pair/aniso.py
+++ b/hoomd/md/pair/aniso.py
@@ -479,7 +479,7 @@ class ALJ(AnisotropicPair):
                                   to_type_converter((float, float, float)),
                                   preprocess=self._to_three_tuple),
                               len_keys=1,
-                              _defaults = {'rounding_radii', 0.0}))
+                              _defaults = {'rounding_radii', (0.0, 0.0, 0.0)}))
 
         self._extend_typeparam((params, shape))
 


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should be based on *trunk-patch*. -->
<!-- Backwards compatible new features should be based on *trunk-minor*. -->
<!-- Incompatible API changes should be based on *trunk-major*. -->

## Description

I changed the default value (following directions in the docstring of `_ValidatedDefaultDict`)

## Motivation and context

See #1395 

## How has this been tested?

Old tests pass.

## Change log

<!-- Propose a change log entry. -->
```
* For the ALJ potential, ``shape.rounding_radii`` now defaults to 0.0.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
