### PR TITLE
Fix the many bond type warning message.

### DIFF
--- a/hoomd/BondedGroupData.cc
+++ b/hoomd/BondedGroupData.cc
@@ -238,10 +238,10 @@ void BondedGroupData<group_size, Group, name, has_type_mapping>::initializeFromS
     if (snapshot.type_mapping.size() >= 40)
         {
         std::ostringstream s;
-        s << "Systems with many " << name << " types perform poorly or result "
+        s << "Systems with many " << name
+          << " types perform poorly or result "
              "in shared memory errors on the GPU.";
-        m_exec_conf->msg->warning() << s.str()
-                                    << std::endl;
+        m_exec_conf->msg->warning() << s.str() << std::endl;
         }
 
     // re-initialize data structures

--- a/hoomd/BondedGroupData.cc
+++ b/hoomd/BondedGroupData.cc
@@ -237,8 +237,10 @@ void BondedGroupData<group_size, Group, name, has_type_mapping>::initializeFromS
 
     if (snapshot.type_mapping.size() >= 40)
         {
-        m_exec_conf->msg->warning() << "Systems with many particle types perform poorly or result "
-                                       "in shared memory errors on the GPU."
+        std::ostringstream s;
+        s << "Systems with many " << name << " types perform poorly or result "
+             "in shared memory errors on the GPU.";
+        m_exec_conf->msg->warning() << s.str()
                                     << std::endl;
         }
 


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should be based on *trunk-patch*. -->
<!-- Backwards compatible new features should be based on *trunk-minor*. -->
<!-- Incompatible API changes should be based on *trunk-major*. -->

## Description

<!-- Describe your changes in detail. -->
Fix the many bond type warning message.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Correctly identify the source of the warning.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
I tested locally with this script:
```
import hoomd

snap = hoomd.Snapshot()
snap.particles.N = 1
snap.particles.types = ['A']
snap.dihedrals.N = 1
snap.dihedrals.types = [str(i) for i in range(50)]
snap.configuration.box = [10, 10, 10, 0, 0, 0]

sim = hoomd.Simulation(device=hoomd.device.CPU())
sim.create_state_from_snapshot(snap)
```
Which gave this output:
```
*Warning*: Systems with many dihedral types perform poorly or result in shared memory errors on the GPU.
```

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
* Fix the many bond type warning message.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
