### PR TITLE
Fix and test pair energy shift

### DIFF
--- a/hoomd/md/EvaluatorPairExpandedLJ.h
+++ b/hoomd/md/EvaluatorPairExpandedLJ.h
@@ -163,11 +163,9 @@ class EvaluatorPairExpandedLJ
         // precompute some quantities
         Scalar rinv = fast::rsqrt(rsq);
         Scalar r = Scalar(1.0) / rinv;
-        Scalar rcutinv = fast::rsqrt(rcutsq);
-        Scalar rcut = Scalar(1.0) / rcutinv;
 
         // compute the force divided by r in force_divr
-        if (r < rcut && lj1 != 0)
+        if (rsq < rcutsq && lj1 != 0)
             {
             Scalar rmd = r - delta;
             Scalar rmdinv = Scalar(1.0) / rmd;
@@ -180,8 +178,12 @@ class EvaluatorPairExpandedLJ
 
             if (energy_shift)
                 {
-                Scalar rcut2inv = rcutinv * rcutinv;
-                Scalar rcut6inv = rcut2inv * rcut2inv * rcut2inv;
+                Scalar rcut = fast::sqrt(rcutsq);
+                Scalar r_cut_shifted = rcut - delta;
+                Scalar r_cut_shifted_inv = Scalar(1.0) / r_cut_shifted;
+
+                Scalar r_cut2inv = r_cut_shifted_inv * r_cut_shifted_inv;
+                Scalar rcut6inv = r_cut2inv * r_cut2inv * r_cut2inv;
                 pair_eng -= rcut6inv * (lj1 * rcut6inv - lj2);
                 }
             return true;

--- a/hoomd/md/EvaluatorPairExpandedLJ.h
+++ b/hoomd/md/EvaluatorPairExpandedLJ.h
@@ -178,13 +178,13 @@ class EvaluatorPairExpandedLJ
 
             if (energy_shift)
                 {
-                Scalar rcut = fast::sqrt(rcutsq);
-                Scalar r_cut_shifted = rcut - delta;
+                Scalar r_cut = fast::sqrt(rcutsq);
+                Scalar r_cut_shifted = r_cut - delta;
                 Scalar r_cut_shifted_inv = Scalar(1.0) / r_cut_shifted;
 
-                Scalar r_cut2inv = r_cut_shifted_inv * r_cut_shifted_inv;
-                Scalar rcut6inv = r_cut2inv * r_cut2inv * r_cut2inv;
-                pair_eng -= rcut6inv * (lj1 * rcut6inv - lj2);
+                Scalar r_cut2_inv = r_cut_shifted_inv * r_cut_shifted_inv;
+                Scalar r_cut6_inv = r_cut2_inv * r_cut2_inv * r_cut2_inv;
+                pair_eng -= r_cut6_inv * (lj1 * r_cut6_inv - lj2);
                 }
             return true;
             }

--- a/hoomd/md/EvaluatorPairExpandedMie.h
+++ b/hoomd/md/EvaluatorPairExpandedMie.h
@@ -171,8 +171,8 @@ class EvaluatorPairExpandedMie
     DEVICE bool evalForceAndEnergy(Scalar& force_divr, Scalar& pair_eng, bool energy_shift) const
         {
         // precompute some quantities
-        const Scalar r = fast::sqrt(rsq);
-        const Scalar rinv = fast::rsqrt(rsq);
+        Scalar rinv = fast::rsqrt(rsq);
+        Scalar r = Scalar(1.0) / rinv;
 
         // compute the force divided by r in force_divr
         if (rsq < rcutsq && repulsive != 0)
@@ -189,8 +189,11 @@ class EvaluatorPairExpandedMie
 
             if (energy_shift)
                 {
-                Scalar rcutninv = fast::pow(rcutsq, -n_pow / Scalar(2.0));
-                Scalar rcutminv = fast::pow(rcutsq, -m_pow / Scalar(2.0));
+                Scalar rcut = fast::sqrt(rcutsq);
+                Scalar r_cut_shifted = rcut - delta;
+
+                Scalar rcutninv = fast::pow(r_cut_shifted, -n_pow);
+                Scalar rcutminv = fast::pow(r_cut_shifted, -m_pow);
                 pair_eng -= repulsive * rcutninv - attractive * rcutminv;
                 }
             return true;

--- a/hoomd/md/EvaluatorPairExpandedMie.h
+++ b/hoomd/md/EvaluatorPairExpandedMie.h
@@ -189,12 +189,12 @@ class EvaluatorPairExpandedMie
 
             if (energy_shift)
                 {
-                Scalar rcut = fast::sqrt(rcutsq);
-                Scalar r_cut_shifted = rcut - delta;
+                Scalar r_cut = fast::sqrt(rcutsq);
+                Scalar r_cut_shifted = r_cut - delta;
 
-                Scalar rcutninv = fast::pow(r_cut_shifted, -n_pow);
-                Scalar rcutminv = fast::pow(r_cut_shifted, -m_pow);
-                pair_eng -= repulsive * rcutninv - attractive * rcutminv;
+                Scalar r_cut_n_inv = fast::pow(r_cut_shifted, -n_pow);
+                Scalar r_cut_m_inv = fast::pow(r_cut_shifted, -m_pow);
+                pair_eng -= repulsive * r_cut_n_inv - attractive * r_cut_m_inv;
                 }
             return true;
             }

--- a/hoomd/md/EvaluatorPairLJGauss.h
+++ b/hoomd/md/EvaluatorPairLJGauss.h
@@ -140,6 +140,7 @@ class EvaluatorPairLJGauss
             {
             return false;
             }
+
         Scalar r = fast::sqrt(rsq);
         Scalar sigma2 = sigma * sigma;
         Scalar rdiff = r - r0;
@@ -156,9 +157,11 @@ class EvaluatorPairLJGauss
             {
             Scalar rcut2inv = Scalar(1.0) / rcutsq;
             Scalar rcut6inv = rcut2inv * rcut2inv * rcut2inv;
+            Scalar r_cut_minus_r0 = fast::sqrt(rcutsq) - r0;
+
             pair_eng
                 -= rcut6inv * (rcut6inv - Scalar(2.0))
-                   - (epsilon * fast::exp(-Scalar(1.0) / Scalar(2.0) * (rcutsq - r0) / sigma2));
+                   - (epsilon * fast::exp(-Scalar(0.5) * r_cut_minus_r0 * r_cut_minus_r0 / sigma2));
             }
 
         return true;

--- a/hoomd/md/EvaluatorPairTWF.h
+++ b/hoomd/md/EvaluatorPairTWF.h
@@ -220,7 +220,7 @@ class EvaluatorPairTWF
 
             if (energy_shift)
                 {
-                Scalar common_term_shift = 1.0 / (sigma2 / rcutsq - 1.0);
+                Scalar common_term_shift = 1.0 / (rcutsq / sigma2 - 1.0);
                 Scalar common_term3_shift
                     = common_term_shift * common_term_shift * common_term_shift;
                 Scalar common_term6_shift = common_term3_shift * common_term3_shift;

--- a/hoomd/md/pair/__init__.py
+++ b/hoomd/md/pair/__init__.py
@@ -53,7 +53,7 @@ potential :math:`U(r)` (by the `Pair` subclass)  and the mode (`Pair.mode`):
 .. math::
     U_\mathrm{pair}(r) =
     \begin{cases}
-    U_(r) & \mathrm{mode\ is\ no\_shift} \\
+    U_(r) & \mathrm{mode\ is\ \mathrm{none}} \\
     U(r) - U(r_{\mathrm{cut}}) & \mathrm{mode\ is\ shift} \\
     S(r) \cdot U_(r) & \mathrm{mode\ is\ xplor}
     \land r_{\mathrm{on}} < r_{\mathrm{cut}} \\

--- a/hoomd/md/pair/pair.py
+++ b/hoomd/md/pair/pair.py
@@ -1601,11 +1601,12 @@ class Fourier(Pair):
 
     .. py:attribute:: mode
 
-        Energy shifting/smoothing mode: ``"none"``, ``"shift"``, or ``"xplor"``.
+        Energy shifting/smoothing mode: ``"none"`` or ``"xplor"``.
 
         Type: `str`
     """
     _cpp_class_name = "PotentialPairFourier"
+    _accepted_modes = ("none", "xplor")
 
     def __init__(self, nlist, default_r_cut=None, default_r_on=0., mode='none'):
         super().__init__(nlist, default_r_cut, default_r_on, mode)

--- a/hoomd/md/pair/pair.py
+++ b/hoomd/md/pair/pair.py
@@ -1708,8 +1708,8 @@ class TWF(Pair):
 
     .. math::
         U(r) = \frac{4 \epsilon}{\alpha^2} {\left[
-        {\left(\frac{\sigma^2}{r^2} - 1 \right)}^6 -
-        \alpha {\left(\frac{\sigma^2}{r^2} - 1 \right)}^3\right]}
+        {\left(\frac{\sigma^2}{r^2} - 1 \right)}^{-6} -
+        \alpha {\left(\frac{\sigma^2}{r^2} - 1 \right)}^{-3}\right]}
 
     The potential was introdcued in `Pieter Rein ten Wolde and Daan Frenkel
     1997`_.

--- a/hoomd/md/pytest/test_potential.py
+++ b/hoomd/md/pytest/test_potential.py
@@ -743,6 +743,14 @@ def test_run(simulation_factory, lattice_snapshot_factory, valid_params):
     autotuned_kernel_parameter_check(instance=pot, activate=lambda: sim.run(1))
 
 
+def set_distance(simulation, distance):
+    snap = simulation.state.get_snapshot()
+    if snap.communicator.rank == 0:
+        snap.particles.position[0] = [0, 0, .1]
+        snap.particles.position[1] = [0, 0, distance + .1]
+    simulation.state.set_snapshot(snap)
+
+
 def test_energy_shifting(simulation_factory, two_particle_snapshot_factory):
     # A subtle bug existed where we used "shifted" instead of "shift" in Python
     # and in C++ we used else if clauses with no error raised if the set Python
@@ -756,13 +764,6 @@ def test_energy_shifting(simulation_factory, two_particle_snapshot_factory):
         numerator = ((r_cut**2 - r**2)**2) * (r_cut**2 + 2 * r**2 - 3 * r_on**2)
         denominator = (r_cut**2 - r_on**2)**3
         return numerator / denominator
-
-    def set_distance(simulation, distance):
-        snap = sim.state.get_snapshot()
-        if snap.communicator.rank == 0:
-            snap.particles.position[0] = [0, 0, .1]
-            snap.particles.position[1] = [0, 0, distance + .1]
-        sim.state.set_snapshot(snap)
 
     def get_energy(simulation):
         energies = sim.operations.integrator.forces[0].energies
@@ -1312,3 +1313,40 @@ def test_forces_multiple_lists(simulation_factory,
     sim.operations.computes.clear()
     assert not lj._attached
     assert lj._use_count == 0
+
+
+@pytest.mark.parametrize("forces_and_energies",
+                         _forces_and_energies(),
+                         ids=lambda x: x.pair_potential.__name__)
+def test_shift(simulation_factory,
+               two_particle_snapshot_factory,
+               forces_and_energies):
+    if 'shift' not in forces_and_energies.pair_potential._accepted_modes:
+        pytest.skip("Potential does not support the shift mode.")
+
+    r_cut = 2.0
+
+    potential = forces_and_energies.pair_potential(**forces_and_energies.extra_args,
+                                             nlist=md.nlist.Cell(buffer=0.4),
+                                             default_r_cut=r_cut)
+    potential.params[('A', 'A')] = forces_and_energies.pair_potential_params
+
+    potential_shifted = forces_and_energies.pair_potential(**forces_and_energies.extra_args,
+                                             nlist=md.nlist.Cell(buffer=0.4),
+                                             default_r_cut=r_cut)
+    potential_shifted.params[('A', 'A')] = forces_and_energies.pair_potential_params
+    potential_shifted.mode = 'shift'
+
+    snap = two_particle_snapshot_factory(particle_types=['A'], d=r_cut-1e-7)
+    _update_snap(forces_and_energies.pair_potential, snap)
+    sim = simulation_factory(snap)
+    sim.operations.computes.extend([potential, potential_shifted])
+    sim.run(0)
+
+    V = potential.energy
+    V_shifted = potential_shifted.energy
+
+    # Ideally, test that V_shifted = 0. In practice, forces_and_energies.json
+    # has a wide range of potential parameters, so check only that V_shifted
+    # is much closer to 0 than V.
+    assert V_shifted == pytest.approx(expected=0, abs=math.fabs(V / 1e4))

--- a/hoomd/md/pytest/test_potential.py
+++ b/hoomd/md/pytest/test_potential.py
@@ -1318,26 +1318,28 @@ def test_forces_multiple_lists(simulation_factory,
 @pytest.mark.parametrize("forces_and_energies",
                          _forces_and_energies(),
                          ids=lambda x: x.pair_potential.__name__)
-def test_shift(simulation_factory,
-               two_particle_snapshot_factory,
+def test_shift(simulation_factory, two_particle_snapshot_factory,
                forces_and_energies):
     if 'shift' not in forces_and_energies.pair_potential._accepted_modes:
         pytest.skip("Potential does not support the shift mode.")
 
     r_cut = 2.0
 
-    potential = forces_and_energies.pair_potential(**forces_and_energies.extra_args,
-                                             nlist=md.nlist.Cell(buffer=0.4),
-                                             default_r_cut=r_cut)
+    potential = forces_and_energies.pair_potential(
+        **forces_and_energies.extra_args,
+        nlist=md.nlist.Cell(buffer=0.4),
+        default_r_cut=r_cut)
     potential.params[('A', 'A')] = forces_and_energies.pair_potential_params
 
-    potential_shifted = forces_and_energies.pair_potential(**forces_and_energies.extra_args,
-                                             nlist=md.nlist.Cell(buffer=0.4),
-                                             default_r_cut=r_cut)
-    potential_shifted.params[('A', 'A')] = forces_and_energies.pair_potential_params
+    potential_shifted = forces_and_energies.pair_potential(
+        **forces_and_energies.extra_args,
+        nlist=md.nlist.Cell(buffer=0.4),
+        default_r_cut=r_cut)
+    potential_shifted.params[('A',
+                              'A')] = forces_and_energies.pair_potential_params
     potential_shifted.mode = 'shift'
 
-    snap = two_particle_snapshot_factory(particle_types=['A'], d=r_cut-1e-7)
+    snap = two_particle_snapshot_factory(particle_types=['A'], d=r_cut - 1e-7)
     _update_snap(forces_and_energies.pair_potential, snap)
     sim = simulation_factory(snap)
     sim.operations.computes.extend([potential, potential_shifted])

--- a/hoomd/md/pytest/test_potential.py
+++ b/hoomd/md/pytest/test_potential.py
@@ -1349,4 +1349,5 @@ def test_shift(simulation_factory,
     # Ideally, test that V_shifted = 0. In practice, forces_and_energies.json
     # has a wide range of potential parameters, so check only that V_shifted
     # is much closer to 0 than V.
-    assert V_shifted == pytest.approx(expected=0, abs=math.fabs(V / 1e4))
+    tolerance = max(math.fabs(V / 1e4), 1e-8)
+    assert V_shifted == pytest.approx(expected=0, abs=tolerance)


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should be based on *trunk-patch*. -->
<!-- Backwards compatible new features should be based on *trunk-minor*. -->
<!-- Incompatible API changes should be based on *trunk-major*. -->

## Description

<!-- Describe your changes in detail. -->
* Fix the energy shift calculations in `ExpandedLJ`, `ExpandedMie`, `LJGauss`, and `TWF`. Document that `Fourier` does not support the mode `"shift"`.
* Fix some inaccuracies in the pair force documentation.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
These potentials did not shift V(r_cut) to 0. 

<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves #1504 

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
I added a unit test checking that all pair potentials shift V(r_cut) to 0.

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
Fixed:

* The pair potentials `ExpandedLJ`, `ExpandedMie`, `LJGauss`, and `TWF` now shift `V(r_cut)` to 0.
* Corrected errors in the pair potential documentation.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
