### PR TITLE
Fix sdf.betaP

### DIFF
--- a/hoomd/hpmc/compute.py
+++ b/hoomd/hpmc/compute.py
@@ -327,10 +327,9 @@ class SDF(Compute):
         """
         if not numpy.isnan(self.sdf).all():
             # get the values to fit
-            n_fit = int(numpy.ceil(self.xmax / self.dx))
-            sdf_fit = self.sdf[0:n_fit]
+            sdf_fit = numpy.array(self.sdf)
             # construct the x coordinates
-            x_fit = numpy.arange(0, self.xmax, self.dx)
+            x_fit = numpy.arange(0, len(sdf_fit), 1) * self.dx
             x_fit += self.dx / 2
             # perform the fit and extrapolation
             p = numpy.polyfit(x_fit, sdf_fit, 5)

--- a/hoomd/hpmc/pytest/test_compute_sdf.py
+++ b/hoomd/hpmc/pytest/test_compute_sdf.py
@@ -82,6 +82,22 @@ def test_after_attaching(valid_args, simulation_factory,
         assert sim.device.communicator.rank > 0
         assert sdf.betaP is None
 
+    # Regression test for array size mismatch bug:
+    # https://github.com/glotzerlab/hoomd-blue/issues/1455
+    sdf.xmax = 0.02
+    sdf.dx = 1e-5
+
+    sim.run(1)
+    if not np.isnan(sdf.sdf).all():
+        assert sim.device.communicator.rank == 0
+        assert isinstance(sdf.sdf, np.ndarray)
+        assert len(sdf.sdf) > 0
+        assert isinstance(sdf.betaP, float)
+        assert not np.isclose(sdf.betaP, 0)
+    else:
+        assert sim.device.communicator.rank > 0
+        assert sdf.betaP is None
+
 
 _avg = np.array([
     55.20126953, 54.89853516, 54.77910156, 54.56660156, 54.22255859,


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should be based on *trunk-patch*. -->
<!-- Backwards compatible new features should be based on *trunk-minor*. -->
<!-- Incompatible API changes should be based on *trunk-major*. -->

## Description

<!-- Describe your changes in detail. -->
Generate appropriately sized `x_fit` array.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Fix a case where `sdf_fit` and `x_fit` have different sizes, causing `polyfit` to raise an exception.

<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves #1455 

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
Tested with the added regression test.

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
Fixed:

* Avoid triggering ``TypeError("expected x and y to have same length")`` in ``hoomd.hpmc.compute.SDF.betaP``.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
