### PR TITLE
Deprecate abbreviated names.

### DIFF
--- a/hoomd/device.py
+++ b/hoomd/device.py
@@ -216,7 +216,8 @@ def _get_message_filename(msg_file, message_file):
 
     if msg_file is not None:
         warnings.warn(
-            f"msg_file is deprecated since v3.10.0. Use message_filename.", FutureWarning)
+            "msg_file is deprecated since v3.10.0. Use message_filename.",
+            FutureWarning)
         return msg_file
 
 
@@ -286,7 +287,8 @@ class GPU(Device):
                  notice_level=2,
                  message_filename=None):
 
-        super().__init__(communicator, notice_level, _get_message_filename(msg_file, message_filename))
+        super().__init__(communicator, notice_level,
+                         _get_message_filename(msg_file, message_filename))
 
         if gpu_ids is None:
             gpu_ids = []
@@ -424,7 +426,8 @@ class CPU(Device):
                  notice_level=2,
                  message_filename=None):
 
-        super().__init__(communicator, notice_level, _get_message_filename(msg_file, message_filename))
+        super().__init__(communicator, notice_level,
+                         _get_message_filename(msg_file, message_filename))
 
         self._cpp_exec_conf = _hoomd.ExecutionConfiguration(
             _hoomd.ExecutionConfiguration.executionMode.CPU, [],
@@ -434,7 +437,10 @@ class CPU(Device):
             self.num_cpu_threads = num_cpu_threads
 
 
-def auto_select(communicator=None, msg_file=None, notice_level=2, message_filename=None):
+def auto_select(communicator=None,
+                msg_file=None,
+                notice_level=2,
+                message_filename=None):
     """Automatically select the hardware device.
 
     Args:
@@ -458,6 +464,10 @@ def auto_select(communicator=None, msg_file=None, notice_level=2, message_filena
     """
     # Set class according to C++ object
     if len(GPU.get_available_devices()) > 0:
-        return GPU(None, None, communicator, _get_message_filename(msg_file, message_filename), notice_level)
+        return GPU(None, None, communicator,
+                   _get_message_filename(msg_file, message_filename),
+                   notice_level)
     else:
-        return CPU(None, communicator, _get_message_filename(msg_file, message_filename), notice_level)
+        return CPU(None, communicator,
+                   _get_message_filename(msg_file, message_filename),
+                   notice_level)

--- a/hoomd/device.py
+++ b/hoomd/device.py
@@ -31,9 +31,9 @@ class Device:
     """Base class device object.
 
     Provides methods and properties common to `CPU` and `GPU`, including those
-    that control where status messages are stored (`msg_file`) how many status
-    messages HOOMD-blue prints (`notice_level`) and a method for user provided
-    status messages (`notice`).
+    that control where status messages are stored (`message_filename`) how many
+    status messages HOOMD-blue prints (`notice_level`) and a method for user
+    provided status messages (`notice`).
 
     Warning:
         `Device` cannot be used directly. Instantate a `CPU` or `GPU` object.
@@ -50,7 +50,7 @@ class Device:
         information.
     """
 
-    def __init__(self, communicator, notice_level, msg_file):
+    def __init__(self, communicator, notice_level, message_filename):
         # MPI communicator
         if communicator is None:
             self._comm = hoomd.communicator.Communicator()
@@ -59,13 +59,13 @@ class Device:
 
         # c++ messenger object
         self._cpp_msg = _create_messenger(self.communicator.cpp_mpi_conf,
-                                          notice_level, msg_file)
+                                          notice_level, message_filename)
 
         # c++ execution configuration mirror class
         self._cpp_exec_conf = None
 
         # name of the message file
-        self._msg_file = msg_file
+        self._message_filename = message_filename
 
     @property
     def communicator(self):
@@ -88,16 +88,18 @@ class Device:
         self._cpp_msg.setNoticeLevel(notice_level)
 
     @property
-    def msg_file(self):
+    def message_filename(self):
         """str: Filename to write messages to.
 
         By default, HOOMD prints all messages and errors to Python's
         `sys.stdout` and `sys.stderr` (or the system's ``stdout`` and ``stderr``
         when running in an MPI environment).
 
-        Set `msg_file` to a filename to redirect these messages to that file.
+        Set `message_filename` to a filename to redirect these messages to that
+        file.
 
-        Set `msg_file` to `None` to use the system's ``stdout`` and ``stderr``.
+        Set `message_filename` to `None` to use the system's ``stdout`` and
+        ``stderr``.
 
         Note:
             All MPI ranks within a given partition must open the same file.
@@ -111,17 +113,36 @@ class Device:
                     ranks_per_partition=2)
                 filename = f'messages.{communicator.partition}'
                 device = hoomd.device.GPU(communicator=communicator,
-                                          msg_file=filename)
+                                          message_filename=filename)
         """
-        return self._msg_file
+        return self._message_filename
 
-    @msg_file.setter
-    def msg_file(self, fname):
-        self._msg_file = fname
-        if fname is not None:
-            self._cpp_msg.openFile(fname)
+    @property
+    def msg_file(self):
+        """str: Filename to write messages to.
+
+        .. deprecated:: v3.10.0
+           ``msg_file`` will be renamed to ``message_Filename`` in v4.
+        """
+        warnings.warn(
+            "msg_file is deprecated since v3.10.0. Use message_filename.",
+            FutureWarning)
+        return self.message_filename
+
+    @message_filename.setter
+    def message_filename(self, filename):
+        self._message_filename = filename
+        if filename is not None:
+            self._cpp_msg.openFile(filename)
         else:
             self._cpp_msg.openStd()
+
+    @msg_file.setter
+    def msg_file(self, filename):
+        warnings.warn(
+            "msg_file is deprecated since v3.10.0. Use message_filename.",
+            FutureWarning)
+        self.message_filename = filename
 
     @property
     def devices(self):
@@ -152,19 +173,19 @@ class Device:
             message (str): Message to write.
             level (int): Message notice level.
 
-        Write the given message string to the output defined by `msg_file`
-        on MPI rank 0 when `notice_level` >= ``level``.
+        Write the given message string to the output defined by
+        `message_filename` on MPI rank 0 when `notice_level` >= ``level``.
 
         Hint:
             Use `notice` instead of `print` to write status messages and your
             scripts will work well in parallel MPI jobs. `notice` writes message
-            only on rank 0. Use with a rank-specific `msg_file` to troubleshoot
-            issues with specific partitions.
+            only on rank 0. Use with a rank-specific `message_filename` to
+            troubleshoot issues with specific partitions.
         """
         self._cpp_msg.notice(level, str(message) + "\n")
 
 
-def _create_messenger(mpi_config, notice_level, msg_file):
+def _create_messenger(mpi_config, notice_level, message_filename):
     msg = _hoomd.Messenger(mpi_config)
 
     # try to detect if we're running inside an MPI job
@@ -177,10 +198,26 @@ def _create_messenger(mpi_config, notice_level, msg_file):
     if notice_level is not None:
         msg.setNoticeLevel(notice_level)
 
-    if msg_file is not None:
-        msg.openFile(msg_file)
+    if message_filename is not None:
+        msg.openFile(message_filename)
 
     return msg
+
+
+def _get_message_filename(msg_file, message_file):
+    if msg_file is None and message_file is None:
+        return None
+
+    if msg_file is not None and message_file is not None:
+        raise ValueError("Pass in msg_file or message_file, not both")
+
+    if message_file is not None:
+        return message_file
+
+    if msg_file is not None:
+        warnings.warn(
+            f"msg_file is deprecated since v3.10.0. Use message_filename.", FutureWarning)
+        return msg_file
 
 
 class GPU(Device):
@@ -196,11 +233,16 @@ class GPU(Device):
         communicator (hoomd.communicator.Communicator): MPI communicator object.
             When `None`, create a default communicator that uses all MPI ranks.
 
-        msg_file (str): Filename to write messages to. When `None`, use
-            `sys.stdout` and `sys.stderr`. Messages from multiple MPI
-            ranks are collected into this file.
+        msg_file (str): Alias for ``message_filename``.
+
+            .. deprecated:: v3.10.0
+               ``msg_file`` will be renamed to ``message_filename`` in v4.
 
         notice_level (int): Minimum level of messages to print.
+
+        message_filename (str): Filename to write messages to. When `None`, use
+            `sys.stdout` and `sys.stderr`. Messages from multiple MPI
+            ranks are collected into this file.
 
     Tip:
         Call `GPU.get_available_devices` to get a human readable list of
@@ -241,9 +283,10 @@ class GPU(Device):
                  num_cpu_threads=None,
                  communicator=None,
                  msg_file=None,
-                 notice_level=2):
+                 notice_level=2,
+                 message_filename=None):
 
-        super().__init__(communicator, notice_level, msg_file)
+        super().__init__(communicator, notice_level, _get_message_filename(msg_file, message_filename))
 
         if gpu_ids is None:
             gpu_ids = []
@@ -358,11 +401,16 @@ class CPU(Device):
         communicator (hoomd.communicator.Communicator): MPI communicator object.
             When `None`, create a default communicator that uses all MPI ranks.
 
-        msg_file (str): Filename to write messages to. When `None` use
-            `sys.stdout` and `sys.stderr`. Messages from multiple MPI
-            ranks are collected into this file.
+        msg_file (str): Alias for ``message_filename``.
+
+            .. deprecated:: v3.10.0
+               ``msg_file`` will be renamed to ``message_filename`` in v4.
 
         notice_level (int): Minimum level of messages to print.
+
+        message_filename (str): Filename to write messages to. When `None`, use
+            `sys.stdout` and `sys.stderr`. Messages from multiple MPI
+            ranks are collected into this file.
 
     .. rubric:: MPI
 
@@ -373,9 +421,10 @@ class CPU(Device):
                  num_cpu_threads=None,
                  communicator=None,
                  msg_file=None,
-                 notice_level=2):
+                 notice_level=2,
+                 message_filename=None):
 
-        super().__init__(communicator, notice_level, msg_file)
+        super().__init__(communicator, notice_level, _get_message_filename(msg_file, message_filename))
 
         self._cpp_exec_conf = _hoomd.ExecutionConfiguration(
             _hoomd.ExecutionConfiguration.executionMode.CPU, [],
@@ -385,7 +434,7 @@ class CPU(Device):
             self.num_cpu_threads = num_cpu_threads
 
 
-def auto_select(communicator=None, msg_file=None, notice_level=2):
+def auto_select(communicator=None, msg_file=None, notice_level=2, message_filename=None):
     """Automatically select the hardware device.
 
     Args:
@@ -393,17 +442,22 @@ def auto_select(communicator=None, msg_file=None, notice_level=2):
         communicator (hoomd.communicator.Communicator): MPI communicator object.
             When `None`, create a default communicator that uses all MPI ranks.
 
-        msg_file (str): Filename to write messages to. When `None` use
-            `sys.stdout` and `sys.stderr`. Messages from multiple MPI
-            ranks are collected into this file.
+        msg_file (str): Alias for ``message_filename``.
+
+            .. deprecated:: v3.10.0
+               ``msg_file`` will be renamed to ``message_filename`` in v4.
 
         notice_level (int): Minimum level of messages to print.
+
+        message_filename (str): Filename to write messages to. When `None`, use
+            `sys.stdout` and `sys.stderr`. Messages from multiple MPI
+            ranks are collected into this file.
 
     Returns:
         Instance of `GPU` if availabile, otherwise `CPU`.
     """
     # Set class according to C++ object
     if len(GPU.get_available_devices()) > 0:
-        return GPU(None, None, communicator, msg_file, notice_level)
+        return GPU(None, None, communicator, _get_message_filename(msg_file, message_filename), notice_level)
     else:
-        return CPU(None, communicator, msg_file, notice_level)
+        return CPU(None, communicator, _get_message_filename(msg_file, message_filename), notice_level)

--- a/hoomd/md/pair/__init__.py
+++ b/hoomd/md/pair/__init__.py
@@ -133,7 +133,7 @@ For anisotropic potentials see `hoomd.md.pair.aniso`
 """
 
 from . import aniso
-from .pair import (Pair, LJ, Gauss, ExpandedLJ, Yukawa, Ewald, Morse, DPD,
-                   DPDConservative, DPDLJ, ForceShiftedLJ, Moliere, ZBL, Mie,
-                   ExpandedMie, ReactionField, DLVO, Buckingham, LJ1208, LJ0804,
-                   Fourier, OPP, Table, TWF, LJGauss)
+from .pair import (Pair, LJ, Gauss, Gaussian, ExpandedLJ, Yukawa, Ewald, Morse,
+                   DPD, DPDConservative, DPDLJ, ForceShiftedLJ, Moliere, ZBL,
+                   Mie, ExpandedMie, ReactionField, DLVO, Buckingham, LJ1208,
+                   LJ0804, Fourier, OPP, Table, TWF, LJGauss)

--- a/hoomd/md/pair/pair.py
+++ b/hoomd/md/pair/pair.py
@@ -227,7 +227,7 @@ class LJ(Pair):
             ParameterDict(tail_correction=bool(tail_correction)))
 
 
-class Gauss(Pair):
+class Gaussian(Pair):
     r"""Gaussian pair force.
 
     Args:
@@ -246,7 +246,7 @@ class Gauss(Pair):
     Example::
 
         nl = nlist.Cell()
-        gauss = pair.Gauss(default_r_cut=3.0, nlist=nl)
+        gauss = pair.Gaussian(default_r_cut=3.0, nlist=nl)
         gauss.params[('A', 'A')] = dict(epsilon=1.0, sigma=1.0)
         gauss.r_cut[('A', 'B')] = 3.0
 
@@ -277,6 +277,20 @@ class Gauss(Pair):
             'params', 'particle_types',
             TypeParameterDict(epsilon=float, sigma=float, len_keys=2))
         self._add_typeparam(params)
+
+
+class Gauss(Gaussian):
+    """Gaussian pair force.
+
+    .. deprecated:: v3.10.0
+        Use `Gaussian`.
+    """
+
+    def __init__(self, nlist, default_r_cut=None, default_r_on=0., mode='none'):
+        warnings.warn(
+            "Gauss is deprecated and will be removed in hoomd 4.0. Use "
+            "Gaussian instead.", FutureWarning)
+        super().__init__(nlist, default_r_cut, default_r_on, mode)
 
 
 class ExpandedLJ(Pair):

--- a/sphinx-doc/deprecated.rst
+++ b/sphinx-doc/deprecated.rst
@@ -72,3 +72,11 @@ v3.x
 * ``log`` attribute and constructor parameter in `hoomd.write.GSD`.
 
   * Use ``logger``.
+
+* ``hoomd.md.pair.Gauss`` (since v3.10.0)
+
+    * Use `hoomd.md.pair.Gaussian`.
+
+* ``msg_file`` property and argument to ``Device`` and subclasses (since v3.10.0)
+
+    * Use `message_filename <hoomd.device.Device.message_filename>`.

--- a/sphinx-doc/module-md-pair.rst
+++ b/sphinx-doc/module-md-pair.rst
@@ -22,6 +22,7 @@ md.pair
     ForceShiftedLJ
     Fourier
     Gauss
+    Gaussian
     LJ
     LJ1208
     LJ0804
@@ -52,6 +53,7 @@ md.pair
         ForceShiftedLJ,
         Fourier,
         Gauss,
+        Gaussian,
         LJ,
         LJ1208,
         LJ0804,


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should be based on *trunk-patch*. -->
<!-- Backwards compatible new features should be based on *trunk-minor*. -->
<!-- Incompatible API changes should be based on *trunk-major*. -->

## Description

<!-- Describe your changes in detail. -->
* Deprecate `msg_file` and replace with `message_filename`.
* Deprecate `Gauss` and replace with `Gaussian`.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Use unabbreviated names so that more people will understand them. The public facing HOOMD-blue API should use abbreviations only when they are present *universally* in the field (e.g. LJ for Lennard-Jones).

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
I built the documentation locally and examined the changes.

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
Added:

* The ``message_filename`` property and argument to ``Device``, ``CPU``, and ``GPU`` to replace ``msg_file``.
* ``hoomd.md.pair.Gaussian`` to replace ``hoomd.md.pair.Gauss``.
 
Deprecated:

* The ``msg_file`` property and argument to ``Device``, ``CPU``, and ``GPU``.
* ``hoomd.md.pair.Gauss``.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
