### PR TITLE
Fix pairwise virial documentation.

### DIFF
--- a/hoomd/md/force.py
+++ b/hoomd/md/force.py
@@ -56,7 +56,7 @@ class Force(Compute):
 
     .. math::
 
-        W^{kl}_i = \sum_j F^k_{ij} \cdot
+        W^{kl}_i = \frac{1}{2} \sum_j F^k_{ij} \cdot
         \mathrm{minimum\_image}(\vec{r}_j - \vec{r}_i)^l
 
     Tip:


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should be based on *trunk-patch*. -->
<!-- Backwards compatible new features should be based on *trunk-minor*. -->
<!-- Incompatible API changes should be based on *trunk-major*. -->

## Description

<!-- Describe your changes in detail. -->
Add the missing 1/2 to the forumla.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
When computing pairwise virials between particle *i* and *j*, HOOMD applies 1/2 of the pairwise virial to each particle. For example, see:
https://github.com/glotzerlab/hoomd-blue/blob/024ad837360dff5742cb61345c1e447614afeeeb/hoomd/md/PotentialPair.h#L775-L788

The documentation should match the implementation.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
I rendered and viewed the docs locally.

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
Fixed:

* Correctly document the 1/2 scaling factor in the pairwise virial computation.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
