### PR TITLE
Add dihedral.Periodic.

### DIFF
--- a/hoomd/md/dihedral.py
+++ b/hoomd/md/dihedral.py
@@ -48,7 +48,6 @@ from hoomd.data.typeparam import TypeParameter
 import hoomd
 
 import numpy
-import math
 
 
 class Dihedral(Force):
@@ -80,10 +79,10 @@ class Dihedral(Force):
         self._cpp_obj = cpp_class(self._simulation.state._cpp_sys_def)
 
 
-class Harmonic(Dihedral):
-    r"""Harmonic dihedral force.
+class Periodic(Dihedral):
+    r"""Periodic dihedral force.
 
-    `Harmonic` computes forces, virials, and energies on all dihedrals in the
+    `Periodic` computes forces, virials, and energies on all dihedrals in the
     simulation state with:
 
     .. math::
@@ -119,10 +118,13 @@ class Harmonic(Dihedral):
         self._add_typeparam(params)
 
 
-def _table_eval(theta, V, T, width):
-    dth = (2 * math.pi) / float(width - 1)
-    i = int(round((theta + math.pi) / dth))
-    return (V[i], T[i])
+class Harmonic(Periodic):
+    """Periodic dihedral force.
+
+    .. deprecated:: v3.4.0
+        Use `Periodic`.
+    """
+    pass
 
 
 class Table(Dihedral):

--- a/hoomd/md/dihedral.py
+++ b/hoomd/md/dihedral.py
@@ -121,7 +121,7 @@ class Periodic(Dihedral):
 class Harmonic(Periodic):
     """Periodic dihedral force.
 
-    .. deprecated:: v3.4.0
+    .. deprecated:: v3.7.0
         Use `Periodic`.
     """
     pass

--- a/hoomd/md/pytest/test_dihedral.py
+++ b/hoomd/md/pytest/test_dihedral.py
@@ -14,6 +14,27 @@ import itertools
 # force, and energy.
 dihedral_test_parameters = [
     (
+        hoomd.md.dihedral.Periodic,
+        dict(),
+        dict(k=3.0, d=-1, n=2, phi0=numpy.pi / 2),
+        0,
+        3,
+    ),
+    (
+        hoomd.md.dihedral.Periodic,
+        dict(),
+        dict(k=10.0, d=1, n=1, phi0=numpy.pi / 4),
+        5.0,
+        5.0,
+    ),
+    (
+        hoomd.md.dihedral.Periodic,
+        dict(),
+        dict(k=5.0, d=1, n=3, phi0=numpy.pi / 6),
+        1.9411,
+        0.0852,
+    ),
+    (
         hoomd.md.dihedral.Harmonic,
         dict(),
         dict(k=3.0, d=-1, n=2, phi0=numpy.pi / 2),
@@ -198,11 +219,12 @@ def test_kernel_parameters(dihedral_snapshot_factory, simulation_factory,
 
 
 # Test Logging
-@pytest.mark.parametrize('cls, expected_namespace, expected_loggables',
-                         zip((md.dihedral.Dihedral, md.dihedral.Harmonic,
-                              md.dihedral.Table, md.dihedral.OPLS),
-                             itertools.repeat(('md', 'dihedral')),
-                             itertools.repeat(expected_loggable_params)))
+@pytest.mark.parametrize(
+    'cls, expected_namespace, expected_loggables',
+    zip((md.dihedral.Dihedral, md.dihedral.Harmonic, md.dihedral.Periodic,
+         md.dihedral.Table, md.dihedral.OPLS),
+        itertools.repeat(('md', 'dihedral')),
+        itertools.repeat(expected_loggable_params)))
 def test_logging(cls, expected_namespace, expected_loggables):
     logging_check(cls, expected_namespace, expected_loggables)
 

--- a/sphinx-doc/deprecated.rst
+++ b/sphinx-doc/deprecated.rst
@@ -27,3 +27,6 @@ v3.x
    * - ``hoomd.device.GPU.memory_traceback`` parameter
      - n/a: ``memory_traceback`` has no effect since v3.0.0.
      - v3.4.0
+   * - ``hoomd.md.dihedral.Harmonic``
+     - ``hoomd.md.dihedral.Periodic`` - new name.
+     - v3.7.0

--- a/sphinx-doc/module-md-dihedral.rst
+++ b/sphinx-doc/module-md-dihedral.rst
@@ -13,6 +13,7 @@ md.dihedral
 
     Dihedral
     Harmonic
+    Periodic
     OPLS
     Table
 
@@ -23,5 +24,6 @@ md.dihedral
     :show-inheritance:
     :members: Dihedral,
               Harmonic,
+              Periodic,
               OPLS,
               Table


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should be based on *trunk-patch*. -->
<!-- Backwards compatible new features should be based on *trunk-minor*. -->
<!-- Incompatible API changes should be based on *trunk-major*. -->

## Description

<!-- Describe your changes in detail. -->
Add `dihedral.Periodic` to replace the old `dihedral.Harmonic`. For v3, keep the old `dihedral.Harmonic` name and deprecate it.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
`dihedral.Harmonic` is misnamed. The functional form of the potential is not `1/2 * k * (phi - phi_0)`. 

<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves #1421

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
Adjusted unit tests.

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
Added:

* ``hoomd.md.dihedral.Periodic`` - a new name for the ``Harmonic`` potential.

Deprecated:

* ``hoomd.md.dihedral.Harmonic`` - use the functionally equivalent ``hoomd.md.dihedral.Periodic``.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
