### PR TITLE
Add deprecation warning to write.GSD log kwarg

### DIFF
--- a/hoomd/md/pytest/test_gsd.py
+++ b/hoomd/md/pytest/test_gsd.py
@@ -379,7 +379,7 @@ def test_write_gsd_log(create_md_sim, tmp_path):
                                  trigger=hoomd.trigger.Periodic(1),
                                  filter=hoomd.filter.Null(),
                                  mode='wb',
-                                 log=logger)
+                                 logger=logger)
     sim.operations.writers.append(gsd_writer)
 
     kinetic_energy_list = []

--- a/hoomd/write/gsd.py
+++ b/hoomd/write/gsd.py
@@ -239,7 +239,7 @@ class GSD(Writer):
                 "log and logger keyword arguments passed to write.GSD.write()."
                 " Keyword argument \"log\" is deprecated since v3.9.0."
                 " Ignoring log and using logger instead.", RuntimeWarning)
-       elif log is not None:
+        elif log is not None:
             warnings.warn(
                 "log keyword arguments passed to write.GSD.write() is"
                 " deprecated since v3.9.0. Use logger instead.",

--- a/hoomd/write/gsd.py
+++ b/hoomd/write/gsd.py
@@ -268,7 +268,7 @@ class GSD(Writer):
            ``log`` will be renamed to ``logger`` in v4.
         """
         warnings.warn(
-            "log property  is deprecated since v3.9.0. Use logger instead.",
+            "log property is deprecated since v3.9.0. Use logger instead.",
             DeprecationWarning)
         return self._logger
 
@@ -285,7 +285,7 @@ class GSD(Writer):
     @log.setter
     def log(self, log):
         warnings.warn(
-            "log property is deprecated since  v3.9.0. Use logger instead.",
+            "log property is deprecated since v3.9.0. Use logger instead.",
             DeprecationWarning)
         if log is not None and isinstance(log, Logger):
             log = _GSDLogWriter(log)

--- a/hoomd/write/gsd.py
+++ b/hoomd/write/gsd.py
@@ -178,11 +178,11 @@ class GSD(Writer):
             warnings.warn(
                 f"log and logger keyword arguments passed to {self}."
                 f" Keyword argument \"log\" is deprecated since v3.9.0."
-                f" Ignoring log and using logger instead.", DeprecationWarning)
+                f" Ignoring log and using logger instead.", FutureWarning)
         elif logger is None and log is not None:
             warnings.warn(
                 f"log keyword arguments passed to {self} is deprecated since"
-                f" v3.9.0. Use logger instead.", DeprecationWarning)
+                f" v3.9.0. Use logger instead.", FutureWarning)
             logger = log
 
         self._logger = None if logger is None else _GSDLogWriter(logger)
@@ -243,7 +243,7 @@ class GSD(Writer):
             warnings.warn(
                 "log keyword arguments passed to write.GSD.write() is"
                 " deprecated since v3.9.0. Use logger instead.",
-                DeprecationWarning)
+                FutureWarning)
             logger = log
 
         if logger is not None:
@@ -269,7 +269,7 @@ class GSD(Writer):
         """
         warnings.warn(
             "log property is deprecated since v3.9.0. Use logger instead.",
-            DeprecationWarning)
+            FutureWarning)
         return self.logger
 
     @logger.setter
@@ -286,7 +286,7 @@ class GSD(Writer):
     def log(self, log):
         warnings.warn(
             "log property is deprecated since v3.9.0. Use logger instead.",
-            DeprecationWarning)
+            FutureWarning)
         self.logger = log
 
 

--- a/hoomd/write/gsd.py
+++ b/hoomd/write/gsd.py
@@ -44,6 +44,9 @@ class GSD(Writer):
         log (hoomd.logging.Logger): Provide log quantities to write. Defaults to
             `None`.
 
+            .. deprecated:: v3.9.0
+               ``log`` will be renamed to ``logger`` in v4.
+
     `GSD` writes the simulation trajectory to the specified file in the GSD
     format. `GSD` can store all particle, bond, angle, dihedral, improper,
     pair, and constraint data fields in every frame of the trajectory.  `GSD`

--- a/hoomd/write/gsd.py
+++ b/hoomd/write/gsd.py
@@ -234,12 +234,12 @@ class GSD(Writer):
         writer = _hoomd.GSDDumpWriter(state._cpp_sys_def, Periodic(1), filename,
                                       state._get_group(filter), mode, False)
 
-        if all((logger is not None, log is not None)):
+        if logger is not None and log is not None:
             warnings.warn(
                 "log and logger keyword arguments passed to write.GSD.write()."
                 " Keyword argument \"log\" is deprecated since v3.9.0."
-                " Ignoring log and using logger instead.", DeprecationWarning)
-        elif logger is None and log is not None:
+                " Ignoring log and using logger instead.", RuntimeWarning)
+       elif log is not None:
             warnings.warn(
                 "log keyword arguments passed to write.GSD.write() is"
                 " deprecated since v3.9.0. Use logger instead.",
@@ -267,6 +267,9 @@ class GSD(Writer):
         .. deprecated:: v3.9.0
            ``log`` will be renamed to ``logger`` in v4.
         """
+        warnings.warn(
+            "log property  is deprecated since v3.9.0. Use logger instead.",
+            DeprecationWarning)
         return self._logger
 
     @logger.setter
@@ -282,8 +285,8 @@ class GSD(Writer):
     @log.setter
     def log(self, log):
         warnings.warn(
-            f"log keyword arguments passed to {self} is deprecated since"
-            f" v3.9.0. Use logger instead.", DeprecationWarning)
+            "log property is deprecated since  v3.9.0. Use logger instead.",
+            DeprecationWarning)
         if log is not None and isinstance(log, Logger):
             log = _GSDLogWriter(log)
         else:

--- a/hoomd/write/gsd.py
+++ b/hoomd/write/gsd.py
@@ -242,8 +242,7 @@ class GSD(Writer):
         elif log is not None:
             warnings.warn(
                 "log keyword arguments passed to write.GSD.write() is"
-                " deprecated since v3.9.0. Use logger instead.",
-                FutureWarning)
+                " deprecated since v3.9.0. Use logger instead.", FutureWarning)
             logger = log
 
         if logger is not None:

--- a/hoomd/write/gsd.py
+++ b/hoomd/write/gsd.py
@@ -270,7 +270,7 @@ class GSD(Writer):
         warnings.warn(
             "log property is deprecated since v3.9.0. Use logger instead.",
             DeprecationWarning)
-        return self._logger
+        return self.logger
 
     @logger.setter
     def logger(self, logger):
@@ -287,13 +287,7 @@ class GSD(Writer):
         warnings.warn(
             "log property is deprecated since v3.9.0. Use logger instead.",
             DeprecationWarning)
-        if log is not None and isinstance(log, Logger):
-            log = _GSDLogWriter(log)
-        else:
-            raise ValueError("GSD.log can only be set with a Logger.")
-        if self._attached:
-            self._cpp_obj.log_writer = log
-        self._log = log
+        self.logger = log
 
 
 def _iterable_is_incomplete(iterable):


### PR DESCRIPTION
## Description

Add a deprecation warning to the `log` kwarg of `write.GSD`.

## Motivation and context

See #1480. The actual change is made on a PR onto `trunk-major`, see #1482.

## How has this been tested?

This is just a note in the documentation. I have built the docs locally.

## Change log

<!-- Propose a change log entry. -->
```
- Deprecate `write.GSD` `log` keyword argument in favor of `logger`.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
