### PR TITLE
Add patchy particle tutorial and rearrange documentation TOC.

### DIFF
--- a/sphinx-doc/changes.rst
+++ b/sphinx-doc/changes.rst
@@ -1,0 +1,12 @@
+.. Copyright (c) 2009-2023 The Regents of the University of Michigan.
+.. Part of HOOMD-blue, released under the BSD 3-Clause License.
+
+Changes
+~~~~~~~
+
+.. toctree::
+    :maxdepth: 1
+
+    changelog
+    migrating
+    deprecated

--- a/sphinx-doc/conf.py
+++ b/sphinx-doc/conf.py
@@ -52,7 +52,7 @@ autodoc_mock_imports = [
 ]
 
 templates_path = ['_templates']
-exclude_patterns = ['_build', 'figures']
+exclude_patterns = ['_build', 'figures', '**/create-figures.ipynb']
 
 source_suffix = '.rst'
 

--- a/sphinx-doc/developers.rst
+++ b/sphinx-doc/developers.rst
@@ -1,0 +1,13 @@
+.. Copyright (c) 2009-2023 The Regents of the University of Michigan.
+.. Part of HOOMD-blue, released under the BSD 3-Clause License.
+
+For developers
+~~~~~~~~~~~~~~
+
+.. toctree::
+    :maxdepth: 1
+
+    contributing
+    style
+    testing
+    components

--- a/sphinx-doc/documentation.rst
+++ b/sphinx-doc/documentation.rst
@@ -1,0 +1,12 @@
+.. Copyright (c) 2009-2023 The Regents of the University of Michigan.
+.. Part of HOOMD-blue, released under the BSD 3-Clause License.
+
+Documentation
+~~~~~~~~~~~~~
+
+.. toctree::
+    :maxdepth: 1
+
+    notation
+    units
+    logo

--- a/sphinx-doc/getting-started.rst
+++ b/sphinx-doc/getting-started.rst
@@ -1,0 +1,13 @@
+.. Copyright (c) 2009-2023 The Regents of the University of Michigan.
+.. Part of HOOMD-blue, released under the BSD 3-Clause License.
+
+Getting started
+~~~~~~~~~~~~~~~
+
+.. toctree::
+    :maxdepth: 1
+
+    features
+    installation
+    building
+    citing

--- a/sphinx-doc/how-to.rst
+++ b/sphinx-doc/how-to.rst
@@ -1,0 +1,11 @@
+.. Copyright (c) 2009-2023 The Regents of the University of Michigan.
+.. Part of HOOMD-blue, released under the BSD 3-Clause License.
+
+How-to
+~~~~~~
+
+.. toctree::
+    :maxdepth: 1
+
+    howto/molecular
+    howto/cpppotential

--- a/sphinx-doc/index.rst
+++ b/sphinx-doc/index.rst
@@ -146,6 +146,7 @@ Molecular dynamics:
     tutorial/04-Custom-Actions-In-Python/00-index
     tutorial/05-Organizing-and-Executing-Simulations/00-index
     tutorial/06-Modelling-Rigid-Bodies/00-index
+    tutorial/07-Modelling-Patchy-Particles/00-index
 
 .. toctree::
     :maxdepth: 1

--- a/sphinx-doc/index.rst
+++ b/sphinx-doc/index.rst
@@ -124,36 +124,16 @@ Molecular dynamics:
 
     sim.run(1e5)
 
-.. toctree::
-    :maxdepth: 1
-    :caption: Getting started
-
-    features
-    installation
-    building
-    migrating
-    changelog
-    citing
+.. rubric::
+    Contents
 
 .. toctree::
-    :maxdepth: 1
-    :caption: Tutorials
+    :maxdepth: 2
+    :caption: Guides
 
-    tutorial/00-Introducing-HOOMD-blue/00-index
-    tutorial/01-Introducing-Molecular-Dynamics/00-index
-    tutorial/02-Logging/00-index
-    tutorial/03-Parallel-Simulations-With-MPI/00-index
-    tutorial/04-Custom-Actions-In-Python/00-index
-    tutorial/05-Organizing-and-Executing-Simulations/00-index
-    tutorial/06-Modelling-Rigid-Bodies/00-index
-    tutorial/07-Modelling-Patchy-Particles/00-index
-
-.. toctree::
-    :maxdepth: 1
-    :caption: How to guides
-
-    howto/molecular
-    howto/cpppotential
+    getting-started
+    tutorials
+    how-to
 
 .. toctree::
    :maxdepth: 1
@@ -164,22 +144,13 @@ Molecular dynamics:
    package-md
 
 .. toctree::
-    :maxdepth: 1
-    :caption: Developer guide
-
-    contributing
-    style
-    testing
-    components
-
-.. toctree::
-   :maxdepth: 1
+   :maxdepth: 2
    :caption: Reference
 
-   notation
-   units
-   deprecated
-   logo
-   license
-   credits
+   documentation
+   changes
+   developers
+
+   open-source
+
    indices

--- a/sphinx-doc/open-source.rst
+++ b/sphinx-doc/open-source.rst
@@ -1,0 +1,11 @@
+.. Copyright (c) 2009-2023 The Regents of the University of Michigan.
+.. Part of HOOMD-blue, released under the BSD 3-Clause License.
+
+Open source
+~~~~~~~~~~~
+
+.. toctree::
+    :maxdepth: 1
+
+    license
+    credits

--- a/sphinx-doc/tutorials.rst
+++ b/sphinx-doc/tutorials.rst
@@ -1,0 +1,17 @@
+.. Copyright (c) 2009-2023 The Regents of the University of Michigan.
+.. Part of HOOMD-blue, released under the BSD 3-Clause License.
+
+Tutorials
+~~~~~~~~~
+
+.. toctree::
+    :maxdepth: 1
+
+    tutorial/00-Introducing-HOOMD-blue/00-index
+    tutorial/01-Introducing-Molecular-Dynamics/00-index
+    tutorial/02-Logging/00-index
+    tutorial/03-Parallel-Simulations-With-MPI/00-index
+    tutorial/04-Custom-Actions-In-Python/00-index
+    tutorial/05-Organizing-and-Executing-Simulations/00-index
+    tutorial/06-Modelling-Rigid-Bodies/00-index
+    tutorial/07-Modelling-Patchy-Particles/00-index


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should be based on *trunk-patch*. -->
<!-- Backwards compatible new features should be based on *trunk-minor*. -->
<!-- Incompatible API changes should be based on *trunk-major*. -->

## Description

<!-- Describe your changes in detail. -->
* Add the new patchy particle tutorial https://github.com/glotzerlab/hoomd-examples/pull/84
* Add more levels to the documentation table of contents.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Make the latest tutorial visible to users in the documentation. With the large number of tutorials and how-to guides, the left sidebar became difficult to navigate. I added the additional levels to the contents so that the left sidebar is concise.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
I rendered and viewed the documentation locally.
Reviewers can see the modified documentation here: https://hoomd-blue--1526.org.readthedocs.build/en/1526/

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
Added:

* Modelling Patchy Particles tutorial.

Changed:

* Improve documentation navigation.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
