### PR TITLE
Fix rigid body force computation with MPI

### DIFF
--- a/hoomd/Communicator.cc
+++ b/hoomd/Communicator.cc
@@ -1202,10 +1202,9 @@ Communicator::Communicator(std::shared_ptr<SystemDefinition> sysdef,
       m_nettorque_copybuf(m_exec_conf), m_netvirial_copybuf(m_exec_conf),
       m_netvirial_recvbuf(m_exec_conf), m_plan(m_exec_conf), m_plan_reverse(m_exec_conf),
       m_tag_reverse(m_exec_conf), m_netforce_reverse_copybuf(m_exec_conf),
-      m_netforce_reverse_recvbuf(m_exec_conf), m_r_ghost_max(Scalar(0.0)),
-      m_r_extra_ghost_max(Scalar(0.0)), m_ghosts_added(0), m_has_ghost_particles(false),
-      m_last_flags(0), m_comm_pending(false), m_bond_comm(*this, m_sysdef->getBondData()),
-      m_angle_comm(*this, m_sysdef->getAngleData()),
+      m_netforce_reverse_recvbuf(m_exec_conf), m_r_ghost_max(Scalar(0.0)), m_ghosts_added(0),
+      m_has_ghost_particles(false), m_last_flags(0), m_comm_pending(false),
+      m_bond_comm(*this, m_sysdef->getBondData()), m_angle_comm(*this, m_sysdef->getAngleData()),
       m_dihedral_comm(*this, m_sysdef->getDihedralData()),
       m_improper_comm(*this, m_sysdef->getImproperData()),
       m_constraint_comm(*this, m_sysdef->getConstraintData()),
@@ -1787,7 +1786,6 @@ void Communicator::updateGhostWidth()
                                            access_location::host,
                                            access_mode::readwrite);
 
-        Scalar r_body_ghost_max = 0.0;
         for (unsigned int cur_type = 0; cur_type < m_pdata->getNTypes(); ++cur_type)
             {
             Scalar r_body_ghost_i = 0.0;
@@ -1801,10 +1799,7 @@ void Communicator::updateGhostWidth()
                 h_r_ghost.data);
 
             h_r_ghost_body.data[cur_type] = r_body_ghost_i;
-            if (r_body_ghost_i > r_body_ghost_max)
-                r_body_ghost_max = r_body_ghost_i;
             }
-        m_r_extra_ghost_max = r_body_ghost_max;
         }
     }
 

--- a/hoomd/Communicator.h
+++ b/hoomd/Communicator.h
@@ -258,7 +258,20 @@ class PYBIND11_EXPORT Communicator
     //! Get the current maximum ghost layer width
     Scalar getGhostLayerMaxWidth() const
         {
-        return m_r_ghost_max; // + m_r_extra_ghost_max;
+        ArrayHandle<Scalar> h_r_ghost(m_r_ghost, access_location::host, access_mode::read);
+        ArrayHandle<Scalar> h_r_ghost_body(m_r_ghost_body,
+                                           access_location::host,
+                                           access_mode::read);
+
+        Scalar ghost_max_width = 0.0;
+        for (unsigned int cur_type = 0; cur_type < m_pdata->getNTypes(); ++cur_type)
+            {
+            ghost_max_width
+                = std::max(ghost_max_width,
+                           std::max(h_r_ghost.data[cur_type], h_r_ghost_body.data[cur_type]));
+            }
+
+        return ghost_max_width;
         }
 
     //! Set the ghost communication flags
@@ -544,7 +557,6 @@ class PYBIND11_EXPORT Communicator
     GlobalArray<Scalar> m_r_ghost;      //!< Width of ghost layer
     GlobalArray<Scalar> m_r_ghost_body; //!< Extra ghost width for rigid bodies
     Scalar m_r_ghost_max;               //!< Maximum ghost layer width
-    Scalar m_r_extra_ghost_max;         //!< Maximum extra ghost layer width
 
     unsigned int m_ghosts_added; //!< Number of ghosts added
     bool m_has_ghost_particles;  //!< True if we have a current copy of ghost particles

--- a/hoomd/Communicator.h
+++ b/hoomd/Communicator.h
@@ -178,15 +178,16 @@ class PYBIND11_EXPORT Communicator
         return m_ghost_layer_width_requests;
         }
 
-    //! Subscribe to list of functions that request a minimum extra ghost layer width (added to the
-    //! maximum ghost layer)
-    /*! This method keeps track of all functions that request a minimum ghost layer width
-     * The actual ghost layer width is chosen from the max over the inputs
+    //! Subscribe to list of functions that request a minimum ghost layer width for rigid bodies.
+    /*! This method keeps track of all functions that request a minimum ghost layer width.
+     * The actual ghost layer width is chosen from the max over the inputs, which is a function
+     * of the previously set cutoff ghost width of all the constituent types belonging to the body.
      * \return A connection to the present class
      */
-    Nano::Signal<Scalar(unsigned int type)>& getExtraGhostLayerWidthRequestSignal()
+    Nano::Signal<Scalar(unsigned int type, Scalar* h_r_ghost)>&
+    getBodyGhostLayerWidthRequestSignal()
         {
-        return m_extra_ghost_layer_width_requests;
+        return m_body_ghost_layer_width_requests;
         }
 
     //! Subscribe to list of functions that determine the communication flags
@@ -257,7 +258,7 @@ class PYBIND11_EXPORT Communicator
     //! Get the current maximum ghost layer width
     Scalar getGhostLayerMaxWidth() const
         {
-        return m_r_ghost_max + m_r_extra_ghost_max;
+        return m_r_ghost_max; // + m_r_extra_ghost_max;
         }
 
     //! Set the ghost communication flags
@@ -563,9 +564,8 @@ class PYBIND11_EXPORT Communicator
         m_ghost_layer_width_requests; //!< List of functions that request a minimum ghost layer
                                       //!< width
 
-    Nano::Signal<Scalar(unsigned int type)>
-        m_extra_ghost_layer_width_requests; //!< List of functions that request an extra ghost layer
-                                            //!< width
+    /// List of functions that compute the body ghost layer width.
+    Nano::Signal<Scalar(unsigned int type, Scalar* h_r_ghost)> m_body_ghost_layer_width_requests;
 
     Nano::Signal<void(uint64_t timestep)>
         m_compute_callbacks; //!< List of functions that are called after ghost communication

--- a/hoomd/CommunicatorGPU.cu
+++ b/hoomd/CommunicatorGPU.cu
@@ -324,12 +324,14 @@ __global__ void gpu_make_ghost_exchange_plan_kernel(unsigned int N,
     Scalar4 postype = d_postype[idx];
     Scalar3 pos = make_scalar3(postype.x, postype.y, postype.z);
     const unsigned int type = __scalar_as_int(postype.w);
-    Scalar3 ghost_fraction = __ldg(d_r_ghost + type) / npd;
+    Scalar ghost_width = __ldg(d_r_ghost + type);
 
     if (d_body[idx] < MIN_FLOPPY)
         {
-        ghost_fraction += __ldg(d_r_ghost_body + type) / npd;
+        ghost_width = max(ghost_width, __ldg(d_r_ghost_body + type));
         }
+
+    Scalar3 ghost_fraction = ghost_width / npd;
 
     Scalar3 f = box.makeFraction(pos);
 

--- a/hoomd/ParticleData.h
+++ b/hoomd/ParticleData.h
@@ -615,20 +615,6 @@ class PYBIND11_EXPORT ParticleData
         return has_bodies;
         }
 
-    //! Return the maximum diameter of all registered composite particles
-    Scalar getMaxCompositeParticleDiameter()
-        {
-        Scalar d_max = 0.0;
-        m_composite_particles_signal.emit_accumulate(
-            [&](Scalar d)
-            {
-                if (d > d_max)
-                    d_max = d;
-            });
-
-        return d_max;
-        }
-
     //! Return positions and types
     const GlobalArray<Scalar4>& getPositions() const
         {
@@ -915,15 +901,6 @@ class PYBIND11_EXPORT ParticleData
 
     //! Notify listeners that ghost particles have been removed
     void notifyGhostParticlesRemoved();
-
-    //! Connects a function to be called every time the maximum diameter of composite particles is
-    //! needed
-    /*! The signal slot returns the maximum diameter
-     */
-    Nano::Signal<Scalar()>& getCompositeParticlesSignal()
-        {
-        return m_composite_particles_signal;
-        }
 
     //! Gets the particle type index given a name
     unsigned int getTypeByName(const std::string& name) const;
@@ -1311,9 +1288,6 @@ class PYBIND11_EXPORT ParticleData
                                                            //!< particles are removed
     Nano::Signal<void()> m_global_particle_num_signal; //!< Signal that is triggered when the global
                                                        //!< number of particles changes
-    Nano::Signal<Scalar()>
-        m_composite_particles_signal; //!< Signal that is triggered when the maximum diameter of a
-                                      //!< composite particle is needed
 
 #ifdef ENABLE_MPI
     Nano::Signal<void(unsigned int, unsigned int, unsigned int)>

--- a/hoomd/md/ForceComposite.cc
+++ b/hoomd/md/ForceComposite.cc
@@ -219,45 +219,6 @@ void ForceComposite::setParam(unsigned int body_typeid,
         }
     }
 
-Scalar ForceComposite::getBodyDiameter(unsigned int body_type)
-    {
-    m_exec_conf->msg->notice(7) << "ForceComposite: calculating body diameter for type "
-                                << m_pdata->getNameByType(body_type) << std::endl;
-
-    // get maximum pairwise distance
-    ArrayHandle<unsigned int> h_body_len(m_body_len, access_location::host, access_mode::read);
-    ArrayHandle<Scalar3> h_body_pos(m_body_pos, access_location::host, access_mode::read);
-    ArrayHandle<unsigned int> h_body_type(m_body_types, access_location::host, access_mode::read);
-
-    Scalar d_max(0.0);
-
-    for (unsigned int i = 0; i < h_body_len.data[body_type]; ++i)
-        {
-        // distance to central particle
-        Scalar3 dr = h_body_pos.data[m_body_idx(body_type, i)];
-        Scalar d = sqrt(dot(dr, dr));
-        if (d > d_max)
-            {
-            d_max = d;
-            }
-
-        // distance to every other particle
-        for (unsigned int j = 0; j < h_body_len.data[body_type]; ++j)
-            {
-            dr = h_body_pos.data[m_body_idx(body_type, i)]
-                 - h_body_pos.data[m_body_idx(body_type, j)];
-            d = sqrt(dot(dr, dr));
-
-            if (d > d_max)
-                {
-                d_max = d;
-                }
-            }
-        }
-
-    return d_max;
-    }
-
 /** Compute the needed body ghost layer width.
 
     For central particles, the body ghost layer width is the maximum of [d_i + r_ghost_i] where d_i

--- a/hoomd/md/ForceComposite.cc
+++ b/hoomd/md/ForceComposite.cc
@@ -294,10 +294,10 @@ Scalar ForceComposite::requestBodyGhostLayerWidth(unsigned int type, Scalar* h_r
             vec3<Scalar> constituent_position(h_body_pos.data[m_body_idx(type, body_particle)]);
             Scalar d = slow::sqrt(dot(constituent_position, constituent_position));
             m_d_max[type] = std::max(m_d_max[type], d + h_r_ghost[constituent_typeid]);
-                }
             }
+        }
 
-        m_d_max_changed[type] = false;
+    m_d_max_changed[type] = false;
     m_exec_conf->msg->notice(7) << "ForceComposite: requesting ghost layer for type "
                                 << m_pdata->getNameByType(type) << ": " << m_d_max[type]
                                 << std::endl;

--- a/hoomd/md/ForceComposite.cc
+++ b/hoomd/md/ForceComposite.cc
@@ -922,13 +922,6 @@ void ForceComposite::updateCompositeParticles(uint64_t timestep)
             continue;
             }
 
-        // Continue if central particle is on another rank and current index is a ghost particle
-        // since there is no updating to do.
-        if (central_idx == NOT_LOCAL && particle_index >= m_pdata->getN())
-            {
-            continue;
-            }
-
         if (central_idx == NOT_LOCAL)
             {
             std::ostringstream error_msg;

--- a/hoomd/md/ForceComposite.h
+++ b/hoomd/md/ForceComposite.h
@@ -28,15 +28,14 @@
 
     Communication:
 
-    The communication scheme for ForceComposite is split between ForceComposite, Communicator,
-    and IntegratorTwoStep. ForceComposite works with Communicator to adjust the ghost communication
-    width for the rigid body types. Constituent particles do not need any extra ghost width as
-    they interact with other particles directly. For every ghost consitutent particle, the
-    corresponding central particle must be present to compute the most up to date constituent
-    position / orientation. To implement this, Communicator requests a special body ghost width
-    that ForceComposite computes. See requestBodyGhostLayerWidth for details on the body ghost
-    width. Communicator then takes the maximum of the existing interaction ghost width and the
-    body ghost width to determine the final ghost width for central particles.
+    The communication scheme for ForceComposite is split between ForceComposite, Communicator, and
+    IntegratorTwoStep. ForceComposite works with Communicator to adjust the ghost communication
+    width for the rigid body types. For every ghost consitutent particle, the corresponding central
+    particle must be present to compute the most up to date constituent position / orientation. To
+    implement this, Communicator requests a special body ghost width that ForceComposite computes.
+    See requestBodyGhostLayerWidth for details on the body ghost width. Communicator then takes the
+    maximum of the existing interaction ghost width and the body ghost width to determine the final
+    ghost width for central particles.
 
     To ensure that constituent particles are synchronized between their home and neighboring ranks,
     IntegratorTwoStep updates the central particles, then updates the constituents
@@ -44,6 +43,12 @@
     update is needed so that the constituent particles are migrated and added to ghost layers when
     needed. The update after communication is needed to ensure that the ghost constituents
     are placed correctly according to the ghost central particles after communicating.
+
+    Working within the above framework, the home rank for the central particle must also be able
+    to access all ghost constituents when summing the net force and torque. The worst case here
+    is a central particle right on the domain boundary and the constituent particle at a distance
+    equal to the ghost width into the ghost layer. Therefore, the minimum ghost width for a
+    constituent is the maximum distance for any particle of that type to its central particle.
 */
 
 #ifdef __HIPCC__

--- a/hoomd/md/ForceComposite.h
+++ b/hoomd/md/ForceComposite.h
@@ -249,8 +249,8 @@ class PYBIND11_EXPORT ForceComposite : public MolecularForceCompute
         return m_global_max_d;
         }
 
-    //! Return the requested minimum ghost layer width
-    virtual Scalar requestExtraGhostLayerWidth(unsigned int type);
+    /// Return the requested minimum ghost layer width for a body's central particle.
+    virtual Scalar requestBodyGhostLayerWidth(unsigned int type, Scalar* h_r_ghost);
 
     //! Compute the forces and torques on the central particle
     virtual void computeForces(uint64_t timestep);

--- a/hoomd/md/ForceComposite.h
+++ b/hoomd/md/ForceComposite.h
@@ -249,9 +249,6 @@ class PYBIND11_EXPORT ForceComposite : public MolecularForceCompute
 
     //! Compute the forces and torques on the central particle
     virtual void computeForces(uint64_t timestep);
-
-    //! Helper method to calculate the body diameter
-    Scalar getBodyDiameter(unsigned int body_type);
     };
 
     } // end namespace md

--- a/hoomd/md/ForceComposite.h
+++ b/hoomd/md/ForceComposite.h
@@ -31,18 +31,19 @@
     The communication scheme for ForceComposite is split between ForceComposite, Communicator, and
     IntegratorTwoStep. ForceComposite works with Communicator to adjust the ghost communication
     width for the rigid body types. For every ghost consitutent particle, the corresponding central
-    particle must be present to compute the most up to date constituent position / orientation. To
-    implement this, Communicator requests a special body ghost width that ForceComposite computes.
-    See requestBodyGhostLayerWidth for details on the body ghost width. Communicator then takes the
+    particle must be present to compute the most up to date constituent position / orientation (as
+    well as all other particles in the body due to indexing limitations). To implement this,
+    Communicator requests a special body ghost width that ForceComposite computes. See
+    requestBodyGhostLayerWidth for details on the body ghost width. Communicator then takes the
     maximum of the existing interaction ghost width and the body ghost width to determine the final
     ghost width for central particles.
 
     To ensure that constituent particles are synchronized between their home and neighboring ranks,
     IntegratorTwoStep updates the central particles, then updates the constituents
-    (updateCompositeParticles), then communicates, and updates the constituents again. The first
-    update is needed so that the constituent particles are migrated and added to ghost layers when
-    needed. The update after communication is needed to ensure that the ghost constituents
-    are placed correctly according to the ghost central particles after communicating.
+    (updateCompositeParticles), then communicates, and Communicator updates the constituents again.
+    The first update is needed so that the constituent particles are migrated and added to ghost
+    layers when needed. The update after communication is needed to ensure that the ghost
+    constituents are placed correctly according to the ghost central particles after communicating.
 
     Working within the above framework, the home rank for the central particle must also be able
     to access all ghost constituents when summing the net force and torque. The worst case here

--- a/hoomd/md/ForceComposite.h
+++ b/hoomd/md/ForceComposite.h
@@ -25,6 +25,25 @@
         even if it isn't "optimal". Since creation and validation are only called infrequently and
         updating is efficient, this preserves the most readability without sacrificing meaningfully
         performance.
+
+    Communication:
+
+    The communication scheme for ForceComposite is split between ForceComposite, Communicator,
+    and IntegratorTwoStep. ForceComposite works with Communicator to adjust the ghost communication
+    width for the rigid body types. Constituent particles do not need any extra ghost width as
+    they interact with other particles directly. For every ghost consitutent particle, the
+    corresponding central particle must be present to compute the most up to date constituent
+    position / orientation. To implement this, Communicator requests a special body ghost width
+    that ForceComposite computes. See requestBodyGhostLayerWidth for details on the body ghost
+    width. Communicator then takes the maximum of the existing interaction ghost width and the
+    body ghost width to determine the final ghost width for central particles.
+
+    To ensure that constituent particles are synchronized between their home and neighboring ranks,
+    IntegratorTwoStep updates the central particles, then updates the constituents
+    (updateCompositeParticles), then communicates, and updates the constituents again. The first
+    update is needed so that the constituent particles are migrated and added to ghost layers when
+    needed. The update after communication is needed to ensure that the ghost constituents
+    are placed correctly according to the ghost central particles after communicating.
 */
 
 #ifdef __HIPCC__

--- a/hoomd/md/ForceComposite.h
+++ b/hoomd/md/ForceComposite.h
@@ -227,8 +227,6 @@ class PYBIND11_EXPORT ForceComposite : public MolecularForceCompute
 
     std::vector<Scalar> m_d_max;       //!< Maximum body diameter per constituent particle type
     std::vector<bool> m_d_max_changed; //!< True if maximum body diameter changed (per type)
-    std::vector<Scalar> m_body_max_diameter; //!< List of diameters for all body types
-    Scalar m_global_max_d;                   //!< Maximum over all body diameters
 
 #ifdef ENABLE_MPI
     /// The system's communicator.
@@ -241,33 +239,6 @@ class PYBIND11_EXPORT ForceComposite : public MolecularForceCompute
         m_particles_added_removed = true;
         }
 
-    //! Returns the maximum diameter over all rigid bodies
-    Scalar getMaxBodyDiameter()
-        {
-        if (m_global_max_d_changed)
-            {
-            // find maximum diameter over all bodies
-            Scalar d_max(0.0);
-            ArrayHandle<unsigned int> h_body_len(m_body_len,
-                                                 access_location::host,
-                                                 access_mode::read);
-            for (unsigned int i = 0; i < m_pdata->getNTypes(); ++i)
-                {
-                if (h_body_len.data[i] != 0 && m_body_max_diameter[i] > d_max)
-                    d_max = m_body_max_diameter[i];
-                }
-
-            // cache value
-            m_global_max_d = d_max;
-            m_global_max_d_changed = false;
-
-            m_exec_conf->msg->notice(7)
-                << "ForceComposite: Maximum body diameter is " << m_global_max_d << std::endl;
-            }
-
-        return m_global_max_d;
-        }
-
     /// Return the requested minimum ghost layer width for a body's central particle.
     virtual Scalar requestBodyGhostLayerWidth(unsigned int type, Scalar* h_r_ghost);
 
@@ -276,9 +247,6 @@ class PYBIND11_EXPORT ForceComposite : public MolecularForceCompute
 
     //! Helper method to calculate the body diameter
     Scalar getBodyDiameter(unsigned int body_type);
-
-    private:
-    bool m_global_max_d_changed; //!< True if we updated any rigid body
     };
 
     } // end namespace md

--- a/hoomd/md/ForceCompositeGPU.cu
+++ b/hoomd/md/ForceCompositeGPU.cu
@@ -680,13 +680,8 @@ __global__ void gpu_update_composite_kernel(unsigned int N,
 
     if (central_idx >= N + n_ghost)
         {
-        // if a molecule with a local member has no central particle, error out
-        if (idx < N)
-            {
-            atomicMax(&(d_flag->x), idx + 1);
-            }
-
-        // otherwise, ignore
+        // if a molecule has no central particle, error out
+        atomicMax(&(d_flag->x), idx + 1);
         return;
         }
 

--- a/hoomd/md/IntegratorTwoStep.cc
+++ b/hoomd/md/IntegratorTwoStep.cc
@@ -88,12 +88,12 @@ void IntegratorTwoStep::update(uint64_t timestep)
     else
 #endif
 
-    // Update rigid body constituent particles after communicating (or once in serial) to ensure
-    // that all ghost constituent particle positions are set in accordance with any just
-    // communicated ghost and/or migrated rigid body centers.
-    updateRigidBodies(timestep + 1);
+        // Update rigid body constituent particles after communicating (or once in serial) to ensure
+        // that all ghost constituent particle positions are set in accordance with any just
+        // communicated ghost and/or migrated rigid body centers.
+        updateRigidBodies(timestep + 1);
 
-    // compute the net force on all particles
+        // compute the net force on all particles
 #ifdef ENABLE_HIP
     if (m_exec_conf->isCUDAEnabled())
         computeNetForceGPU(timestep + 1);

--- a/hoomd/md/IntegratorTwoStep.cc
+++ b/hoomd/md/IntegratorTwoStep.cc
@@ -84,16 +84,19 @@ void IntegratorTwoStep::update(uint64_t timestep)
         // b) that forces are calculated correctly, if ghost atom positions are updated every time
         // step
         m_comm->communicate(timestep + 1);
+
+        // Communicator uses a compute callback to trigger updateRigidBodies again and ensure that
+        // all ghost constituent particle positions are set in accordance with any just communicated
+        // ghost and/or migrated rigid body centers.
         }
     else
 #endif
-
-        // Update rigid body constituent particles after communicating (or once in serial) to ensure
-        // that all ghost constituent particle positions are set in accordance with any just
-        // communicated ghost and/or migrated rigid body centers.
+        {
+        // Update rigid body constituent particles in serial simulations.
         updateRigidBodies(timestep + 1);
+        }
 
-        // compute the net force on all particles
+    // compute the net force on all particles
 #ifdef ENABLE_HIP
     if (m_exec_conf->isCUDAEnabled())
         computeNetForceGPU(timestep + 1);

--- a/hoomd/md/IntegratorTwoStep.cc
+++ b/hoomd/md/IntegratorTwoStep.cc
@@ -75,19 +75,23 @@ void IntegratorTwoStep::update(uint64_t timestep)
 #ifdef ENABLE_MPI
     if (m_sysdef->isDomainDecomposed())
         {
+        // Update the rigid body consituent particles before communicating so that any such
+        // particles that move from one domain to another are migrated.
+        updateRigidBodies(timestep + 1);
+
         // perform all necessary communication steps. This ensures
         // a) that particles have migrated to the correct domains
         // b) that forces are calculated correctly, if ghost atom positions are updated every time
         // step
-
-        // also updates rigid bodies after ghost updating
         m_comm->communicate(timestep + 1);
         }
     else
 #endif
-        {
-        updateRigidBodies(timestep + 1);
-        }
+
+    // Update rigid body constituent particles after communicating (or once in serial) to ensure
+    // that all ghost constituent particle positions are set in accordance with any just
+    // communicated ghost and/or migrated rigid body centers.
+    updateRigidBodies(timestep + 1);
 
     // compute the net force on all particles
 #ifdef ENABLE_HIP

--- a/hoomd/md/NeighborList.cc
+++ b/hoomd/md/NeighborList.cc
@@ -544,13 +544,6 @@ void NeighborList::checkBoxSize()
     if (m_diameter_shift)
         rmax += m_d_max - Scalar(1.0);
 
-    if (m_filter_body)
-        {
-        // add the maximum diameter of all composite particles
-        Scalar max_d_comp = m_pdata->getMaxCompositeParticleDiameter();
-        rmax += 0.5 * max_d_comp;
-        }
-
     if ((periodic.x && nearest_plane_distance.x <= rmax * 2.0)
         || (periodic.y && nearest_plane_distance.y <= rmax * 2.0)
         || (m_sysdef->getNDimensions() == 3 && periodic.z

--- a/hoomd/md/NeighborListGPUStencil.cc
+++ b/hoomd/md/NeighborListGPUStencil.cc
@@ -234,13 +234,6 @@ void NeighborListGPUStencil::buildNlist(uint64_t timestep)
     if (m_diameter_shift)
         rmax += m_d_max - Scalar(1.0);
 
-    if (m_filter_body)
-        {
-        // add the maximum diameter of all composite particles
-        Scalar max_d_comp = m_pdata->getMaxCompositeParticleDiameter();
-        rmax += 0.5 * max_d_comp;
-        }
-
     ArrayHandle<Scalar> d_r_cut(m_r_cut, access_location::device, access_mode::read);
     ArrayHandle<Scalar> d_r_listsq(m_r_listsq, access_location::device, access_mode::read);
 

--- a/hoomd/md/NeighborListStencil.cc
+++ b/hoomd/md/NeighborListStencil.cc
@@ -108,13 +108,6 @@ void NeighborListStencil::buildNlist(uint64_t timestep)
     if (m_diameter_shift)
         rmax += m_d_max - Scalar(1.0);
 
-    if (m_filter_body)
-        {
-        // add the maximum diameter of all composite particles
-        Scalar max_d_comp = m_pdata->getMaxCompositeParticleDiameter();
-        rmax += 0.5 * max_d_comp;
-        }
-
     // get periodic flags
     uchar3 periodic = box.getPeriodic();
 

--- a/hoomd/mpcd/Integrator.cc
+++ b/hoomd/mpcd/Integrator.cc
@@ -99,10 +99,10 @@ void mpcd::Integrator::update(uint64_t timestep)
     else
 #endif // ENABLE_MPI
 
-    // Update rigid body constituent particles after communicating (or once in serial) to ensure
-    // that all ghost constituent particle positions are set in accordance with any just
-    // communicated ghost and/or migrated rigid body centers.
-    updateRigidBodies(timestep + 1);
+        // Update rigid body constituent particles after communicating (or once in serial) to ensure
+        // that all ghost constituent particle positions are set in accordance with any just
+        // communicated ghost and/or migrated rigid body centers.
+        updateRigidBodies(timestep + 1);
 
     // execute the MPCD streaming step now that MD particles are communicated onto their final
     // domains

--- a/hoomd/mpcd/Integrator.cc
+++ b/hoomd/mpcd/Integrator.cc
@@ -95,14 +95,17 @@ void mpcd::Integrator::update(uint64_t timestep)
         updateRigidBodies(timestep + 1);
 
         m_comm->communicate(timestep + 1);
+
+        // Communicator uses a compute callback to trigger updateRigidBodies again and ensure that
+        // all ghost constituent particle positions are set in accordance with any just communicated
+        // ghost and/or migrated rigid body centers.
         }
     else
 #endif // ENABLE_MPI
-
-        // Update rigid body constituent particles after communicating (or once in serial) to ensure
-        // that all ghost constituent particle positions are set in accordance with any just
-        // communicated ghost and/or migrated rigid body centers.
+        {
+        // Update rigid body constituent particles in serial simulations.
         updateRigidBodies(timestep + 1);
+        }
 
     // execute the MPCD streaming step now that MD particles are communicated onto their final
     // domains

--- a/hoomd/mpcd/Integrator.cc
+++ b/hoomd/mpcd/Integrator.cc
@@ -90,13 +90,19 @@ void mpcd::Integrator::update(uint64_t timestep)
 #ifdef ENABLE_MPI
     if (m_sysdef->isDomainDecomposed())
         {
+        // Update the rigid body consituent particles before communicating so that any such
+        // particles that move from one domain to another are migrated.
+        updateRigidBodies(timestep + 1);
+
         m_comm->communicate(timestep + 1);
         }
     else
 #endif // ENABLE_MPI
-        {
-        updateRigidBodies(timestep + 1);
-        }
+
+    // Update rigid body constituent particles after communicating (or once in serial) to ensure
+    // that all ghost constituent particle positions are set in accordance with any just
+    // communicated ghost and/or migrated rigid body centers.
+    updateRigidBodies(timestep + 1);
 
     // execute the MPCD streaming step now that MD particles are communicated onto their final
     // domains


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should be based on *trunk-patch*. -->
<!-- Backwards compatible new features should be based on *trunk-minor*. -->
<!-- Incompatible API changes should be based on *trunk-major*. -->

## Description

<!-- Describe your changes in detail. -->
Rewrite the rigid body communication scheme so that `F_{ij} = -F_{ji}` for interactions that involve at least one constituent particle near the domain boundary.

Reviewers: Note that I documented the details of each change in the full commit log. Check that first for more details on these changes.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Previously, HOOMD was computing `F_{ij}` as a function of `\vec{r}_i(t-1)` and `\vec{r}_j(t)` for interactions involving some constituent particles near the domain boundaries. There were many errors in the previous communication scheme.

<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves #1468

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
See the minimal test case in #1468.

I am running longer momentum/energy conservation tests now.

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
Fixed:

* Compute pairwise forces that add to zero for rigid body constituent particles near MPI domain boundaries.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
