### PR TITLE
Clarify migration guide documentation.

### DIFF
--- a/sphinx-doc/migrating.rst
+++ b/sphinx-doc/migrating.rst
@@ -12,47 +12,53 @@ Breaking changes to existing functionalities
 
 For some functionalities, you will need to update your scripts to use a new API:
 
-.. list-table::
-   :header-rows: 1
+* ``hoomd.md.dihedral.Harmonic``
 
-   * - v3 Feature
-     - Replace with
-   * - ``hoomd.md.dihedral.Harmonic``
-     - `hoomd.md.dihedral.Periodic` - new name.
-   * - ``charges`` key in `Rigid.body <hoomd.md.constrain.Rigid.body>`
-     - Pass charges to `Rigid.create_bodies <hoomd.md.constrain.Rigid.create_bodies>` or set in
-       system state.
-   * - ``diameters`` key in `Rigid.body <hoomd.md.constrain.Rigid.body>`
-     - Set diameters in system state.
-   * - ``hoomd.md.methods.NVE``
-     - `hoomd.md.methods.ConstantVolume` with ``thermostat=None``.
-   * - ``hoomd.md.methods.NVT``
-     - `hoomd.md.methods.ConstantVolume` with a `hoomd.md.methods.thermostats.MTTK` thermostat.
-   * - ``hoomd.md.methods.Berendsen``
-     - `hoomd.md.methods.ConstantVolume` with a `hoomd.md.methods.thermostats.Berendsen` thermostat.
-   * - ``hoomd.md.methods.NPH``
-     - `hoomd.md.methods.ConstantPressure` with ``thermostat=None``.
-   * - ``hoomd.md.methods.NPT``
-     - `hoomd.md.methods.ConstantPressure` with a `hoomd.md.methods.thermostats.MTTK` thermostat.
-   * - ``hoomd.write.GSD.log``
-     - `hoomd.write.GSD.logger`
+  * Use `hoomd.md.dihedral.Periodic`.
+
+* ``charges`` key in `Rigid.body <hoomd.md.constrain.Rigid.body>`.
+
+  * Pass charges to `Rigid.create_bodies <hoomd.md.constrain.Rigid.create_bodies>` or set in
+    the system state.
+
+* ``diameters`` key in `Rigid.body <hoomd.md.constrain.Rigid.body>`.
+
+  * Set diameters in system state.
+
+* ``hoomd.md.methods.NVE``.
+
+  * Use `hoomd.md.methods.ConstantVolume` with ``thermostat=None``.
+
+* ``hoomd.md.methods.NVT``.
+
+  * Use `hoomd.md.methods.ConstantVolume` with a `hoomd.md.methods.thermostats.MTTK` thermostat.
+
+* ``hoomd.md.methods.Berendsen``.
+
+  * Use `hoomd.md.methods.ConstantVolume` with a `hoomd.md.methods.thermostats.Berendsen`
+    thermostat.
+
+* ``hoomd.md.methods.NPH``.
+
+  * Use `hoomd.md.methods.ConstantPressure` with ``thermostat=None``.
+
+* ``hoomd.md.methods.NPT``.
+
+  * Use `hoomd.md.methods.ConstantPressure` with a `hoomd.md.methods.thermostats.MTTK` thermostat.
+
+* ``hoomd.write.GSD.log``.
+
+  * Use `hoomd.write.GSD.logger`.
+
 
 Removed functionalities
 ^^^^^^^^^^^^^^^^^^^^^^^
 
 HOOMD-blue v4 removes functionalities deprecated in v3.x releases:
 
-.. list-table::
-   :header-rows: 1
-
-   * - v3 Feature
-     - Replace with
-   * - ``hoomd.md.pair.aniso.ALJ.mode`` parameter
-     - n/a: ``mode`` has no effect since v3.0.0.
-   * - ``hoomd.md.pair.aniso.Dipole.mode`` parameter
-     - n/a: ``mode`` has no effect since v3.0.0.
-   * - ``hoomd.device.GPU.memory_traceback`` parameter
-     - n/a: ``memory_traceback`` has no effect since v3.0.0.
+* ``hoomd.md.pair.aniso.ALJ.mode`` parameter
+* ``hoomd.md.pair.aniso.Dipole.mode`` parameter
+* ``hoomd.device.GPU.memory_traceback`` parameter
 
 Compiling
 ^^^^^^^^^


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should be based on *trunk-patch*. -->
<!-- Backwards compatible new features should be based on *trunk-minor*. -->
<!-- Incompatible API changes should be based on *trunk-major*. -->

## Description

<!-- Describe your changes in detail. -->
Reformat the migration guide as a list.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
A recent change in sphinx-rtd-theme stopped wrapping content in table entries. The resulting table of deprecated features required scrolling to read in the narrow main content column.

I chose to reformat only the v4 migration guide.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
I rendered and viewed the documentation locally. Reviewers can click the readthedocs link in the checks section below

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
* Reformat v4 migration guide.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
