### PR TITLE
refactor: Remove _remove and _add from data model

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -234,13 +234,10 @@ except where necessary.
 ### Base Data Model
 
 #### Definitions
-- added: An object is associated with a `Simulation`.
 - attached: An object has its corresponding C++ class instantiated and is
   connected to a `Simulation`.
-- unattached: An object's data resides in pure Python and may be or not be
-  added.
+- unattached: An object's data resides in pure Python.
 - detach: The transition from attached to unattached.
-- removed: The removal of an unattached object from a `Simulation`.
 - sync: The process of making a C++ container match a corresponding Python
   container. See the section on `SyncedList` for a concrete example.
 - type parameter: An attribute that must be specified for all types or groups of
@@ -290,9 +287,9 @@ provide dependency handling, validated and processed attribute setting,
 pickling, and pybind11 C++ class syncing in an automated and structured way.
 Most methods unique to or customized from base classes revolve around allowing
 `_param_dict` and `_typeparam_dict` to sync to and from C++ when attached and
-not when unattached. See `hoomd/operation.py` for source code. The `_add`,
-`_attach`, `_remove`, and `_detach` methods handle the process of adding,
-attaching, detaching, and removal.
+not when unattached. See `hoomd/operation.py` for source code. The
+`_attach_hook`, and `_detach_hook` methods handle the subclass specific logic
+of attaching and detaching.
 
 ### Attribute Validation and Defaults
 
@@ -362,9 +359,9 @@ be exposed by the internal C++ class `obj._cpp_obj` instance.
 `SyncedList` implements an arbitrary length list that is value validated and
 synced with C++. List objects do not need to have a C++ direct counterpart, but
 `SyncedList` must be provided a transform function from the Python object to the
-expected C++ one. `SyncedList` can also handle the added and attached status of
-its items automatically. An example of this class in use is in the MD integrator
-for forces and methods (see `hoomd/md/integrate.py`).
+expected C++ one. `SyncedList` can also handle the attached status of its items
+automatically. An example of this class in use is in the MD integrator for
+forces and methods (see `hoomd/md/integrate.py`).
 
 #### Value Validation
 

--- a/example_plugins/updater_plugin/update.py
+++ b/example_plugins/updater_plugin/update.py
@@ -18,10 +18,6 @@ class ExampleUpdater(operation.Updater):
         # initialize base class
         super().__init__(trigger)
 
-    def _add(self, simulation):
-        """Add the operation to a simulation."""
-        super()._add(simulation)
-
     def _attach_hook(self):
         # initialize the reflected c++ class
         if isinstance(self._simulation.device, hoomd.device.CPU):

--- a/hoomd/custom/custom_operation.py
+++ b/hoomd/custom/custom_operation.py
@@ -39,7 +39,7 @@ class CustomOperation(TriggeredOperation, metaclass=_AbstractLoggable):
             wrapped `hoomd.custom.Action` is run.
     """
 
-    _override_setattr = {'_action', "_export_dict"}
+    _override_setattr = {'_action', "_export_dict", "_simulation"}
 
     @abstractmethod
     def _cpp_class_name(self):
@@ -76,12 +76,7 @@ class CustomOperation(TriggeredOperation, metaclass=_AbstractLoggable):
         object.__setattr__(self, attr, value)
 
     def _attach_hook(self):
-        """Attach to a `hoomd.Simulation`.
-
-        Args:
-            simulation (hoomd.Simulation): The simulation the operation operates
-                on.
-        """
+        """Create the C++ custom operation."""
         self._cpp_obj = getattr(_hoomd, self._cpp_class_name)(
             self._simulation.state._cpp_sys_def, self.trigger, self._action)
         self._action.attach(self._simulation)

--- a/hoomd/data/syncedlist.py
+++ b/hoomd/data/syncedlist.py
@@ -185,16 +185,10 @@ class SyncedList(MutableSequence):
         if not self._attach_members:
             return
         if self._synced:
-            if not value._added:
-                value._add(self._simulation)
-                value._attach()
-                return
-            if value._simulation != self._simulation:
-                raise RuntimeError(
-                    f"Cannot place {value} into two simulations.")
-            value._attach()
+            value._attach(self._simulation)
+            return
         else:
-            if value._added:
+            if value._attached:
                 raise RuntimeError(
                     f"Cannot place {value} into two simulations.")
 
@@ -209,8 +203,6 @@ class SyncedList(MutableSequence):
             return
         if self._synced:
             value._detach()
-        if value._added:
-            value._remove()
 
     def _validate_or_error(self, value):
         """Complete error checking and processing of value."""

--- a/hoomd/hpmc/update.py
+++ b/hoomd/hpmc/update.py
@@ -288,17 +288,9 @@ class BoxMC(Updater):
         self.betaP = betaP
         self.instance = 0
 
-    def _add(self, simulation):
-        """Add the operation to a simulation.
-
-        HPMC uses RNGs. Warn the user if they did not set the seed.
-        """
-        if isinstance(simulation, hoomd.Simulation):
-            simulation._warn_if_seed_unset()
-
-        super()._add(simulation)
-
     def _attach_hook(self):
+        # HPMC uses RNGs. Warn the user if they did not set the seed.
+        self._simulation._warn_if_seed_unset()
         integrator = self._simulation.operations.integrator
         if not isinstance(integrator, integrate.HPMCIntegrator):
             raise RuntimeError("The integrator must be a HPMC integrator.")
@@ -585,38 +577,6 @@ class Shape(Updater):
         param_dict["shape_move"] = shape_move
         self._param_dict.update(param_dict)
 
-    def _add(self, simulation):
-        super()._add(simulation)
-        self._add_shape_move(self.shape_move)
-
-    def _add_shape_move(self, shape_move):
-        if not isinstance(self._simulation, hoomd.Simulation):
-            if shape_move._added:
-                raise RuntimeError(
-                    f"Shape move {shape_move} cannot be added to two lists at "
-                    f"once.")
-            return
-        # We need to check if the force is added since if it is not then this is
-        # being called by a SyncedList object and a disagreement between the
-        # simulation and shape_move._simulation is an error. If the updater is
-        # added then the shape_move is compatible. We cannot just check the
-        # shape_move's _added property because _add is also called when the
-        # SyncedList is synced.
-        if shape_move._added and shape_move._simulation != self._simulation:
-            raise RuntimeError(
-                f"Shape move {shape_move} cannot be added to two lists at once."
-            )
-        self.shape_move._add(self._simulation)
-
-    def _attach_shape_move(self):
-        # This should never happen, but leaving it in case the logic for adding
-        # missed some edge case.
-        if self._simulation != self.shape_move._simulation:
-            raise RuntimeError(
-                f"{type(self)}.shape_move is used in a different simulation.")
-        if not self.shape_move._attached:
-            self.shape_move._attach()
-
     def _setattr_param(self, attr, value):
         if attr == "shape_move":
             self._set_shape_move(value)
@@ -633,17 +593,13 @@ class Shape(Updater):
         if old_move is not None:
             if self._attached:
                 old_move._detach()
-            if self._added:
-                old_move._remove()
 
         if new_move is None:
             self._param_dict["shape_move"] = None
             return
 
-        if self._added:
-            self._add_shape_move(new_move)
         if self._attached:
-            new_move._attach()
+            new_move._attach(self._simulation)
         self._param_dict["shape_move"] = new_move
 
     def _attach_hook(self):
@@ -657,7 +613,7 @@ class Shape(Updater):
         integrator_name = integrator.__class__.__name__
         updater_cls = getattr(_hpmc, 'UpdaterShape' + integrator_name)
 
-        self._attach_shape_move()
+        self.shape_move._attach(self._simulation)
         self._cpp_obj = updater_cls(self._simulation.state._cpp_sys_def,
                                     self.trigger, integrator._cpp_obj,
                                     self.shape_move._cpp_obj)
@@ -734,17 +690,9 @@ class Clusters(Updater):
         self._param_dict.update(param_dict)
         self.instance = 0
 
-    def _add(self, simulation):
-        """Add the operation to a simulation.
-
-        HPMC uses RNGs. Warn the user if they did not set the seed.
-        """
-        if isinstance(simulation, hoomd.Simulation):
-            simulation._warn_if_seed_unset()
-
-        super()._add(simulation)
-
     def _attach_hook(self):
+        # HPMC uses RNGs. Warn the user if they did not set the seed.
+        self._simulation._warn_if_seed_unset()
         integrator = self._simulation.operations.integrator
         if not isinstance(integrator, integrate.HPMCIntegrator):
             raise RuntimeError("The integrator must be a HPMC integrator.")
@@ -946,17 +894,9 @@ class QuickCompress(Updater):
 
         self.instance = 0
 
-    def _add(self, simulation):
-        """Add the operation to a simulation.
-
-        HPMC uses RNGs. Warn the user if they did not set the seed.
-        """
-        if isinstance(simulation, hoomd.Simulation):
-            simulation._warn_if_seed_unset()
-
-        super()._add(simulation)
-
     def _attach_hook(self):
+        # HPMC uses RNGs. Warn the user if they did not set the seed.
+        self._simulation._warn_if_seed_unset()
         integrator = self._simulation.operations.integrator
         if not isinstance(integrator, integrate.HPMCIntegrator):
             raise RuntimeError("The integrator must be a HPMC integrator.")

--- a/hoomd/md/alchemy/pair.py
+++ b/hoomd/md/alchemy/pair.py
@@ -175,7 +175,7 @@ class AlchemicalDOF(_HOOMDBaseObject):
         self.name = name
         self.typepair = typepair
         if self._force._attached:
-            self._attach()
+            self._attach(force._simulation)
         # store metadata
         param_dict = ParameterDict(mass=float,
                                    mu=float,

--- a/hoomd/md/constrain.py
+++ b/hoomd/md/constrain.py
@@ -311,22 +311,10 @@ class Rigid(Constraint):
         if self._attached:
             raise RuntimeError(
                 "Cannot call create_bodies after running simulation.")
-        # Attach and store information for detaching after calling
-        # createRigidBodies
-        old_sim = None
-        if self._added:
-            old_sim = self._simulation
-        self._add(state._simulation)
-        super()._attach()
-
+        super()._attach(state._simulation)
         self._cpp_obj.createRigidBodies()
-
         # Restore previous state
         self._detach()
-        if old_sim is not None:
-            self._simulation = old_sim
-        else:
-            self._remove()
 
     def _attach_hook(self):
         super()._attach_hook()

--- a/hoomd/md/force.py
+++ b/hoomd/md/force.py
@@ -394,18 +394,9 @@ class Active(Force):
 
         self._extend_typeparam([active_force, active_torque])
 
-    def _add(self, simulation):
-        """Add the operation to a simulation.
-
-        Active forces use RNGs. Warn the user if they did not set the seed.
-        """
-        if isinstance(simulation, hoomd.Simulation):
-            simulation._warn_if_seed_unset()
-
-        super()._add(simulation)
-
     def _attach_hook(self):
-
+        # Active forces use RNGs. Warn the user if they did not set the seed.
+        self._simulation._warn_if_seed_unset()
         # Set C++ class
         self._set_cpp_obj()
 
@@ -520,7 +511,7 @@ class ActiveOnManifold(Active):
         sim = self._simulation
 
         if not self.manifold_constraint._attached:
-            self.manifold_constraint._attach()
+            self.manifold_constraint._attach(sim)
 
         base_class_str = 'ActiveForceConstraintCompute'
         base_class_str += self.manifold_constraint.__class__.__name__

--- a/hoomd/md/integrate.py
+++ b/hoomd/md/integrate.py
@@ -39,7 +39,7 @@ class _DynamicIntegrator(BaseIntegrator):
             Method, syncedlist._PartialGetAttr('_cpp_obj'), iterable=methods)
 
         param_dict = ParameterDict(rigid=OnlyTypes(Rigid, allow_none=True))
-        if rigid is not None and rigid._added:
+        if rigid is not None and rigid._attached:
             raise ValueError("Rigid object can only belong to one integrator.")
         param_dict["rigid"] = rigid
         self._param_dict.update(param_dict)
@@ -49,7 +49,7 @@ class _DynamicIntegrator(BaseIntegrator):
         self._constraints._sync(self._simulation, self._cpp_obj.constraints)
         self._methods._sync(self._simulation, self._cpp_obj.methods)
         if self.rigid is not None:
-            self.rigid._attach()
+            self.rigid._attach(self._simulation)
         super()._attach_hook()
 
     def _detach_hook(self):
@@ -58,16 +58,6 @@ class _DynamicIntegrator(BaseIntegrator):
         self._constraints._unsync()
         if self.rigid is not None:
             self.rigid._detach()
-
-    def _remove(self):
-        if self.rigid is not None:
-            self.rigid._remove()
-        super()._remove()
-
-    def _add(self, simulation):
-        super()._add(simulation)
-        if self.rigid is not None:
-            self.rigid._add(simulation)
 
     @property
     def forces(self):
@@ -120,23 +110,19 @@ class _DynamicIntegrator(BaseIntegrator):
 
         old_rigid = self.rigid
 
-        if new_rigid is not None and new_rigid._added:
+        if new_rigid is not None and new_rigid._attached:
             raise ValueError("Cannot add Rigid object to multiple integrators.")
 
         if old_rigid is not None:
             if self._attached:
                 old_rigid._detach()
-            if self._added:
-                old_rigid._remove()
 
         if new_rigid is None:
             self._param_dict["rigid"] = None
             return
 
-        if self._added:
-            new_rigid._add(self._simulation)
         if self._attached:
-            new_rigid._attach()
+            new_rigid._attach(self._simulation)
         self._param_dict["rigid"] = new_rigid
 
 

--- a/hoomd/md/long_range/pppm.py
+++ b/hoomd/md/long_range/pppm.py
@@ -174,15 +174,7 @@ class Coulomb(Force):
         self._pair_force = pair_force
 
     def _attach_hook(self):
-        if not self._nlist._added:
-            self._nlist._add(self._simulation)
-        else:
-            if self._simulation != self._nlist._simulation:
-                raise RuntimeError("{} object's neighbor list is used in a "
-                                   "different simulation.".format(type(self)))
-
-        if not self.nlist._attached:
-            self.nlist._attach()
+        self.nlist._attach(self._simulation)
 
         if isinstance(self._simulation.device, hoomd.device.CPU):
             cls = hoomd.md._md.PPPMForceCompute

--- a/hoomd/md/manifold.py
+++ b/hoomd/md/manifold.py
@@ -90,7 +90,7 @@ class Cylinder(Manifold):
         self._cpp_obj = _md.ManifoldZCylinder(
             self.r, _hoomd.make_scalar3(self.P[0], self.P[1], self.P[2]))
 
-        super()._attach()
+        super()._attach(self._simulation)
 
 
 class Diamond(Manifold):
@@ -146,7 +146,7 @@ class Diamond(Manifold):
         self._cpp_obj = _md.ManifoldDiamond(
             _hoomd.make_int3(self.N[0], self.N[1], self.N[2]), self.epsilon)
 
-        super()._attach()
+        super()._attach(self._simulation)
 
 
 class Ellipsoid(Manifold):
@@ -194,7 +194,7 @@ class Ellipsoid(Manifold):
             self.a, self.b, self.c,
             _hoomd.make_scalar3(self.P[0], self.P[1], self.P[2]))
 
-        super()._attach()
+        super()._attach(self._simulation)
 
 
 class Gyroid(Manifold):
@@ -251,7 +251,7 @@ class Gyroid(Manifold):
         self._cpp_obj = _md.ManifoldGyroid(
             _hoomd.make_int3(self.N[0], self.N[1], self.N[2]), self.epsilon)
 
-        super()._attach()
+        super()._attach(self._simulation)
 
 
 class Plane(Manifold):
@@ -279,7 +279,7 @@ class Plane(Manifold):
     def _attach_hook(self):
         self._cpp_obj = _md.ManifoldXYPlane(self.shift)
 
-        super()._attach()
+        super()._attach(self._simulation)
 
 
 class Primitive(Manifold):
@@ -333,7 +333,7 @@ class Primitive(Manifold):
         self._cpp_obj = _md.ManifoldPrimitive(
             _hoomd.make_int3(self.N[0], self.N[1], self.N[2]), self.epsilon)
 
-        super()._attach()
+        super()._attach(self._simulation)
 
 
 class Sphere(Manifold):
@@ -371,4 +371,4 @@ class Sphere(Manifold):
         self._cpp_obj = _md.ManifoldSphere(
             self.r, _hoomd.make_scalar3(self.P[0], self.P[1], self.P[2]))
 
-        super()._attach()
+        super()._attach(self._simulation)

--- a/hoomd/md/mesh/potential.py
+++ b/hoomd/md/mesh/potential.py
@@ -27,43 +27,16 @@ class MeshPotential(Force):
     def __init__(self, mesh):
         self._mesh = validate_mesh(mesh)
 
-    def _add(self, simulation):
-        # if mesh was associated with multiple pair forces and is still
-        # attached, we need to deepcopy existing mesh.
-        mesh = self._mesh
-        if (not self._attached and mesh._attached
-                and mesh._simulation != simulation):
+    def _attach_hook(self):
+        """Create the c++ mirror class."""
+        if self._mesh._attached and self._simulation != self._mesh._simulation:
             warnings.warn(
                 f"{self} object is creating a new equivalent mesh structure."
                 f" This is happending since the force is moving to a new "
                 f"simulation. To supress the warning explicitly set new mesh.",
                 RuntimeWarning)
-            self._mesh = copy.deepcopy(mesh)
-        # We need to check if the force is added since if it is not then this is
-        # being called by a SyncedList object and a disagreement between the
-        # simulation and mesh._simulation is an error. If the force is added
-        # then the mesh is compatible. We cannot just check the mesh's _added
-        # property because _add is also called when the SyncedList is synced.
-        elif (not self._added and mesh._added
-              and mesh._simulation != simulation):
-            raise RuntimeError(
-                f"Mesh associated with {self} is associated with "
-                f"another simulation.")
-        super()._add(simulation)
-        # this ideopotent given the above check.
-        self._mesh._add(simulation)
-        # This is ideopotent, but we need to ensure that if we change
-        # mesh when not attached we handle correctly.
-        self._add_dependency(self._mesh)
-
-    def _attach_hook(self):
-        """Create the c++ mirror class."""
-        if self._simulation != self._mesh._simulation:
-            raise RuntimeError("{} object's mesh is used in a "
-                               "different simulation.".format(type(self)))
-
-        if not self.mesh._attached:
-            self.mesh._attach()
+            self._mesh = copy.deepcopy(self._mesh)
+        self.mesh._attach(self._simulation)
 
         if isinstance(self._simulation.device, hoomd.device.CPU):
             cpp_cls = getattr(_md, self._cpp_class_name)
@@ -72,6 +45,9 @@ class MeshPotential(Force):
 
         self._cpp_obj = cpp_cls(self._simulation.state._cpp_sys_def,
                                 self._mesh._cpp_obj)
+
+    def _detach_hook(self):
+        self._mesh._detach()
 
     def _apply_typeparam_dict(self, cpp_obj, simulation):
         for typeparam in self._typeparam_dict.values():
@@ -93,9 +69,4 @@ class MeshPotential(Force):
             raise RuntimeError(
                 "mesh cannot be set after calling Simulation.run().")
         mesh = validate_mesh(value)
-        if self._added:
-            if mesh._added and self._simulation != mesh._simulation:
-                raise RuntimeError("Mesh and forces must belong to the same "
-                                   "simulation or SyncedList.")
-            self._mesh._add(self._simulation)
         self._mesh = mesh

--- a/hoomd/md/methods/methods.py
+++ b/hoomd/md/methods/methods.py
@@ -904,7 +904,7 @@ class Langevin(Method):
 
         self._extend_typeparam([gamma, gamma_r])
 
-    def _attach_hook(self, simulation):
+    def _attach_hook(self):
         """Langevin uses RNGs. Warn the user if they did not set the seed."""
         self._simulation._warn_if_seed_unset()
         sim = self._simulation
@@ -1080,7 +1080,7 @@ class Brownian(Method):
                                                              len_keys=1))
         self._extend_typeparam([gamma, gamma_r])
 
-    def _attach_hook(self, simulation):
+    def _attach_hook(self):
         """Brownian uses RNGs. Warn the user if they did not set the seed."""
         self._simulation._warn_if_seed_unset()
         sim = self._simulation
@@ -1281,7 +1281,7 @@ class OverdampedViscous(Method):
                                                              len_keys=1))
         self._extend_typeparam([gamma, gamma_r])
 
-    def _attach_hook(self, simulation):
+    def _attach_hook(self):
         """Class uses RNGs. Warn the user if they did not set the seed."""
         self._simulation._warn_if_seed_unset()
         sim = self._simulation

--- a/hoomd/md/methods/methods.py
+++ b/hoomd/md/methods/methods.py
@@ -904,18 +904,9 @@ class Langevin(Method):
 
         self._extend_typeparam([gamma, gamma_r])
 
-    def _add(self, simulation):
-        """Add the operation to a simulation.
-
-        Langevin uses RNGs. Warn the user if they did not set the seed.
-        """
-        if isinstance(simulation, hoomd.Simulation):
-            simulation._warn_if_seed_unset()
-
-        super()._add(simulation)
-
-    def _attach_hook(self):
-
+    def _attach_hook(self, simulation):
+        """Langevin uses RNGs. Warn the user if they did not set the seed."""
+        self._simulation._warn_if_seed_unset()
         sim = self._simulation
         if isinstance(sim.device, hoomd.device.CPU):
             my_class = _md.TwoStepLangevin
@@ -1089,18 +1080,9 @@ class Brownian(Method):
                                                              len_keys=1))
         self._extend_typeparam([gamma, gamma_r])
 
-    def _add(self, simulation):
-        """Add the operation to a simulation.
-
-        Brownian uses RNGs. Warn the user if they did not set the seed.
-        """
-        if isinstance(simulation, hoomd.Simulation):
-            simulation._warn_if_seed_unset()
-
-        super()._add(simulation)
-
-    def _attach_hook(self):
-
+    def _attach_hook(self, simulation):
+        """Brownian uses RNGs. Warn the user if they did not set the seed."""
+        self._simulation._warn_if_seed_unset()
         sim = self._simulation
         if isinstance(sim.device, hoomd.device.CPU):
             self._cpp_obj = _md.TwoStepBD(sim.state._cpp_sys_def,
@@ -1299,18 +1281,9 @@ class OverdampedViscous(Method):
                                                              len_keys=1))
         self._extend_typeparam([gamma, gamma_r])
 
-    def _add(self, simulation):
-        """Add the operation to a simulation.
-
-        OverdampedViscous uses RNGs. Warn the user if they did not set the seed.
-        """
-        if isinstance(simulation, hoomd.Simulation):
-            simulation._warn_if_seed_unset()
-
-        super()._add(simulation)
-
-    def _attach_hook(self):
-
+    def _attach_hook(self, simulation):
+        """Class uses RNGs. Warn the user if they did not set the seed."""
+        self._simulation._warn_if_seed_unset()
         sim = self._simulation
         if isinstance(sim.device, hoomd.device.CPU):
             self._cpp_obj = _md.TwoStepBD(sim.state._cpp_sys_def,

--- a/hoomd/md/methods/rattle.py
+++ b/hoomd/md/methods/rattle.py
@@ -43,13 +43,8 @@ class MethodRATTLE(Method):
         # set defaults
         self._param_dict.update(param_dict)
 
-    def _add(self, sim):
-        self.manifold_constraint._add(sim)
-        super()._add(sim)
-
     def _attach_constraint(self, sim):
-        if not self.manifold_constraint._attached:
-            self.manifold_constraint._attach()
+        self.manifold_constraint._attach(sim)
 
     def _setattr_param(self, attr, value):
         if attr == "manifold_constraint":
@@ -116,7 +111,6 @@ class NVE(MethodRATTLE):
         super().__init__(manifold_constraint, tolerance)
 
     def _attach_hook(self):
-
         self._attach_constraint(self._simulation)
 
         # initialize the reflected c++ class
@@ -324,19 +318,10 @@ class Langevin(MethodRATTLE):
 
         super().__init__(manifold_constraint, tolerance)
 
-    def _add(self, simulation):
-        """Add the operation to a simulation.
-
-        Langevin uses RNGs. Warn the user if they did not set the seed.
-        """
-        if isinstance(simulation, hoomd.Simulation):
-            simulation._warn_if_seed_unset()
-
-        super()._add(simulation)
-
     def _attach_hook(self):
-
         sim = self._simulation
+        # Langevin uses RNGs. Warn the user if they did not set the seed.
+        sim._warn_if_seed_unset()
         self._attach_constraint(sim)
 
         if isinstance(sim.device, hoomd.device.CPU):
@@ -460,19 +445,10 @@ class Brownian(MethodRATTLE):
 
         super().__init__(manifold_constraint, tolerance)
 
-    def _add(self, simulation):
-        """Add the operation to a simulation.
-
-        Brownian uses RNGs. Warn the user if they did not set the seed.
-        """
-        if isinstance(simulation, hoomd.Simulation):
-            simulation._warn_if_seed_unset()
-
-        super()._add(simulation)
-
     def _attach_hook(self):
-
         sim = self._simulation
+        # Brownian uses RNGs. Warn the user if they did not set the seed.
+        sim._warn_if_seed_unset()
         self._attach_constraint(sim)
 
         if isinstance(sim.device, hoomd.device.CPU):
@@ -586,19 +562,11 @@ class OverdampedViscous(MethodRATTLE):
 
         super().__init__(manifold_constraint, tolerance)
 
-    def _add(self, simulation):
-        """Add the operation to a simulation.
-
-        OverdampedViscous uses RNGs. Warn the user if they did not set the seed.
-        """
-        if isinstance(simulation, hoomd.Simulation):
-            simulation._warn_if_seed_unset()
-
-        super()._add(simulation)
-
     def _attach_hook(self):
-
         sim = self._simulation
+        # OverdampedViscous uses RNGs. Warn the user if they did not set the
+        # seed.
+        sim._warn_if_seed_unset()
         self._attach_constraint(sim)
 
         if isinstance(sim.device, hoomd.device.CPU):

--- a/hoomd/md/nlist.py
+++ b/hoomd/md/nlist.py
@@ -126,16 +126,6 @@ class NeighborList(AutotunedObject):
         """
         return self._cpp_obj.num_builds
 
-    def _remove_dependent(self, obj):
-        super()._remove_dependent(obj)
-        if len(self._dependents) == 0:
-            if self._attached:
-                self._detach()
-                self._remove()
-                return
-            if self._added:
-                self._remove()
-
 
 class Cell(NeighborList):
     r"""Neighbor list computed via a cell list.

--- a/hoomd/md/pair/pair.py
+++ b/hoomd/md/pair/pair.py
@@ -123,42 +123,15 @@ class Pair(force.Force):
         # above and raise an error if they occur.
         return self._cpp_obj.computeEnergyBetweenSets(tags1, tags2)
 
-    def _add(self, simulation):
-        super()._add(simulation)
-        self._add_nlist()
-
-    def _add_nlist(self):
-        nlist = self.nlist
-        deepcopy = False
-        if not isinstance(self._simulation, hoomd.Simulation):
-            if nlist._added:
-                deepcopy = True
-            else:
-                return
-        # We need to check if the force is added since if it is not then this is
-        # being called by a SyncedList object and a disagreement between the
-        # simulation and nlist._simulation is an error. If the force is added
-        # then the nlist is compatible. We cannot just check the nlist's _added
-        # property because _add is also called when the SyncedList is synced.
-        if deepcopy or nlist._added and nlist._simulation != self._simulation:
+    def _attach_hook(self):
+        if self.nlist._attached and self._simulation != self.nlist._simulation:
             warnings.warn(
                 f"{self} object is creating a new equivalent neighbor list."
                 f" This is happending since the force is moving to a new "
                 f"simulation. Set a new nlist to suppress this warning.",
                 RuntimeWarning)
-            self.nlist = copy.deepcopy(nlist)
-        self.nlist._add(self._simulation)
-        # This is ideopotent, but we need to ensure that if we change
-        # neighbor list when not attached we handle correctly.
-        self._add_dependency(self.nlist)
-
-    def _attach_hook(self):
-        # This should never happen, but leaving it in case the logic for adding
-        # missed some edge case.
-        if self._simulation != self.nlist._simulation:
-            raise RuntimeError("{} object's neighbor list is used in a "
-                               "different simulation.".format(type(self)))
-        self.nlist._attach()
+            self.nlist = copy.deepcopy(self.nlist)
+        self.nlist._attach(self._simulation)
         if isinstance(self._simulation.device, hoomd.device.CPU):
             cls = getattr(self._ext_module, self._cpp_class_name)
             self.nlist._cpp_obj.setStorageMode(
@@ -184,11 +157,7 @@ class Pair(force.Force):
             return
         if self._attached:
             raise RuntimeError("nlist cannot be set after scheduling.")
-        old_nlist = self.nlist
         self._param_dict._dict["nlist"] = new_nlist
-        if self._added:
-            self._add_nlist()
-            old_nlist._remove_dependent(self)
 
 
 class LJ(Pair):
@@ -748,15 +717,10 @@ class DPD(Pair):
         param_dict["kT"] = kT
         self._param_dict.update(param_dict)
 
-    def _add(self, simulation):
-        """Add the operation to a simulation.
-
-        DPD uses RNGs. Warn the user if they did not set the seed.
-        """
-        if isinstance(simulation, hoomd.Simulation):
-            simulation._warn_if_seed_unset()
-
-        super()._add(simulation)
+    def _attach_hook(self):
+        """DPD uses RNGs. Warn the user if they did not set the seed."""
+        self._simulation._warn_if_seed_unset()
+        super()._attach_hook()
 
 
 class DPDConservative(Pair):
@@ -908,15 +872,10 @@ class DPDLJ(Pair):
 
         self.kT = kT
 
-    def _add(self, simulation):
-        """Add the operation to a simulation.
-
-        DPDLJ uses RNGs. Warn the user if they did not set the seed.
-        """
-        if isinstance(simulation, hoomd.Simulation):
-            simulation._warn_if_seed_unset()
-
-        super()._add(simulation)
+    def _attach_hook(self):
+        """DPDLJ uses RNGs. Warn the user if they did not set the seed."""
+        self._simulation._warn_if_seed_unset()
+        super()._attach_hook()
 
 
 class ForceShiftedLJ(Pair):

--- a/hoomd/md/pytest/test_active_rotational_diffusion.py
+++ b/hoomd/md/pytest/test_active_rotational_diffusion.py
@@ -109,11 +109,6 @@ def test_attaching(active_force, local_simulation_factory):
         sim.operations.integrator.forces.remove(active_force)
 
     sim.operations.remove(rd_updater)
-    # Exception above happens before removing "_simulation" attribute. We need
-    # to manual do this to perform the other checks. We don't worry about this,
-    # because a SimulationDefinitionError is not really meant to be caught and
-    # dealt with dynamically.
-    active_force._remove()
     sim.operations.integrator.forces.clear()
 
     # Reset simulation to test for variouos error conditions

--- a/hoomd/mesh.py
+++ b/hoomd/mesh.py
@@ -88,16 +88,6 @@ class Mesh(_HOOMDBaseObject):
                 self._cpp_obj.setCommunicator(
                     self._simulation._system_communicator)
 
-    def _remove_dependent(self, obj):
-        super()._remove_dependent(obj)
-        if len(self._dependents) == 0:
-            if self._attached:
-                self._detach()
-                self._remove()
-                return
-            if self._added:
-                self._remove()
-
     @log(category='sequence')
     def triangles(self):
         """((*N*, 3) `numpy.ndarray` of ``uint32``): Mesh triangulation.

--- a/hoomd/pytest/dummy.py
+++ b/hoomd/pytest/dummy.py
@@ -80,7 +80,7 @@ class DummyOperation(Operation):
         self.id = self._current_obj_number
         self.__class__._current_obj_number += 1
 
-    def _attach(self):
+    def _attach_hook(self):
         self._cpp_obj = DummyCppObj()
 
     def __eq__(self, other):

--- a/hoomd/pytest/test_mesh.py
+++ b/hoomd/pytest/test_mesh.py
@@ -49,8 +49,7 @@ def test_empty_mesh(simulation_factory, two_particle_snapshot_factory):
     with pytest.raises(DataAccessError):
         mesh.bonds
 
-    mesh._add(sim)
-    mesh._attach()
+    mesh._attach(sim)
 
     assert mesh.size == 0
     assert mesh.types[0] == "mesh"
@@ -79,8 +78,7 @@ def test_mesh_setter_attached(simulation_factory, mesh_snapshot_factory):
     sim = simulation_factory(mesh_snapshot_factory(d=0.969, L=5))
     mesh = Mesh()
 
-    mesh._add(sim)
-    mesh._attach()
+    mesh._attach(sim)
 
     with pytest.raises(MutabilityError):
         mesh.types = ["vesicle"]

--- a/hoomd/pytest/test_operation.py
+++ b/hoomd/pytest/test_operation.py
@@ -89,16 +89,6 @@ def test_setattr(full_op):
     assert full_op.param1 == 4.
 
 
-def test_adding(full_op):
-    assert not full_op._added
-    # need a non-None dummy simulation 1 works
-    full_op._add(1)
-    assert full_op._added
-    assert full_op._simulation == 1
-    full_op._remove()
-    assert full_op._simulation is None
-
-
 def test_apply_typeparam_dict(full_op):
     """Tests _apply_typeparam_dict and by necessity getattr."""
     full_op.type_param['A'] = dict(bar='world')
@@ -125,7 +115,7 @@ def test_apply_param_dict(full_op):
 def attached(full_op):
     cp = deepcopy(full_op)
     op = test_apply_param_dict(cp)
-    op._add(1)
+    op._simulation = 1
     return op
 
 

--- a/hoomd/tune/custom_tuner.py
+++ b/hoomd/tune/custom_tuner.py
@@ -3,8 +3,6 @@
 
 """Implement CustomTuner."""
 
-from hoomd import _hoomd
-from hoomd.operation import Operation
 from hoomd.custom import (CustomOperation, _InternalCustomOperation, Action)
 from hoomd.operation import Tuner
 
@@ -54,12 +52,6 @@ class _InternalCustomTuner(_InternalCustomOperation, Tuner):
     _cpp_list_name = 'tuners'
     _cpp_class_name = 'PythonTuner'
     _operation_func = "tune"
-
-    def _attach(self):
-        self._cpp_obj = getattr(_hoomd, self._cpp_class_name)(
-            self._simulation.state._cpp_sys_def, self.trigger, self._action)
-        self._action.attach(self._simulation)
-        Operation._attach(self)
 
     def tune(self, timestep):
         return self._action.act(timestep)

--- a/hoomd/update/remove_drift.py
+++ b/hoomd/update/remove_drift.py
@@ -54,10 +54,6 @@ class RemoveDrift(Updater):
             }))
         self.reference_positions = reference_positions
 
-    def _add(self, simulation):
-        """Add the operation to a simulation."""
-        super()._add(simulation)
-
     def _attach_hook(self):
         if isinstance(self._simulation.device, hoomd.device.GPU):
             self._simulation.device._cpp_msg.warning(


### PR DESCRIPTION
## Description
Removes `_remove` and `_add` from the HOOMD object data model. Given the changes on #1413, we can no longer detect an object being added to multiple lists early which was the main purpose of the methods to aid users by erroring early.

This also removes excess and (now) faulty logic in `Pair` and similar classes regarding neighbor lists.

## Motivation and context
This is required/useful to simplify logic and enable #1399.
## How has this been tested?
Existing test pass.

## Change log

Don't know if this should go into changelog.
<!-- Propose a change log entry. -->
```
Changed: Removed internal methods ``_remove`` and ``_add`` from HOOMD data model.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
