### PR TITLE
Remove sdf.

### DIFF
--- a/hoomd/hpmc/compute.py
+++ b/hoomd/hpmc/compute.py
@@ -20,7 +20,6 @@ from hoomd.data.parameterdicts import ParameterDict
 from hoomd.logging import log
 import hoomd
 import numpy
-import warnings
 
 
 class FreeVolume(Compute):
@@ -347,20 +346,6 @@ class SDF(Compute):
             self.xmax,
             self.dx,
         )
-
-    @log(category='sequence', requires_run=True)
-    def sdf(self):
-        """(*N_bins*,) `numpy.ndarray` of `float`): :math:`s[k]` - The scale \
-        distribution function for compression moves \
-        :math:`[\\mathrm{probability\\ density}]`.
-
-        .. deprecated:: v3.11.0
-            Use `sdf_compression`.
-        """
-        warnings.warn("sdf is deprecated since v3.11.0. Use sdf_compression.",
-                      FutureWarning)
-        self._cpp_obj.compute(self._simulation.timestep)
-        return self._cpp_obj.sdf_compression
 
     @log(category='sequence', requires_run=True)
     def sdf_compression(self):

--- a/hoomd/hpmc/pytest/test_compute_sdf.py
+++ b/hoomd/hpmc/pytest/test_compute_sdf.py
@@ -224,7 +224,7 @@ def test_values(simulation_factory, lattice_snapshot_factory):
     sdf = hoomd.hpmc.compute.SDF(xmax=0.02, dx=1e-4)
     sim.operations.add(sdf)
 
-    sdf_log = hoomd.conftest.ListWriter(sdf, 'sdf')
+    sdf_log = hoomd.conftest.ListWriter(sdf, 'sdf_compression')
     sim.operations.writers.append(
         hoomd.write.CustomWriter(action=sdf_log,
                                  trigger=hoomd.trigger.Periodic(10)))

--- a/hoomd/hpmc/pytest/test_compute_sdf.py
+++ b/hoomd/hpmc/pytest/test_compute_sdf.py
@@ -352,10 +352,6 @@ def test_logging():
                 'category': LoggerCategories.scalar,
                 'default': True
             },
-            'sdf': {
-                'category': LoggerCategories.sequence,
-                'default': True
-            },
             'sdf_compression': {
                 'category': LoggerCategories.sequence,
                 'default': True

--- a/sphinx-doc/migrating.rst
+++ b/sphinx-doc/migrating.rst
@@ -66,6 +66,10 @@ For some functionalities, you will need to update your scripts to use a new API:
 
   * Use `message_filename <hoomd.device.Device.message_filename>`.
 
+* ``sdf`` property of `hoomd.hpmc.compute.SDF`.
+
+  * Use `sdf_compression <hoomd.hpmc.compute.SDF.sdf_compression>`.
+
 Removed functionalities
 ^^^^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should be based on *trunk-patch*. -->
<!-- Backwards compatible new features should be based on *trunk-minor*. -->
<!-- Incompatible API changes should be based on *trunk-major*. -->

## Description

<!-- Describe your changes in detail. -->
Remove the deprecated sdf property of SDF.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
We remove deprecated functionality in major releases.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
Updated the unit tests.

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
Removed:

* The ``sdf`` attribute of ``hoomd.hpmc.compute.SDF`` - use ``sdf_compression``
  (`#1523 <https://github.com/glotzerlab/hoomd-blue/pull/1523>`__).
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
