### PR TITLE
Document the integration method deprecations.

### DIFF
--- a/sphinx-doc/deprecated.rst
+++ b/sphinx-doc/deprecated.rst
@@ -6,6 +6,11 @@ Deprecated
 
 Features deprecated in v3.x may be removed in a future v4.0.0 release.
 
+.. note::
+
+    Where noted, suggested replacements will be first available with v4.0.0 and there  will be no
+    releases with overlapping support for the two APIs.
+
 v3.x
 ----
 
@@ -42,3 +47,18 @@ v3.x
    * - ``diameters`` key in `Rigid.body <hoomd.md.constrain.Rigid.body>`
      - Set diameters in system state.
      - v3.7.0
+   * - ``hoomd.md.methods.NVE``
+     - ``hoomd.md.methods.ConstantVolume`` with ``thermostat=None`` (available in >=4.0.0).
+     - v3.8.0
+   * - ``hoomd.md.methods.NVT``
+     - ``hoomd.md.methods.ConstantVolume`` with a ``hoomd.md.methods.thermostats.MTTK`` thermostat (available in >=4.0.0).
+     - v3.8.0
+   * - ``hoomd.md.methods.Berendsen``
+     - ``hoomd.md.methods.ConstantVolume`` with a ``hoomd.md.methods.thermostats.Berendsen`` thermostat (available in >=4.0.0).
+     - v3.8.0
+   * - ``hoomd.md.methods.NPH``
+     - ``hoomd.md.methods.ConstantPressure` with ``thermostat=None`` (available in >=4.0.0).
+     - v3.8.0
+   * - ``hoomd.md.methods.NPT``
+     - ``hoomd.md.methods.ConstantPressure`` with a ``hoomd.md.methods.thermostats.MTTK`` thermostat (available in >=4.0.0).
+     - v3.8.0


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should be based on *trunk-patch*. -->
<!-- Backwards compatible new features should be based on *trunk-minor*. -->
<!-- Incompatible API changes should be based on *trunk-major*. -->

## Description

<!-- Describe your changes in detail. -->
Document all the MD integration method deprecations coming in v4.0 (#1424).

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Provide warning to users in v3.8 of the upcoming changes they will need in their scripts. Unfortunately, these APIs are different enough that we cannot feasibly provide any v3.x releases with overlapping support to ease the transition.

## How has this been tested?

I rendered and viewed the sphinx documentation. Reviewers can click the readthecocs link in the "Checks" section below to do so.

<!--- Please describe in detail how you tested your changes. -->

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
Deprecated:

* ``hoomd.md.methods.NVE``. ``hoomd.md.methods.NVT``, ``hoomd.md.methods.Berendsen``, ``hoomd.md.methods.NPH``, ``hoomd.md.methods.NPT``. Starting in v4.0.0, the same functionalities
 will be available via ``hoomd.md.methods.ConstantVolume``/``hoomd.md.methods.ConstantPressure``
 with an appropriately chosen ``thermostat`` argument.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
