### PR TITLE
Add default_gamma, default_gamma_r, and reservoir_energy

### DIFF
--- a/hoomd/md/methods/methods.py
+++ b/hoomd/md/methods/methods.py
@@ -906,14 +906,15 @@ class Langevin(Method):
 
         gamma = TypeParameter('gamma',
                               type_kind='particle_types',
-                              param_dict=TypeParameterDict(float,
-                                                           len_keys=1))
+                              param_dict=TypeParameterDict(float, len_keys=1))
         gamma.default = default_gamma
 
         gamma_r = TypeParameter('gamma_r',
                                 type_kind='particle_types',
-                                param_dict=TypeParameterDict(default_gamma_r,
-                                                             len_keys=1))
+                                param_dict=TypeParameterDict(
+                                    (float, float, float), len_keys=1))
+
+        gamma_r.default = default_gamma_r
 
         self._extend_typeparam([gamma, gamma_r])
 
@@ -1101,14 +1102,15 @@ class Brownian(Method):
 
         gamma = TypeParameter('gamma',
                               type_kind='particle_types',
-                              param_dict=TypeParameterDict(float,
-                                                           len_keys=1))
+                              param_dict=TypeParameterDict(float, len_keys=1))
         gamma.default = default_gamma
 
         gamma_r = TypeParameter('gamma_r',
                                 type_kind='particle_types',
-                                param_dict=TypeParameterDict(default_gamma_r,
-                                                             len_keys=1))
+                                param_dict=TypeParameterDict(
+                                    (float, float, float), len_keys=1))
+
+        gamma_r.default = default_gamma_r
         self._extend_typeparam([gamma, gamma_r])
 
     def _attach_hook(self):
@@ -1311,14 +1313,15 @@ class OverdampedViscous(Method):
 
         gamma = TypeParameter('gamma',
                               type_kind='particle_types',
-                              param_dict=TypeParameterDict(float,
-                                                           len_keys=1))
+                              param_dict=TypeParameterDict(float, len_keys=1))
         gamma.default = default_gamma
 
         gamma_r = TypeParameter('gamma_r',
                                 type_kind='particle_types',
-                                param_dict=TypeParameterDict(default_gamma_r,
-                                                             len_keys=1))
+                                param_dict=TypeParameterDict(
+                                    (float, float, float), len_keys=1))
+
+        gamma_r.default = default_gamma_r
         self._extend_typeparam([gamma, gamma_r])
 
     def _attach_hook(self):

--- a/hoomd/md/methods/methods.py
+++ b/hoomd/md/methods/methods.py
@@ -906,8 +906,9 @@ class Langevin(Method):
 
         gamma = TypeParameter('gamma',
                               type_kind='particle_types',
-                              param_dict=TypeParameterDict(default_gamma,
+                              param_dict=TypeParameterDict(float,
                                                            len_keys=1))
+        gamma.default = default_gamma
 
         gamma_r = TypeParameter('gamma_r',
                                 type_kind='particle_types',
@@ -1100,8 +1101,9 @@ class Brownian(Method):
 
         gamma = TypeParameter('gamma',
                               type_kind='particle_types',
-                              param_dict=TypeParameterDict(default_gamma,
+                              param_dict=TypeParameterDict(float,
                                                            len_keys=1))
+        gamma.default = default_gamma
 
         gamma_r = TypeParameter('gamma_r',
                                 type_kind='particle_types',
@@ -1309,8 +1311,9 @@ class OverdampedViscous(Method):
 
         gamma = TypeParameter('gamma',
                               type_kind='particle_types',
-                              param_dict=TypeParameterDict(default_gamma,
+                              param_dict=TypeParameterDict(float,
                                                            len_keys=1))
+        gamma.default = default_gamma
 
         gamma_r = TypeParameter('gamma_r',
                                 type_kind='particle_types',

--- a/hoomd/md/pytest/test_methods.py
+++ b/hoomd/md/pytest/test_methods.py
@@ -678,3 +678,44 @@ def test_logging():
             'default': True
         }
     })
+
+
+@pytest.mark.parametrize("cls, init_args", [
+    (hoomd.md.methods.Brownian, {
+        'kT': 1.5
+    }),
+    (hoomd.md.methods.Langevin, {
+        'kT': 1.5
+    }),
+    (hoomd.md.methods.OverdampedViscous, {}),
+])
+def test_default_gamma(cls, init_args):
+    c = cls(filter=hoomd.filter.All(), **init_args)
+    assert c.gamma['A'] == 1.0
+    assert c.gamma_r['A'] == (1.0, 1.0, 1.0)
+
+    c = cls(filter=hoomd.filter.All(), **init_args, default_gamma=2.0)
+    assert c.gamma['A'] == 2.0
+    assert c.gamma_r['A'] == (1.0, 1.0, 1.0)
+
+    c = cls(filter=hoomd.filter.All(),
+            **init_args,
+            default_gamma_r=(3.0, 4.0, 5.0))
+    assert c.gamma['A'] == 1.0
+    assert c.gamma_r['A'] == (3.0, 4.0, 5.0)
+
+
+def test_langevin_reservoir(simulation_factory, two_particle_snapshot_factory):
+
+    langevin = hoomd.md.methods.Langevin(filter=hoomd.filter.All(), kT=1.5)
+
+    sim = simulation_factory(two_particle_snapshot_factory())
+    sim.operations.integrator = hoomd.md.Integrator(dt=0.005,
+                                                    methods=[langevin])
+    sim.run(10)
+    assert langevin.reservoir_energy == 0.0
+
+    langevin.tally_reservoir_energy = True
+
+    sim.run(10)
+    assert langevin.reservoir_energy != 0.0


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should be based on *trunk-patch*. -->
<!-- Backwards compatible new features should be based on *trunk-minor*. -->
<!-- Incompatible API changes should be based on *trunk-major*. -->

## Description

<!-- Describe your changes in detail. -->
Add `default_gamma` and `default_gamma_r` to `Brownian`, `Langevin`, and `OverdampedViscous`. Also add `reservoir_energy` to `Langevin` and fix some errors in the method documentation.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Document the default values for `gamma` and `gamma_r` and make them overridable in the same way as other type parameter defaults. Ensure that the method documentation is correct and that the reservoir energy is accessible.

<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves #1431

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
Added unit tests.

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
Added:

* `default_gamma` and `default_gamma_r` arguments to `hoomd.md.methods.Brownian`, `Langevin`, and `OverdampedViscous`.
* `reservoir_energy` loggable in `hoomd.md.methods.Langevin`.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
