### PR TITLE
Added different error messages to table writer

### DIFF
--- a/hoomd/pytest/test_table.py
+++ b/hoomd/pytest/test_table.py
@@ -227,7 +227,6 @@ print(combinations)
     argvalues=combinations[1:],
 )
 def test_invalid_permutations(device, combination):
-    #print(combination[5:10])
     # Test every combination raises the correct ValueError
     logger = hoomd.logging.Logger(categories=combination)
     output = StringIO("")

--- a/hoomd/pytest/test_table.py
+++ b/hoomd/pytest/test_table.py
@@ -207,14 +207,16 @@ def test_pickling(simulation_factory, two_particle_snapshot_factory, logger):
     table = hoomd.write.Table(1, logger)
     operation_pickling_check(table, sim)
 
+
 def test_invalid_permutations(device):
-    _test_categories = str(hoomd.logging.LoggerCategories.ALL).split("|")[1:]
+    test_categories = str(hoomd.logging.LoggerCategories.ALL).split("|")[1:]
     # Generate a set for each invalid permutation of the input logger categories
     # Sets that don't fail are covered by test_only_string_and_scalar_quantities
     combinations = [
         set(combo)
-        for i in range(1, len(_test_categories) + 1)
-        for combo in itertools.combinations(_test_categories, i)
+        for i in range(1,
+                       len(test_categories) + 1)
+        for combo in itertools.combinations(test_categories, i)
         if set(combo) - {"string", "scalar"} != set()
     ]
     # Test every combination raises the correct ValueError
@@ -227,8 +229,7 @@ def test_invalid_permutations(device):
             # Check if correct error is being raised given no valid categories
             assert (
                 "Given Logger must have the scalar or string categories set."
-                in str(ve.value)
-            )
+                in str(ve.value))
         else:
             # Check if correct error is being raised
             assert "incompatible" in str(ve.value)
@@ -236,5 +237,3 @@ def test_invalid_permutations(device):
             for category in combo:
                 assert "category" in str(ve.value)
         # No further cases are possible, as valid configurations are pruned out
-
-

--- a/hoomd/pytest/test_table.py
+++ b/hoomd/pytest/test_table.py
@@ -4,6 +4,7 @@
 from io import StringIO
 from math import isclose
 import pytest
+import itertools
 
 from hoomd.conftest import operation_pickling_check
 import hoomd
@@ -205,3 +206,35 @@ def test_pickling(simulation_factory, two_particle_snapshot_factory, logger):
     sim = simulation_factory(two_particle_snapshot_factory())
     table = hoomd.write.Table(1, logger)
     operation_pickling_check(table, sim)
+
+def test_invalid_permutations(device):
+    _test_categories = str(hoomd.logging.LoggerCategories.ALL).split("|")[1:]
+    # Generate a set for each invalid permutation of the input logger categories
+    # Sets that don't fail are covered by test_only_string_and_scalar_quantities
+    combinations = [
+        set(combo)
+        for i in range(1, len(_test_categories) + 1)
+        for combo in itertools.combinations(_test_categories, i)
+        if set(combo) - {"string", "scalar"} != set()
+    ]
+    # Test every combination raises the correct ValueError
+    for combo in combinations:
+        logger = hoomd.logging.Logger(categories=combo)
+        output = StringIO("")
+        with pytest.raises(ValueError) as ve:
+            hoomd.write.Table(1, logger, output)
+        if "string" and "scalar" not in combo:
+            # Check if correct error is being raised given no valid categories
+            assert (
+                "Given Logger must have the scalar or string categories set."
+                in str(ve.value)
+            )
+        else:
+            # Check if correct error is being raised
+            assert "incompatible" in str(ve.value)
+            # Now ensure category formatting operates correctly
+            for category in combo:
+                assert "category" in str(ve.value)
+        # No further cases are possible, as valid configurations are pruned out
+
+

--- a/hoomd/pytest/test_table.py
+++ b/hoomd/pytest/test_table.py
@@ -229,18 +229,11 @@ def test_invalid_permutations(device, combination):
     # Test every combination raises the correct ValueError
     logger = hoomd.logging.Logger(categories=combination)
     output = StringIO("")
-    valid_inputs = {"string", "scalar"}
     with pytest.raises(ValueError) as ve:
         hoomd.write.Table(1, logger, output)
-    # Ensure that no correct category is set
-    if combination & valid_inputs == set():
-        # Check if correct error is being raised given no valid categories
-        assert ("Table Logger may only have scalar or string categories set."
-                in str(ve.value))
-    else:
-        # Check if correct error is being raised
-        assert "incompatible" in str(ve.value)
-        # Now ensure category formatting operates correctly
-        for category in combination - {"string", "scalar"}:
-            assert category in str(ve.value)
-    # No further cases are possible, as valid configurations are pruned out
+    # Ensure that correct error message is sent
+    assert "Table Logger may only have scalar or string categories set." in str(
+        ve.value)
+    # Now ensure category formatting operates correctly
+    for category in combination - {"string", "scalar"}:
+        assert category in str(ve.value)

--- a/hoomd/write/table.py
+++ b/hoomd/write/table.py
@@ -211,7 +211,6 @@ class _TableInternal(_InternalAction):
         _invalid_inputs = logger.categories & self._invalid_logger_categories
 
         # Ensure that only scalar and potentially string are set for the logger
-        # If logger.categories == none, pass automatically
         if logger.categories == LoggerCategories.NONE:
             pass
         elif LoggerCategories.any([

--- a/hoomd/write/table.py
+++ b/hoomd/write/table.py
@@ -208,13 +208,21 @@ class _TableInternal(_InternalAction):
 
         # internal variables that are not part of the state.
         # Ensure that only scalar and potentially string are set for the logger
-        if LoggerCategories.scalar & LoggerCategories.string not in logger.categories:
-            raise ValueError("Given Logger must have the scalar or string categories set.")
-        elif (
-            logger.categories & self._invalid_logger_categories != LoggerCategories.NONE
+        if (
+            LoggerCategories.scalar & LoggerCategories.string
+            not in logger.categories
         ):
-            # logger.categories != NONE passes if the logger is empty (no invalid categories)
-            # invalid_categories != NONE passes if the 
+            raise ValueError(
+                "Given Logger must have the scalar or string categories set."
+            )
+        elif (
+            logger.categories & self._invalid_logger_categories
+            != LoggerCategories.NONE
+        ):
+            # If logger.categories != NONE passes:
+            # -  Logger is empty (no invalid categories)
+            # If invalid_categories != NONE passes: 
+            # - No invalid categories are set
             raise ValueError(
                 "{} are incompatible with write.Table: use write.GSD instead.".format(
                     logger.categories & self._invalid_logger_categories

--- a/hoomd/write/table.py
+++ b/hoomd/write/table.py
@@ -205,29 +205,24 @@ class _TableInternal(_InternalAction):
                  output=output,
                  logger=logger))
         self._param_dict = param_dict
-
         # internal variables that are not part of the state.
+
+        # Generate list of current invalid categories
+        _invalid_inputs = logger.categories & self._invalid_logger_categories
+
         # Ensure that only scalar and potentially string are set for the logger
-        if (
-            LoggerCategories.scalar & LoggerCategories.string
-            not in logger.categories
-        ):
+        if (LoggerCategories.scalar & LoggerCategories.string
+                not in logger.categories):
             raise ValueError(
-                "Given Logger must have the scalar or string categories set."
-            )
-        elif (
-            logger.categories & self._invalid_logger_categories
-            != LoggerCategories.NONE
-        ):
+                "Given Logger must have the scalar or string categories set.")
+        elif _invalid_inputs != LoggerCategories.NONE:
             # If logger.categories != NONE passes:
-            # -  Logger is empty (no invalid categories)
-            # If invalid_categories != NONE passes: 
+            # - Logger is empty (no invalid categories)
+            # If invalid_categories != NONE passes:
             # - No invalid categories are set
             raise ValueError(
-                "{} are incompatible with write.Table: use write.GSD instead.".format(
-                    logger.categories & self._invalid_logger_categories
-                )
-            )
+                "{} are incompatible with write.Table: use write.GSD instead."
+                .format(_invalid_inputs))
 
         self._cur_headers_with_width = dict()
         self._fmt = _Formatter(pretty, max_precision)

--- a/hoomd/write/table.py
+++ b/hoomd/write/table.py
@@ -216,9 +216,9 @@ class _TableInternal(_InternalAction):
             pass
         elif LoggerCategories.any([
                 LoggerCategories.scalar, LoggerCategories.string
-        ]) & logger.categories != LoggerCategories.NONE:
+        ]) & logger.categories == LoggerCategories.NONE:
             raise ValueError(
-                "Given Logger must have the scalar or string categories set.")
+                "Table Logger may only have scalar or string categories set.")
         elif _invalid_inputs != LoggerCategories.NONE:
             # If logger.categories != NONE passes:
             # - Logger is empty (no invalid categories)

--- a/hoomd/write/table.py
+++ b/hoomd/write/table.py
@@ -208,12 +208,14 @@ class _TableInternal(_InternalAction):
 
         # internal variables that are not part of the state.
         # Ensure that only scalar and potentially string are set for the logger
-        if (LoggerCategories.scalar not in logger.categories
-                or logger.categories & self._invalid_logger_categories
-                !=  # noqa: W504 (yapf formats this incorrectly
-                LoggerCategories.NONE):
+        if LoggerCategories.scalar not in logger.categories:
+            raise ValueError("Given Logger must have the scalar categories set.")
+        elif logger.categories & self._invalid_logger_categories != LoggerCategories.NONE:
             raise ValueError(
-                "Given Logger must have the scalar categories set.")
+                "{} are incompatible with write.Table: use write.GSD instead.".format(
+                    logger.categories & self._invalid_logger_categories
+                )
+            )
 
         self._cur_headers_with_width = dict()
         self._fmt = _Formatter(pretty, max_precision)

--- a/hoomd/write/table.py
+++ b/hoomd/write/table.py
@@ -207,25 +207,21 @@ class _TableInternal(_InternalAction):
         self._param_dict = param_dict
         # internal variables that are not part of the state.
 
-        # Generate list of current invalid categories
+        # Generate LoggerCategories for valid and invalid categories
+        _valid_categories = LoggerCategories.any(
+            [LoggerCategories.scalar, LoggerCategories.string])
         _invalid_inputs = logger.categories & self._invalid_logger_categories
 
-        # Ensure that only scalar and potentially string are set for the logger
+        # Ensure that only scalar and string categories are set for the logger
         if logger.categories == LoggerCategories.NONE:
             pass
-        elif LoggerCategories.any([
-                LoggerCategories.scalar, LoggerCategories.string
-        ]) & logger.categories == LoggerCategories.NONE:
+        elif (_valid_categories ^ LoggerCategories.ALL
+              ) & logger.categories == LoggerCategories.NONE:
+            pass
+        else:
             raise ValueError(
-                "Table Logger may only have scalar or string categories set.")
-        elif _invalid_inputs != LoggerCategories.NONE:
-            # If logger.categories != NONE passes:
-            # - Logger is empty (no invalid categories)
-            # If invalid_categories != NONE passes:
-            # - No invalid categories are set
-            raise ValueError(
-                "{} are incompatible with write.Table: use write.GSD instead."
-                .format(_invalid_inputs))
+                "Table Logger may only have scalar or string categories set. \
+                    Use hoomd.write.GSD for {}.".format(_invalid_inputs))
 
         self._cur_headers_with_width = dict()
         self._fmt = _Formatter(pretty, max_precision)

--- a/hoomd/write/table.py
+++ b/hoomd/write/table.py
@@ -210,7 +210,9 @@ class _TableInternal(_InternalAction):
         # Ensure that only scalar and potentially string are set for the logger
         if LoggerCategories.scalar not in logger.categories:
             raise ValueError("Given Logger must have the scalar categories set.")
-        elif logger.categories & self._invalid_logger_categories != LoggerCategories.NONE:
+        elif (
+            logger.categories & self._invalid_logger_categories != LoggerCategories.NONE
+        ):
             raise ValueError(
                 "{} are incompatible with write.Table: use write.GSD instead.".format(
                     logger.categories & self._invalid_logger_categories

--- a/hoomd/write/table.py
+++ b/hoomd/write/table.py
@@ -211,8 +211,12 @@ class _TableInternal(_InternalAction):
         _invalid_inputs = logger.categories & self._invalid_logger_categories
 
         # Ensure that only scalar and potentially string are set for the logger
-        if (LoggerCategories.scalar & LoggerCategories.string
-                not in logger.categories):
+        # If logger.categories == none, pass automatically
+        if logger.categories == LoggerCategories.NONE:
+            pass
+        elif LoggerCategories.any([
+                LoggerCategories.scalar, LoggerCategories.string
+        ]) & logger.categories != LoggerCategories.NONE:
             raise ValueError(
                 "Given Logger must have the scalar or string categories set.")
         elif _invalid_inputs != LoggerCategories.NONE:

--- a/hoomd/write/table.py
+++ b/hoomd/write/table.py
@@ -208,11 +208,13 @@ class _TableInternal(_InternalAction):
 
         # internal variables that are not part of the state.
         # Ensure that only scalar and potentially string are set for the logger
-        if LoggerCategories.scalar not in logger.categories:
-            raise ValueError("Given Logger must have the scalar categories set.")
+        if LoggerCategories.scalar & LoggerCategories.string not in logger.categories:
+            raise ValueError("Given Logger must have the scalar or string categories set.")
         elif (
             logger.categories & self._invalid_logger_categories != LoggerCategories.NONE
         ):
+            # logger.categories != NONE passes if the logger is empty (no invalid categories)
+            # invalid_categories != NONE passes if the 
             raise ValueError(
                 "{} are incompatible with write.Table: use write.GSD instead.".format(
                     logger.categories & self._invalid_logger_categories

--- a/sphinx-doc/credits.rst
+++ b/sphinx-doc/credits.rst
@@ -57,6 +57,7 @@ The following people have contributed to the to HOOMD-blue:
 * James Antonaglia, University of Michigan
 * James Proctor, University of Michigan
 * James W. Swan, Massachusetts Institute of Technology
+* Jen Bradley, University of Michigan
 * Jenny Fothergill, Boise State University
 * Jens Glaser, Oak Ridge National Laboratory
 * Joseph Berleant, University of Michigan


### PR DESCRIPTION
## Description

- Improved error logic for setting ``LoggerCategories`` in ``hoomd.write.Table``.
- Added new error message that details if invalid categories have been set


## Motivation and context

Prior to this change, users adding disallowed categories to ``hoomd.write.Table`` would receive an error intended for when ``LoggerCategories.scalar`` was not set. This fix updates the error logic to raise a more descriptive error detailing which disallowed categories have been set by the user.

Resolves #1510 

## How has this been tested?

Changes were tested with every permutation of LoggerCategories, which return the expected errors.

## Change log

```
Fixed:

* hoomd.write.Table now raises correct error if invalid LoggerCategories are set.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
