### PR TITLE
Normalize the orientation quaternion in rotational diffusion.

### DIFF
--- a/hoomd/md/ActiveForceCompute.cc
+++ b/hoomd/md/ActiveForceCompute.cc
@@ -270,6 +270,7 @@ void ActiveForceCompute::rotationalDiffusion(Scalar rotational_diffusion, uint64
                 quat<Scalar> rot_quat = quat<Scalar>::fromAxisAngle(b, delta_theta);
 
                 quati = rot_quat * quati; // rotational diffusion quaternion applied to orientation
+                quati = quati * (Scalar(1.0) / slow::sqrt(norm2(quati)));
                 h_orientation.data[idx] = quat_to_scalar4(quati);
                 // In 2D, the only meaningful torque vector is out of plane and should not change
                 }
@@ -293,6 +294,7 @@ void ActiveForceCompute::rotationalDiffusion(Scalar rotational_diffusion, uint64
                 quat<Scalar> rot_quat = quat<Scalar>::fromAxisAngle(aux_vec, delta_theta);
 
                 quati = rot_quat * quati; // rotational diffusion quaternion applied to orientation
+                quati = quati * (Scalar(1.0) / slow::sqrt(norm2(quati)));
                 h_orientation.data[idx] = quat_to_scalar4(quati);
                 }
             }

--- a/hoomd/md/ActiveForceComputeGPU.cu
+++ b/hoomd/md/ActiveForceComputeGPU.cu
@@ -109,6 +109,7 @@ __global__ void gpu_compute_active_force_rotational_diffusion_kernel(const unsig
             quat<Scalar> rot_quat = quat<Scalar>::fromAxisAngle(b, delta_theta);
 
             quati = rot_quat * quati;
+            quati = quati * (Scalar(1.0) / slow::sqrt(norm2(quati)));
             d_orientation[idx] = quat_to_scalar4(quati);
             // in 2D there is only one meaningful direction for torque
             }
@@ -129,6 +130,7 @@ __global__ void gpu_compute_active_force_rotational_diffusion_kernel(const unsig
             quat<Scalar> rot_quat = quat<Scalar>::fromAxisAngle(aux_vec, delta_theta);
 
             quati = rot_quat * quati;
+            quati = quati * (Scalar(1.0) / slow::sqrt(norm2(quati)));
             d_orientation[idx] = quat_to_scalar4(quati);
             }
         }

--- a/hoomd/md/ActiveForceConstraintCompute.h
+++ b/hoomd/md/ActiveForceConstraintCompute.h
@@ -122,6 +122,7 @@ void ActiveForceConstraintCompute<Manifold>::rotationalDiffusion(Scalar rotation
         quat<Scalar> rot_quat = quat<Scalar>::fromAxisAngle(norm, delta_theta);
 
         quati = rot_quat * quati; // rotational diffusion quaternion applied to orientation
+        quati = quati * (Scalar(1.0) / slow::sqrt(norm2(quati)));
         h_orientation.data[idx] = quat_to_scalar4(quati);
         }
     }
@@ -177,7 +178,7 @@ template<class Manifold> void ActiveForceConstraintCompute<Manifold>::setConstra
             quat<Scalar> rot_quat = quat<Scalar>::fromAxisAngle(rot_vec, phi);
 
             quati = rot_quat * quati;
-
+            quati = quati * (Scalar(1.0) / slow::sqrt(norm2(quati)));
             h_orientation.data[idx] = quat_to_scalar4(quati);
             }
         }

--- a/hoomd/md/ActiveForceConstraintComputeGPU.cuh
+++ b/hoomd/md/ActiveForceConstraintComputeGPU.cuh
@@ -101,7 +101,7 @@ __global__ void gpu_compute_active_force_set_constraints_kernel(const unsigned i
         quat<Scalar> rot_quat = quat<Scalar>::fromAxisAngle(rot_vec, phi);
 
         quati = rot_quat * quati;
-
+        quati = quati * (Scalar(1.0) / slow::sqrt(norm2(quati)));
         d_orientation[idx] = quat_to_scalar4(quati);
         }
     }
@@ -151,6 +151,7 @@ gpu_compute_active_force_constraint_rotational_diffusion_kernel(const unsigned i
     quat<Scalar> rot_quat = quat<Scalar>::fromAxisAngle(norm, delta_theta);
 
     quati = rot_quat * quati;
+    quati = quati * (Scalar(1.0) / slow::sqrt(norm2(quati)));
     d_orientation[idx] = quat_to_scalar4(quati);
     }
 


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should be based on *trunk-patch*. -->
<!-- Backwards compatible new features should be based on *trunk-minor*. -->
<!-- Incompatible API changes should be based on *trunk-major*. -->

## Description

<!-- Describe your changes in detail. -->
After rotating the orientation quaternion in the rotational diffusion updaters, normalize it.

## Motivation and context

Due to limited floating point precision, the rotation operation may change the magnitude of the quaternion. Over long simulations, the magnitude may degrade significantly - especially in single precision simulations. See https://groups.google.com/g/hoomd-users/c/kMjNHuIdB_w for further discussion.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
Tested with this notebook: https://gist.github.com/joaander/03b6963f8ba1da245bf619d782980d9d
The test is too long to include in the normal unit test suite. We could examine this in a future active particle hoomd-validation test.

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
Fixed:

* Improve numerical stability of orientation quaternions when using ``hoomd.md.update.ActiveRotationalDiffusion``
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
