### PR TITLE
Replace gsd log with logger

### DIFF
--- a/hoomd/md/pytest/test_gsd.py
+++ b/hoomd/md/pytest/test_gsd.py
@@ -379,7 +379,7 @@ def test_write_gsd_log(create_md_sim, tmp_path):
                                  trigger=hoomd.trigger.Periodic(1),
                                  filter=hoomd.filter.Null(),
                                  mode='wb',
-                                 log=logger)
+                                 logger=logger)
     sim.operations.writers.append(gsd_writer)
 
     kinetic_energy_list = []

--- a/hoomd/write/gsd.py
+++ b/hoomd/write/gsd.py
@@ -14,7 +14,6 @@ from hoomd.logging import Logger, LoggerCategories
 from hoomd.operation import Writer
 import numpy as np
 import json
-import warnings
 
 
 def _array_to_strings(value):

--- a/hoomd/write/gsd.py
+++ b/hoomd/write/gsd.py
@@ -236,6 +236,7 @@ class GSD(Writer):
         self._logger = logger
         return self.logger
 
+
 def _iterable_is_incomplete(iterable):
     """Checks that any nested attribute has no instances of RequiredArg.
 

--- a/hoomd/write/gsd.py
+++ b/hoomd/write/gsd.py
@@ -125,7 +125,7 @@ class GSD(Writer):
 
     Tip:
         All logged data chunks must be present in the first frame in the gsd
-        file to provide the default value. To achieve this, set the `log`
+        file to provide the default value. To achieve this, set the `logger`
         attribute before the operation is triggered to write the first frame
         in the file.
 

--- a/sphinx-doc/migrating.rst
+++ b/sphinx-doc/migrating.rst
@@ -12,47 +12,53 @@ Breaking changes to existing functionalities
 
 For some functionalities, you will need to update your scripts to use a new API:
 
-.. list-table::
-   :header-rows: 1
+* ``hoomd.md.dihedral.Harmonic``
 
-   * - v3 Feature
-     - Replace with
-   * - ``hoomd.md.dihedral.Harmonic``
-     - `hoomd.md.dihedral.Periodic` - new name.
-   * - ``charges`` key in `Rigid.body <hoomd.md.constrain.Rigid.body>`
-     - Pass charges to `Rigid.create_bodies <hoomd.md.constrain.Rigid.create_bodies>` or set in
-       system state.
-   * - ``diameters`` key in `Rigid.body <hoomd.md.constrain.Rigid.body>`
-     - Set diameters in system state.
-   * - ``hoomd.md.methods.NVE``
-     - `hoomd.md.methods.ConstantVolume` with ``thermostat=None``.
-   * - ``hoomd.md.methods.NVT``
-     - `hoomd.md.methods.ConstantVolume` with a `hoomd.md.methods.thermostats.MTTK` thermostat.
-   * - ``hoomd.md.methods.Berendsen``
-     - `hoomd.md.methods.ConstantVolume` with a `hoomd.md.methods.thermostats.Berendsen` thermostat.
-   * - ``hoomd.md.methods.NPH``
-     - `hoomd.md.methods.ConstantPressure` with ``thermostat=None``.
-   * - ``hoomd.md.methods.NPT``
-     - `hoomd.md.methods.ConstantPressure` with a `hoomd.md.methods.thermostats.MTTK` thermostat.
-   * - ``hoomd.write.GSD.log``
-     - `hoomd.write.GSD.logger`
+  * Use `hoomd.md.dihedral.Periodic`.
+
+* ``charges`` key in `Rigid.body <hoomd.md.constrain.Rigid.body>`.
+
+  * Pass charges to `Rigid.create_bodies <hoomd.md.constrain.Rigid.create_bodies>` or set in
+    the system state.
+
+* ``diameters`` key in `Rigid.body <hoomd.md.constrain.Rigid.body>`.
+
+  * Set diameters in system state.
+
+* ``hoomd.md.methods.NVE``.
+
+  * Use `hoomd.md.methods.ConstantVolume` with ``thermostat=None``.
+
+* ``hoomd.md.methods.NVT``.
+
+  * Use `hoomd.md.methods.ConstantVolume` with a `hoomd.md.methods.thermostats.MTTK` thermostat.
+
+* ``hoomd.md.methods.Berendsen``.
+
+  * Use `hoomd.md.methods.ConstantVolume` with a `hoomd.md.methods.thermostats.Berendsen`
+    thermostat.
+
+* ``hoomd.md.methods.NPH``.
+
+  * Use `hoomd.md.methods.ConstantPressure` with ``thermostat=None``.
+
+* ``hoomd.md.methods.NPT``.
+
+  * Use `hoomd.md.methods.ConstantPressure` with a `hoomd.md.methods.thermostats.MTTK` thermostat.
+
+* ``hoomd.write.GSD.log``.
+
+  * Use `hoomd.write.GSD.logger`.
+
 
 Removed functionalities
 ^^^^^^^^^^^^^^^^^^^^^^^
 
 HOOMD-blue v4 removes functionalities deprecated in v3.x releases:
 
-.. list-table::
-   :header-rows: 1
-
-   * - v3 Feature
-     - Replace with
-   * - ``hoomd.md.pair.aniso.ALJ.mode`` parameter
-     - n/a: ``mode`` has no effect since v3.0.0.
-   * - ``hoomd.md.pair.aniso.Dipole.mode`` parameter
-     - n/a: ``mode`` has no effect since v3.0.0.
-   * - ``hoomd.device.GPU.memory_traceback`` parameter
-     - n/a: ``memory_traceback`` has no effect since v3.0.0.
+* ``hoomd.md.pair.aniso.ALJ.mode`` parameter
+* ``hoomd.md.pair.aniso.Dipole.mode`` parameter
+* ``hoomd.device.GPU.memory_traceback`` parameter
 
 Compiling
 ^^^^^^^^^

--- a/sphinx-doc/migrating.rst
+++ b/sphinx-doc/migrating.rst
@@ -34,6 +34,8 @@ For some functionalities, you will need to update your scripts to use a new API:
      - `hoomd.md.methods.ConstantPressure` with ``thermostat=None``.
    * - ``hoomd.md.methods.NPT``
      - `hoomd.md.methods.ConstantPressure` with a `hoomd.md.methods.thermostats.MTTK` thermostat.
+   * - ``hoomd.write.GSD.log``
+     - `hoomd.write.GSD.logger`
 
 Removed functionalities
 ^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
## Description

Renames `log` kwarg of `write.GSD` to `logger`. See #1481 and #1480.

## Motivation and context

Resolves #1480. 

## How has this been tested?

The unit tests should be sufficient.

## Change log

<!-- Propose a change log entry. -->
```
Rename `log` keyword argument and property of `write.GSD` to `logger`.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.