### PR TITLE
Remove more deprecated names.

### DIFF
--- a/hoomd/md/external/wall.py
+++ b/hoomd/md/external/wall.py
@@ -282,20 +282,20 @@ class LJ(WallPotential):
         self._add_typeparam(params)
 
 
-class Gauss(WallPotential):
+class Gaussian(WallPotential):
     r"""Gaussian wall force.
 
     Args:
         walls (`list` [`hoomd.wall.WallGeometry` ]): A list of wall definitions
             to use for the force.
 
-    Wall force evaluated using the Gaussian force.  See `hoomd.md.pair.Gauss`
+    Wall force evaluated using the Gaussian force.  See `hoomd.md.pair.Gaussian`
     for the functional form of the force and parameter definitions.
 
     Example::
 
         walls = [hoomd.wall.Sphere(radius=4.0)]
-        gaussian_wall = hoomd.md.external.wall.Gauss(walls=walls)
+        gaussian_wall = hoomd.md.external.wall.Gaussian(walls=walls)
         gaussian_wall.params['A'] = {"epsilon": 1.0, "sigma": 1.0, "r_cut": 2.5}
         gaussian_wall.params[['A','B']] = {
             "epsilon": 2.0, "sigma": 1.0, "r_cut": 1.0}

--- a/hoomd/md/pair/__init__.py
+++ b/hoomd/md/pair/__init__.py
@@ -133,7 +133,7 @@ For anisotropic potentials see `hoomd.md.pair.aniso`
 """
 
 from . import aniso
-from .pair import (Pair, LJ, Gauss, Gaussian, ExpandedLJ, Yukawa, Ewald, Morse,
-                   DPD, DPDConservative, DPDLJ, ForceShiftedLJ, Moliere, ZBL,
-                   Mie, ExpandedMie, ReactionField, DLVO, Buckingham, LJ1208,
-                   LJ0804, Fourier, OPP, Table, TWF, LJGauss)
+from .pair import (Pair, LJ, Gaussian, ExpandedLJ, Yukawa, Ewald, Morse, DPD,
+                   DPDConservative, DPDLJ, ForceShiftedLJ, Moliere, ZBL, Mie,
+                   ExpandedMie, ReactionField, DLVO, Buckingham, LJ1208, LJ0804,
+                   Fourier, OPP, Table, TWF, LJGauss)

--- a/hoomd/md/pair/pair.py
+++ b/hoomd/md/pair/pair.py
@@ -236,7 +236,7 @@ class Gaussian(Pair):
         default_r_on (float): Default turn-on radius :math:`[\mathrm{length}]`.
         mode (str): Energy shifting/smoothing mode.
 
-    `Gauss` computes the Gaussian pair force should on every particle in the
+    `Gaussian` computes the Gaussian pair force should on every particle in the
     simulation state:
 
     .. math::
@@ -277,20 +277,6 @@ class Gaussian(Pair):
             'params', 'particle_types',
             TypeParameterDict(epsilon=float, sigma=float, len_keys=2))
         self._add_typeparam(params)
-
-
-class Gauss(Gaussian):
-    """Gaussian pair force.
-
-    .. deprecated:: v3.10.0
-        Use `Gaussian`.
-    """
-
-    def __init__(self, nlist, default_r_cut=None, default_r_on=0., mode='none'):
-        warnings.warn(
-            "Gauss is deprecated and will be removed in hoomd 4.0. Use "
-            "Gaussian instead.", FutureWarning)
-        super().__init__(nlist, default_r_cut, default_r_on, mode)
 
 
 class ExpandedLJ(Pair):

--- a/hoomd/md/pytest/forces_and_energies.json
+++ b/hoomd/md/pytest/forces_and_energies.json
@@ -64,7 +64,7 @@
       ]
     ]
   },
-  "Gauss": {
+  "Gaussian": {
     "params": [
       {
         "sigma": 0.5,

--- a/hoomd/md/pytest/test_half_step_hook.py
+++ b/hoomd/md/pytest/test_half_step_hook.py
@@ -42,7 +42,7 @@ def make_simulation(simulation_factory, two_particle_snapshot_factory):
 def integrator_elements():
     nlist = md.nlist.Cell(buffer=0.4)
     lj = md.pair.LJ(nlist=nlist, default_r_cut=2.5)
-    gauss = md.pair.Gauss(nlist, default_r_cut=3.0)
+    gauss = md.pair.Gaussian(nlist, default_r_cut=3.0)
     lj.params[("A", "A")] = {"epsilon": 1.0, "sigma": 1.0}
     gauss.params[("A", "A")] = {"epsilon": 1.0, "sigma": 1.0}
     return {

--- a/hoomd/md/pytest/test_integrate.py
+++ b/hoomd/md/pytest/test_integrate.py
@@ -27,7 +27,7 @@ def make_simulation(simulation_factory, two_particle_snapshot_factory):
 def integrator_elements():
     nlist = md.nlist.Cell(buffer=0.4)
     lj = md.pair.LJ(nlist=nlist, default_r_cut=2.5)
-    gauss = md.pair.Gauss(nlist, default_r_cut=3.0)
+    gauss = md.pair.Gaussian(nlist, default_r_cut=3.0)
     lj.params[("A", "A")] = {"epsilon": 1.0, "sigma": 1.0}
     gauss.params[("A", "A")] = {"epsilon": 1.0, "sigma": 1.0}
     return {

--- a/hoomd/md/pytest/test_potential.py
+++ b/hoomd/md/pytest/test_potential.py
@@ -183,7 +183,7 @@ def _invalid_params():
     gauss_valid_dict = {'sigma': 0.05, 'epsilon': 0.05}
     gauss_invalid_dicts = _make_invalid_param_dict(gauss_valid_dict)
     invalid_params_list.extend(
-        _make_invalid_params(gauss_invalid_dicts, md.pair.Gauss, {}))
+        _make_invalid_params(gauss_invalid_dicts, md.pair.Gaussian, {}))
 
     yukawa_valid_dict = {"epsilon": 0.0005, "kappa": 1}
     yukawa_invalid_dicts = _make_invalid_param_dict(yukawa_valid_dict)
@@ -396,7 +396,7 @@ def _valid_params(particle_types=['A', 'B']):
     gauss_arg_dict = {'epsilon': [0.025, 0.05, 0.075], 'sigma': [0.5, 1.0, 1.5]}
     gauss_valid_param_dicts = _make_valid_param_dicts(gauss_arg_dict)
     valid_params_list.append(
-        paramtuple(md.pair.Gauss, dict(zip(combos, gauss_valid_param_dicts)),
+        paramtuple(md.pair.Gaussian, dict(zip(combos, gauss_valid_param_dicts)),
                    {}))
 
     yukawa_arg_dict = {
@@ -1167,11 +1167,12 @@ def test_lrc_non_lj(simulation_factory, two_particle_snapshot_factory):
     # test we can't pass in tail_correction to non-LJ pair potential
     cell = md.nlist.Cell(buffer=0.4)
     with pytest.raises(TypeError):
-        # flake8 complains about unused variable with gauss = md.pair.Gauss(...)
-        md.pair.Gauss(nlist=cell,
-                      default_r_cut=2.5,
-                      mode='none',
-                      tail_correction=True)
+        # flake8 complains about unused variable with
+        # gauss = md.pair.Gaussian(...)
+        md.pair.Gaussian(nlist=cell,
+                         default_r_cut=2.5,
+                         mode='none',
+                         tail_correction=True)
 
 
 def test_tail_corrections(simulation_factory, two_particle_snapshot_factory):

--- a/hoomd/md/pytest/test_wall_potential.py
+++ b/hoomd/md/pytest/test_wall_potential.py
@@ -63,7 +63,7 @@ class WallGenerator:
 
 _potential_cls = (
     md.external.wall.LJ,
-    md.external.wall.Gauss,
+    md.external.wall.Gaussian,
     md.external.wall.Yukawa,
     md.external.wall.Morse,
     md.external.wall.ForceShiftedLJ,

--- a/hoomd/pytest/test_custom_writer.py
+++ b/hoomd/pytest/test_custom_writer.py
@@ -49,7 +49,7 @@ class TestCustomWriter:
         action = WriteTimestep()
         action.flags = [hoomd.custom.Action.Flags.PRESSURE_TENSOR]
         sim.operations += hoomd.write.CustomWriter(2, action)
-        gauss = hoomd.md.pair.Gauss(hoomd.md.nlist.Cell(0.5))
+        gauss = hoomd.md.pair.Gaussian(hoomd.md.nlist.Cell(0.5))
         gauss.params[("A", "A")] = {"sigma": 1.0, "epsilon": 1.0}
         gauss.r_cut[("A", "A")] = 2.0
         sim.operations += hoomd.md.Integrator(

--- a/hoomd/pytest/test_device.py
+++ b/hoomd/pytest/test_device.py
@@ -16,11 +16,11 @@ def test_gpu_profile(device):
 
 def _assert_common_properties(dev,
                               notice_level,
-                              msg_file,
+                              message_filename,
                               num_cpu_threads=None):
     """Assert the properties common to all devices are correct."""
     assert dev.notice_level == notice_level
-    assert dev.msg_file == msg_file
+    assert dev.message_filename == message_filename
     if num_cpu_threads is not None:
         if hoomd.version.tbb_enabled:
             assert dev.num_cpu_threads == num_cpu_threads
@@ -36,18 +36,18 @@ def test_common_properties(device, tmp_path):
 
     # make sure we can set those properties
     device.notice_level = 3
-    device.msg_file = str(tmp_path / "example.txt")
+    device.message_filename = str(tmp_path / "example.txt")
     device.num_cpu_threads = 5
     _assert_common_properties(device, 3, str(tmp_path / "example.txt"), 5)
 
     # now make a device with non-default arguments
     device_type = type(device)
-    dev = device_type(msg_file=str(tmp_path / "example2.txt"),
+    dev = device_type(message_filename=str(tmp_path / "example2.txt"),
                       notice_level=10,
                       num_cpu_threads=10)
     _assert_common_properties(dev,
                               notice_level=10,
-                              msg_file=str(tmp_path / "example2.txt"),
+                              message_filename=str(tmp_path / "example2.txt"),
                               num_cpu_threads=10)
 
 
@@ -106,28 +106,28 @@ def test_cpu_build_specifics():
 def test_device_notice(device, tmp_path):
     # Message file declared. Should output in specified file.
     device.notice_level = 4
-    device.msg_file = str(tmp_path / "str_message")
+    device.message_filename = str(tmp_path / "str_message")
     msg = "This message should output."
     device.notice(msg)
 
     if device.communicator.rank == 0:
-        with open(device.msg_file) as fh:
+        with open(device.message_filename) as fh:
             assert fh.read() == msg + "\n"
 
     # Test notice with a message that is not a string.
-    device.msg_file = str(tmp_path / "int_message")
+    device.message_filename = str(tmp_path / "int_message")
     msg = 123456
     device.notice(msg)
 
     if device.communicator.rank == 0:
-        with open(device.msg_file) as fh:
+        with open(device.message_filename) as fh:
             assert fh.read() == str(msg) + "\n"
 
     # Test the level argument.
-    device.msg_file = str(tmp_path / "empty_notice")
+    device.message_filename = str(tmp_path / "empty_notice")
     msg = "This message should not output."
     device.notice(msg, level=5)
 
     if device.communicator.rank == 0:
-        with open(device.msg_file) as fh:
+        with open(device.message_filename) as fh:
             assert fh.read() == ""

--- a/sphinx-doc/migrating.rst
+++ b/sphinx-doc/migrating.rst
@@ -50,6 +50,17 @@ For some functionalities, you will need to update your scripts to use a new API:
 
   * Use `hoomd.write.GSD.logger`.
 
+* ``hoomd.md.pair.Gauss``.
+
+  * Use `hoomd.md.pair.Gaussian`.
+
+* ``hoomd.md.external.wall.Gauss``.
+
+  * Use `hoomd.md.external.wall.Gaussian`.
+
+* ``msg_file`` property and argument in `hoomd.device.Device`.
+
+  * Use `message_filename <hoomd.device.Device.message_filename>`.
 
 Removed functionalities
 ^^^^^^^^^^^^^^^^^^^^^^^

--- a/sphinx-doc/module-md-external-wall.rst
+++ b/sphinx-doc/module-md-external-wall.rst
@@ -12,7 +12,7 @@ md.external.wall
     :nosignatures:
 
     ForceShiftedLJ
-    Gauss
+    Gaussian
     LJ
     Mie
     Morse
@@ -24,7 +24,7 @@ md.external.wall
 .. automodule:: hoomd.md.external.wall
     :synopsis: MD wall potentials.
     :members: ForceShiftedLJ,
-        Gauss,
+        Gaussian,
         LJ,
         Mie,
         Morse,

--- a/sphinx-doc/module-md-pair.rst
+++ b/sphinx-doc/module-md-pair.rst
@@ -21,7 +21,6 @@ md.pair
     ExpandedMie
     ForceShiftedLJ
     Fourier
-    Gauss
     Gaussian
     LJ
     LJ1208
@@ -52,7 +51,6 @@ md.pair
         ExpandedMie,
         ForceShiftedLJ,
         Fourier,
-        Gauss,
         Gaussian,
         LJ,
         LJ1208,


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should be based on *trunk-patch*. -->
<!-- Backwards compatible new features should be based on *trunk-minor*. -->
<!-- Incompatible API changes should be based on *trunk-major*. -->

## Description

<!-- Describe your changes in detail. -->
Remove `msg_file` and `Gauss`.

In #1497, I failed to notice that `md.external.wall.Gauss`. I doubt there are many users, so I will remove in v4 without a deprecation cycle in v3.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
See #1497.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
I checked a local documentation build and did not see the removed quantities.

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
Added:

* ``hoomd.md.external.wall.Gaussian``

Removed:

* ``hoomd.md.pair.Gauss``
* ``hoomd.md.external.wall.Gauss``
* ``msg_file`` property and argument in ``hoomd.device.Device``.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
