### PR TITLE
Compute 2D volume correctly in NEC.

### DIFF
--- a/hoomd/hpmc/IntegratorHPMCMonoNEC.h
+++ b/hoomd/hpmc/IntegratorHPMCMonoNEC.h
@@ -136,7 +136,7 @@ template<class Shape> class IntegratorHPMCMonoNEC : public IntegratorHPMCMono<Sh
     inline double getPressure()
         {
         return (1 + count_pressurevirial / count_movelength) * this->m_pdata->getN()
-               / this->m_pdata->getBox().getVolume();
+               / this->m_pdata->getBox().getVolume(this->m_sysdef->getNDimensions() == 2);
         }
 
     //! Get the current counter values for NEC


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should be based on *trunk-patch*. -->
<!-- Backwards compatible new features should be based on *trunk-minor*. -->
<!-- Incompatible API changes should be based on *trunk-major*. -->

## Description

<!-- Describe your changes in detail. -->
Fix a bug that produced `inf` virial pressures in NEC.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
`NEC` is capable of performing 2D simulations, it should produce proper values for virial pressures. I found this when testing 2D hard disks in the `hoomd-validation` repository. 

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
Short runs in `hoomd-validation` appear to give correct values. Long runs in `hoomd-validation` will be possible after this fix is released and built in a container for HPC.

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
* ``hoomd.hpmc.nec`` integrators compute non-infinite virial pressures for 2D simulations.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
