### PR TITLE
Fix failing neighbor list tests.

### DIFF
--- a/hoomd/CellList.cc
+++ b/hoomd/CellList.cc
@@ -137,6 +137,11 @@ void CellList::compute(uint64_t timestep)
 
     m_exec_conf->msg->notice(10) << "Cell list compute" << endl;
 
+    if (m_nominal_width == 0)
+        {
+        throw std::runtime_error("Cell: cell width must be non-zero");
+        }
+
     if (m_params_changed)
         {
         m_exec_conf->msg->notice(10) << "Cell list params changed" << endl;

--- a/hoomd/md/pytest/test_nlist.py
+++ b/hoomd/md/pytest/test_nlist.py
@@ -232,7 +232,7 @@ def _setup_standard_rcut(sim_factory, snap_factory):
 
 
 def _setup_no_rcut(sim_factory, snap_factory):
-    nlist = hoomd.md.nlist.Cell(buffer=0.0, default_r_cut=0.0)
+    nlist = hoomd.md.nlist.Tree(buffer=0.0, default_r_cut=0.0)
     sim: hoomd.Simulation = sim_factory(snap_factory())
     sim.operations.computes.append(nlist)
     sim.run(0)
@@ -252,7 +252,7 @@ def _setup_set_rcut_later(sim_factory, snap_factory):
 
 
 def _setup_with_force_no_rcut(sim_factory, snap_factory):
-    nlist = hoomd.md.nlist.Cell(buffer=0.0, default_r_cut=0.0)
+    nlist = hoomd.md.nlist.Tree(buffer=0.0, default_r_cut=0.0)
     sim: hoomd.Simulation = sim_factory(snap_factory())
     sim.operations.computes.append(nlist)
 
@@ -268,7 +268,7 @@ def _setup_with_force_no_rcut(sim_factory, snap_factory):
 
 
 def _setup_with_force_rcut_later(sim_factory, snap_factory):
-    nlist = hoomd.md.nlist.Cell(buffer=0.0, default_r_cut=0.0)
+    nlist = hoomd.md.nlist.Tree(buffer=0.0, default_r_cut=0.0)
     sim: hoomd.Simulation = sim_factory(snap_factory())
     sim.operations.computes.append(nlist)
 


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should be based on *trunk-patch*. -->
<!-- Backwards compatible new features should be based on *trunk-minor*. -->
<!-- Incompatible API changes should be based on *trunk-major*. -->

## Description

<!-- Describe your changes in detail. -->
* Use the `Tree` neighbor list instead of `Cell` whenever tests use a 0 r_cut.
* Throw an exception when the cell width is exactly 0.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
When `Cell` is given a nominal width of 0, it creates a 4294967295 x 4294967295 x 4294967295 cell array. I'm not sure how these tests ever passed. On my Mac, I am getting particle out of the box errors.

There is no way to fix `Cell` in this case 1) because it is behaving correctly given the inputs and 2) because we cannot place an artificial minimum width on cells. Users might run simulations in SI or other unit systems where the cell width is correctly set to a small value such as `1e-9`. It is an error to have a cell width of exactly 0.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
Tests now pass on my Mac.

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
Fixed:

* Reduced memory usage and fix spurious failures in `test_nlist.py`.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
