### PR TITLE
Fix builds with ROCM 5.1.0.

### DIFF
--- a/BUILDING.rst
+++ b/BUILDING.rst
@@ -115,7 +115,7 @@ Install prerequisites
 
 .. note::
 
-    When ``ENABLE_GPU=on``, HOOMD-blue will default to CUDA. Set ``HHOOMD_GPU_PLATFORM=HIP`` to
+    When ``ENABLE_GPU=on``, HOOMD-blue will default to CUDA. Set ``HOOMD_GPU_PLATFORM=HIP`` to
     choose HIP.
 
 **For threaded parallelism on the CPU** (required when ``ENABLE_TBB=on``):

--- a/hoomd/Autotuner.h
+++ b/hoomd/Autotuner.h
@@ -51,6 +51,8 @@ class PYBIND11_EXPORT AutotunerBase
     public:
     AutotunerBase(const std::string& name) : m_name(name) { }
 
+    virtual ~AutotunerBase() { }
+
     /// Call to start the autotuning sequence.
     virtual void startScan() { }
 

--- a/hoomd/ExecutionConfiguration.cc
+++ b/hoomd/ExecutionConfiguration.cc
@@ -412,9 +412,10 @@ void ExecutionConfiguration::scanGPUs()
             continue;
             }
 
+#ifdef __HIP_PLATFORM_NVCC__
         // exclude a GPU if it's compute version is not high enough
         int compoundComputeVer = prop.minor + prop.major * 10;
-#ifdef __HIP_PLATFORM_NVCC__
+
         if (compoundComputeVer < CUDA_ARCH)
             {
             ostringstream s;

--- a/hoomd/ManagedArray.h
+++ b/hoomd/ManagedArray.h
@@ -30,7 +30,7 @@ template<class T> class ManagedArray
     {
     public:
     //! Default constructor
-    DEVICE ManagedArray()
+    HOSTDEVICE ManagedArray()
         : data(nullptr), ptr(nullptr), N(0), managed(0), align(0), allocation_ptr(nullptr),
           allocation_bytes(0)
         {
@@ -48,7 +48,7 @@ template<class T> class ManagedArray
         }
 #endif
 
-    DEVICE ~ManagedArray()
+    HOSTDEVICE ~ManagedArray()
         {
 #ifndef __HIPCC__
         deallocate();
@@ -60,7 +60,7 @@ template<class T> class ManagedArray
        the host. If the GPU isn't synced up, this can lead to errors, so proper multi-GPU
        synchronization needs to be ensured
      */
-    DEVICE ManagedArray(const ManagedArray<T>& other)
+    HOSTDEVICE ManagedArray(const ManagedArray<T>& other)
         : data(nullptr), ptr(nullptr), N(other.N), managed(other.managed), align(other.align),
           allocation_ptr(nullptr), allocation_bytes(0)
         {
@@ -82,7 +82,7 @@ template<class T> class ManagedArray
        the host. If the GPU isn't synced up, this can lead to errors, so proper multi-GPU
        synchronization needs to be ensured
      */
-    DEVICE ManagedArray(const ManagedArray<T>&& other)
+    HOSTDEVICE ManagedArray(const ManagedArray<T>&& other)
         : data(nullptr), ptr(nullptr), N(other.N), managed(other.managed), align(other.align),
           allocation_ptr(nullptr), allocation_bytes(0)
         {
@@ -104,7 +104,7 @@ template<class T> class ManagedArray
        available on the host. If the GPU isn't synced up, this can lead to errors, so proper
        multi-GPU synchronization needs to be ensured
      */
-    DEVICE ManagedArray& operator=(const ManagedArray<T>& other)
+    HOSTDEVICE ManagedArray& operator=(const ManagedArray<T>& other)
         {
 #ifndef __HIPCC__
         deallocate();
@@ -134,7 +134,7 @@ template<class T> class ManagedArray
        available on the host. If the GPU isn't synced up, this can lead to errors, so proper
        multi-GPU synchronization needs to be ensured
      */
-    DEVICE ManagedArray& operator=(const ManagedArray<T>&& other)
+    HOSTDEVICE ManagedArray& operator=(const ManagedArray<T>&& other)
         {
 #ifndef __HIPCC__
         deallocate();
@@ -236,7 +236,7 @@ template<class T> class ManagedArray
 
         \returns true if array was loaded into shared memory
      */
-    DEVICE bool load_shared(char*& s_ptr, unsigned int& available_bytes)
+    HOSTDEVICE bool load_shared(char*& s_ptr, unsigned int& available_bytes)
         {
         // align ptr to size of data type
         void* ptr_align = allocate_shared(s_ptr, available_bytes);

--- a/hoomd/RandomNumbers.h
+++ b/hoomd/RandomNumbers.h
@@ -18,6 +18,7 @@
 #ifndef __CUDACC_RTC__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wconversion"
+#pragma GCC diagnostic ignored "-Wdangling-else"
 #endif
 
 #include <hoomd/extern/random123/include/Random123/philox.h>

--- a/hoomd/hpmc/CMakeLists.txt
+++ b/hoomd/hpmc/CMakeLists.txt
@@ -137,6 +137,7 @@ endif(ENABLE_HIP)
 
 if (ENABLE_HIP)
 set(_cuda_sources ${_hpmc_cu_sources})
+set_source_files_properties(${_hpmc_cu_sources} PROPERTIES LANGUAGE ${HOOMD_DEVICE_LANGUAGE})
 endif (ENABLE_HIP)
 
 pybind11_add_module(_hpmc SHARED ${_hpmc_sources} ${_cuda_sources} ${_hpmc_headers} NO_EXTRAS)

--- a/hoomd/hpmc/GPUTree.h
+++ b/hoomd/hpmc/GPUTree.h
@@ -39,7 +39,7 @@ class GPUTree
     {
     public:
     //! Empty constructor
-    DEVICE GPUTree() : m_num_nodes(0), m_num_leaves(0), m_leaf_capacity(0) { }
+    HOSTDEVICE GPUTree() : m_num_nodes(0), m_num_leaves(0), m_leaf_capacity(0) { }
 
 #ifndef __HIPCC__
     //! Constructor

--- a/hoomd/hpmc/XenoSweep3D.h
+++ b/hoomd/hpmc/XenoSweep3D.h
@@ -16,9 +16,7 @@
     \brief Implements XenoCollide in 3D
 */
 
-// need to declare these class methods with __device__ qualifiers when building in nvcc
-// DEVICE is __device__ when included in nvcc and blank when included into the host compiler
-#ifdef NVCC
+#ifdef __HIPCC__
 #define DEVICE __device__
 #else
 #define DEVICE

--- a/hoomd/hpmc/test/CMakeLists.txt
+++ b/hoomd/hpmc/test/CMakeLists.txt
@@ -20,6 +20,7 @@ foreach (CUR_TEST ${TEST_LIST})
     # add and link the unit test executable
     if(ENABLE_HIP AND EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${CUR_TEST}.cu)
         set(_cuda_sources ${CUR_TEST}.cu)
+        set_source_files_properties(${_cuda_sources} PROPERTIES LANGUAGE ${HOOMD_DEVICE_LANGUAGE})
     else()
         set(_cuda_sources "")
     endif()

--- a/hoomd/md/ForceCompositeGPU.cc
+++ b/hoomd/md/ForceCompositeGPU.cc
@@ -425,10 +425,11 @@ void ForceCompositeGPU::findRigidCenters()
 
     m_rigid_center.resize(m_pdata->getN() + m_pdata->getNGhosts());
 
-    size_t old_size = m_lookup_center.getNumElements();
     m_lookup_center.resize(m_pdata->getN() + m_pdata->getNGhosts());
 
 #ifdef __HIP_PLATFORM_NVCC__
+    size_t old_size = m_lookup_center.getNumElements();
+
     if (m_exec_conf->allConcurrentManagedAccess() && m_lookup_center.getNumElements() != old_size)
         {
         // set memory hints

--- a/hoomd/md/ForceDistanceConstraintGPU.cu
+++ b/hoomd/md/ForceDistanceConstraintGPU.cu
@@ -347,7 +347,6 @@ hipError_t gpu_count_nnz(unsigned int n_constraint,
                  &nnz);
     return hipSuccess;
     }
-#endif
 
 #ifndef CUSPARSE_NEW_API
 hipError_t gpu_dense2sparse(unsigned int n_constraint,
@@ -375,6 +374,7 @@ hipError_t gpu_dense2sparse(unsigned int n_constraint,
 
     return hipSuccess;
     }
+#endif
 #endif
 
 hipError_t gpu_compute_constraint_forces(const Scalar4* d_pos,

--- a/hoomd/test/CMakeLists.txt
+++ b/hoomd/test/CMakeLists.txt
@@ -48,6 +48,7 @@ foreach (CUR_TEST ${TEST_LIST} ${MPI_TEST_LIST})
     # add and link the unit test executable
     if(ENABLE_HIP AND EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${CUR_TEST}.cu)
         set(_cuda_sources ${CUR_TEST}.cu)
+        set_source_files_properties(${_cuda_sources} PROPERTIES LANGUAGE ${HOOMD_DEVICE_LANGUAGE})
     else()
         set(_cuda_sources "")
     endif()


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should be based on *trunk-patch*. -->
<!-- Backwards compatible new features should be based on *trunk-minor*. -->
<!-- Incompatible API changes should be based on *trunk-major*. -->

## Description

<!-- Describe your changes in detail. -->
Make all changes needed to build HOOMD against ROCM 5.1.0.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
These changes allow HOOMD to run on OLCF Crusher, the test system for Frontier.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
I executed the unit tests (ctest and pytest). The core and md test pass. I'm getting seg faults in the HPMC tests. Our immediate need is for MD simulations on Frontier, so let's merge this set of fixes now. I will revisit HPMC support in a later PR.

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
Fixed:

* Compile without errors using `hipcc` and ROCM 5.1.0.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
