### PR TITLE
Correctly compute free area in 2D simulation boxes using FreeVolume

### DIFF
--- a/hoomd/hpmc/ComputeFreeVolume.h
+++ b/hoomd/hpmc/ComputeFreeVolume.h
@@ -175,7 +175,10 @@ template<class Shape> void ComputeFreeVolume<Shape>::computeFreeVolume(uint64_t 
             Scalar xrand = hoomd::detail::generate_canonical<Scalar>(rng_i);
             Scalar yrand = hoomd::detail::generate_canonical<Scalar>(rng_i);
             Scalar zrand = hoomd::detail::generate_canonical<Scalar>(rng_i);
-
+            if (this->m_sysdef->getNDimensions() == 2)
+                {
+                zrand = 0;
+                }
             Scalar3 f = make_scalar3(xrand, yrand, zrand);
             vec3<Scalar> pos_i = vec3<Scalar>(box.makeCoordinates(f));
 
@@ -294,8 +297,8 @@ template<class Shape> Scalar ComputeFreeVolume<Shape>::getFreeVolume()
 
     // total free volume
     const BoxDim global_box = this->m_pdata->getGlobalBox();
-    Scalar V_free
-        = (Scalar)(n_sample - *h_n_overlap_all.data) / (Scalar)n_sample * global_box.getVolume();
+    Scalar V_free = (Scalar)(n_sample - *h_n_overlap_all.data) / (Scalar)n_sample
+                    * global_box.getVolume(this->m_sysdef->getNDimensions() == 2);
 
     return V_free;
     }

--- a/hoomd/hpmc/ComputeFreeVolumeGPU.cuh
+++ b/hoomd/hpmc/ComputeFreeVolumeGPU.cuh
@@ -274,6 +274,11 @@ __global__ void gpu_hpmc_free_volume_kernel(unsigned int n_sample,
         Scalar yrand = hoomd::detail::generate_canonical<Scalar>(rng);
         Scalar zrand = hoomd::detail::generate_canonical<Scalar>(rng);
 
+        if (this->m_sysdef->getNDimensions() == 2)
+            {
+            zrand = 0;
+            }
+
         Scalar3 f = make_scalar3(xrand, yrand, zrand);
         pos_i = vec3<Scalar>(box.makeCoordinates(f));
 

--- a/hoomd/hpmc/ComputeFreeVolumeGPU.cuh
+++ b/hoomd/hpmc/ComputeFreeVolumeGPU.cuh
@@ -274,7 +274,7 @@ __global__ void gpu_hpmc_free_volume_kernel(unsigned int n_sample,
         Scalar yrand = hoomd::detail::generate_canonical<Scalar>(rng);
         Scalar zrand = hoomd::detail::generate_canonical<Scalar>(rng);
 
-        if (this->m_sysdef->getNDimensions() == 2)
+        if (dim == 2)
             {
             zrand = 0;
             }

--- a/hoomd/hpmc/pytest/test_compute_free_volume.py
+++ b/hoomd/hpmc/pytest/test_compute_free_volume.py
@@ -96,7 +96,7 @@ def test_logging():
         }})
 
 
-def test_2D_free_volume(simulation_factory):
+def test_2d_free_volume(simulation_factory):
     snapshot = hoomd.Snapshot()
     if snapshot.communicator.rank == 0:
         snapshot.configuration.box = (100, 100, 0, 0, 0, 0)

--- a/hoomd/hpmc/pytest/test_compute_free_volume.py
+++ b/hoomd/hpmc/pytest/test_compute_free_volume.py
@@ -2,6 +2,7 @@
 # Part of HOOMD-blue, released under the BSD 3-Clause License.
 
 import hoomd
+import math
 import pytest
 import numpy as np
 from hoomd.error import DataAccessError
@@ -93,3 +94,27 @@ def test_logging():
             'category': LoggerCategories.scalar,
             'default': True
         }})
+
+
+def test_2D_free_volume(simulation_factory):
+    snapshot = hoomd.Snapshot()
+    if snapshot.communicator.rank == 0:
+        snapshot.configuration.box = (100, 100, 0, 0, 0, 0)
+        snapshot.particles.N = 1
+        snapshot.particles.types = ['A']
+
+    sim = simulation_factory(snapshot)
+
+    mc = hoomd.hpmc.integrate.Sphere()
+    mc.shape['A'] = dict(diameter=1)
+
+    free_volume = hoomd.hpmc.compute.FreeVolume(test_particle_type='A', num_samples=100000)
+
+    sim.operations.integrator = mc
+    sim.operations.computes.append(free_volume)
+
+    sim.run(0)
+    f = free_volume.free_volume
+    if snapshot.communicator.rank == 0:
+        assert f == pytest.approx(expected = 100*100 - math.pi, rel = 1e-3)
+

--- a/hoomd/hpmc/pytest/test_compute_free_volume.py
+++ b/hoomd/hpmc/pytest/test_compute_free_volume.py
@@ -108,7 +108,8 @@ def test_2D_free_volume(simulation_factory):
     mc = hoomd.hpmc.integrate.Sphere()
     mc.shape['A'] = dict(diameter=1)
 
-    free_volume = hoomd.hpmc.compute.FreeVolume(test_particle_type='A', num_samples=100000)
+    free_volume = hoomd.hpmc.compute.FreeVolume(test_particle_type='A',
+                                                num_samples=100000)
 
     sim.operations.integrator = mc
     sim.operations.computes.append(free_volume)
@@ -116,5 +117,4 @@ def test_2D_free_volume(simulation_factory):
     sim.run(0)
     f = free_volume.free_volume
     if snapshot.communicator.rank == 0:
-        assert f == pytest.approx(expected = 100*100 - math.pi, rel = 1e-3)
-
+        assert f == pytest.approx(expected=100 * 100 - math.pi, rel=1e-3)

--- a/sphinx-doc/credits.rst
+++ b/sphinx-doc/credits.rst
@@ -75,6 +75,7 @@ The following people have contributed to the to HOOMD-blue:
 * Malcolm Ramsay
 * Marco Klement, Friedrich-Alexander-Universität Erlangen-Nürnberg (FAU)
 * Matthew Spellings, University of Michgan
+* Melody Zhang, University of Michigan
 * Michael Howard, University of Texas
 * Mike Henry, Boise State University
 * Nathan Horst


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should be based on *trunk-patch*. -->
<!-- Backwards compatible new features should be based on *trunk-minor*. -->
<!-- Incompatible API changes should be based on *trunk-major*. -->

## Description
Passed the system dimensionality to `getVolume` in `ComputeFreeVolume.h` and generated 0 z coordinates when the system dimensionality is 2. These changes will compute correct free area for 2D boxes. 
<!-- Describe your changes in detail. -->

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->

<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves #1473 

## How has this been tested?
Add a 2D test to `test_compute_free_volume.py`
<!--- Please describe in detail how you tested your changes. -->

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->


## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
