### PR TITLE
File object notice stream

### DIFF
--- a/hoomd/pytest/test_table.py
+++ b/hoomd/pytest/test_table.py
@@ -58,8 +58,12 @@ def get_output_from_table_writer(writer_function, output):
 
 
 def write_table_lines(table_writer):
-    for i in range(10):
-        table_writer.write()
+
+    def _write_table_lines():
+        for i in range(10):
+            table_writer.write()
+
+    return _write_table_lines
 
 
 def get_stdout(writer_function, output):
@@ -113,21 +117,13 @@ def test_invalid_attrs(logger):
 def test_header_generation(device, logger, get_table_writer, get_output_str):
 
     table_writer, output = get_table_writer(device, logger)
-    output_str = get_output_str(lambda: write_table_lines(table_writer), output)
+    output_str = get_output_str(write_table_lines(table_writer), output)
     lines = output_str.split('\n')
     headers = lines[0].split()
     expected_headers = [
         'dummy.loggable.int', 'dummy.loggable.float', 'dummy.loggable.string'
     ]
     assert all(hdr in headers for hdr in expected_headers)
-    """
-    for i in range(1, 10):
-        values = lines[i].split()
-        assert not any(v in expected_headers for v in values)
-    table_writer.logger[('new', 'quantity')] = (lambda: 53, 'scalar')
-    table_writer.write()
-    output_str = output.getvalue()
-    """
     for i in range(1, 10):
         values = lines[i].split()
         assert not any(v in expected_headers for v in values)

--- a/hoomd/write/table.py
+++ b/hoomd/write/table.py
@@ -406,9 +406,9 @@ class Table(_InternalCustomWriter):
         logger (hoomd.logging.Logger): The logger to query for output. The
             'scalar' categories must be set on the logger, and the 'string'
             categories is optional.
-        output (``file-like`` object): A file-like object to output
-            the data from. The object must have ``write`` and ``flush`` methods
-            and a ``mode`` attribute.
+        output (``file-like`` object or str): Either a file-like object to
+            output the data from or the string 'notice'. The object must have
+            ``write`` and ``flush`` methods and a ``mode`` attribute.
         header_sep (str): String to use to separate names in
             the logger's namespace.'. For example, if logging the total energy
             of an `hoomd.md.pair.LJ` pair force object, the default header would

--- a/sphinx-doc/credits.rst
+++ b/sphinx-doc/credits.rst
@@ -51,6 +51,7 @@ The following people have contributed to the to HOOMD-blue:
 * Greg van Anders, University of Michigan
 * Grey Garrett, University of Michigan
 * Ian Graham, University of Pennsylvania
+* Ignacio Blanco Varela, University of Michigan
 * Igor Morozov, Joint Institute for High Temperatures of RAS
 * Isaac Bruss, University of Michigan
 * Jakin B. Delony, University of South Florida


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should be based on *trunk-patch*. -->
<!-- Backwards compatible new features should be based on *trunk-minor*. -->
<!-- Incompatible API changes should be based on *trunk-major*. -->

## Description

<!-- Describe your changes in detail. -->
Provide a Python file-like object that writes to the HOOMD notice message stream
## Motivation and context
This will allow user to write Table output to the same output file as notice.
<!--- Why is this change required? What problem does it solve? -->
It allows the user with more flexibility to write on Table output
<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves #1449 

## How has this been tested?
We implemented the appropriate tests in ``test_table.py`` 
<!--- Please describe in detail how you tested your changes. -->
We parameterized the relevant tests to also test the new implementation of notice. 
<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
-Added the functionality, tests and documentation needed to recognize device from the string 'notice'
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
