### PR TITLE
Expand Force documentation.

### DIFF
--- a/hoomd/md/force.py
+++ b/hoomd/md/force.py
@@ -59,6 +59,13 @@ class Force(Compute):
         W^{kl}_i = \sum_j F^k_{ij} \cdot
         \mathrm{minimum\_image}(\vec{r}_j - \vec{r}_i)^l
 
+    Tip:
+        Add a `Force` to your integrator's `forces <hoomd.md.Integrator.forces>`
+        list to include it in the equations of motion of your system. Add a
+        `Force` to your simulation's `operations.computes
+        <hoomd.Operations.computes>` list to compute the forces and energy
+        without influencing the system dynamics.
+
     Warning:
         This class should not be instantiated by users. The class can be used
         for `isinstance` or `issubclass` checks.

--- a/sphinx-doc/module-md-force.rst
+++ b/sphinx-doc/module-md-force.rst
@@ -24,6 +24,7 @@ md.force
 
     .. autoclass:: Force
         :members:
+        :show-inheritance:
 
     .. autoclass:: Active
         :show-inheritance:


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should be based on *trunk-patch*. -->
<!-- Backwards compatible new features should be based on *trunk-minor*. -->
<!-- Incompatible API changes should be based on *trunk-major*. -->

## Description

<!-- Describe your changes in detail. -->
Document how to compute forces without applying them to the equations of motion.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
This has been possible since v3.6.0 (#1413), but was not documented outside the change log.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
I rendered and viewed the `Force` documentation locally. Reviewers can click the readthedocs link in the *checks* section below.

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
* Document that `hoomd.md.force.Force` can be added to `Operations.computes`.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
