### PR TITLE
fix: Add deprecation warnings to deprecated features.

### DIFF
--- a/hoomd/device.py
+++ b/hoomd/device.py
@@ -20,6 +20,8 @@ See Also:
     `hoomd.Simulation`
 """
 
+import warnings
+
 import contextlib
 import hoomd
 from hoomd import _hoomd
@@ -263,11 +265,14 @@ class GPU(Device):
         .. deprecated:: v3.4.0
            `memory_traceback` has no effect.
         """
+        warnings.warn("memory_traceback will be removed in hoomd 4.0.",
+                      DeprecationWarning)
         return self._cpp_exec_conf.memoryTracingEnabled()
 
     @memory_traceback.setter
     def memory_traceback(self, mem_traceback):
-
+        warnings.warn("memory_traceback will be removed in hoomd 4.0.",
+                      DeprecationWarning)
         self._cpp_exec_conf.setMemoryTracing(mem_traceback)
 
     @property

--- a/hoomd/device.py
+++ b/hoomd/device.py
@@ -266,13 +266,13 @@ class GPU(Device):
            `memory_traceback` has no effect.
         """
         warnings.warn("memory_traceback will be removed in hoomd 4.0.",
-                      DeprecationWarning)
+                      FutureWarning)
         return self._cpp_exec_conf.memoryTracingEnabled()
 
     @memory_traceback.setter
     def memory_traceback(self, mem_traceback):
         warnings.warn("memory_traceback will be removed in hoomd 4.0.",
-                      DeprecationWarning)
+                      FutureWarning)
         self._cpp_exec_conf.setMemoryTracing(mem_traceback)
 
     @property

--- a/hoomd/md/constrain.py
+++ b/hoomd/md/constrain.py
@@ -41,7 +41,7 @@ class _DeprecateKey:
         msg += f"{self.version}."
         if self.alt:
             msg += f" Use {self.alt} in version {self.version} instead."
-        warnings.warn(msg, DeprecationWarning)
+        warnings.warn(msg, FutureWarning)
         return value
 
 

--- a/hoomd/md/constrain.py
+++ b/hoomd/md/constrain.py
@@ -19,12 +19,30 @@ Warning:
     instance solves for its constraints independently.
 """
 
+import warnings
+
 from hoomd.md import _md
 from hoomd.data.parameterdicts import ParameterDict, TypeParameterDict
 from hoomd.data.typeparam import TypeParameter
 from hoomd.data.typeconverter import OnlyIf, to_type_converter
 from hoomd.md.force import Force
 import hoomd
+
+
+class _DeprecateKey:
+
+    def __init__(self, name, version="4.0", alt=""):
+        self.name = name
+        self.version = version
+        self.alt = alt
+
+    def __call__(self, value):
+        msg = f"The {self.name} key is deprecated and will be removed in hoomd "
+        msg += f"{self.version}."
+        if self.alt:
+            msg += f" Use {self.alt} in version {self.version} instead."
+        warnings.warn(msg, DeprecationWarning)
+        return value
 
 
 class Constraint(Force):
@@ -300,8 +318,12 @@ class Rigid(Constraint):
                 'constituent_types': [str],
                 'positions': [(float,) * 3],
                 'orientations': [(float,) * 4],
-                'charges': [float],
-                'diameters': [float]
+                'charges':
+                    OnlyIf(to_type_converter([float]),
+                           preprocess=_DeprecateKey("charges")),
+                'diameters':
+                    OnlyIf(to_type_converter([float]),
+                           preprocess=_DeprecateKey("diameters"))
             }),
                                      allow_none=True),
                               len_keys=1))

--- a/hoomd/md/dihedral.py
+++ b/hoomd/md/dihedral.py
@@ -130,7 +130,7 @@ class Harmonic(Periodic):
     def __init__(self):
         warnings.warn(
             "Harmonic is deprecated and will be removed in hoomd 4.0. Use "
-            "Periodic instead.", DeprecationWarning)
+            "Periodic instead.", FutureWarning)
         super().__init__()
 
 

--- a/hoomd/md/dihedral.py
+++ b/hoomd/md/dihedral.py
@@ -41,6 +41,8 @@ Important:
     parallel compact state ( \|_\| ).
 """
 
+import warnings
+
 from hoomd.md import _md
 from hoomd.md.force import Force
 from hoomd.data.parameterdicts import TypeParameterDict
@@ -124,7 +126,12 @@ class Harmonic(Periodic):
     .. deprecated:: v3.7.0
         Use `Periodic`.
     """
-    pass
+
+    def __init__(self):
+        warnings.warn(
+            "Harmonic is deprecated and will be removed in hoomd 4.0. Use "
+            "Periodic instead.", DeprecationWarning)
+        super().__init__()
 
 
 class Table(Dihedral):

--- a/hoomd/md/methods/methods.py
+++ b/hoomd/md/methods/methods.py
@@ -102,7 +102,7 @@ class NVT(Method):
         warnings.warn(
             "NVT is deprecated and wil be removed in hoomd 4.0. In version "
             "4.0, use the ConstantVolume method with the desired thermostat "
-            "from hoomd.md.methods.thermostats.", DeprecationWarning)
+            "from hoomd.md.methods.thermostats.", FutureWarning)
         # store metadata
         param_dict = ParameterDict(filter=ParticleFilter,
                                    kT=Variant,
@@ -365,7 +365,7 @@ class NPT(Method):
         warnings.warn(
             "NPT is deprecated and wil be removed in hoomd 4.0. In version "
             "4.0, use the ConstantPressure method with the desired thermostat "
-            "from hoomd.md.methods.thermostats.", DeprecationWarning)
+            "from hoomd.md.methods.thermostats.", FutureWarning)
 
         # store metadata
         param_dict = ParameterDict(filter=ParticleFilter,
@@ -574,7 +574,7 @@ class NPH(Method):
         warnings.warn(
             "NPH is deprecated and wil be removed in hoomd 4.0. In version "
             "4.0, use the ConstantPressure method without a thermostat.",
-            DeprecationWarning)
+            FutureWarning)
         # store metadata
         param_dict = ParameterDict(filter=ParticleFilter,
                                    kT=Variant,
@@ -699,7 +699,7 @@ class NVE(Method):
         warnings.warn(
             "NVE is deprecated and wil be removed in hoomd 4.0. In version "
             "4.0, use the ConstantVolume method without a thermostat.",
-            DeprecationWarning)
+            FutureWarning)
 
         # store metadata
         param_dict = ParameterDict(filter=ParticleFilter,)
@@ -1196,7 +1196,7 @@ class Berendsen(Method):
         warnings.warn(
             "Berendsen is deprecated and wil be removed in hoomd 4.0. In "
             "version 4.0, use the ConstantVolume method with the Berendsen "
-            "thermostat from hoomd.md.methods.thermostats.", DeprecationWarning)
+            "thermostat from hoomd.md.methods.thermostats.", FutureWarning)
         # store metadata
         param_dict = ParameterDict(filter=ParticleFilter,
                                    kT=Variant,

--- a/hoomd/md/methods/methods.py
+++ b/hoomd/md/methods/methods.py
@@ -3,6 +3,8 @@
 
 """MD integration methods."""
 
+import warnings
+
 from hoomd.md import _md
 import hoomd
 from hoomd.operation import AutotunedObject
@@ -97,7 +99,10 @@ class NVT(Method):
     """
 
     def __init__(self, filter, kT, tau):
-
+        warnings.warn(
+            "NVT is deprecated and wil be removed in hoomd 4.0. In version "
+            "4.0, use the ConstantVolume method with the desired thermostat "
+            "from hoomd.md.methods.thermostats.", DeprecationWarning)
         # store metadata
         param_dict = ParameterDict(filter=ParticleFilter,
                                    kT=Variant,
@@ -357,6 +362,10 @@ class NPT(Method):
                  box_dof=[True, True, True, False, False, False],
                  rescale_all=False,
                  gamma=0.0):
+        warnings.warn(
+            "NPT is deprecated and wil be removed in hoomd 4.0. In version "
+            "4.0, use the ConstantPressure method with the desired thermostat "
+            "from hoomd.md.methods.thermostats.", DeprecationWarning)
 
         # store metadata
         param_dict = ParameterDict(filter=ParticleFilter,
@@ -562,6 +571,10 @@ class NPH(Method):
                  box_dof=(True, True, True, False, False, False),
                  rescale_all=False,
                  gamma=0.0):
+        warnings.warn(
+            "NPH is deprecated and wil be removed in hoomd 4.0. In version "
+            "4.0, use the ConstantPressure method without a thermostat.",
+            DeprecationWarning)
         # store metadata
         param_dict = ParameterDict(filter=ParticleFilter,
                                    kT=Variant,
@@ -683,6 +696,10 @@ class NVE(Method):
     """
 
     def __init__(self, filter):
+        warnings.warn(
+            "NVE is deprecated and wil be removed in hoomd 4.0. In version "
+            "4.0, use the ConstantVolume method without a thermostat.",
+            DeprecationWarning)
 
         # store metadata
         param_dict = ParameterDict(filter=ParticleFilter,)
@@ -1176,6 +1193,10 @@ class Berendsen(Method):
     """
 
     def __init__(self, filter, kT, tau):
+        warnings.warn(
+            "Berendsen is deprecated and wil be removed in hoomd 4.0. In "
+            "version 4.0, use the ConstantVolume method with the Berendsen "
+            "thermostat from hoomd.md.methods.thermostats.", DeprecationWarning)
         # store metadata
         param_dict = ParameterDict(filter=ParticleFilter,
                                    kT=Variant,

--- a/hoomd/md/pair/aniso.py
+++ b/hoomd/md/pair/aniso.py
@@ -145,7 +145,7 @@ class Dipole(AnisotropicPair):
         if attr == "mode":
             warnings.warn(
                 "'mode' key is deprectated and will be removed in hoomd 4.0.",
-                DeprecationWarning)
+                FutureWarning)
         super()._setattr_param(attr, value)
 
 
@@ -588,5 +588,5 @@ class ALJ(AnisotropicPair):
         if attr == "mode":
             warnings.warn(
                 "'mode' key is deprectated and will be removed in hoomd 4.0.",
-                DeprecationWarning)
+                FutureWarning)
         super()._setattr_param(attr, value)

--- a/hoomd/md/pair/aniso.py
+++ b/hoomd/md/pair/aniso.py
@@ -19,6 +19,8 @@ energies and virials in the same manner as `hoomd.md.pair.Pair`
 parameter.
 """
 
+import warnings
+
 from collections.abc import Sequence
 import json
 from numbers import Number
@@ -138,6 +140,13 @@ class Dipole(AnisotropicPair):
         mu = TypeParameter('mu', 'particle_types',
                            TypeParameterDict((float, float, float), len_keys=1))
         self._extend_typeparam((params, mu))
+
+    def _setattr_param(self, attr, value):
+        if attr == "mode":
+            warnings.warn(
+                "'mode' key is deprectated and will be removed in hoomd 4.0.",
+                DeprecationWarning)
+        super()._setattr_param(attr, value)
 
 
 class GayBerne(AnisotropicPair):
@@ -574,3 +583,10 @@ class ALJ(AnisotropicPair):
         log shape for visualization and storage through the GSD file type.
         """
         return self._return_type_shapes()
+
+    def _setattr_param(self, attr, value):
+        if attr == "mode":
+            warnings.warn(
+                "'mode' key is deprectated and will be removed in hoomd 4.0.",
+                DeprecationWarning)
+        super()._setattr_param(attr, value)

--- a/sphinx-doc/deprecated.rst
+++ b/sphinx-doc/deprecated.rst
@@ -6,6 +6,11 @@ Deprecated
 
 Features deprecated in v3.x may be removed in a future v4.0.0 release.
 
+HOOMD may issue `FutureWarning` messages to provide warnings for breaking changes in the next major
+release. Use Python's warnings module to silence warnings which may not be correctable until the
+next major release. Use this filter: ``ignore::FutureWarning:hoomd``. See Python's `warnings`
+documentation for more information on warning filters.
+
 .. note::
 
     Where noted, suggested replacements will be first available with v4.0.0 and there  will be no

--- a/sphinx-doc/migrating.rst
+++ b/sphinx-doc/migrating.rst
@@ -3,6 +3,7 @@
 
 Note about Warnings
 ===================
+
 HOOMD developers may use ``FutureWarnings`` to provide warnings for breaking changes in the next
 major release. For users who wish to silence these warnings which may not be correctable until the
 next major release use Python's warnings module. Specifically, this filter will work,

--- a/sphinx-doc/migrating.rst
+++ b/sphinx-doc/migrating.rst
@@ -1,17 +1,6 @@
 .. Copyright (c) 2009-2023 The Regents of the University of Michigan.
 .. Part of HOOMD-blue, released under the BSD 3-Clause License.
 
-Note about Warnings
-===================
-
-HOOMD developers may use ``FutureWarnings`` to provide warnings for breaking changes in the next
-major release. For users who wish to silence these warnings which may not be correctable until the
-next major release use Python's warnings module. Specifically, this filter will work,
-``ignore::FutureWarning:hoomd``. See Python's `warnings`_ documentation for more information on
-warning filters.
-
-.. _warnings: https://docs.python.org/3/library/warnings.html#describing-warning-filters
-
 Migrating to HOOMD v3
 =====================
 

--- a/sphinx-doc/migrating.rst
+++ b/sphinx-doc/migrating.rst
@@ -1,6 +1,16 @@
 .. Copyright (c) 2009-2023 The Regents of the University of Michigan.
 .. Part of HOOMD-blue, released under the BSD 3-Clause License.
 
+Note about Warnings
+===================
+HOOMD developers may use ``FutureWarnings`` to provide warnings for breaking changes in the next
+major release. For users who wish to silence these warnings which may not be correctable until the
+next major release use Python's warnings module. Specifically, this filter will work,
+``ignore::FutureWarning:hoomd``. See Python's `warnings`_ documentation for more information on
+warning filters.
+
+.. _warnings: https://docs.python.org/3/library/warnings.html#describing-warning-filters
+
 Migrating to HOOMD v3
 =====================
 


### PR DESCRIPTION
## Description
So `gh` removes all data when moving to the browser... This adds deprecation warnings.
<!-- Describe your changes in detail. -->

## Motivation and context
Will warn those who test hoomd code.

## How has this been tested?
No need beyond existing tests.

## Change log
NA

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
