### PR TITLE
Add missing Berendsen documentation.

### DIFF
--- a/hoomd/md/methods/methods.py
+++ b/hoomd/md/methods/methods.py
@@ -1144,12 +1144,12 @@ class Berendsen(Method):
     .. attention::
         `Berendsen` does not integrate rotational degrees of freedom.
 
-        Examples::
+    Examples::
 
-            berendsen = hoomd.md.methods.Berendsen(
-                filter=hoomd.filter.All(), kT=0.2, tau=10.0)
-            integrator = hoomd.md.Integrator(
-                dt=0.001, methods=[berendsen], forces=[lj])
+        berendsen = hoomd.md.methods.Berendsen(
+            filter=hoomd.filter.All(), kT=0.2, tau=10.0)
+        integrator = hoomd.md.Integrator(
+            dt=0.001, methods=[berendsen], forces=[lj])
 
 
     Attributes:

--- a/sphinx-doc/module-md-methods.rst
+++ b/sphinx-doc/module-md-methods.rst
@@ -12,6 +12,7 @@ md.methods
     :nosignatures:
 
     Method
+    Berendsen
     Brownian
     DisplacementCapped
     Langevin
@@ -27,6 +28,7 @@ md.methods
 .. automodule:: hoomd.md.methods
     :synopsis: Integration methods.
     :members: Method,
+              Berendsen,
               Brownian,
               DisplacementCapped,
               Langevin,


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should be based on *trunk-patch*. -->
<!-- Backwards compatible new features should be based on *trunk-minor*. -->
<!-- Incompatible API changes should be based on *trunk-major*. -->

## Description

<!-- Describe your changes in detail. -->
List Berendsen in the documentation.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Public, supported APIs should be documented. Berendsen was added in v3.0.0-beta.4 but it is not currently listed in the documentation.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->
I checked the documentation locally. You can view it by clicking on the readthedocs build in the PR checks.

## Change log

<!-- Propose a change log entry. -->
```
* Add missing documentation for ``hoomd.md.methods.Berendsen``.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
