### PR TITLE
feat: Support adding force directly to simulation.

### DIFF
--- a/example_plugins/updater_plugin/update.py
+++ b/example_plugins/updater_plugin/update.py
@@ -22,7 +22,7 @@ class ExampleUpdater(operation.Updater):
         """Add the operation to a simulation."""
         super()._add(simulation)
 
-    def _attach(self):
+    def _attach_hook(self):
         # initialize the reflected c++ class
         if isinstance(self._simulation.device, hoomd.device.CPU):
             self._cpp_obj = _updater_plugin.ExampleUpdater(
@@ -30,4 +30,3 @@ class ExampleUpdater(operation.Updater):
         else:
             self._cpp_obj = _updater_plugin.ExampleUpdaterGPU(
                 self._simulation.state._cpp_sys_def, self.trigger)
-        super()._attach()

--- a/hoomd/custom/custom_operation.py
+++ b/hoomd/custom/custom_operation.py
@@ -75,7 +75,7 @@ class CustomOperation(TriggeredOperation, metaclass=_AbstractLoggable):
             return
         object.__setattr__(self, attr, value)
 
-    def _attach(self):
+    def _attach_hook(self):
         """Attach to a `hoomd.Simulation`.
 
         Args:
@@ -84,14 +84,11 @@ class CustomOperation(TriggeredOperation, metaclass=_AbstractLoggable):
         """
         self._cpp_obj = getattr(_hoomd, self._cpp_class_name)(
             self._simulation.state._cpp_sys_def, self.trigger, self._action)
-
-        super()._attach()
         self._action.attach(self._simulation)
 
-    def _detach(self):
+    def _detach_hook(self):
         """Detaching from a `hoomd.Simulation`."""
         self._action.detach()
-        super()._detach()
 
     def act(self, timestep):
         """Perform the action of the custom action if attached.

--- a/hoomd/data/syncedlist.py
+++ b/hoomd/data/syncedlist.py
@@ -28,16 +28,6 @@ def identity(obj):
     return obj
 
 
-class _SimulationPlaceHolder:
-    """Used to ensure objects are not added to two locations at once."""
-
-    def __init__(self, obj):
-        self._id = id(obj)
-
-    def __eq__(self, other):
-        return isinstance(other, type(self)) and self._id == other._id
-
-
 class SyncedList(MutableSequence):
     """Provides syncing and validation for a Python and C++ list.
 
@@ -90,7 +80,6 @@ class SyncedList(MutableSequence):
 
         self._to_synced_list_conversion = to_synced_list
         self._synced = False
-        self._simulation = _SimulationPlaceHolder(self)
         self._list = []
         if iterable is not None:
             for it in iterable:
@@ -188,42 +177,40 @@ class SyncedList(MutableSequence):
         if self._synced:
             yield from self._synced_list
 
-    def _register_item(self, value, raise_if_added=True):
+    def _register_item(self, value):
         """Attaches and/or adds value to simulation if unattached.
 
         Raises an error if value is already in this or another list.
         """
         if not self._attach_members:
             return
-        if raise_if_added and value._added:
-            raise RuntimeError(f"Object {value} cannot be added to two lists.")
-        value._add(self._simulation)
         if self._synced:
-            # To allow for dependencies within operations (like computes e.g.
-            # forces and neighbor list) we need to check it the object is
-            # attached first. Assuming the code for adding a simulation to an
-            # operation is correct, this is safe.
-            if not value._attached:
+            if not value._added:
+                value._add(self._simulation)
                 value._attach()
+                return
+            if value._simulation != self._simulation:
+                raise RuntimeError(
+                    f"Cannot place {value} into two simulations.")
+            value._attach()
+        else:
+            if value._added:
+                raise RuntimeError(
+                    f"Cannot place {value} into two simulations.")
 
-    def _unregister_item(self, value, remove=True):
+    def _unregister_item(self, value):
         """Detaches and/or removes value to simulation if attached.
 
         Args:
             value (``any``): The member of the synced list to dissociate from
                 its current simulation.
-            remove (bool, optional): Whether to add back to the `SyncedList`'s
-                current simulation or id. This defaults to ``True`` which is
-                desired when the object is removed completely from the list.
         """
         if not self._attach_members:
             return
         if self._synced:
             value._detach()
-        if remove and value._added:
+        if value._added:
             value._remove()
-        else:
-            value._add(self._simulation)
 
     def _validate_or_error(self, value):
         """Complete error checking and processing of value."""
@@ -242,7 +229,7 @@ class SyncedList(MutableSequence):
         # this case) even when facing an error.
         try:
             for item in self:
-                self._register_item(item, False)
+                self._register_item(item)
                 self._synced_list.append(self._to_synced_list_conversion(item))
         except Exception as err:
             self._synced = False
@@ -256,10 +243,10 @@ class SyncedList(MutableSequence):
         # avoid looping unless necessary (_unregister_item checks
         # self._attach_members as well) making the check a slight performance
         # bump for non-attaching members.
-        self._simulation = _SimulationPlaceHolder(self)
+        self._simulation = None
         if self._attach_members:
             for item in self:
-                self._unregister_item(item, False)
+                self._unregister_item(item)
         del self._synced_list
         self._synced = False
 

--- a/hoomd/data/syncedlist.py
+++ b/hoomd/data/syncedlist.py
@@ -199,7 +199,12 @@ class SyncedList(MutableSequence):
             raise RuntimeError(f"Object {value} cannot be added to two lists.")
         value._add(self._simulation)
         if self._synced:
-            value._attach()
+            # To allow for dependencies within operations (like computes e.g.
+            # forces and neighbor list) we need to check it the object is
+            # attached first. Assuming the code for adding a simulation to an
+            # operation is correct, this is safe.
+            if not value._attached:
+                value._attach()
 
     def _detach_value(self, value, remove=True):
         """Detaches and/or removes value to simulation if attached.

--- a/hoomd/hpmc/compute.py
+++ b/hoomd/hpmc/compute.py
@@ -108,7 +108,7 @@ class FreeVolume(Compute):
                  num_samples=num_samples))
         self._param_dict.update(param_dict)
 
-    def _attach(self):
+    def _attach_hook(self):
         integrator = self._simulation.operations.integrator
         if not isinstance(integrator, integrate.HPMCIntegrator):
             raise RuntimeError("The integrator must be an HPMC integrator.")
@@ -127,8 +127,6 @@ class FreeVolume(Compute):
         cl = _hoomd.CellList(self._simulation.state._cpp_sys_def)
         self._cpp_obj = cpp_cls(self._simulation.state._cpp_sys_def,
                                 integrator._cpp_obj, cl)
-
-        super()._attach()
 
     @log(requires_run=True)
     def free_volume(self):
@@ -277,7 +275,7 @@ class SDF(Compute):
         )
         self._param_dict.update(param_dict)
 
-    def _attach(self):
+    def _attach_hook(self):
         integrator = self._simulation.operations.integrator
         if not isinstance(integrator, integrate.HPMCIntegrator):
             raise RuntimeError("The integrator must be an HPMC integrator.")
@@ -293,8 +291,6 @@ class SDF(Compute):
             self.xmax,
             self.dx,
         )
-
-        super()._attach()
 
     @log(category='sequence', requires_run=True)
     def sdf(self):

--- a/hoomd/hpmc/external/field.py
+++ b/hoomd/hpmc/external/field.py
@@ -104,7 +104,7 @@ class Harmonic(ExternalField):
         param_dict['symmetries'] = symmetries
         self._param_dict.update(param_dict)
 
-    def _attach(self):
+    def _attach_hook(self):
         cls = None
 
         integrator = self._simulation.operations.integrator
@@ -162,7 +162,7 @@ class Harmonic(ExternalField):
             self.k_rotational,
             self.symmetries,
         )
-        super()._attach()
+        super()._attach_hook()
 
     @log(requires_run=True)
     def energy(self):

--- a/hoomd/hpmc/external/user.py
+++ b/hoomd/hpmc/external/user.py
@@ -135,7 +135,7 @@ class CPPExternalPotential(ExternalField):
                         """
         return cpp_function
 
-    def _attach(self):
+    def _attach_hook(self):
         integrator_pairs = {
             integrate.Sphere:
                 _jit.ExternalFieldJITSphere,
@@ -178,7 +178,7 @@ class CPPExternalPotential(ExternalField):
         self._cpp_obj = cpp_cls(self._simulation.state._cpp_sys_def,
                                 self._simulation.device._cpp_exec_conf,
                                 cpu_code, cpu_include_options)
-        super()._attach()
+        super()._attach_hook()
 
     @log(requires_run=True)
     def energy(self):

--- a/hoomd/hpmc/external/wall.py
+++ b/hoomd/hpmc/external/wall.py
@@ -150,7 +150,7 @@ class WallPotential(ExternalField):
     def __init__(self, walls):
         self._walls = _HPMCWallsMetaList(self, walls, _to_hpmc_cpp_wall)
 
-    def _attach(self):
+    def _attach_hook(self):
         if isinstance(self._simulation.device, hoomd.device.GPU):
             raise RuntimeError('HPMC walls are not supported on the GPU.')
         integrator = self._simulation.operations.integrator
@@ -169,7 +169,7 @@ class WallPotential(ExternalField):
             hoomd.wall.Cylinder: self._cpp_obj.CylinderWalls,
             hoomd.wall.Plane: self._cpp_obj.PlaneWalls,
         })
-        super()._attach()
+        super()._attach_hook()
 
     @property
     def walls(self):

--- a/hoomd/hpmc/integrate.py
+++ b/hoomd/hpmc/integrate.py
@@ -406,7 +406,7 @@ class HPMCIntegrator(Integrator):
         if self._pair_potential is not None:
             self._pair_potential._add(simulation)
 
-    def _attach(self):
+    def _attach_hook(self):
         """Initialize the reflected c++ class."""
         sys_def = self._simulation.state._cpp_sys_def
         if (isinstance(self._simulation.device, hoomd.device.GPU)
@@ -422,8 +422,6 @@ class HPMCIntegrator(Integrator):
             self._cpp_obj = getattr(_hpmc, self._cpp_cls)(sys_def)
             self._cpp_cell = None
 
-        super()._attach()
-
         if self._external_potential is not None:
             self._external_potential._attach()
             self._cpp_obj.setExternalField(self._external_potential._cpp_obj)
@@ -431,13 +429,13 @@ class HPMCIntegrator(Integrator):
         if self._pair_potential is not None:
             self._pair_potential._attach()
             self._cpp_obj.setPatchEnergy(self._pair_potential._cpp_obj)
+        super()._attach_hook()
 
-    def _detach(self):
+    def _detach_hook(self):
         if self._external_potential is not None:
             self._external_potential._detach()
         if self._pair_potential is not None:
             self._pair_potential._detach()
-        super()._detach()
 
     def _remove(self):
         if self._external_potential is not None:

--- a/hoomd/hpmc/nec/integrate.py
+++ b/hoomd/hpmc/nec/integrate.py
@@ -72,9 +72,6 @@ class HPMCNECIntegrator(HPMCIntegrator):
                 "update_fraction has to be between 0 and 1. (got {})".format(
                     value))
 
-    def _attach(self):
-        super()._attach()
-
     @property
     def nec_counters(self):
         """Trial move counters.

--- a/hoomd/hpmc/pair/user.py
+++ b/hoomd/hpmc/pair/user.py
@@ -259,7 +259,7 @@ class CPPPotential(CPPPotentialBase):
             return self._param_dict[attr]
         return super()._getattr_param(attr)
 
-    def _attach(self):
+    def _attach_hook(self):
         integrator = self._simulation.operations.integrator
         if not isinstance(integrator, integrate.HPMCIntegrator):
             raise RuntimeError("The integrator must be a HPMC integrator.")
@@ -300,7 +300,7 @@ class CPPPotential(CPPPotentialBase):
                 self.param_array,
             )
         # attach patch object to the integrator
-        super()._attach()
+        super()._attach_hook()
 
 
 class CPPPotentialUnion(CPPPotentialBase):
@@ -530,7 +530,7 @@ class CPPPotentialUnion(CPPPotentialBase):
             return self._param_dict[attr]
         return super()._getattr_param(attr)
 
-    def _attach(self):
+    def _attach_hook(self):
         integrator = self._simulation.operations.integrator
         if not isinstance(integrator, integrate.HPMCIntegrator):
             raise RuntimeError("The integrator must be an HPMC integrator.")
@@ -585,4 +585,4 @@ class CPPPotentialUnion(CPPPotentialBase):
                 self.param_array_constituent,
             )
         # attach patch object to the integrator
-        super()._attach()
+        super()._attach_hook()

--- a/hoomd/hpmc/shape_move.py
+++ b/hoomd/hpmc/shape_move.py
@@ -54,7 +54,7 @@ class ShapeMove(_HOOMDBaseObject):
                                                 step_size, len_keys=1))
         self._add_typeparam(typeparam_step_size)
 
-    def _attach(self):
+    def _attach_hook(self):
         integrator = self._simulation.operations.integrator
         if not isinstance(integrator, integrate.HPMCIntegrator):
             raise RuntimeError("The integrator must be a HPMC integrator.")
@@ -70,7 +70,6 @@ class ShapeMove(_HOOMDBaseObject):
         self._cpp_obj = self._move_cls(
             self._simulation.state._cpp_sys_def,
             self._simulation.operations.integrator._cpp_obj)
-        super()._attach()
 
 
 class Elastic(ShapeMove):
@@ -165,7 +164,7 @@ class Elastic(ShapeMove):
         shape.name = "reference_shape"
         return shape
 
-    def _attach(self):
+    def _attach_hook(self):
         integrator = self._simulation.operations.integrator
         if isinstance(integrator, integrate.Ellipsoid):
             for shape in integrator.shape.values():
@@ -173,7 +172,7 @@ class Elastic(ShapeMove):
                                            shape["a"])
                 if not is_sphere:
                     raise ValueError("This updater only works when a=b=c.")
-        super()._attach()
+        super()._attach_hook()
 
 
 class ShapeSpace(ShapeMove):

--- a/hoomd/hpmc/update.py
+++ b/hoomd/hpmc/update.py
@@ -298,7 +298,7 @@ class BoxMC(Updater):
 
         super()._add(simulation)
 
-    def _attach(self):
+    def _attach_hook(self):
         integrator = self._simulation.operations.integrator
         if not isinstance(integrator, integrate.HPMCIntegrator):
             raise RuntimeError("The integrator must be a HPMC integrator.")
@@ -309,7 +309,6 @@ class BoxMC(Updater):
         self._cpp_obj = _hpmc.UpdaterBoxMC(self._simulation.state._cpp_sys_def,
                                            self.trigger, integrator._cpp_obj,
                                            self.betaP)
-        super()._attach()
 
     @property
     def counter(self):
@@ -449,7 +448,7 @@ class MuVT(Updater):
                                          _defaults=hoomd.variant.Constant(0.0)))
         self._append_typeparam(typeparam_fugacity)
 
-    def _attach(self):
+    def _attach_hook(self):
         integrator = self._simulation.operations.integrator
         if not isinstance(integrator, integrate.HPMCIntegrator):
             raise RuntimeError("The integrator must be a HPMC integrator.")
@@ -460,7 +459,6 @@ class MuVT(Updater):
 
         self._cpp_obj = cpp_cls(self._simulation.state._cpp_sys_def,
                                 self.trigger, integrator._cpp_obj, self.ngibbs)
-        super()._attach()
 
     @log(category='sequence', requires_run=True)
     def insert_moves(self):
@@ -648,7 +646,7 @@ class Shape(Updater):
             new_move._attach()
         self._param_dict["shape_move"] = new_move
 
-    def _attach(self):
+    def _attach_hook(self):
         integrator = self._simulation.operations.integrator
         if not isinstance(integrator, integrate.HPMCIntegrator):
             raise RuntimeError("The integrator must be a HPMC integrator.")
@@ -663,7 +661,6 @@ class Shape(Updater):
         self._cpp_obj = updater_cls(self._simulation.state._cpp_sys_def,
                                     self.trigger, integrator._cpp_obj,
                                     self.shape_move._cpp_obj)
-        super()._attach()
 
     @log(category='sequence', requires_run=True)
     def shape_moves(self):
@@ -747,7 +744,7 @@ class Clusters(Updater):
 
         super()._add(simulation)
 
-    def _attach(self):
+    def _attach_hook(self):
         integrator = self._simulation.operations.integrator
         if not isinstance(integrator, integrate.HPMCIntegrator):
             raise RuntimeError("The integrator must be a HPMC integrator.")
@@ -773,7 +770,6 @@ class Clusters(Updater):
         else:
             self._cpp_obj = cpp_cls(self._simulation.state._cpp_sys_def,
                                     self.trigger, integrator._cpp_obj)
-        super()._attach()
 
     @log(requires_run=True)
     def avg_cluster_size(self):
@@ -960,7 +956,7 @@ class QuickCompress(Updater):
 
         super()._add(simulation)
 
-    def _attach(self):
+    def _attach_hook(self):
         integrator = self._simulation.operations.integrator
         if not isinstance(integrator, integrate.HPMCIntegrator):
             raise RuntimeError("The integrator must be a HPMC integrator.")
@@ -972,7 +968,6 @@ class QuickCompress(Updater):
             self._simulation.state._cpp_sys_def, self.trigger,
             integrator._cpp_obj, self.max_overlaps_per_particle, self.min_scale,
             self.target_box._cpp_obj)
-        super()._attach()
 
     @property
     def complete(self):

--- a/hoomd/md/NeighborList.cc
+++ b/hoomd/md/NeighborList.cc
@@ -745,14 +745,14 @@ void NeighborList::setSingleExclusion(std::string exclusion)
         }
     }
 
-pybind11::tuple NeighborList::getExclusions()
+pybind11::list NeighborList::getExclusions()
     {
     auto exclusions = pybind11::list();
     for (auto exclusion : m_exclusions)
         {
         exclusions.append(exclusion);
         }
-    return (pybind11::tuple)exclusions;
+    return exclusions;
     }
 
 /*! \post Gather some statistics about exclusions usage.

--- a/hoomd/md/NeighborList.h
+++ b/hoomd/md/NeighborList.h
@@ -344,7 +344,7 @@ class PYBIND11_EXPORT NeighborList : public Compute
 
     void setSingleExclusion(std::string exclusion);
 
-    pybind11::tuple getExclusions();
+    pybind11::list getExclusions();
 
     bool getExclusionsSet()
         {

--- a/hoomd/md/alchemy/methods.py
+++ b/hoomd/md/alchemy/methods.py
@@ -28,12 +28,11 @@ class Alchemostat(Method):
         if alchemical_dof is not None:
             self._alchemical_dof.extend(alchemical_dof)
 
-    def _attach(self):
-        super()._attach()
+    def _attach_hook(self):
         self._alchemical_dof._sync(self._simulation,
                                    self._cpp_obj.alchemical_dof)
 
-    def _detach(self):
+    def _detach_hook(self):
         self._alchemical_dof._unsync()
 
     @property
@@ -101,9 +100,9 @@ class NVT(Alchemostat):
         self._param_dict.update(param_dict)
         super().__init__(alchemical_dof)
 
-    def _attach(self):
+    def _attach_hook(self):
         cpp_class = hoomd.md._md.TwoStepNVTAlchemy
         cpp_sys_def = self._simulation.state._cpp_sys_def
         self._cpp_obj = cpp_class(cpp_sys_def, self.period, self.alchemical_kT)
         self._cpp_obj.setNextAlchemicalTimestep(self._simulation.timestep)
-        super()._attach()
+        super()._attach_hook()

--- a/hoomd/md/alchemy/pair.py
+++ b/hoomd/md/alchemy/pair.py
@@ -189,7 +189,7 @@ class AlchemicalDOF(_HOOMDBaseObject):
         # set defaults
         self._param_dict.update(param_dict)
 
-    def _attach(self):
+    def _attach_hook(self):
         if not self._force._attached:
             raise RuntimeError("Call Simulation.run(0) before attaching "
                                "alchemical degrees of freedom.")
@@ -197,14 +197,9 @@ class AlchemicalDOF(_HOOMDBaseObject):
             self.typepair, self.name)
         self._force._cpp_obj.enableAlchemicalPairParticle(self._cpp_obj)
 
-    def _add(self, simulation):
-        super()._add(simulation)
-
-    def _detach(self):
-        if self._attached:
-            self._force.params[self.typepair][self.name] = self.value
-            self._force._cpp_obj.disableAlchemicalPairParticle(self._cpp_obj)
-            super()._detach()
+    def _detach_hook(self):
+        self._force.params[self.typepair][self.name] = self.value
+        self._force._cpp_obj.disableAlchemicalPairParticle(self._cpp_obj)
 
     @log(requires_run=True)
     def value(self):

--- a/hoomd/md/angle.py
+++ b/hoomd/md/angle.py
@@ -54,7 +54,7 @@ class Angle(Force):
     def __init__(self):
         super().__init__()
 
-    def _attach(self):
+    def _attach_hook(self):
         # check that some angles are defined
         if self._simulation.state._cpp_sys_def.getAngleData().getNGlobal() == 0:
             self._simulation.device._cpp_msg.warning("No angles are defined.\n")
@@ -66,8 +66,6 @@ class Angle(Force):
             cpp_cls = getattr(_md, self._cpp_class_name + "GPU")
 
         self._cpp_obj = cpp_cls(self._simulation.state._cpp_sys_def)
-
-        super()._attach()
 
 
 class Harmonic(Angle):
@@ -202,7 +200,7 @@ class Table(Angle):
                 len_keys=1))
         self._add_typeparam(params)
 
-    def _attach(self):
+    def _attach_hook(self):
         """Create the c++ mirror class."""
         if isinstance(self._simulation.device, hoomd.device.CPU):
             cpp_cls = _md.TableAngleForceCompute
@@ -210,5 +208,3 @@ class Table(Angle):
             cpp_cls = _md.TableAngleForceComputeGPU
 
         self._cpp_obj = cpp_cls(self._simulation.state._cpp_sys_def, self.width)
-
-        Force._attach(self)

--- a/hoomd/md/bond.py
+++ b/hoomd/md/bond.py
@@ -55,7 +55,7 @@ class Bond(Force):
     def __init__(self):
         super().__init__()
 
-    def _attach(self):
+    def _attach_hook(self):
         """Create the c++ mirror class."""
         if isinstance(self._simulation.device, hoomd.device.CPU):
             cpp_cls = getattr(_md, self._cpp_class_name)
@@ -63,8 +63,6 @@ class Bond(Force):
             cpp_cls = getattr(_md, self._cpp_class_name + "GPU")
 
         self._cpp_obj = cpp_cls(self._simulation.state._cpp_sys_def)
-
-        super()._attach()
 
 
 class Harmonic(Bond):
@@ -261,7 +259,7 @@ class Table(Bond):
                 len_keys=1))
         self._add_typeparam(params)
 
-    def _attach(self):
+    def _attach_hook(self):
         """Create the c++ mirror class."""
         if isinstance(self._simulation.device, hoomd.device.CPU):
             cpp_cls = _md.BondTablePotential
@@ -269,8 +267,6 @@ class Table(Bond):
             cpp_cls = _md.BondTablePotentialGPU
 
         self._cpp_obj = cpp_cls(self._simulation.state._cpp_sys_def, self.width)
-
-        Force._attach(self)
 
 
 class Tether(Bond):

--- a/hoomd/md/compute.py
+++ b/hoomd/md/compute.py
@@ -44,14 +44,13 @@ class ThermodynamicQuantities(Compute):
         super().__init__()
         self._filter = filter
 
-    def _attach(self):
+    def _attach_hook(self):
         if isinstance(self._simulation.device, hoomd.device.CPU):
             thermo_cls = _md.ComputeThermo
         else:
             thermo_cls = _md.ComputeThermoGPU
         group = self._simulation.state._get_group(self._filter)
         self._cpp_obj = thermo_cls(self._simulation.state._cpp_sys_def, group)
-        super()._attach()
 
     @log(requires_run=True)
     def kinetic_temperature(self):
@@ -351,7 +350,7 @@ class HarmonicAveragedThermodynamicQuantities(Compute):
         # initialize base class
         super().__init__()
 
-    def _attach(self):
+    def _attach_hook(self):
         if isinstance(self._simulation.device, hoomd.device.CPU):
             thermoHMA_cls = _md.ComputeThermoHMA
         else:
@@ -359,7 +358,6 @@ class HarmonicAveragedThermodynamicQuantities(Compute):
         group = self._simulation.state._get_group(self._filter)
         self._cpp_obj = thermoHMA_cls(self._simulation.state._cpp_sys_def,
                                       group, self.kT, self.harmonic_pressure)
-        super()._attach()
 
     @log(requires_run=True)
     def potential_energy(self):

--- a/hoomd/md/constrain.py
+++ b/hoomd/md/constrain.py
@@ -37,7 +37,7 @@ class Constraint(Force):
         for `isinstance` or `issubclass` checks.
     """
 
-    def _attach(self):
+    def _attach_hook(self):
         """Create the c++ mirror class."""
         if isinstance(self._simulation.device, hoomd.device.CPU):
             cpp_cls = getattr(_md, self._cpp_class_name)
@@ -45,8 +45,6 @@ class Constraint(Force):
             cpp_cls = getattr(_md, self._cpp_class_name + "GPU")
 
         self._cpp_obj = cpp_cls(self._simulation.state._cpp_sys_def)
-
-        super()._attach()
 
 
 class Distance(Constraint):
@@ -330,8 +328,8 @@ class Rigid(Constraint):
         else:
             self._remove()
 
-    def _attach(self):
-        super()._attach()
+    def _attach_hook(self):
+        super()._attach_hook()
         # Need to ensure body tags and molecule sizes are correct and that the
         # positions and orientations are accurate before integration.
         self._cpp_obj.validateRigidBodies()

--- a/hoomd/md/dihedral.py
+++ b/hoomd/md/dihedral.py
@@ -64,7 +64,7 @@ class Dihedral(Force):
     def __init__(self):
         super().__init__()
 
-    def _attach(self):
+    def _attach_hook(self):
         # check that some dihedrals are defined
         if self._simulation.state._cpp_sys_def.getDihedralData().getNGlobal(
         ) == 0:
@@ -78,7 +78,6 @@ class Dihedral(Force):
             cpp_class = getattr(_md, self._cpp_class_name + "GPU")
 
         self._cpp_obj = cpp_class(self._simulation.state._cpp_sys_def)
-        super()._attach()
 
 
 class Harmonic(Dihedral):
@@ -181,7 +180,7 @@ class Table(Dihedral):
                 len_keys=1))
         self._add_typeparam(params)
 
-    def _attach(self):
+    def _attach_hook(self):
         """Create the c++ mirror class."""
         if isinstance(self._simulation.device, hoomd.device.CPU):
             cpp_cls = _md.TableDihedralForceCompute
@@ -189,8 +188,6 @@ class Table(Dihedral):
             cpp_cls = _md.TableDihedralForceComputeGPU
 
         self._cpp_obj = cpp_cls(self._simulation.state._cpp_sys_def, self.width)
-
-        Force._attach(self)
 
 
 class OPLS(Dihedral):

--- a/hoomd/md/external/field.py
+++ b/hoomd/md/external/field.py
@@ -21,14 +21,13 @@ class Field(force.Force):
         for `isinstance` or `issubclass` checks.
     """
 
-    def _attach(self):
+    def _attach_hook(self):
         if isinstance(self._simulation.device, hoomd.device.CPU):
             cls = getattr(_md, self._cpp_class_name)
         else:
             cls = getattr(_md, self._cpp_class_name + "GPU")
 
         self._cpp_obj = cls(self._simulation.state._cpp_sys_def)
-        super()._attach()
 
 
 class Periodic(Field):

--- a/hoomd/md/external/wall.py
+++ b/hoomd/md/external/wall.py
@@ -184,7 +184,7 @@ class WallPotential(force.Force):
         self._walls = None
         self.walls = hoomd.wall._WallsMetaList(walls, _to_md_cpp_wall)
 
-    def _attach(self):
+    def _attach_hook(self):
         if isinstance(self._simulation.device, hoomd.device.CPU):
             cls = getattr(_md, self._cpp_class_name)
         else:
@@ -201,7 +201,6 @@ class WallPotential(force.Force):
                 _ArrayViewWrapper(
                     _WallArrayViewFactory(self._cpp_obj, hoomd.wall.Plane)),
         })
-        super()._attach()
 
     @property
     def walls(self):

--- a/hoomd/md/force.py
+++ b/hoomd/md/force.py
@@ -7,7 +7,7 @@ from abc import abstractmethod
 
 import hoomd
 from hoomd.md import _md
-from hoomd.operation import AutotunedObject
+from hoomd.operation import Compute
 from hoomd.logging import log
 from hoomd.data.typeparam import TypeParameter
 from hoomd.data.typeconverter import OnlyTypes
@@ -17,7 +17,7 @@ from hoomd.md.manifold import Manifold
 import numpy
 
 
-class Force(AutotunedObject):
+class Force(Compute):
     r"""Defines a force for molecular dynamics simulations.
 
     `Force` is the base class for all molecular dynamics forces and provides

--- a/hoomd/md/force.py
+++ b/hoomd/md/force.py
@@ -291,11 +291,10 @@ class Custom(Force):
 
         self._state = None  # to be set on attaching
 
-    def _attach(self):
+    def _attach_hook(self):
         self._state = self._simulation.state
         self._cpp_obj = _md.CustomForceCompute(self._state._cpp_sys_def,
                                                self.set_forces, self._aniso)
-        super()._attach()
 
     @abstractmethod
     def set_forces(self, timestep):
@@ -405,13 +404,10 @@ class Active(Force):
 
         super()._add(simulation)
 
-    def _attach(self):
+    def _attach_hook(self):
 
         # Set C++ class
         self._set_cpp_obj()
-
-        # Attach param_dict and typeparam_dict
-        super()._attach()
 
     def _set_cpp_obj(self):
 

--- a/hoomd/md/improper.py
+++ b/hoomd/md/improper.py
@@ -53,7 +53,7 @@ class Improper(md.force.Force):
     def __init__(self):
         super().__init__()
 
-    def _attach(self):
+    def _attach_hook(self):
         # check that some impropers are defined
         if self._simulation.state._cpp_sys_def.getImproperData().getNGlobal(
         ) == 0:
@@ -67,7 +67,6 @@ class Improper(md.force.Force):
             cpp_class = getattr(hoomd.md._md, self._cpp_class_name + "GPU")
 
         self._cpp_obj = cpp_class(self._simulation.state._cpp_sys_def)
-        super()._attach()
 
 
 class Harmonic(Improper):

--- a/hoomd/md/integrate.py
+++ b/hoomd/md/integrate.py
@@ -44,21 +44,20 @@ class _DynamicIntegrator(BaseIntegrator):
         param_dict["rigid"] = rigid
         self._param_dict.update(param_dict)
 
-    def _attach(self):
+    def _attach_hook(self):
         self._forces._sync(self._simulation, self._cpp_obj.forces)
         self._constraints._sync(self._simulation, self._cpp_obj.constraints)
         self._methods._sync(self._simulation, self._cpp_obj.methods)
         if self.rigid is not None:
             self.rigid._attach()
-        super()._attach()
+        super()._attach_hook()
 
-    def _detach(self):
+    def _detach_hook(self):
         self._forces._unsync()
         self._methods._unsync()
         self._constraints._unsync()
         if self.rigid is not None:
             self.rigid._detach()
-        super()._detach()
 
     def _remove(self):
         if self.rigid is not None:
@@ -301,13 +300,13 @@ class Integrator(_DynamicIntegrator):
 
         self.half_step_hook = half_step_hook
 
-    def _attach(self):
+    def _attach_hook(self):
         # initialize the reflected c++ class
         self._cpp_obj = _md.IntegratorTwoStep(
             self._simulation.state._cpp_sys_def, self.dt)
         # Call attach from DynamicIntegrator which attaches forces,
         # constraint_forces, and methods, and calls super()._attach() itself.
-        super()._attach()
+        super()._attach_hook()
 
     def __setattr__(self, attr, value):
         """Hande group DOF update when setting integrate_rotational_dof."""

--- a/hoomd/md/long_range/pppm.py
+++ b/hoomd/md/long_range/pppm.py
@@ -173,7 +173,7 @@ class Coulomb(Force):
         self.alpha = alpha
         self._pair_force = pair_force
 
-    def _attach(self):
+    def _attach_hook(self):
         if not self._nlist._added:
             self._nlist._add(self._simulation)
         else:
@@ -262,8 +262,6 @@ class Coulomb(Force):
                 self._pair_force.r_cut[(a, b)] = rcut
 
         self._cpp_obj.setParams(Nx, Ny, Nz, order, kappa, rcut, alpha)
-
-        super()._attach()
 
     @property
     def nlist(self):

--- a/hoomd/md/manifold.py
+++ b/hoomd/md/manifold.py
@@ -34,9 +34,6 @@ class Manifold(_HOOMDBaseObject):
         Only one manifold can be applied to a given method or active forces.
     """
 
-    def _attach(self):
-        self._apply_param_dict()
-
     @staticmethod
     def _preprocess_unitcell(value):
         if isinstance(value, Sequence):
@@ -89,7 +86,7 @@ class Cylinder(Manifold):
 
         self._param_dict.update(param_dict)
 
-    def _attach(self):
+    def _attach_hook(self):
         self._cpp_obj = _md.ManifoldZCylinder(
             self.r, _hoomd.make_scalar3(self.P[0], self.P[1], self.P[2]))
 
@@ -145,7 +142,7 @@ class Diamond(Manifold):
         param_dict['N'] = N
         self._param_dict.update(param_dict)
 
-    def _attach(self):
+    def _attach_hook(self):
         self._cpp_obj = _md.ManifoldDiamond(
             _hoomd.make_int3(self.N[0], self.N[1], self.N[2]), self.epsilon)
 
@@ -192,7 +189,7 @@ class Ellipsoid(Manifold):
 
         self._param_dict.update(param_dict)
 
-    def _attach(self):
+    def _attach_hook(self):
         self._cpp_obj = _md.ManifoldEllipsoid(
             self.a, self.b, self.c,
             _hoomd.make_scalar3(self.P[0], self.P[1], self.P[2]))
@@ -250,7 +247,7 @@ class Gyroid(Manifold):
         param_dict['N'] = N
         self._param_dict.update(param_dict)
 
-    def _attach(self):
+    def _attach_hook(self):
         self._cpp_obj = _md.ManifoldGyroid(
             _hoomd.make_int3(self.N[0], self.N[1], self.N[2]), self.epsilon)
 
@@ -279,7 +276,7 @@ class Plane(Manifold):
 
         self._param_dict.update(param_dict)
 
-    def _attach(self):
+    def _attach_hook(self):
         self._cpp_obj = _md.ManifoldXYPlane(self.shift)
 
         super()._attach()
@@ -332,7 +329,7 @@ class Primitive(Manifold):
         param_dict['N'] = N
         self._param_dict.update(param_dict)
 
-    def _attach(self):
+    def _attach_hook(self):
         self._cpp_obj = _md.ManifoldPrimitive(
             _hoomd.make_int3(self.N[0], self.N[1], self.N[2]), self.epsilon)
 
@@ -370,7 +367,7 @@ class Sphere(Manifold):
 
         self._param_dict.update(param_dict)
 
-    def _attach(self):
+    def _attach_hook(self):
         self._cpp_obj = _md.ManifoldSphere(
             self.r, _hoomd.make_scalar3(self.P[0], self.P[1], self.P[2]))
 

--- a/hoomd/md/many_body.py
+++ b/hoomd/md/many_body.py
@@ -134,7 +134,7 @@ class Triplet(Force):
             self._add_nlist()
             old_nlist._remove_dependent(self)
 
-    def _attach(self):
+    def _attach_hook(self):
         if self._simulation != self.nlist._simulation:
             raise RuntimeError("{} object's neighbor list is used in a "
                                "different simulation.".format(type(self)))
@@ -147,8 +147,6 @@ class Triplet(Force):
 
         self._cpp_obj = cls(self._simulation.state._cpp_sys_def,
                             self.nlist._cpp_obj)
-
-        super()._attach()
 
 
 class Tersoff(Triplet):

--- a/hoomd/md/mesh/potential.py
+++ b/hoomd/md/mesh/potential.py
@@ -56,7 +56,7 @@ class MeshPotential(Force):
         # mesh when not attached we handle correctly.
         self._add_dependency(self._mesh)
 
-    def _attach(self):
+    def _attach_hook(self):
         """Create the c++ mirror class."""
         if self._simulation != self._mesh._simulation:
             raise RuntimeError("{} object's mesh is used in a "
@@ -72,8 +72,6 @@ class MeshPotential(Force):
 
         self._cpp_obj = cpp_cls(self._simulation.state._cpp_sys_def,
                                 self._mesh._cpp_obj)
-
-        super()._attach()
 
     def _apply_typeparam_dict(self, cpp_obj, simulation):
         for typeparam in self._typeparam_dict.values():

--- a/hoomd/md/methods/methods.py
+++ b/hoomd/md/methods/methods.py
@@ -23,13 +23,11 @@ class Method(AutotunedObject):
         Users should use the subclasses and not instantiate `Method` directly.
     """
 
-    def _attach(self):
+    def _attach_hook(self):
         self._simulation.state.update_group_dof()
-        super()._attach()
 
-    def _detach(self):
+    def _detach_hook(self):
         self._simulation.state.update_group_dof()
-        super()._detach()
 
 
 class NVT(Method):
@@ -114,7 +112,7 @@ class NVT(Method):
         # set defaults
         self._param_dict.update(param_dict)
 
-    def _attach(self):
+    def _attach_hook(self):
 
         # initialize the reflected cpp class
         if isinstance(self._simulation.device, hoomd.device.CPU):
@@ -128,7 +126,7 @@ class NVT(Method):
         cpp_sys_def = self._simulation.state._cpp_sys_def
         thermo = thermo_cls(cpp_sys_def, group)
         self._cpp_obj = my_class(cpp_sys_def, group, thermo, self.tau, self.kT)
-        super()._attach()
+        super()._attach_hook()
 
     def thermalize_thermostat_dof(self):
         r"""Set the thermostat momenta to random values.
@@ -390,7 +388,7 @@ class NPT(Method):
         # set defaults
         self._param_dict.update(param_dict)
 
-    def _attach(self):
+    def _attach_hook(self):
         # initialize the reflected c++ class
         if isinstance(self._simulation.device, hoomd.device.CPU):
             cpp_cls = _md.TwoStepNPTMTK
@@ -411,7 +409,7 @@ class NPT(Method):
                                 self.S, self.couple, self.box_dof, False)
 
         # Attach param_dict and typeparam_dict
-        super()._attach()
+        super()._attach_hook()
 
     def _preprocess_stress(self, value):
         if isinstance(value, Sequence):
@@ -590,7 +588,7 @@ class NPH(Method):
         # set defaults
         self._param_dict.update(param_dict)
 
-    def _attach(self):
+    def _attach_hook(self):
         # initialize the reflected c++ class
         if isinstance(self._simulation.device, hoomd.device.CPU):
             cpp_cls = _md.TwoStepNPTMTK
@@ -611,7 +609,7 @@ class NPH(Method):
                                 self.S, self.couple, self.box_dof, True)
 
         # Attach param_dict and typeparam_dict
-        super()._attach()
+        super()._attach_hook()
 
     @staticmethod
     def _preprocess_stress(value):
@@ -693,7 +691,7 @@ class NVE(Method):
         # set defaults
         self._param_dict.update(param_dict)
 
-    def _attach(self):
+    def _attach_hook(self):
 
         sim = self._simulation
         # initialize the reflected c++ class
@@ -705,7 +703,7 @@ class NVE(Method):
                                               sim.state._get_group(self.filter))
 
         # Attach param_dict and typeparam_dict
-        super()._attach()
+        super()._attach_hook()
 
 
 class DisplacementCapped(NVE):
@@ -916,7 +914,7 @@ class Langevin(Method):
 
         super()._add(simulation)
 
-    def _attach(self):
+    def _attach_hook(self):
 
         sim = self._simulation
         if isinstance(sim.device, hoomd.device.CPU):
@@ -928,7 +926,7 @@ class Langevin(Method):
                                  sim.state._get_group(self.filter), self.kT)
 
         # Attach param_dict and typeparam_dict
-        super()._attach()
+        super()._attach_hook()
 
 
 class Brownian(Method):
@@ -1101,7 +1099,7 @@ class Brownian(Method):
 
         super()._add(simulation)
 
-    def _attach(self):
+    def _attach_hook(self):
 
         sim = self._simulation
         if isinstance(sim.device, hoomd.device.CPU):
@@ -1114,7 +1112,7 @@ class Brownian(Method):
                                              self.kT, False, False)
 
         # Attach param_dict and typeparam_dict
-        super()._attach()
+        super()._attach_hook()
 
 
 class Berendsen(Method):
@@ -1172,7 +1170,7 @@ class Berendsen(Method):
         # set defaults
         self._param_dict.update(param_dict)
 
-    def _attach(self):
+    def _attach_hook(self):
         sim = self._simulation
         # Error out in MPI simulations
         if hoomd.version.mpi_enabled:
@@ -1191,7 +1189,7 @@ class Berendsen(Method):
         self._cpp_obj = cpp_method(sim.state._cpp_sys_def, group,
                                    thermo_cls(sim.state._cpp_sys_def, group),
                                    self.tau, self.kT)
-        super()._attach()
+        super()._attach_hook()
 
 
 class OverdampedViscous(Method):
@@ -1311,7 +1309,7 @@ class OverdampedViscous(Method):
 
         super()._add(simulation)
 
-    def _attach(self):
+    def _attach_hook(self):
 
         sim = self._simulation
         if isinstance(sim.device, hoomd.device.CPU):
@@ -1326,4 +1324,4 @@ class OverdampedViscous(Method):
                                              True)
 
         # Attach param_dict and typeparam_dict
-        super()._attach()
+        super()._attach_hook()

--- a/hoomd/md/methods/rattle.py
+++ b/hoomd/md/methods/rattle.py
@@ -115,7 +115,7 @@ class NVE(MethodRATTLE):
 
         super().__init__(manifold_constraint, tolerance)
 
-    def _attach(self):
+    def _attach_hook(self):
 
         self._attach_constraint(self._simulation)
 
@@ -133,9 +133,6 @@ class NVE(MethodRATTLE):
                                  self._simulation.state._get_group(self.filter),
                                  self.manifold_constraint._cpp_obj,
                                  self.tolerance)
-
-        # Attach param_dict and typeparam_dict
-        super()._attach()
 
 
 class DisplacementCapped(NVE):
@@ -337,7 +334,7 @@ class Langevin(MethodRATTLE):
 
         super()._add(simulation)
 
-    def _attach(self):
+    def _attach_hook(self):
 
         sim = self._simulation
         self._attach_constraint(sim)
@@ -355,9 +352,6 @@ class Langevin(MethodRATTLE):
                                  sim.state._get_group(self.filter),
                                  self.manifold_constraint._cpp_obj, self.kT,
                                  self.tolerance)
-
-        # Attach param_dict and typeparam_dict
-        super()._attach()
 
 
 class Brownian(MethodRATTLE):
@@ -476,7 +470,7 @@ class Brownian(MethodRATTLE):
 
         super()._add(simulation)
 
-    def _attach(self):
+    def _attach_hook(self):
 
         sim = self._simulation
         self._attach_constraint(sim)
@@ -494,9 +488,6 @@ class Brownian(MethodRATTLE):
                                  sim.state._get_group(self.filter),
                                  self.manifold_constraint._cpp_obj, self.kT,
                                  False, False, self.tolerance)
-
-        # Attach param_dict and typeparam_dict
-        super()._attach()
 
 
 class OverdampedViscous(MethodRATTLE):
@@ -605,7 +596,7 @@ class OverdampedViscous(MethodRATTLE):
 
         super()._add(simulation)
 
-    def _attach(self):
+    def _attach_hook(self):
 
         sim = self._simulation
         self._attach_constraint(sim)
@@ -624,6 +615,3 @@ class OverdampedViscous(MethodRATTLE):
                                  self.manifold_constraint._cpp_obj,
                                  hoomd.variant.Constant(0.0), True, True,
                                  self.tolerance)
-
-        # Attach param_dict and typeparam_dict
-        super()._attach()

--- a/hoomd/md/minimize/fire.py
+++ b/hoomd/md/minimize/fire.py
@@ -250,13 +250,13 @@ class FIRE(_DynamicIntegrator):
             iterable=methods)
         self._methods = methods_list
 
-    def _attach(self):
+    def _attach_hook(self):
         if isinstance(self._simulation.device, hoomd.device.CPU):
             cls = getattr(_md, self._cpp_class_name)
         else:
             cls = getattr(_md, self._cpp_class_name + "GPU")
         self._cpp_obj = cls(self._simulation.state._cpp_sys_def, self.dt)
-        super()._attach()
+        super()._attach_hook()
 
     @log(requires_run=True)
     def energy(self):

--- a/hoomd/md/nlist.py
+++ b/hoomd/md/nlist.py
@@ -104,11 +104,9 @@ class NeighborList(AutotunedObject):
 
         self._mesh = validate_mesh(mesh)
 
-    def _attach(self):
+    def _attach_hook(self):
         if self._mesh is not None:
             self._cpp_obj.addMesh(self._mesh._cpp_obj)
-
-        super()._attach()
 
     @log(requires_run=True)
     def shortest_rebuild(self):
@@ -201,15 +199,14 @@ class Cell(NeighborList):
         self._param_dict.update(
             ParameterDict(deterministic=bool(deterministic)))
 
-    def _attach(self):
+    def _attach_hook(self):
         if isinstance(self._simulation.device, hoomd.device.CPU):
             nlist_cls = _md.NeighborListBinned
         else:
             nlist_cls = _md.NeighborListGPUBinned
         self._cpp_obj = nlist_cls(self._simulation.state._cpp_sys_def,
                                   self.buffer)
-
-        super()._attach()
+        super()._attach_hook()
 
     @log(requires_run=True, default=False, category='sequence')
     def dimensions(self):
@@ -311,14 +308,14 @@ class Stencil(NeighborList):
 
         self._param_dict.update(params)
 
-    def _attach(self):
+    def _attach_hook(self):
         if isinstance(self._simulation.device, hoomd.device.CPU):
             nlist_cls = _md.NeighborListStencil
         else:
             nlist_cls = _md.NeighborListGPUStencil
         self._cpp_obj = nlist_cls(self._simulation.state._cpp_sys_def,
                                   self.buffer)
-        super()._attach()
+        super()._attach_hook()
 
 
 class Tree(NeighborList):
@@ -378,11 +375,11 @@ class Tree(NeighborList):
         super().__init__(buffer, exclusions, rebuild_check_delay, check_dist,
                          mesh)
 
-    def _attach(self):
+    def _attach_hook(self):
         if isinstance(self._simulation.device, hoomd.device.CPU):
             nlist_cls = _md.NeighborListTree
         else:
             nlist_cls = _md.NeighborListGPUTree
         self._cpp_obj = nlist_cls(self._simulation.state._cpp_sys_def,
                                   self.buffer)
-        super()._attach()
+        super()._attach_hook()

--- a/hoomd/md/pair/aniso.py
+++ b/hoomd/md/pair/aniso.py
@@ -481,11 +481,11 @@ class ALJ(AnisotropicPair):
 
         self._extend_typeparam((params, shape))
 
-    def _attach(self):
+    def _attach_hook(self):
         self._cpp_class_name = "AnisoPotentialPairALJ{}".format(
             "2D" if self._simulation.state.box.is2D else "3D")
 
-        super()._attach()
+        super()._attach_hook()
 
     @staticmethod
     def _to_three_tuple(value):

--- a/hoomd/md/pair/pair.py
+++ b/hoomd/md/pair/pair.py
@@ -152,7 +152,7 @@ class Pair(force.Force):
         # neighbor list when not attached we handle correctly.
         self._add_dependency(self.nlist)
 
-    def _attach(self):
+    def _attach_hook(self):
         # This should never happen, but leaving it in case the logic for adding
         # missed some edge case.
         if self._simulation != self.nlist._simulation:
@@ -170,7 +170,8 @@ class Pair(force.Force):
         self._cpp_obj = cls(self._simulation.state._cpp_sys_def,
                             self.nlist._cpp_obj)
 
-        super()._attach()
+    def _detach_hook(self):
+        self.nlist._detach()
 
     def _setattr_param(self, attr, value):
         if attr == "nlist":

--- a/hoomd/md/pytest/test_active_rotational_diffusion.py
+++ b/hoomd/md/pytest/test_active_rotational_diffusion.py
@@ -108,16 +108,16 @@ def test_attaching(active_force, local_simulation_factory):
     with pytest.raises(hoomd.error.SimulationDefinitionError):
         sim.operations.integrator.forces.remove(active_force)
 
-    # Exception happens before removing "_simulation" attribute. We need to
-    # manual do this to perform the other checks. We don't worry about this,
+    sim.operations.remove(rd_updater)
+    # Exception above happens before removing "_simulation" attribute. We need
+    # to manual do this to perform the other checks. We don't worry about this,
     # because a SimulationDefinitionError is not really meant to be caught and
     # dealt with dynamically.
-    del active_force._simulation
+    active_force._remove()
+    sim.operations.integrator.forces.clear()
 
     # Reset simulation to test for variouos error conditions
     sim.operations._unschedule()
-    sim.operations.remove(rd_updater)
-    sim.operations.integrator.forces.clear()
 
     # ActiveRotationalDiffusion should error when active force is not attached
     sim.operations += rd_updater

--- a/hoomd/md/pytest/test_potential.py
+++ b/hoomd/md/pytest/test_potential.py
@@ -1260,3 +1260,15 @@ def test_tail_corrections(simulation_factory, two_particle_snapshot_factory):
     # make sure corrections correct in the right direction
     assert e_true < e_false
     assert p_true < p_false
+
+
+def test_adding_to_operations(simulation_factory,
+                              two_particle_snapshot_factory):
+    """Test that forces can work like computes since they are."""
+    sim = simulation_factory(two_particle_snapshot_factory(d=0.5))
+    lj = hoomd.md.pair.LJ(nlist=hoomd.md.nlist.Cell(0.4))
+    lj.r_cut.default = 2.5
+    lj.params.default = {"epsilon": 1.0, "sigma": 1.0}
+    sim.operations += lj
+    sim.run(0)
+    assert lj.energy != 0

--- a/hoomd/md/pytest/test_potential.py
+++ b/hoomd/md/pytest/test_potential.py
@@ -1036,10 +1036,8 @@ def test_setting_to_new_sim(simulation_factory, two_particle_snapshot_factory):
     lj = md.pair.LJ(nlist, default_r_cut=1.1)
     lj.params[("A", "A")] = {"sigma": 0.5, "epsilon": 1.0}
     sim1.operations.integrator.forces.append(lj)
-
-    # Test cannot add to new integrator
-    with pytest.raises(RuntimeError):
-        sim2.operations.integrator.forces.append(lj)
+    sim2.operations.integrator.forces.append(lj)
+    sim2.operations.integrator.forces.clear()
 
     # Ensure that removing and appending works
     sim1.operations.integrator.forces.remove(lj)
@@ -1055,8 +1053,9 @@ def test_setting_to_new_sim(simulation_factory, two_particle_snapshot_factory):
     lj2.params[("A", "A")] = {"sigma": 0.5, "epsilon": 1.0}
     sim2.operations.integrator.forces.append(lj2)
     sim2.operations.integrator.forces.remove(lj)
+    sim1.operations.integrator.forces.append(lj)
     with pytest.warns(RuntimeWarning):
-        sim1.operations.integrator.forces.append(lj)
+        sim1.run(0)
 
 
 @pytest.mark.filterwarnings("always")
@@ -1272,3 +1271,44 @@ def test_adding_to_operations(simulation_factory,
     sim.operations += lj
     sim.run(0)
     assert lj.energy != 0
+
+
+def test_forces_multiple_lists(simulation_factory,
+                               two_particle_snapshot_factory):
+    """Test that forces added to an integrator and compute work correctly.
+
+    Look at the edge cases where a force is added twice to a simulation: once
+    through the integrator and once through the compute list. We check that the
+    correct thing happens when one or both are removed.
+    """
+    sim = simulation_factory(two_particle_snapshot_factory())
+    lj = hoomd.md.pair.LJ(nlist=hoomd.md.nlist.Cell(0.4))
+    lj.r_cut[("A", "A")] = 2.5
+    lj.params[("A", "A")] = {"sigma": 1.0, "epsilon": 1.0}
+    integrator = md.Integrator(dt=0.005)
+    integrator.forces.append(lj)
+    sim.operations.integrator = integrator
+    sim.operations.computes.append(lj)
+    sim.run(0)
+    assert lj._use_count == 2
+    sim.operations.computes.clear()
+    assert lj._attached
+    assert lj._use_count == 1
+    sim.operations.integrator = None
+    assert not lj._attached
+    assert lj._use_count == 0
+
+    # Test adding to second list after attaching
+    sim.operations._unschedule()
+    sim.operations.integrator = integrator
+    sim.run(0)
+    assert lj._attached
+    assert lj._use_count == 1
+    sim.operations.computes.append(lj)
+    assert lj._use_count == 2
+    sim.operations.integrator = None
+    assert lj._attached
+    assert lj._use_count == 1
+    sim.operations.computes.clear()
+    assert not lj._attached
+    assert lj._use_count == 0

--- a/hoomd/md/special_pair.py
+++ b/hoomd/md/special_pair.py
@@ -58,7 +58,7 @@ class SpecialPair(Force):
     def __init__(self):
         super().__init__()
 
-    def _attach(self):
+    def _attach_hook(self):
         # check that some special pairs are defined
         if self._simulation.state._cpp_sys_def.getPairData().getNGlobal() == 0:
             self._simulation.device._cpp_msg.error("No pairs are defined.\n")
@@ -69,7 +69,6 @@ class SpecialPair(Force):
         else:
             cpp_cls = getattr(_md, self._cpp_class_name + "GPU")
         self._cpp_obj = cpp_cls(self._simulation.state._cpp_sys_def)
-        super()._attach()
 
 
 class LJ(SpecialPair):

--- a/hoomd/md/update.py
+++ b/hoomd/md/update.py
@@ -49,11 +49,10 @@ class ZeroMomentum(Updater):
         # initialize base class
         super().__init__(trigger)
 
-    def _attach(self):
+    def _attach_hook(self):
         # create the c++ mirror class
         self._cpp_obj = _md.ZeroMomentumUpdater(
             self._simulation.state._cpp_sys_def, self.trigger)
-        super()._attach()
 
 
 class ReversePerturbationFlow(Updater):
@@ -205,7 +204,7 @@ class ReversePerturbationFlow(Updater):
                               min_slab = max_slab = {min_slab}")
         return min_slab
 
-    def _attach(self):
+    def _attach_hook(self):
         group = self._simulation.state._get_group(self.filter)
         sys_def = self._simulation.state._cpp_sys_def
         if isinstance(self._simulation.device, hoomd.device.CPU):
@@ -218,7 +217,6 @@ class ReversePerturbationFlow(Updater):
                 sys_def, self.trigger, group, self.flow_target,
                 self.slab_direction, self.flow_direction, self.n_slabs,
                 self.min_slab, self.max_slab, self.flow_epsilon)
-        super()._attach()
 
     @log(category="scalar", requires_run=True)
     def summed_exchanged_momentum(self):
@@ -277,7 +275,7 @@ class ActiveRotationalDiffusion(Updater):
         self._add_dependency(active_force)
         self._param_dict.update(param_dict)
 
-    def _attach(self):
+    def _attach_hook(self):
         # Since integrators are attached first, if the active force is not
         # attached then the active force is not a part of the simulation, and we
         # should error.
@@ -292,7 +290,6 @@ class ActiveRotationalDiffusion(Updater):
         self._cpp_obj = _md.ActiveRotationalDiffusionUpdater(
             self._simulation.state._cpp_sys_def, self.trigger,
             self.rotational_diffusion, self.active_force._cpp_obj)
-        # No need to call super
 
     def _handle_removed_dependency(self, active_force):
         raise SimulationDefinitionError(

--- a/hoomd/mesh.py
+++ b/hoomd/mesh.py
@@ -71,7 +71,7 @@ class Mesh(_HOOMDBaseObject):
 
         self._param_dict.update(param_dict)
 
-    def _attach(self):
+    def _attach_hook(self):
 
         self._cpp_obj = _hoomd.MeshDefinition(
             self._simulation.state._cpp_sys_def)
@@ -87,8 +87,6 @@ class Mesh(_HOOMDBaseObject):
                     self._cpp_obj)
                 self._cpp_obj.setCommunicator(
                     self._simulation._system_communicator)
-
-        super()._attach()
 
     def _remove_dependent(self, obj):
         super()._remove_dependent(obj)

--- a/hoomd/operation.py
+++ b/hoomd/operation.py
@@ -192,16 +192,26 @@ class _HOOMDBaseObject(_HOOMDGetSetAttrBase,
     infrastructure for HOOMD-blue objects.
 
     This class's main features are handling attaching and detaching from
-    simulations and adding and removing from containing object such as methods
-    for MD integrators and updaters for the operations list. Attaching is the
-    idea of creating a C++ object that is tied to a given simulation while
-    detaching is removing an object from its simulation.
+    simulations and _adding_ and _removing_ from containing object such as
+    methods for MD integrators and updaters for the operations list. _Attaching_
+    is the idea of creating a C++ object that is tied to a given simulation
+    while _detaching_ is removing an object from its simulation.
+
+    The class also has a counter ``_use_count`` which keeps track of consumers
+    of an operation outside of regular dependencies. This is necessary to avoid
+    double attaching or premature detaching if the object is removed from one of
+    its consumers. This does allow for simple dependency handling outside of the
+    features of `_DependencyRelation`.
     """
     _reserved_default_attrs = {
-        **_HOOMDGetSetAttrBase._reserved_default_attrs, '_cpp_obj': None,
+        **_HOOMDGetSetAttrBase._reserved_default_attrs,
+        '_cpp_obj': None,
         '_simulation': None,
         '_dependents': list,
-        '_dependencies': list
+        '_dependencies': list,
+        # Keeps track of the number of times _attach is called to avoid
+        # premature detaching.
+        "_use_count": int,
     }
 
     _skip_for_equality = {
@@ -210,18 +220,65 @@ class _HOOMDBaseObject(_HOOMDGetSetAttrBase,
     _remove_for_pickling = ('_simulation', '_cpp_obj')
 
     def _detach(self):
-        if self._attached:
-            self._unapply_typeparam_dict()
-            self._param_dict._detach()
-            if hasattr(self._cpp_obj, "notifyDetach"):
-                self._cpp_obj.notifyDetach()
-            # In case the C++ object is necessary for proper disconnect
-            # notification we call _notify_disconnect here as well.
-            self._notify_disconnect()
-            self._cpp_obj = None
+        """Decrement attach count and destroy C++ object if count == 0.
+
+        This method is not designed to be overwritten, but handles the necessary
+        detaching procedures for all `_HOOMDBaseObject` subclasses.
+
+        Note:
+            Use `~._detach_hook` in subclasses to provide custom detaching
+            logic.
+        """
+        if self._use_count == 0:
             return self
+        self._use_count -= 1
+        if self._use_count > 0:
+            return self
+        self._unapply_typeparam_dict()
+        self._param_dict._detach()
+        if hasattr(self._cpp_obj, "notifyDetach"):
+            self._cpp_obj.notifyDetach()
+        # In case the C++ object is necessary for proper disconnect
+        # notification we call _notify_disconnect here as well.
+        self._notify_disconnect()
+        self._cpp_obj = None
+        self._detach_hook()
+        return self
+
+    def _detach_hook(self):
+        """Implement custom detaching behavior.
+
+        This is to provide custom detaching behavior not to:
+            - Change the instance's ``_use_count`` member.
+            - Remove the C++ instance.
+            - Handle the ``_param_dict`` and ``_typeparam_dict``.
+            - Notifying dependencies in C++ or Python of detaching.
+
+        Note:
+            This is only called when the attach counter goes to zero.
+        """
+        pass
+
+    def _attach_hook(self):
+        """Create the C++ object and store it in ``_cpp_obj``.
+
+        All subclasses should implement this to create the correct pybind11
+        wrapped C++ object. This should not worry about the consumer count or
+        deal with ``_param_dict`` or ``_typeparam_dict``.
+        """
+        pass
 
     def _attach(self):
+        """Attach the object to the added simulation.
+
+        This should not be overwritten by subclasses, see `~._attach_hook`
+        instead. This method handles consumer count book keeping and
+        ``_param_dict`` and ``_typeparam_dict``.
+        """
+        self._use_count += 1
+        if self._use_count > 1:
+            return
+        self._attach_hook()
         self._apply_param_dict()
         self._apply_typeparam_dict(self._cpp_obj, self._simulation)
 
@@ -235,7 +292,7 @@ class _HOOMDBaseObject(_HOOMDGetSetAttrBase,
     def _remove(self):
         # Since objects can be added without being attached, we need to call
         # _notify_disconnect on both _remove and _detach. The method should be
-        # do nothing after being called onces so being called twice is not a
+        # do nothing after being called once so being called twice is not a
         # concern. I should note that if
         # `hoomd.operations.Operations._unschedule` is called this is
         # invalidated, but as that is not public facing this should be fine.
@@ -483,9 +540,8 @@ class Integrator(Operation):
         for `isinstance` or `issubclass` checks.
     """
 
-    def _attach(self):
+    def _attach_hook(self):
         self._simulation._cpp_sys.setIntegrator(self._cpp_obj)
-        super()._attach()
 
         # The integrator has changed, update the number of DOF in all groups
         self._simulation.state.update_group_dof()

--- a/hoomd/pytest/test_syncedlist.py
+++ b/hoomd/pytest/test_syncedlist.py
@@ -82,17 +82,15 @@ class TestSyncedList(BaseListTest):
     def final_check(self, test_list):
         if test_list._synced:
             if test_list._attach_members:
+                assert all(item._added for item in test_list)
                 assert all(item._attached for item in test_list)
-            else:
-                assert not any(
-                    getattr(item, "_attached", False) for item in test_list)
             for item, synced_item in zip(test_list, self._synced_list):
                 assert self.is_equal(item, synced_item)
             assert self._synced_list is test_list._synced_list
-        if test_list._attach_members:
-            assert all(item._added for item in test_list)
-        else:
+        if not test_list._attach_members:
             assert not any(getattr(item, "_added", False) for item in test_list)
+            assert not any(
+                getattr(item, "_attached", False) for item in test_list)
 
     def test_init(self, generate_plain_collection, item_cls):
 
@@ -114,7 +112,6 @@ class TestSyncedList(BaseListTest):
         assert synced_list._to_synced_list_conversion == cpp_identity
         op._cpp_obj = 2
         assert synced_list._to_synced_list_conversion(op) == 2
-        assert all(op._added for op in synced_list)
         self.check_equivalent(plain_list, synced_list)
 
     def test_synced(self):
@@ -125,12 +122,13 @@ class TestSyncedList(BaseListTest):
         test_list._unsync()
         assert not test_list._synced
 
-    def test_attach_value(self, empty_collection, item_cls):
+    def test_register_item(self, empty_collection, item_cls):
         op = item_cls()
-        empty_collection._attach_value(op)
+        empty_collection._register_item(op)
         assert op._attached == (empty_collection._synced
                                 and empty_collection._attach_members)
-        assert op._added or not empty_collection._attach_members
+        assert op._added == (empty_collection._attach_members
+                             and empty_collection._synced)
 
     def test_validate_or_error(self, empty_collection, item_cls):
         with pytest.raises(ValueError):

--- a/hoomd/tune/balance.py
+++ b/hoomd/tune/balance.py
@@ -107,7 +107,7 @@ class LoadBalancer(Tuner):
         self._param_dict.update(load_balancer_params)
         self._param_dict.update(defaults)
 
-    def _attach(self):
+    def _attach_hook(self):
         if isinstance(self._simulation.device, hoomd.device.GPU):
             cpp_cls = getattr(_hoomd, 'LoadBalancerGPU')
         else:
@@ -115,5 +115,3 @@ class LoadBalancer(Tuner):
 
         self._cpp_obj = cpp_cls(self._simulation.state._cpp_sys_def,
                                 self.trigger)
-
-        super()._attach()

--- a/hoomd/tune/sorter.py
+++ b/hoomd/tune/sorter.py
@@ -65,11 +65,10 @@ class ParticleSorter(Tuner):
         except TypeError:
             raise ValueError("Expected positive integer.")
 
-    def _attach(self):
+    def _attach_hook(self):
         if isinstance(self._simulation.device, hoomd.device.GPU):
             cpp_cls = getattr(_hoomd, 'SFCPackTunerGPU')
         else:
             cpp_cls = getattr(_hoomd, 'SFCPackTuner')
         self._cpp_obj = cpp_cls(self._simulation.state._cpp_sys_def,
                                 self.trigger)
-        super()._attach()

--- a/hoomd/update/box_resize.py
+++ b/hoomd/update/box_resize.py
@@ -115,12 +115,11 @@ class BoxResize(Updater):
         self._param_dict.update(params)
         super().__init__(trigger)
 
-    def _attach(self):
+    def _attach_hook(self):
         group = self._simulation.state._get_group(self.filter)
         self._cpp_obj = _hoomd.BoxResizeUpdater(
             self._simulation.state._cpp_sys_def, self.trigger,
             self.box1._cpp_obj, self.box2._cpp_obj, self.variant, group)
-        super()._attach()
 
     def get_box(self, timestep):
         """Get the box for a given timestep.

--- a/hoomd/update/particle_filter.py
+++ b/hoomd/update/particle_filter.py
@@ -83,14 +83,13 @@ class FilterUpdater(hoomd.operation.Updater):
         self._filters.clear()
         self._filters.extend(new_filters)
 
-    def _attach(self):
+    def _attach_hook(self):
         # We use a SyncedList internal API to allow for storing the state to
         # query groups from filters.
         self._filters._to_synced_list_conversion._attach(self._simulation)
         self._cpp_obj = hoomd._hoomd.ParticleFilterUpdater(
             self._simulation.state._cpp_sys_def, self.trigger)
         self._filters._sync(self._simulation, self._cpp_obj.groups)
-        super()._attach()
 
     def __eq__(self, other):
         """Return whether two objects are equivalent."""

--- a/hoomd/update/remove_drift.py
+++ b/hoomd/update/remove_drift.py
@@ -58,7 +58,7 @@ class RemoveDrift(Updater):
         """Add the operation to a simulation."""
         super()._add(simulation)
 
-    def _attach(self):
+    def _attach_hook(self):
         if isinstance(self._simulation.device, hoomd.device.GPU):
             self._simulation.device._cpp_msg.warning(
                 "Falling back on CPU. No GPU implementation available.\n")
@@ -66,4 +66,3 @@ class RemoveDrift(Updater):
         self._cpp_obj = _hoomd.UpdaterRemoveDrift(
             self._simulation.state._cpp_sys_def, self.trigger,
             self.reference_positions)
-        super()._attach()

--- a/hoomd/write/dcd.py
+++ b/hoomd/write/dcd.py
@@ -93,9 +93,8 @@ class DCD(Writer):
                           angle_z=bool(angle_z)))
         self.filter = filter
 
-    def _attach(self):
+    def _attach_hook(self):
         group = self._simulation.state._get_group(self.filter)
         self._cpp_obj = _hoomd.DCDDumpWriter(
             self._simulation.state._cpp_sys_def, self.trigger, self.filename,
             int(self.trigger.period), group, self.overwrite)
-        super()._attach()

--- a/hoomd/write/gsd.py
+++ b/hoomd/write/gsd.py
@@ -169,7 +169,7 @@ class GSD(Writer):
 
         self._log = None if log is None else _GSDLogWriter(log)
 
-    def _attach(self):
+    def _attach_hook(self):
         # validate dynamic property
         categories = ['attribute', 'property', 'momentum', 'topology']
         dynamic_quantities = ['property']
@@ -192,7 +192,6 @@ class GSD(Writer):
         self._cpp_obj.setWriteMomentum('momentum' in dynamic_quantities)
         self._cpp_obj.setWriteTopology('topology' in dynamic_quantities)
         self._cpp_obj.log_writer = self.log
-        super()._attach()
 
     @staticmethod
     def write(state, filename, filter=All(), mode='wb', log=None):


### PR DESCRIPTION
## Description
This makes the force a Compute on the Python side so it can be querried for force and energy even when not applied to the system.
<!-- Describe your changes in detail. -->

## Motivation and context
This was motivated by a use case for querying a non-existent force by @Charlottez112.

## How has this been tested?
~Has not been tested currently, though I plan to add tests soon.~ Tests added.

## Change log

<!-- Propose a change log entry. -->
```
Added
- MD forces can now be added to the Operations list allowing for force, energy, virial querying without the forces effecting the system.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
