### PR TITLE
Prevent seg fault in type_shapes when number of elements is 0.

### DIFF
--- a/hoomd/hpmc/ShapePolyhedron.h
+++ b/hoomd/hpmc/ShapePolyhedron.h
@@ -368,6 +368,11 @@ struct ShapePolyhedron
         unsigned int n_verts = data.n_verts;
         unsigned int n_faces = data.n_faces;
 
+        if (n_verts == 0)
+            {
+            throw std::runtime_error("Shape definition not supported for 0-vertex polyhedra.");
+            }
+
         std::ostringstream shapedef;
         if (n_verts == 1 && data.verts[0].x == 0.0f && data.verts[0].y == data.verts[0].x
             && data.verts[0].y == data.verts[0].z)

--- a/hoomd/hpmc/ShapeSimplePolygon.h
+++ b/hoomd/hpmc/ShapeSimplePolygon.h
@@ -348,6 +348,12 @@ template<> inline std::string getShapeSpec(const ShapeSimplePolygon& poly)
     {
     std::ostringstream shapedef;
     auto& verts = poly.verts;
+
+    if (verts.N == 0)
+        {
+        throw std::runtime_error("Shape definition not supported for 0-vertex polygon.");
+        }
+
     shapedef << "{\"type\": \"Polygon\", \"rounding_radius\": " << poly.verts.sweep_radius
              << ", \"vertices\": [";
     for (unsigned int i = 0; i < verts.N - 1; i++)

--- a/hoomd/hpmc/ShapeSpheropolygon.h
+++ b/hoomd/hpmc/ShapeSpheropolygon.h
@@ -198,6 +198,10 @@ template<> inline std::string getShapeSpec(const ShapeSpheropolygon& spoly)
     std::ostringstream shapedef;
     auto& verts = spoly.verts;
     unsigned int nverts = verts.N;
+    if (nverts == 0)
+        {
+        throw std::runtime_error("Shape definition not supported for 0-vertex spheropolygons");
+        }
     if (nverts == 1)
         {
         shapedef << "{\"type\": \"Sphere\", "
@@ -205,7 +209,7 @@ template<> inline std::string getShapeSpec(const ShapeSpheropolygon& spoly)
         }
     else if (nverts == 2)
         {
-        throw std::runtime_error("Shape definition not supported for 2-vertex spheropolygons");
+        throw std::runtime_error("Shape definition not supported for 2-vertex spheropolygons.");
         }
     else
         {

--- a/hoomd/hpmc/ShapeSpheropolyhedron.h
+++ b/hoomd/hpmc/ShapeSpheropolyhedron.h
@@ -201,6 +201,10 @@ template<> inline std::string getShapeSpec(const ShapeSpheropolyhedron& spoly)
     std::ostringstream shapedef;
     auto& verts = spoly.verts;
     unsigned int nverts = verts.N;
+    if (nverts == 0)
+        {
+        throw std::runtime_error("Shape definition not supported for 0-vertex spheropolyhedra.");
+        }
     if (nverts == 1)
         {
         shapedef << "{\"type\": \"Sphere\", "

--- a/hoomd/hpmc/ShapeUnion.h
+++ b/hoomd/hpmc/ShapeUnion.h
@@ -1507,6 +1507,12 @@ template<> inline std::string getShapeSpec(const ShapeUnion<ShapeSphere>& sphere
     auto& members = sphere_union.members;
 
     unsigned int n_centers = members.N;
+
+    if (n_centers == 0)
+        {
+        throw std::runtime_error("Shape definition not supported for 0-center union.");
+        }
+
     std::ostringstream shapedef;
     shapedef << "{\"type\": \"SphereUnion\", \"centers\": [";
     for (unsigned int i = 0; i < n_centers - 1; i++)


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should be based on *trunk-patch*. -->
<!-- Backwards compatible new features should be based on *trunk-minor*. -->
<!-- Incompatible API changes should be based on *trunk-major*. -->

## Description

<!-- Describe your changes in detail. -->
Provide an exception instead of a seg fault when a user provides 0 elements and then calls `type_shapes`.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
The error message helps users troubleshoot the cause of the problem.

<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves #1430.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
I ran the test script from #1430 and got the expected exception.

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
Fixed:

* Raise an exception when attempting to get the shape specification of shapes with 0 elements.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
