### PR TITLE
Mention the body exclusion in constrain.Rigid docs.

### DIFF
--- a/hoomd/md/constrain.py
+++ b/hoomd/md/constrain.py
@@ -212,6 +212,13 @@ class Rigid(Constraint):
     constraint force (see `Glaser 2020
     <https://dx.doi.org/10.1016/j.commatsci.2019.109430>`_).
 
+    Note:
+        Include `'body'` in the `Neighborlist exclusions
+        <hoomd.md.nlist.NeighborList.exclusions>` to avoid calculating
+        inter-body forces that will sum to 0. This is *required* in many cases
+        where nearby particles lead to numerical errors from extremely large
+        forces.
+
     .. rubric:: Integrating bodies
 
     Set the ``rigid`` attribute of `hoomd.md.Integrator` to an instance of

--- a/hoomd/md/constrain.py
+++ b/hoomd/md/constrain.py
@@ -213,7 +213,7 @@ class Rigid(Constraint):
     <https://dx.doi.org/10.1016/j.commatsci.2019.109430>`_).
 
     Note:
-        Include `'body'` in the `Neighborlist exclusions
+        Include ``'body'`` in the `Neighborlist exclusions
         <hoomd.md.nlist.NeighborList.exclusions>` to avoid calculating
         inter-body forces that will sum to 0. This is *required* in many cases
         where nearby particles lead to numerical errors from extremely large


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should be based on *trunk-patch*. -->
<!-- Backwards compatible new features should be based on *trunk-minor*. -->
<!-- Incompatible API changes should be based on *trunk-major*. -->

## Description

<!-- Describe your changes in detail. -->
Note that the `'body'` exclusion should be set when using rigid bodies.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Setting the exclusion is important and it was not mentioned in the `constrain.Rigid` documentation. Note that it is covered in the tutorial, but some users may read only the reference documentation.

<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves #1465.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
I rendered the documentation locally.

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
Fixed:

* Note that the 'body' exclusion should be used with ``hoomd.md.constrain.Rigid``.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
