### PR TITLE
Name hoomd.Box in error message.

### DIFF
--- a/hoomd/box.py
+++ b/hoomd/box.py
@@ -297,7 +297,7 @@ class Box:
                 if not len(box) in [2, 3, 6]:
                     raise ValueError(
                         "List-like objects must have length 2, 3, or 6 to be "
-                        "converted to freud.box.Box.")
+                        "converted to hoomd.Box.")
                 # Handle list-like
                 Lx = box[0]
                 Ly = box[1]


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should be based on *trunk-patch*. -->
<!-- Backwards compatible new features should be based on *trunk-minor*. -->
<!-- Incompatible API changes should be based on *trunk-major*. -->

## Description

<!-- Describe your changes in detail. -->
Name `hoomd.Box` in the box conversion error message.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
This error previously had a copy and paste bug that named freud.

<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves #1426.

## How has this been tested?

I did not test the change.
<!--- Please describe in detail how you tested your changes. -->

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
Fixed:

* Box conversion error message now names ``hoomd.Box``.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
