### PR TITLE
Extended alchemical calculations

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
     name: Build release tarball
     runs-on: ubuntu-latest
     container:
-      image: glotzerlab/ci:2022.12-ubuntu20.04
+      image: glotzerlab/ci:2023.02-ubuntu20.04
 
     steps:
       - name: Checkout

--- a/.github/workflows/templates/workflow.yml
+++ b/.github/workflows/templates/workflow.yml
@@ -1,5 +1,5 @@
 <% block name %><% endblock %>
-<% set container_prefix="glotzerlab/ci:2022.12" %>
+<% set container_prefix="glotzerlab/ci:2023.02" %>
 
 <% block concurrency %>
 concurrency:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,7 +59,7 @@ jobs:
     name: Build [${{ join(matrix.config, '_') }}]
     runs-on: ${{ matrix.build_runner }}
     container:
-      image: glotzerlab/ci:2022.12-${{ matrix.config[0] }}
+      image: glotzerlab/ci:2023.02-${{ matrix.config[0] }}
     strategy:
       matrix:
         include:
@@ -170,7 +170,7 @@ jobs:
     needs: build
     runs-on: ${{ matrix.test_runner }}
     container:
-      image: glotzerlab/ci:2022.12-${{ matrix.config[0] }}
+      image: glotzerlab/ci:2023.02-${{ matrix.config[0] }}
       options: ${{ matrix.test_docker_options }} -e CUDA_VISIBLE_DEVICES
     strategy:
       matrix:
@@ -228,7 +228,7 @@ jobs:
     needs: build
     runs-on: ${{ matrix.test_runner }}
     container:
-      image: glotzerlab/ci:2022.12-${{ matrix.config[0] }}
+      image: glotzerlab/ci:2023.02-${{ matrix.config[0] }}
       options: ${{ matrix.test_docker_options }} -e CUDA_VISIBLE_DEVICES
     strategy:
       matrix:
@@ -279,7 +279,7 @@ jobs:
     needs: build
     runs-on: ${{ matrix.test_runner }}
     container:
-      image: glotzerlab/ci:2022.12-${{ matrix.config[0] }}
+      image: glotzerlab/ci:2023.02-${{ matrix.config[0] }}
       options: ${{ matrix.test_docker_options }} -e CUDA_VISIBLE_DEVICES
     strategy:
       matrix:
@@ -321,7 +321,7 @@ jobs:
     name: Build [${{ join(matrix.config, '_') }}]
     runs-on: ${{ matrix.build_runner }}
     container:
-      image: glotzerlab/ci:2022.12-${{ matrix.config[0] }}
+      image: glotzerlab/ci:2023.02-${{ matrix.config[0] }}
     strategy:
       matrix:
         include:
@@ -437,7 +437,7 @@ jobs:
     needs: build_release
     runs-on: ${{ matrix.test_runner }}
     container:
-      image: glotzerlab/ci:2022.12-${{ matrix.config[0] }}
+      image: glotzerlab/ci:2023.02-${{ matrix.config[0] }}
       options: ${{ matrix.test_docker_options }} -e CUDA_VISIBLE_DEVICES
     strategy:
       matrix:
@@ -504,7 +504,7 @@ jobs:
     needs: build_release
     runs-on: ${{ matrix.test_runner }}
     container:
-      image: glotzerlab/ci:2022.12-${{ matrix.config[0] }}
+      image: glotzerlab/ci:2023.02-${{ matrix.config[0] }}
       options: ${{ matrix.test_docker_options }} -e CUDA_VISIBLE_DEVICES
     strategy:
       matrix:

--- a/BUILDING.rst
+++ b/BUILDING.rst
@@ -115,7 +115,7 @@ Install prerequisites
 
 .. note::
 
-    When ``ENABLE_GPU=on``, HOOMD-blue will default to CUDA. Set ``HHOOMD_GPU_PLATFORM=HIP`` to
+    When ``ENABLE_GPU=on``, HOOMD-blue will default to CUDA. Set ``HOOMD_GPU_PLATFORM=HIP`` to
     choose HIP.
 
 **For threaded parallelism on the CPU** (required when ``ENABLE_TBB=on``):

--- a/hoomd/Autotuner.h
+++ b/hoomd/Autotuner.h
@@ -51,6 +51,8 @@ class PYBIND11_EXPORT AutotunerBase
     public:
     AutotunerBase(const std::string& name) : m_name(name) { }
 
+    virtual ~AutotunerBase() { }
+
     /// Call to start the autotuning sequence.
     virtual void startScan() { }
 

--- a/hoomd/ExecutionConfiguration.cc
+++ b/hoomd/ExecutionConfiguration.cc
@@ -412,9 +412,10 @@ void ExecutionConfiguration::scanGPUs()
             continue;
             }
 
+#ifdef __HIP_PLATFORM_NVCC__
         // exclude a GPU if it's compute version is not high enough
         int compoundComputeVer = prop.minor + prop.major * 10;
-#ifdef __HIP_PLATFORM_NVCC__
+
         if (compoundComputeVer < CUDA_ARCH)
             {
             ostringstream s;

--- a/hoomd/ManagedArray.h
+++ b/hoomd/ManagedArray.h
@@ -30,7 +30,7 @@ template<class T> class ManagedArray
     {
     public:
     //! Default constructor
-    DEVICE ManagedArray()
+    HOSTDEVICE ManagedArray()
         : data(nullptr), ptr(nullptr), N(0), managed(0), align(0), allocation_ptr(nullptr),
           allocation_bytes(0)
         {
@@ -48,7 +48,7 @@ template<class T> class ManagedArray
         }
 #endif
 
-    DEVICE ~ManagedArray()
+    HOSTDEVICE ~ManagedArray()
         {
 #ifndef __HIPCC__
         deallocate();
@@ -60,7 +60,7 @@ template<class T> class ManagedArray
        the host. If the GPU isn't synced up, this can lead to errors, so proper multi-GPU
        synchronization needs to be ensured
      */
-    DEVICE ManagedArray(const ManagedArray<T>& other)
+    HOSTDEVICE ManagedArray(const ManagedArray<T>& other)
         : data(nullptr), ptr(nullptr), N(other.N), managed(other.managed), align(other.align),
           allocation_ptr(nullptr), allocation_bytes(0)
         {
@@ -82,7 +82,7 @@ template<class T> class ManagedArray
        the host. If the GPU isn't synced up, this can lead to errors, so proper multi-GPU
        synchronization needs to be ensured
      */
-    DEVICE ManagedArray(const ManagedArray<T>&& other)
+    HOSTDEVICE ManagedArray(const ManagedArray<T>&& other)
         : data(nullptr), ptr(nullptr), N(other.N), managed(other.managed), align(other.align),
           allocation_ptr(nullptr), allocation_bytes(0)
         {
@@ -104,7 +104,7 @@ template<class T> class ManagedArray
        available on the host. If the GPU isn't synced up, this can lead to errors, so proper
        multi-GPU synchronization needs to be ensured
      */
-    DEVICE ManagedArray& operator=(const ManagedArray<T>& other)
+    HOSTDEVICE ManagedArray& operator=(const ManagedArray<T>& other)
         {
 #ifndef __HIPCC__
         deallocate();
@@ -134,7 +134,7 @@ template<class T> class ManagedArray
        available on the host. If the GPU isn't synced up, this can lead to errors, so proper
        multi-GPU synchronization needs to be ensured
      */
-    DEVICE ManagedArray& operator=(const ManagedArray<T>&& other)
+    HOSTDEVICE ManagedArray& operator=(const ManagedArray<T>&& other)
         {
 #ifndef __HIPCC__
         deallocate();
@@ -236,7 +236,7 @@ template<class T> class ManagedArray
 
         \returns true if array was loaded into shared memory
      */
-    DEVICE bool load_shared(char*& s_ptr, unsigned int& available_bytes)
+    HOSTDEVICE bool load_shared(char*& s_ptr, unsigned int& available_bytes)
         {
         // align ptr to size of data type
         void* ptr_align = allocate_shared(s_ptr, available_bytes);

--- a/hoomd/RandomNumbers.h
+++ b/hoomd/RandomNumbers.h
@@ -18,6 +18,7 @@
 #ifndef __CUDACC_RTC__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wconversion"
+#pragma GCC diagnostic ignored "-Wdangling-else"
 #endif
 
 #include <hoomd/extern/random123/include/Random123/philox.h>

--- a/hoomd/hpmc/CMakeLists.txt
+++ b/hoomd/hpmc/CMakeLists.txt
@@ -137,6 +137,7 @@ endif(ENABLE_HIP)
 
 if (ENABLE_HIP)
 set(_cuda_sources ${_hpmc_cu_sources})
+set_source_files_properties(${_hpmc_cu_sources} PROPERTIES LANGUAGE ${HOOMD_DEVICE_LANGUAGE})
 endif (ENABLE_HIP)
 
 pybind11_add_module(_hpmc SHARED ${_hpmc_sources} ${_cuda_sources} ${_hpmc_headers} NO_EXTRAS)

--- a/hoomd/hpmc/GPUTree.h
+++ b/hoomd/hpmc/GPUTree.h
@@ -39,7 +39,7 @@ class GPUTree
     {
     public:
     //! Empty constructor
-    DEVICE GPUTree() : m_num_nodes(0), m_num_leaves(0), m_leaf_capacity(0) { }
+    HOSTDEVICE GPUTree() : m_num_nodes(0), m_num_leaves(0), m_leaf_capacity(0) { }
 
 #ifndef __HIPCC__
     //! Constructor

--- a/hoomd/hpmc/XenoSweep3D.h
+++ b/hoomd/hpmc/XenoSweep3D.h
@@ -16,9 +16,7 @@
     \brief Implements XenoCollide in 3D
 */
 
-// need to declare these class methods with __device__ qualifiers when building in nvcc
-// DEVICE is __device__ when included in nvcc and blank when included into the host compiler
-#ifdef NVCC
+#ifdef __HIPCC__
 #define DEVICE __device__
 #else
 #define DEVICE

--- a/hoomd/hpmc/test/CMakeLists.txt
+++ b/hoomd/hpmc/test/CMakeLists.txt
@@ -20,6 +20,7 @@ foreach (CUR_TEST ${TEST_LIST})
     # add and link the unit test executable
     if(ENABLE_HIP AND EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${CUR_TEST}.cu)
         set(_cuda_sources ${CUR_TEST}.cu)
+        set_source_files_properties(${_cuda_sources} PROPERTIES LANGUAGE ${HOOMD_DEVICE_LANGUAGE})
     else()
         set(_cuda_sources "")
     endif()

--- a/hoomd/md/ForceCompositeGPU.cc
+++ b/hoomd/md/ForceCompositeGPU.cc
@@ -425,10 +425,11 @@ void ForceCompositeGPU::findRigidCenters()
 
     m_rigid_center.resize(m_pdata->getN() + m_pdata->getNGhosts());
 
-    size_t old_size = m_lookup_center.getNumElements();
     m_lookup_center.resize(m_pdata->getN() + m_pdata->getNGhosts());
 
 #ifdef __HIP_PLATFORM_NVCC__
+    size_t old_size = m_lookup_center.getNumElements();
+
     if (m_exec_conf->allConcurrentManagedAccess() && m_lookup_center.getNumElements() != old_size)
         {
         // set memory hints

--- a/hoomd/md/ForceDistanceConstraintGPU.cu
+++ b/hoomd/md/ForceDistanceConstraintGPU.cu
@@ -347,7 +347,6 @@ hipError_t gpu_count_nnz(unsigned int n_constraint,
                  &nnz);
     return hipSuccess;
     }
-#endif
 
 #ifndef CUSPARSE_NEW_API
 hipError_t gpu_dense2sparse(unsigned int n_constraint,
@@ -375,6 +374,7 @@ hipError_t gpu_dense2sparse(unsigned int n_constraint,
 
     return hipSuccess;
     }
+#endif
 #endif
 
 hipError_t gpu_compute_constraint_forces(const Scalar4* d_pos,

--- a/hoomd/md/PotentialPair.h
+++ b/hoomd/md/PotentialPair.h
@@ -1079,7 +1079,7 @@ template<class evaluator>
 void PotentialPair<evaluator>::setTypeOverridePython(std::string type)
 {
     if(type == "")
-        m_type_override == UINT32_MAX;
+        m_type_override = UINT32_MAX;
     else
     {
         auto typ = m_pdata->getTypeByName(type);

--- a/hoomd/md/PotentialPair.h
+++ b/hoomd/md/PotentialPair.h
@@ -755,6 +755,11 @@ template<class evaluator> void PotentialPair<evaluator>::computeForces(uint64_t 
 
             if (evaluated)
                 {
+                // the usual decomposition in hoomd is 1/2 per particle, so if we're computing the change in energy
+                // for a single change, its twice of that.
+                if(m_type_override != UINT32_MAX)
+                    pair_eng *= Scalar(2.0);
+
                 // modify the potential for xplor shifting
                 if (m_shift_mode == xplor)
                     {

--- a/hoomd/md/PotentialPairGPU.cuh
+++ b/hoomd/md/PotentialPairGPU.cuh
@@ -340,6 +340,11 @@ gpu_compute_pair_forces_shared_kernel(Scalar4* d_force,
 
                 eval.evalForceAndEnergy(force_divr, pair_eng, energy_shift);
 
+                // the usual decomposition in hoomd is 1/2 per particle, so if we're computing the change in energy
+                // for a single change, its twice of that.
+                if(type_override != UINT32_MAX)
+                    pair_eng *= Scalar(2.0);
+
                 if (shift_mode == 2)
                     {
                     if (rsq >= ronsq && rsq < rcutsq)

--- a/hoomd/md/PotentialPairGPU.h
+++ b/hoomd/md/PotentialPairGPU.h
@@ -160,6 +160,7 @@ template<class evaluator> void PotentialPairGPU<evaluator>::computeForces(uint64
                             this->m_shift_mode,
                             flags[pdata_flag::pressure_tensor],
                             threads_per_particle,
+                            this->m_type_override,
                             this->m_pdata->getGPUPartition(),
                             this->m_exec_conf->dev_prop),
         this->m_params.data());

--- a/hoomd/md/alchemy/FEP.py
+++ b/hoomd/md/alchemy/FEP.py
@@ -1,0 +1,22 @@
+import hoomd
+from hoomd.md import _md
+from hoomd.operation import Compute
+from hoomd.logging import log
+
+class FEPPair(Compute):
+    pass
+
+    @log(category="particle", requires_run=True)
+    def energies(self):
+        """(*N_particles*, ) `numpy.ndarray` of ``float``: Energy \
+        contribution :math:`U_i` from each particle :math:`[\\mathrm{energy}]`.
+
+        Attention:
+            In MPI parallel execution, the array is available on rank 0 only.
+            `energies` is `None` on ranks >= 1.
+        """
+        self._cpp_obj.compute(self._simulation.timestep)
+        return self._cpp_obj.getEnergies()
+
+def LJ(FEPPair):
+    pass

--- a/hoomd/test/CMakeLists.txt
+++ b/hoomd/test/CMakeLists.txt
@@ -48,6 +48,7 @@ foreach (CUR_TEST ${TEST_LIST} ${MPI_TEST_LIST})
     # add and link the unit test executable
     if(ENABLE_HIP AND EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${CUR_TEST}.cu)
         set(_cuda_sources ${CUR_TEST}.cu)
+        set_source_files_properties(${_cuda_sources} PROPERTIES LANGUAGE ${HOOMD_DEVICE_LANGUAGE})
     else()
         set(_cuda_sources "")
     endif()


### PR DESCRIPTION
## Description

Introduces a type override in PotentialPair classes to directly compute energy changes related to per-particle type changes. This is in essence a free energy perturbation method, which can be used to compute free energies of different transformations in the system. 

This is currently implemented by passing an extra int to kernels, which determines whether the pair (i,j) or (override, j) is used for computation. Performance-wise, this is not optimal: the forces computed / virial are meaningless. Alternatives are: one more kernel template parameter, or boiler-plate kernel with superfluous values non-computed. 

Python implementation detail: The FEP python type (unfinished) currently doesn't inherit from `Force` to avoid being added as a force to the simulation. Two other options: leaving the user free to add the FEP to the force list, or preventing the object from being casted as a Force, while inheriting from Force (I'm not so familiar with the python type casting used). 

## Motivation and context

This type of calculation is required to sample a semi-grand canonical ensemble as Metropolis weights are identical to FEP values. 

Required for #1445

Further implementation for bonded FF is not required as their parameters can already directly be handled. 

## How has this been tested?
Exactness of FEP can be tested by computing free energy difference of LJ liquids at two different state points. 

## Change log

```
Added free energy perturbation methods in hoomd.md.alchemy.FEP
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
