### PR TITLE
Embed the latest gsd source.

### DIFF
--- a/hoomd/extern/gsd.c
+++ b/hoomd/extern/gsd.c
@@ -1,6 +1,5 @@
-// Copyright (c) 2016-2020 The Regents of the University of Michigan
-// This file is part of the General Simulation Data (GSD) project, released under the BSD 2-Clause
-// License.
+// Copyright (c) 2016-2023 The Regents of the University of Michigan
+// Part of GSD, released under the BSD 2-Clause License.
 
 #include <sys/stat.h>
 #ifdef _WIN32
@@ -9,7 +8,9 @@
 #pragma warning(disable : 4996)
 
 #define GSD_USE_MMAP 0
+#define WIN32_LEAN_AND_MEAN
 #include <io.h>
+#include <windows.h>
 
 #else // linux / mac
 
@@ -41,50 +42,55 @@ const uint64_t GSD_MAGIC_ID = 0x65DF65DF65DF65DF;
 
 /// Initial index size
 enum
-{
+    {
     GSD_INITIAL_INDEX_SIZE = 128
-};
+    };
 
 /// Initial namelist size
 enum
-{
+    {
     GSD_INITIAL_NAME_BUFFER_SIZE = 1024
-};
+    };
 
 /// Size of initial frame index
 enum
-{
+    {
     GSD_INITIAL_FRAME_INDEX_SIZE = 16
-};
+    };
 
-/// Size of write buffer
+/// Initial size of write buffer
 enum
-{
-    GSD_WRITE_BUFFER_SIZE = 16 * 1024 * 1024
-};
+    {
+    GSD_INITIAL_WRITE_BUFFER_SIZE = 1024
+    };
+
+/// Maximum size of write buffer
+enum
+    {
+    GSD_MAXIMUM_WRITE_BUFFER_SIZE = 16 * 1024 * 1024
+    };
 
 /// Size of copy buffer
 enum
-{
+    {
     GSD_COPY_BUFFER_SIZE = 128 * 1024
-};
+    };
 
 /// Size of hash map
 enum
-{
+    {
     GSD_NAME_MAP_SIZE = 57557
-};
+    };
 
 /// Current GSD file specification
 enum
-{
+    {
     GSD_CURRENT_FILE_VERSION = 2
-};
+    };
 
 // define windows wrapper functions
 #ifdef _WIN32
 #define lseek _lseeki64
-#define open _open
 #define ftruncate _chsize
 #define fsync _commit
 typedef int64_t ssize_t;
@@ -95,7 +101,7 @@ int S_IRGRP = _S_IREAD;
 int S_IWGRP = _S_IWRITE;
 
 inline ssize_t pread(int fd, void* buf, size_t count, int64_t offset)
-{
+    {
     // Note: _read only accepts unsigned int values
     if (count > UINT_MAX)
         return GSD_ERROR_IO;
@@ -105,10 +111,10 @@ inline ssize_t pread(int fd, void* buf, size_t count, int64_t offset)
     ssize_t result = _read(fd, buf, (unsigned int)count);
     _lseeki64(fd, oldpos, SEEK_SET);
     return result;
-}
+    }
 
 inline ssize_t pwrite(int fd, const void* buf, size_t count, int64_t offset)
-{
+    {
     // Note: _write only accepts unsigned int values
     if (count > UINT_MAX)
         return GSD_ERROR_IO;
@@ -118,7 +124,7 @@ inline ssize_t pwrite(int fd, const void* buf, size_t count, int64_t offset)
     ssize_t result = _write(fd, buf, (unsigned int)count);
     _lseeki64(fd, oldpos, SEEK_SET);
     return result;
-}
+    }
 
 #endif
 
@@ -128,9 +134,9 @@ inline ssize_t pwrite(int fd, const void* buf, size_t count, int64_t offset)
     @param size_to_zero size of the area to zero in bytes
 */
 inline static void gsd_util_zero_memory(void* d, size_t size_to_zero)
-{
+    {
     memset(d, 0, size_to_zero);
-}
+    }
 
 /** @internal
     @brief Write large data buffer to file
@@ -146,13 +152,13 @@ inline static void gsd_util_zero_memory(void* d, size_t size_to_zero)
     @returns The total number of bytes written or a negative value on error.
 */
 inline static ssize_t gsd_io_pwrite_retry(int fd, const void* buf, size_t count, int64_t offset)
-{
+    {
     size_t total_bytes_written = 0;
     const char* ptr = (char*)buf;
 
     // perform multiple pwrite calls to complete a large write successfully
     while (total_bytes_written < count)
-    {
+        {
         size_t to_write = count - total_bytes_written;
 #if defined(_WIN32) || defined(__APPLE__)
         // win32 and apple raise an error for writes greater than INT_MAX
@@ -164,15 +170,15 @@ inline static ssize_t gsd_io_pwrite_retry(int fd, const void* buf, size_t count,
         ssize_t bytes_written
             = pwrite(fd, ptr + total_bytes_written, to_write, offset + total_bytes_written);
         if (bytes_written == -1 || (bytes_written == 0 && errno != 0))
-        {
+            {
             return GSD_ERROR_IO;
-        }
+            }
 
         total_bytes_written += bytes_written;
-    }
+        }
 
     return total_bytes_written;
-}
+    }
 
 /** @internal
     @brief Read large data buffer to file
@@ -188,13 +194,13 @@ inline static ssize_t gsd_io_pwrite_retry(int fd, const void* buf, size_t count,
     @returns The total number of bytes read or a negative value on error.
 */
 inline static ssize_t gsd_io_pread_retry(int fd, void* buf, size_t count, int64_t offset)
-{
+    {
     size_t total_bytes_read = 0;
     char* ptr = (char*)buf;
 
     // perform multiple pread calls to complete a large write successfully
     while (total_bytes_read < count)
-    {
+        {
         size_t to_read = count - total_bytes_read;
 #if defined(_WIN32) || defined(__APPLE__)
         // win32 and apple raise errors for reads greater than INT_MAX
@@ -205,21 +211,21 @@ inline static ssize_t gsd_io_pread_retry(int fd, void* buf, size_t count, int64_
         errno = 0;
         ssize_t bytes_read = pread(fd, ptr + total_bytes_read, to_read, offset + total_bytes_read);
         if (bytes_read == -1 || (bytes_read == 0 && errno != 0))
-        {
+            {
             return GSD_ERROR_IO;
-        }
+            }
 
         total_bytes_read += bytes_read;
 
         // handle end of file
         if (bytes_read == 0)
-        {
+            {
             return total_bytes_read;
+            }
         }
-    }
 
     return total_bytes_read;
-}
+    }
 
 /** @internal
     @brief Allocate a name/id map
@@ -230,22 +236,22 @@ inline static ssize_t gsd_io_pread_retry(int fd, void* buf, size_t count, int64_
     @returns GSD_SUCCESS on success, GSD_* error codes on error.
 */
 inline static int gsd_name_id_map_allocate(struct gsd_name_id_map* map, size_t size)
-{
-    if (map == NULL || map->v || size == 0 || map->size != 0)
     {
+    if (map == NULL || map->v || size == 0 || map->size != 0)
+        {
         return GSD_ERROR_INVALID_ARGUMENT;
-    }
+        }
 
     map->v = calloc(size, sizeof(struct gsd_name_id_pair));
     if (map->v == NULL)
-    {
+        {
         return GSD_ERROR_MEMORY_ALLOCATION_FAILED;
-    }
+        }
 
     map->size = size;
 
     return GSD_SUCCESS;
-}
+    }
 
 /** @internal
     @brief Free a name/id map
@@ -255,27 +261,27 @@ inline static int gsd_name_id_map_allocate(struct gsd_name_id_map* map, size_t s
     @returns GSD_SUCCESS on success, GSD_* error codes on error.
 */
 inline static int gsd_name_id_map_free(struct gsd_name_id_map* map)
-{
-    if (map == NULL || map->v == NULL || map->size == 0)
     {
+    if (map == NULL || map->v == NULL || map->size == 0)
+        {
         return GSD_ERROR_INVALID_ARGUMENT;
-    }
+        }
 
     // free all of the linked lists
     size_t i;
     for (i = 0; i < map->size; i++)
-    {
+        {
         free(map->v[i].name);
 
         struct gsd_name_id_pair* cur = map->v[i].next;
         while (cur != NULL)
-        {
+            {
             struct gsd_name_id_pair* prev = cur;
             cur = cur->next;
             free(prev->name);
             free(prev);
+            }
         }
-    }
 
     // free the main map
     free(map->v);
@@ -284,7 +290,7 @@ inline static int gsd_name_id_map_free(struct gsd_name_id_map* map)
     map->size = 0;
 
     return GSD_SUCCESS;
-}
+    }
 
 /** @internal
     @brief Hash a string
@@ -294,17 +300,17 @@ inline static int gsd_name_id_map_free(struct gsd_name_id_map* map)
     @returns Hashed value of the string.
 */
 inline static unsigned long gsd_hash_str(const unsigned char* str)
-{
+    {
     unsigned long hash = 5381; // NOLINT
     int c;
 
     while ((c = *str++))
-    {
+        {
         hash = ((hash << 5) + hash) + c; /* hash * 33 + c NOLINT */
-    }
+        }
 
     return hash;
-}
+    }
 
 /** @internal
     @brief Insert a string into a name/id map
@@ -316,55 +322,55 @@ inline static unsigned long gsd_hash_str(const unsigned char* str)
     @returns GSD_SUCCESS on success, GSD_* error codes on error.
 */
 inline static int gsd_name_id_map_insert(struct gsd_name_id_map* map, const char* str, uint16_t id)
-{
-    if (map == NULL || map->v == NULL || map->size == 0)
     {
+    if (map == NULL || map->v == NULL || map->size == 0)
+        {
         return GSD_ERROR_INVALID_ARGUMENT;
-    }
+        }
 
     size_t hash = gsd_hash_str((const unsigned char*)str) % map->size;
 
     // base case: no conflict
     if (map->v[hash].name == NULL)
-    {
+        {
         map->v[hash].name = calloc(strlen(str) + 1, sizeof(char));
         if (map->v[hash].name == NULL)
-        {
+            {
             return GSD_ERROR_MEMORY_ALLOCATION_FAILED;
-        }
+            }
         memcpy(map->v[hash].name, str, strlen(str) + 1);
         map->v[hash].id = id;
         map->v[hash].next = NULL;
-    }
+        }
     else
-    {
+        {
         // go to the end of the conflict list
         struct gsd_name_id_pair* insert_point = map->v + hash;
 
         while (insert_point->next != NULL)
-        {
+            {
             insert_point = insert_point->next;
-        }
+            }
 
         // allocate and insert a new entry
         insert_point->next = malloc(sizeof(struct gsd_name_id_pair));
         if (insert_point->next == NULL)
-        {
+            {
             return GSD_ERROR_MEMORY_ALLOCATION_FAILED;
-        }
+            }
 
         insert_point->next->name = calloc(strlen(str) + 1, sizeof(char));
         if (insert_point->next->name == NULL)
-        {
+            {
             return GSD_ERROR_MEMORY_ALLOCATION_FAILED;
-        }
+            }
         memcpy(insert_point->next->name, str, strlen(str) + 1);
         insert_point->next->id = id;
         insert_point->next->next = NULL;
-    }
+        }
 
     return GSD_SUCCESS;
-}
+    }
 
 /** @internal
     @brief Find an ID in a name/id mapping
@@ -375,37 +381,37 @@ inline static int gsd_name_id_map_insert(struct gsd_name_id_map* map, const char
     @returns The ID if found, or UINT16_MAX if not found.
 */
 inline static uint16_t gsd_name_id_map_find(struct gsd_name_id_map* map, const char* str)
-{
-    if (map == NULL || map->v == NULL || map->size == 0)
     {
+    if (map == NULL || map->v == NULL || map->size == 0)
+        {
         return UINT16_MAX;
-    }
+        }
 
     size_t hash = gsd_hash_str((const unsigned char*)str) % map->size;
 
     struct gsd_name_id_pair* cur = map->v + hash;
 
     while (cur != NULL)
-    {
-        if (cur->name == NULL)
         {
+        if (cur->name == NULL)
+            {
             // not found
             return UINT16_MAX;
-        }
+            }
 
         if (strcmp(str, cur->name) == 0)
-        {
+            {
             // found
             return cur->id;
-        }
+            }
 
         // keep looking
         cur = cur->next;
-    }
+        }
 
     // not found in any conflict
     return UINT16_MAX;
-}
+    }
 
 /** @internal
     @brief Utility function to validate index entry
@@ -415,42 +421,42 @@ inline static uint16_t gsd_name_id_map_find(struct gsd_name_id_map* map, const c
     @returns 1 if the entry is valid, 0 if it is not
 */
 inline static int gsd_is_entry_valid(struct gsd_handle* handle, size_t idx)
-{
+    {
     const struct gsd_index_entry entry = handle->file_index.data[idx];
 
     // check for valid type
     if (gsd_sizeof_type((enum gsd_type)entry.type) == 0)
-    {
+        {
         return 0;
-    }
+        }
 
     // validate that we don't read past the end of the file
     size_t size = entry.N * entry.M * gsd_sizeof_type((enum gsd_type)entry.type);
     if ((entry.location + size) > (uint64_t)handle->file_size)
-    {
+        {
         return 0;
-    }
+        }
 
     // check for valid frame (frame cannot be more than the number of index entries)
     if (entry.frame >= handle->header.index_allocated_entries)
-    {
+        {
         return 0;
-    }
+        }
 
     // check for valid id
     if (entry.id >= (handle->file_names.n_names + handle->frame_names.n_names))
-    {
+        {
         return 0;
-    }
+        }
 
     // check for valid flags
     if (entry.flags != 0)
-    {
+        {
         return 0;
-    }
+        }
 
     return 1;
-}
+    }
 
 /** @internal
     @brief Allocate a write buffer
@@ -461,23 +467,23 @@ inline static int gsd_is_entry_valid(struct gsd_handle* handle, size_t idx)
     @returns GSD_SUCCESS on success, GSD_* error codes on error.
 */
 inline static int gsd_byte_buffer_allocate(struct gsd_byte_buffer* buf, size_t reserve)
-{
-    if (buf == NULL || buf->data || reserve == 0 || buf->reserved != 0 || buf->size != 0)
     {
+    if (buf == NULL || buf->data || reserve == 0 || buf->reserved != 0 || buf->size != 0)
+        {
         return GSD_ERROR_INVALID_ARGUMENT;
-    }
+        }
 
     buf->data = calloc(reserve, sizeof(char));
     if (buf->data == NULL)
-    {
+        {
         return GSD_ERROR_MEMORY_ALLOCATION_FAILED;
-    }
+        }
 
     buf->size = 0;
     buf->reserved = reserve;
 
     return GSD_SUCCESS;
-}
+    }
 
 /** @internal
     @brief Append bytes to a byte buffer
@@ -489,41 +495,41 @@ inline static int gsd_byte_buffer_allocate(struct gsd_byte_buffer* buf, size_t r
     @returns GSD_SUCCESS on success, GSD_* error codes on error.
 */
 inline static int gsd_byte_buffer_append(struct gsd_byte_buffer* buf, const char* data, size_t size)
-{
-    if (buf == NULL || buf->data == NULL || size == 0 || buf->reserved == 0)
     {
+    if (buf == NULL || buf->data == NULL || size == 0 || buf->reserved == 0)
+        {
         return GSD_ERROR_INVALID_ARGUMENT;
-    }
+        }
 
     if (buf->size + size > buf->reserved)
-    {
+        {
         // reallocate by doubling
         size_t new_reserved = buf->reserved * 2;
         while (buf->size + size >= new_reserved)
-        {
+            {
             new_reserved = new_reserved * 2;
-        }
+            }
 
         char* old_data = buf->data;
         buf->data = realloc(buf->data, sizeof(char) * new_reserved);
         if (buf->data == NULL)
-        {
+            {
             // this free should not be necessary, but clang-tidy disagrees
             free(old_data);
             return GSD_ERROR_MEMORY_ALLOCATION_FAILED;
-        }
+            }
 
         // zero the new memory, but only the portion after the end of the new section to be appended
         gsd_util_zero_memory(buf->data + (buf->size + size),
                              sizeof(char) * (new_reserved - (buf->size + size)));
         buf->reserved = new_reserved;
-    }
+        }
 
     memcpy(buf->data + buf->size, data, size);
     buf->size += size;
 
     return GSD_SUCCESS;
-}
+    }
 
 /** @internal
     @brief Free the memory allocated by the write buffer or unmap the mapped memory.
@@ -533,17 +539,17 @@ inline static int gsd_byte_buffer_append(struct gsd_byte_buffer* buf, const char
     @returns GSD_SUCCESS on success, GSD_* error codes on error.
 */
 inline static int gsd_byte_buffer_free(struct gsd_byte_buffer* buf)
-{
-    if (buf == NULL || buf->data == NULL)
     {
+    if (buf == NULL || buf->data == NULL)
+        {
         return GSD_ERROR_INVALID_ARGUMENT;
-    }
+        }
 
     free(buf->data);
 
     gsd_util_zero_memory(buf, sizeof(struct gsd_byte_buffer));
     return GSD_SUCCESS;
-}
+    }
 
 /** @internal
     @brief Allocate a buffer of index entries
@@ -556,18 +562,18 @@ inline static int gsd_byte_buffer_free(struct gsd_byte_buffer* buf)
     @returns GSD_SUCCESS on success, GSD_* error codes on error.
 */
 inline static int gsd_index_buffer_allocate(struct gsd_index_buffer* buf, size_t reserve)
-{
+    {
     if (buf == NULL || buf->mapped_data || buf->data || reserve == 0 || buf->reserved != 0
         || buf->size != 0)
-    {
+        {
         return GSD_ERROR_INVALID_ARGUMENT;
-    }
+        }
 
     buf->data = calloc(reserve, sizeof(struct gsd_index_entry));
     if (buf->data == NULL)
-    {
+        {
         return GSD_ERROR_MEMORY_ALLOCATION_FAILED;
-    }
+        }
 
     buf->size = 0;
     buf->reserved = reserve;
@@ -575,7 +581,7 @@ inline static int gsd_index_buffer_allocate(struct gsd_index_buffer* buf, size_t
     buf->mapped_len = 0;
 
     return GSD_SUCCESS;
-}
+    }
 
 /** @internal
     @brief Map index entries from the file
@@ -591,19 +597,19 @@ inline static int gsd_index_buffer_allocate(struct gsd_index_buffer* buf, size_t
     @returns GSD_SUCCESS on success, GSD_* error codes on error.
 */
 inline static int gsd_index_buffer_map(struct gsd_index_buffer* buf, struct gsd_handle* handle)
-{
-    if (buf == NULL || buf->mapped_data || buf->data || buf->reserved != 0 || buf->size != 0)
     {
+    if (buf == NULL || buf->mapped_data || buf->data || buf->reserved != 0 || buf->size != 0)
+        {
         return GSD_ERROR_INVALID_ARGUMENT;
-    }
+        }
 
     // validate that the index block exists inside the file
     if (handle->header.index_location
             + sizeof(struct gsd_index_entry) * handle->header.index_allocated_entries
         > (uint64_t)handle->file_size)
-    {
+        {
         return GSD_ERROR_FILE_CORRUPT;
-    }
+        }
 
 #if GSD_USE_MMAP
     // map the index in read only mode
@@ -618,9 +624,9 @@ inline static int gsd_index_buffer_map(struct gsd_index_buffer* buf, struct gsd_
                             offset);
 
     if (buf->mapped_data == MAP_FAILED)
-    {
+        {
         return GSD_ERROR_IO;
-    }
+        }
 
     buf->data = (struct gsd_index_entry*)(((char*)buf->mapped_data)
                                           + (handle->header.index_location - offset));
@@ -631,9 +637,9 @@ inline static int gsd_index_buffer_map(struct gsd_index_buffer* buf, struct gsd_
     // mmap not supported, read the data from the disk
     int retval = gsd_index_buffer_allocate(buf, handle->header.index_allocated_entries);
     if (retval != GSD_SUCCESS)
-    {
+        {
         return retval;
-    }
+        }
 
     ssize_t bytes_read = gsd_io_pread_retry(handle->fd,
                                             buf->data,
@@ -643,24 +649,24 @@ inline static int gsd_index_buffer_map(struct gsd_index_buffer* buf, struct gsd_
 
     if (bytes_read == -1
         || bytes_read != sizeof(struct gsd_index_entry) * handle->header.index_allocated_entries)
-    {
+        {
         return GSD_ERROR_IO;
-    }
+        }
 #endif
 
     // determine the number of index entries in the list
     // file is corrupt if first index entry is invalid
     if (buf->data[0].location != 0 && !gsd_is_entry_valid(handle, 0))
-    {
+        {
         return GSD_ERROR_FILE_CORRUPT;
-    }
+        }
 
     if (buf->data[0].location == 0)
-    {
+        {
         buf->size = 0;
-    }
+        }
     else
-    {
+        {
         // determine the number of index entries (marked by location = 0)
         // binary search for the first index entry with location 0
         size_t L = 0;
@@ -668,33 +674,33 @@ inline static int gsd_index_buffer_map(struct gsd_index_buffer* buf, struct gsd_
 
         // progressively narrow the search window by halves
         do
-        {
+            {
             size_t m = (L + R) / 2;
 
             // file is corrupt if any index entry is invalid or frame does not increase
             // monotonically
             if (buf->data[m].location != 0
                 && (!gsd_is_entry_valid(handle, m) || buf->data[m].frame < buf->data[L].frame))
-            {
+                {
                 return GSD_ERROR_FILE_CORRUPT;
-            }
+                }
 
             if (buf->data[m].location != 0)
-            {
+                {
                 L = m;
-            }
+                }
             else
-            {
+                {
                 R = m;
-            }
-        } while ((R - L) > 1);
+                }
+            } while ((R - L) > 1);
 
         // this finds R = the first index entry with location = 0
         buf->size = R;
-    }
+        }
 
     return GSD_SUCCESS;
-}
+    }
 
 /** @internal
     @brief Free the memory allocated by the index buffer or unmap the mapped memory.
@@ -704,31 +710,31 @@ inline static int gsd_index_buffer_map(struct gsd_index_buffer* buf, struct gsd_
     @returns GSD_SUCCESS on success, GSD_* error codes on error.
 */
 inline static int gsd_index_buffer_free(struct gsd_index_buffer* buf)
-{
-    if (buf == NULL || buf->data == NULL)
     {
+    if (buf == NULL || buf->data == NULL)
+        {
         return GSD_ERROR_INVALID_ARGUMENT;
-    }
+        }
 
 #if GSD_USE_MMAP
     if (buf->mapped_data)
-    {
+        {
         int retval = munmap(buf->mapped_data, buf->mapped_len);
 
         if (retval != 0)
-        {
+            {
             return GSD_ERROR_IO;
+            }
         }
-    }
     else
 #endif
-    {
+        {
         free(buf->data);
-    }
+        }
 
     gsd_util_zero_memory(buf, sizeof(struct gsd_index_buffer));
     return GSD_SUCCESS;
-}
+    }
 
 /** @internal
     @brief Add a new index entry and provide a pointer to it.
@@ -742,88 +748,88 @@ inline static int gsd_index_buffer_free(struct gsd_index_buffer* buf)
     @returns GSD_SUCCESS on success, GSD_* error codes on error.
 */
 inline static int gsd_index_buffer_add(struct gsd_index_buffer* buf, struct gsd_index_entry** entry)
-{
-    if (buf == NULL || buf->mapped_data || entry == NULL || buf->reserved == 0)
     {
+    if (buf == NULL || buf->mapped_data || entry == NULL || buf->reserved == 0)
+        {
         return GSD_ERROR_INVALID_ARGUMENT;
-    }
+        }
 
     if (buf->size == buf->reserved)
-    {
+        {
         // grow the array
         size_t new_reserved = buf->reserved * 2;
         buf->data = realloc(buf->data, sizeof(struct gsd_index_entry) * new_reserved);
         if (buf->data == NULL)
-        {
+            {
             return GSD_ERROR_MEMORY_ALLOCATION_FAILED;
-        }
+            }
 
         // zero the new memory
         gsd_util_zero_memory(buf->data + buf->reserved,
                              sizeof(struct gsd_index_entry) * (new_reserved - buf->reserved));
         buf->reserved = new_reserved;
-    }
+        }
 
     size_t insert_pos = buf->size;
     buf->size++;
     *entry = buf->data + insert_pos;
 
     return GSD_SUCCESS;
-}
+    }
 
 inline static int gsd_cmp_index_entry(const struct gsd_index_entry* a,
                                       const struct gsd_index_entry* b)
-{
+    {
     int result = 0;
 
     if (a->frame < b->frame)
-    {
+        {
         result = -1;
-    }
+        }
 
     if (a->frame > b->frame)
-    {
+        {
         result = 1;
-    }
+        }
 
     if (a->frame == b->frame)
-    {
-        if (a->id < b->id)
         {
+        if (a->id < b->id)
+            {
             result = -1;
-        }
+            }
 
         if (a->id > b->id)
-        {
+            {
             result = 1;
-        }
+            }
 
         if (a->id == b->id)
-        {
+            {
             result = 0;
+            }
         }
-    }
 
     return result;
-}
+    }
 
 /** @internal
     @brief Compute heap parent node.
     @param i Node index.
 */
 inline static size_t gsd_heap_parent(size_t i)
-{
+    {
     return (i - 1) / 2;
-}
+    }
 
 /** @internal
     @brief Compute heap left child.
     @param i Node index.
 */
 inline static size_t gsd_heap_left_child(size_t i)
-{
+    {
     return 2 * i + 1;
-}
+    }
 
 /** @internal
     @brief Swap the nodes *a* and *b* in the buffer
@@ -832,11 +838,11 @@ inline static size_t gsd_heap_left_child(size_t i)
     @param b Second index to swap.
 */
 inline static void gsd_heap_swap(struct gsd_index_buffer* buf, size_t a, size_t b)
-{
+    {
     struct gsd_index_entry tmp = buf->data[a];
     buf->data[a] = buf->data[b];
     buf->data[b] = tmp;
-}
+    }
 
 /** @internal
     @brief Shift heap node downward
@@ -845,47 +851,47 @@ inline static void gsd_heap_swap(struct gsd_index_buffer* buf, size_t a, size_t 
     @param end Last index of the valid hep in *buf*.
 */
 inline static void gsd_heap_shift_down(struct gsd_index_buffer* buf, size_t start, size_t end)
-{
+    {
     size_t root = start;
 
     while (gsd_heap_left_child(root) <= end)
-    {
+        {
         size_t child = gsd_heap_left_child(root);
         size_t swap = root;
 
         if (gsd_cmp_index_entry(buf->data + swap, buf->data + child) < 0)
-        {
+            {
             swap = child;
-        }
+            }
         if (child + 1 <= end && gsd_cmp_index_entry(buf->data + swap, buf->data + child + 1) < 0)
-        {
+            {
             swap = child + 1;
-        }
+            }
 
         if (swap == root)
-        {
+            {
             return;
-        }
+            }
 
         gsd_heap_swap(buf, root, swap);
         root = swap;
+        }
     }
-}
 
 /** @internal
     @brief Convert unordered index buffer to a heap
     @param buf Buffer.
 */
 inline static void gsd_heapify(struct gsd_index_buffer* buf)
-{
+    {
     ssize_t start = gsd_heap_parent(buf->size - 1);
 
     while (start >= 0)
-    {
+        {
         gsd_heap_shift_down(buf, start, buf->size - 1);
         start--;
+        }
     }
-}
 
 /** @internal
     @brief Sort the index buffer.
@@ -897,30 +903,30 @@ inline static void gsd_heapify(struct gsd_index_buffer* buf)
     @returns GSD_SUCCESS on success, GSD_* error codes on error.
 */
 inline static int gsd_index_buffer_sort(struct gsd_index_buffer* buf)
-{
-    if (buf == NULL || buf->mapped_data || buf->reserved == 0)
     {
+    if (buf == NULL || buf->mapped_data || buf->reserved == 0)
+        {
         return GSD_ERROR_INVALID_ARGUMENT;
-    }
+        }
 
     // arrays of size 0 or 1 are already sorted
     if (buf->size <= 1)
-    {
+        {
         return GSD_SUCCESS;
-    }
+        }
 
     gsd_heapify(buf);
 
     size_t end = buf->size - 1;
     while (end > 0)
-    {
+        {
         gsd_heap_swap(buf, end, 0);
         end = end - 1;
         gsd_heap_shift_down(buf, 0, end);
-    }
+        }
 
     return GSD_SUCCESS;
-}
+    }
 
 /** @internal
     @brief Utility function to expand the memory space for the index block in the file.
@@ -931,11 +937,11 @@ inline static int gsd_index_buffer_sort(struct gsd_index_buffer* buf)
     @returns GSD_SUCCESS on success, GSD_* error codes on error.
 */
 inline static int gsd_expand_file_index(struct gsd_handle* handle, size_t size_required)
-{
-    if (handle->open_flags == GSD_OPEN_READONLY)
     {
+    if (handle->open_flags == GSD_OPEN_READONLY)
+        {
         return GSD_ERROR_FILE_MUST_BE_WRITABLE;
-    }
+        }
 
     // multiply the index size each time it grows
     // this allows the index to grow rapidly to accommodate new frames
@@ -946,17 +952,17 @@ inline static int gsd_expand_file_index(struct gsd_handle* handle, size_t size_r
     size_t size_new = size_old * multiplication_factor;
 
     while (size_new <= size_required)
-    {
+        {
         size_new *= multiplication_factor;
-    }
+        }
 
     // Mac systems deadlock when writing from a mapped region into the tail end of that same region
     // unmap the index first and copy it over by chunks
     int retval = gsd_index_buffer_free(&handle->file_index);
     if (retval != 0)
-    {
+        {
         return retval;
-    }
+        }
 
     // allocate the copy buffer
     char* buf = malloc(GSD_COPY_BUFFER_SIZE);
@@ -967,12 +973,12 @@ inline static int gsd_expand_file_index(struct gsd_handle* handle, size_t size_r
     size_t total_bytes_written = 0;
     size_t old_index_bytes = size_old * sizeof(struct gsd_index_entry);
     while (total_bytes_written < old_index_bytes)
-    {
+        {
         size_t bytes_to_copy = GSD_COPY_BUFFER_SIZE;
         if (old_index_bytes - total_bytes_written < GSD_COPY_BUFFER_SIZE)
-        {
+            {
             bytes_to_copy = old_index_bytes - total_bytes_written;
-        }
+            }
 
         ssize_t bytes_read = gsd_io_pread_retry(handle->fd,
                                                 buf,
@@ -980,10 +986,10 @@ inline static int gsd_expand_file_index(struct gsd_handle* handle, size_t size_r
                                                 old_index_location + total_bytes_written);
 
         if (bytes_read == -1 || bytes_read != bytes_to_copy)
-        {
+            {
             free(buf);
             return GSD_ERROR_IO;
-        }
+            }
 
         ssize_t bytes_written = gsd_io_pwrite_retry(handle->fd,
                                                     buf,
@@ -991,25 +997,25 @@ inline static int gsd_expand_file_index(struct gsd_handle* handle, size_t size_r
                                                     new_index_location + total_bytes_written);
 
         if (bytes_written == -1 || bytes_written != bytes_to_copy)
-        {
+            {
             free(buf);
             return GSD_ERROR_IO;
-        }
+            }
 
         total_bytes_written += bytes_written;
-    }
+        }
 
     // fill the new index space with 0s
     gsd_util_zero_memory(buf, GSD_COPY_BUFFER_SIZE);
 
     size_t new_index_bytes = size_new * sizeof(struct gsd_index_entry);
     while (total_bytes_written < new_index_bytes)
-    {
+        {
         size_t bytes_to_copy = GSD_COPY_BUFFER_SIZE;
         if (new_index_bytes - total_bytes_written < GSD_COPY_BUFFER_SIZE)
-        {
+            {
             bytes_to_copy = new_index_bytes - total_bytes_written;
-        }
+            }
 
         ssize_t bytes_written = gsd_io_pwrite_retry(handle->fd,
                                                     buf,
@@ -1017,21 +1023,21 @@ inline static int gsd_expand_file_index(struct gsd_handle* handle, size_t size_r
                                                     new_index_location + total_bytes_written);
 
         if (bytes_written == -1 || bytes_written != bytes_to_copy)
-        {
+            {
             free(buf);
             return GSD_ERROR_IO;
-        }
+            }
 
         total_bytes_written += bytes_written;
-    }
+        }
 
     // sync the expanded index
     retval = fsync(handle->fd);
     if (retval != 0)
-    {
+        {
         free(buf);
         return GSD_ERROR_IO;
-    }
+        }
 
     // free the copy buffer
     free(buf);
@@ -1045,26 +1051,26 @@ inline static int gsd_expand_file_index(struct gsd_handle* handle, size_t size_r
     ssize_t bytes_written
         = gsd_io_pwrite_retry(handle->fd, &(handle->header), sizeof(struct gsd_header), 0);
     if (bytes_written != sizeof(struct gsd_header))
-    {
+        {
         return GSD_ERROR_IO;
-    }
+        }
 
     // sync the updated header
     retval = fsync(handle->fd);
     if (retval != 0)
-    {
+        {
         return GSD_ERROR_IO;
-    }
+        }
 
     // remap the file index
     retval = gsd_index_buffer_map(&handle->file_index, handle);
     if (retval != 0)
-    {
+        {
         return retval;
-    }
+        }
 
     return GSD_SUCCESS;
-}
+    }
 
 /** @internal
     @brief Flush the write buffer.
@@ -1079,23 +1085,23 @@ inline static int gsd_expand_file_index(struct gsd_handle* handle, size_t size_r
     @returns GSD_SUCCESS on success or GSD_* error codes on error
 */
 inline static int gsd_flush_write_buffer(struct gsd_handle* handle)
-{
-    if (handle == NULL)
     {
+    if (handle == NULL)
+        {
         return GSD_ERROR_INVALID_ARGUMENT;
-    }
+        }
 
     if (handle->write_buffer.size == 0 && handle->buffer_index.size == 0)
-    {
+        {
         // nothing to do
         return GSD_SUCCESS;
-    }
+        }
 
     if (handle->write_buffer.size > 0 && handle->buffer_index.size == 0)
-    {
+        {
         // error: bytes in buffer, but no index for them
         return GSD_ERROR_INVALID_ARGUMENT;
-    }
+        }
 
     // write the buffer to the end of the file
     uint64_t offset = handle->file_size;
@@ -1105,9 +1111,9 @@ inline static int gsd_flush_write_buffer(struct gsd_handle* handle)
                                                 offset);
 
     if (bytes_written == -1 || bytes_written != handle->write_buffer.size)
-    {
+        {
         return GSD_ERROR_IO;
-    }
+        }
 
     handle->file_size += handle->write_buffer.size;
 
@@ -1117,23 +1123,23 @@ inline static int gsd_flush_write_buffer(struct gsd_handle* handle)
     // move buffer_index entries to file_index
     size_t i;
     for (i = 0; i < handle->buffer_index.size; i++)
-    {
+        {
         struct gsd_index_entry* new_index;
         int retval = gsd_index_buffer_add(&handle->frame_index, &new_index);
         if (retval != GSD_SUCCESS)
-        {
+            {
             return retval;
-        }
+            }
 
         *new_index = handle->buffer_index.data[i];
         new_index->location += offset;
-    }
+        }
 
     // clear the buffer index for new entries
     handle->buffer_index.size = 0;
 
     return GSD_SUCCESS;
-}
+    }
 
 /** @internal
     @brief Flush the name buffer.
@@ -1146,23 +1152,23 @@ inline static int gsd_flush_write_buffer(struct gsd_handle* handle)
     @returns GSD_SUCCESS on success or GSD_* error codes on error
 */
 inline static int gsd_flush_name_buffer(struct gsd_handle* handle)
-{
-    if (handle == NULL)
     {
+    if (handle == NULL)
+        {
         return GSD_ERROR_INVALID_ARGUMENT;
-    }
+        }
 
     if (handle->frame_names.n_names == 0)
-    {
+        {
         // nothing to do
         return GSD_SUCCESS;
-    }
+        }
 
     if (handle->frame_names.data.size == 0)
-    {
+        {
         // error: bytes in buffer, but no names for them
         return GSD_ERROR_INVALID_ARGUMENT;
-    }
+        }
 
     size_t old_reserved = handle->file_names.data.reserved;
     size_t old_size = handle->file_names.data.size;
@@ -1172,9 +1178,9 @@ inline static int gsd_flush_name_buffer(struct gsd_handle* handle)
                                         handle->frame_names.data.data,
                                         handle->frame_names.data.size);
     if (retval != GSD_SUCCESS)
-    {
+        {
         return retval;
-    }
+        }
 
     handle->file_names.n_names += handle->frame_names.n_names;
     handle->frame_names.n_names = 0;
@@ -1183,12 +1189,12 @@ inline static int gsd_flush_name_buffer(struct gsd_handle* handle)
 
     // reserved space must be a multiple of the GSD name size
     if (handle->file_names.data.reserved % GSD_NAME_SIZE != 0)
-    {
+        {
         return GSD_ERROR_INVALID_ARGUMENT;
-    }
+        }
 
     if (handle->file_names.data.reserved > old_reserved)
-    {
+        {
         // write the new name list to the end of the file
         uint64_t offset = handle->file_size;
         ssize_t bytes_written = gsd_io_pwrite_retry(handle->fd,
@@ -1197,16 +1203,16 @@ inline static int gsd_flush_name_buffer(struct gsd_handle* handle)
                                                     offset);
 
         if (bytes_written == -1 || bytes_written != handle->file_names.data.reserved)
-        {
+            {
             return GSD_ERROR_IO;
-        }
+            }
 
         // sync the updated name list
         retval = fsync(handle->fd);
         if (retval != 0)
-        {
+            {
             return GSD_ERROR_IO;
-        }
+            }
 
         handle->file_size += handle->file_names.data.reserved;
         handle->header.namelist_location = offset;
@@ -1217,12 +1223,12 @@ inline static int gsd_flush_name_buffer(struct gsd_handle* handle)
         bytes_written
             = gsd_io_pwrite_retry(handle->fd, &(handle->header), sizeof(struct gsd_header), 0);
         if (bytes_written != sizeof(struct gsd_header))
-        {
+            {
             return GSD_ERROR_IO;
+            }
         }
-    }
     else
-    {
+        {
         // write the new name list to the old index location
         uint64_t offset = handle->header.namelist_location;
         ssize_t bytes_written = gsd_io_pwrite_retry(handle->fd,
@@ -1230,20 +1236,20 @@ inline static int gsd_flush_name_buffer(struct gsd_handle* handle)
                                                     handle->file_names.data.reserved - old_size,
                                                     offset + old_size);
         if (bytes_written != (handle->file_names.data.reserved - old_size))
-        {
+            {
             return GSD_ERROR_IO;
+            }
         }
-    }
 
     // sync the updated name list or header
     retval = fsync(handle->fd);
     if (retval != 0)
-    {
+        {
         return GSD_ERROR_IO;
-    }
+        }
 
     return GSD_SUCCESS;
-}
+    }
 
 /** @internal
     @brief utility function to append a name to the namelist
@@ -1262,23 +1268,23 @@ inline static int gsd_flush_name_buffer(struct gsd_handle* handle)
       - GSD_ERROR_FILE_MUST_BE_WRITABLE: File must not be read only.
 */
 inline static int gsd_append_name(uint16_t* id, struct gsd_handle* handle, const char* name)
-{
-    if (handle->open_flags == GSD_OPEN_READONLY)
     {
+    if (handle->open_flags == GSD_OPEN_READONLY)
+        {
         return GSD_ERROR_FILE_MUST_BE_WRITABLE;
-    }
+        }
 
     if (handle->file_names.n_names + handle->frame_names.n_names == UINT16_MAX)
-    {
+        {
         // no more names may be added
         return GSD_ERROR_NAMELIST_FULL;
-    }
+        }
 
     // Provide the ID of the new name
     *id = (uint16_t)(handle->file_names.n_names + handle->frame_names.n_names);
 
     if (handle->header.gsd_version < gsd_make_version(2, 0))
-    {
+        {
         // v1 files always allocate GSD_NAME_SIZE bytes for each name and put a NULL terminator
         // at address 63
         char name_v1[GSD_NAME_SIZE];
@@ -1290,25 +1296,52 @@ inline static int gsd_append_name(uint16_t* id, struct gsd_handle* handle, const
         // update the name/id mapping with the truncated name
         int retval = gsd_name_id_map_insert(&handle->name_map, name_v1, *id);
         if (retval != GSD_SUCCESS)
-        {
+            {
             return retval;
+            }
         }
-    }
     else
-    {
+        {
         gsd_byte_buffer_append(&handle->frame_names.data, name, strlen(name) + 1);
         handle->frame_names.n_names++;
 
         // update the name/id mapping
         int retval = gsd_name_id_map_insert(&handle->name_map, name, *id);
         if (retval != GSD_SUCCESS)
-        {
+            {
             return retval;
+            }
         }
-    }
 
     return GSD_SUCCESS;
-}
+    }
+
+/** @internal
+    @brief Cross-platform wrapper for the POSIX open() system function.
+    @param pathname file path using UTF-8 encoding on all platforms
+    @return file descriptor
+*/
+inline static int gsd_open_file(const char* pathname, int flags, int mode)
+    {
+#ifndef _WIN32
+    return open(pathname, flags, mode);
+#else
+    // On Windows, we call the _wopen() function, which requires converting the UTF-8 input path to
+    // UTF-16 wide-character encoding.
+    int count_wchars;
+    wchar_t* wpathname;
+    int fd;
+
+    // First, determine the number of wide characters needed to represent the input string.
+    count_wchars = MultiByteToWideChar(CP_UTF8, 0, pathname, -1, NULL, 0);
+    // Then allocate temporary wchar_t buffer and perform the string conversion.
+    wpathname = malloc(sizeof(wchar_t) * count_wchars);
+    MultiByteToWideChar(CP_UTF8, 0, pathname, -1, wpathname, count_wchars);
+    fd = _wopen(wpathname, flags, mode);
+    free(wpathname);
+    return fd;
+#endif
+    }
 
 /** @internal
     @brief Truncate the file and write a new gsd header.
@@ -1320,18 +1353,18 @@ inline static int gsd_append_name(uint16_t* id, struct gsd_handle* handle, const
 */
 inline static int
 gsd_initialize_file(int fd, const char* application, const char* schema, uint32_t schema_version)
-{
+    {
     // check if the file was created
     if (fd == -1)
-    {
+        {
         return GSD_ERROR_IO;
-    }
+        }
 
     int retval = ftruncate(fd, 0);
     if (retval != 0)
-    {
+        {
         return GSD_ERROR_IO;
-    }
+        }
 
     // populate header fields
     struct gsd_header header;
@@ -1354,9 +1387,9 @@ gsd_initialize_file(int fd, const char* application, const char* schema, uint32_
     // write the header out
     ssize_t bytes_written = gsd_io_pwrite_retry(fd, &header, sizeof(header), 0);
     if (bytes_written != sizeof(header))
-    {
+        {
         return GSD_ERROR_IO;
-    }
+        }
 
     // allocate and zero default index memory
     struct gsd_index_entry index[GSD_INITIAL_INDEX_SIZE];
@@ -1365,9 +1398,9 @@ gsd_initialize_file(int fd, const char* application, const char* schema, uint32_
     // write the empty index out
     bytes_written = gsd_io_pwrite_retry(fd, index, sizeof(index), sizeof(header));
     if (bytes_written != sizeof(index))
-    {
+        {
         return GSD_ERROR_IO;
-    }
+        }
 
     // allocate and zero the namelist memory
     char names[GSD_INITIAL_NAME_BUFFER_SIZE];
@@ -1376,19 +1409,19 @@ gsd_initialize_file(int fd, const char* application, const char* schema, uint32_
     // write the namelist out
     bytes_written = gsd_io_pwrite_retry(fd, names, sizeof(names), sizeof(header) + sizeof(index));
     if (bytes_written != sizeof(names))
-    {
+        {
         return GSD_ERROR_IO;
-    }
+        }
 
     // sync file
     retval = fsync(fd);
     if (retval != 0)
-    {
+        {
         return GSD_ERROR_IO;
-    }
+        }
 
     return GSD_SUCCESS;
-}
+    }
 
 /** @internal
     @brief Read in the file index and initialize the handle.
@@ -1399,41 +1432,41 @@ gsd_initialize_file(int fd, const char* application, const char* schema, uint32_
     @pre handle->open_flags is set.
 */
 inline static int gsd_initialize_handle(struct gsd_handle* handle)
-{
+    {
     // check if the file was created
     if (handle->fd == -1)
-    {
+        {
         return GSD_ERROR_IO;
-    }
+        }
 
     // read the header
     ssize_t bytes_read
         = gsd_io_pread_retry(handle->fd, &handle->header, sizeof(struct gsd_header), 0);
     if (bytes_read == -1)
-    {
+        {
         return GSD_ERROR_IO;
-    }
+        }
     if (bytes_read != sizeof(struct gsd_header))
-    {
+        {
         return GSD_ERROR_NOT_A_GSD_FILE;
-    }
+        }
 
     // validate the header
     if (handle->header.magic != GSD_MAGIC_ID)
-    {
+        {
         return GSD_ERROR_NOT_A_GSD_FILE;
-    }
+        }
 
     if (handle->header.gsd_version < gsd_make_version(1, 0)
         && handle->header.gsd_version != gsd_make_version(0, 3))
-    {
+        {
         return GSD_ERROR_INVALID_GSD_FILE_VERSION;
-    }
+        }
 
     if (handle->header.gsd_version >= gsd_make_version(3, 0))
-    {
+        {
         return GSD_ERROR_INVALID_GSD_FILE_VERSION;
-    }
+        }
 
     // determine the file size
     handle->file_size = lseek(handle->fd, 0, SEEK_END);
@@ -1442,147 +1475,147 @@ inline static int gsd_initialize_handle(struct gsd_handle* handle)
     if (handle->header.namelist_location
             + (GSD_NAME_SIZE * handle->header.namelist_allocated_entries)
         > (uint64_t)handle->file_size)
-    {
+        {
         return GSD_ERROR_FILE_CORRUPT;
-    }
+        }
 
     // allocate the hash map
     int retval = gsd_name_id_map_allocate(&handle->name_map, GSD_NAME_MAP_SIZE);
     if (retval != GSD_SUCCESS)
-    {
+        {
         return retval;
-    }
+        }
 
     // read the namelist block
     size_t namelist_n_bytes = GSD_NAME_SIZE * handle->header.namelist_allocated_entries;
     retval = gsd_byte_buffer_allocate(&handle->file_names.data, namelist_n_bytes);
     if (retval != GSD_SUCCESS)
-    {
+        {
         return retval;
-    }
+        }
     bytes_read = gsd_io_pread_retry(handle->fd,
                                     handle->file_names.data.data,
                                     namelist_n_bytes,
                                     handle->header.namelist_location);
 
     if (bytes_read == -1 || bytes_read != namelist_n_bytes)
-    {
+        {
         return GSD_ERROR_IO;
-    }
+        }
 
     // The name buffer must end in a NULL terminator or else the file is corrupt
     if (handle->file_names.data.data[handle->file_names.data.reserved - 1] != 0)
-    {
+        {
         return GSD_ERROR_FILE_CORRUPT;
-    }
+        }
 
     // Add the names to the hash map. Also determine the number of used bytes in the namelist.
     size_t name_start = 0;
     handle->file_names.n_names = 0;
     while (name_start < handle->file_names.data.reserved)
-    {
+        {
         char* name = handle->file_names.data.data + name_start;
 
         // an empty name notes the end of the list
         if (name[0] == 0)
-        {
+            {
             break;
-        }
+            }
 
         retval
             = gsd_name_id_map_insert(&handle->name_map, name, (uint16_t)handle->file_names.n_names);
         if (retval != GSD_SUCCESS)
-        {
+            {
             return retval;
-        }
+            }
         handle->file_names.n_names++;
 
         if (handle->header.gsd_version < gsd_make_version(2, 0))
-        {
+            {
             // gsd v1 stores names in fixed 64 byte segments
             name_start += GSD_NAME_SIZE;
-        }
+            }
         else
-        {
+            {
             size_t len = strnlen(name, handle->file_names.data.reserved - name_start);
             name_start += len + 1;
+            }
         }
-    }
 
     handle->file_names.data.size = name_start;
 
     // read in the file index
     retval = gsd_index_buffer_map(&handle->file_index, handle);
     if (retval != GSD_SUCCESS)
-    {
+        {
         return retval;
-    }
+        }
 
     // determine the current frame counter
     if (handle->file_index.size == 0)
-    {
+        {
         handle->cur_frame = 0;
-    }
+        }
     else
-    {
+        {
         handle->cur_frame = handle->file_index.data[handle->file_index.size - 1].frame + 1;
-    }
+        }
 
     // if this is a write mode, allocate the initial frame index and the name buffer
     if (handle->open_flags != GSD_OPEN_READONLY)
-    {
+        {
         retval = gsd_index_buffer_allocate(&handle->frame_index, GSD_INITIAL_FRAME_INDEX_SIZE);
         if (retval != GSD_SUCCESS)
-        {
+            {
             return retval;
-        }
+            }
 
         retval = gsd_index_buffer_allocate(&handle->buffer_index, GSD_INITIAL_FRAME_INDEX_SIZE);
         if (retval != GSD_SUCCESS)
-        {
+            {
             return retval;
-        }
+            }
 
-        retval = gsd_byte_buffer_allocate(&handle->write_buffer, GSD_WRITE_BUFFER_SIZE);
+        retval = gsd_byte_buffer_allocate(&handle->write_buffer, GSD_INITIAL_WRITE_BUFFER_SIZE);
         if (retval != GSD_SUCCESS)
-        {
+            {
             return retval;
-        }
+            }
 
         handle->frame_names.n_names = 0;
         retval = gsd_byte_buffer_allocate(&handle->frame_names.data, GSD_NAME_SIZE);
         if (retval != GSD_SUCCESS)
-        {
+            {
             return retval;
+            }
         }
-    }
 
     return GSD_SUCCESS;
-}
+    }
 
 uint32_t gsd_make_version(unsigned int major, unsigned int minor)
-{
+    {
     return major << (sizeof(uint32_t) * 4) | minor;
-}
+    }
 
 int gsd_create(const char* fname,
                const char* application,
                const char* schema,
                uint32_t schema_version)
-{
+    {
     int extra_flags = 0;
 #ifdef _WIN32
     extra_flags = _O_BINARY;
 #endif
 
     // create the file
-    int fd = open(fname,
-                  O_RDWR | O_CREAT | O_TRUNC | extra_flags,
-                  S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP);
+    int fd = gsd_open_file(fname,
+                           O_RDWR | O_CREAT | O_TRUNC | extra_flags,
+                           S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP);
     int retval = gsd_initialize_file(fd, application, schema, schema_version);
     close(fd);
     return retval;
-}
+    }
 
 int gsd_create_and_open(struct gsd_handle* handle,
                         const char* fname,
@@ -1591,7 +1624,7 @@ int gsd_create_and_open(struct gsd_handle* handle,
                         uint32_t schema_version,
                         const enum gsd_open_flag flags,
                         int exclusive_create)
-{
+    {
     // zero the handle
     gsd_util_zero_memory(handle, sizeof(struct gsd_handle));
 
@@ -1602,45 +1635,45 @@ int gsd_create_and_open(struct gsd_handle* handle,
 
     // set the open flags in the handle
     if (flags == GSD_OPEN_READWRITE)
-    {
+        {
         handle->open_flags = GSD_OPEN_READWRITE;
-    }
+        }
     else if (flags == GSD_OPEN_READONLY)
-    {
+        {
         return GSD_ERROR_FILE_MUST_BE_WRITABLE;
-    }
+        }
     else if (flags == GSD_OPEN_APPEND)
-    {
+        {
         handle->open_flags = GSD_OPEN_APPEND;
-    }
+        }
 
     // set the exclusive create bit
     if (exclusive_create)
-    {
+        {
         extra_flags |= O_EXCL;
-    }
+        }
 
     // create the file
-    handle->fd = open(fname,
-                      O_RDWR | O_CREAT | O_TRUNC | extra_flags,
-                      S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP);
+    handle->fd = gsd_open_file(fname,
+                               O_RDWR | O_CREAT | O_TRUNC | extra_flags,
+                               S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP);
     int retval = gsd_initialize_file(handle->fd, application, schema, schema_version);
     if (retval != 0)
-    {
+        {
         close(handle->fd);
         return retval;
-    }
+        }
 
     retval = gsd_initialize_handle(handle);
     if (retval != 0)
-    {
+        {
         close(handle->fd);
-    }
+        }
     return retval;
-}
+    }
 
 int gsd_open(struct gsd_handle* handle, const char* fname, const enum gsd_open_flag flags)
-{
+    {
     // zero the handle
     gsd_util_zero_memory(handle, sizeof(struct gsd_handle));
 
@@ -1651,99 +1684,99 @@ int gsd_open(struct gsd_handle* handle, const char* fname, const enum gsd_open_f
 
     // open the file
     if (flags == GSD_OPEN_READWRITE)
-    {
-        handle->fd = open(fname, O_RDWR | extra_flags);
+        {
+        handle->fd = gsd_open_file(fname, O_RDWR | extra_flags, 0);
         handle->open_flags = GSD_OPEN_READWRITE;
-    }
+        }
     else if (flags == GSD_OPEN_READONLY)
-    {
-        handle->fd = open(fname, O_RDONLY | extra_flags);
+        {
+        handle->fd = gsd_open_file(fname, O_RDONLY | extra_flags, 0);
         handle->open_flags = GSD_OPEN_READONLY;
-    }
+        }
     else if (flags == GSD_OPEN_APPEND)
-    {
-        handle->fd = open(fname, O_RDWR | extra_flags);
+        {
+        handle->fd = gsd_open_file(fname, O_RDWR | extra_flags, 0);
         handle->open_flags = GSD_OPEN_APPEND;
-    }
+        }
 
     int retval = gsd_initialize_handle(handle);
     if (retval != 0)
-    {
+        {
         close(handle->fd);
-    }
+        }
     return retval;
-}
+    }
 
 int gsd_truncate(struct gsd_handle* handle)
-{
+    {
     if (handle == NULL)
-    {
+        {
         return GSD_ERROR_INVALID_ARGUMENT;
-    }
+        }
     if (handle->open_flags == GSD_OPEN_READONLY)
-    {
+        {
         return GSD_ERROR_FILE_MUST_BE_WRITABLE;
-    }
+        }
 
     int retval = 0;
 
     // deallocate indices
     if (handle->frame_names.data.reserved > 0)
-    {
+        {
         retval = gsd_byte_buffer_free(&handle->frame_names.data);
         if (retval != GSD_SUCCESS)
-        {
+            {
             return retval;
+            }
         }
-    }
 
     if (handle->file_names.data.reserved > 0)
-    {
+        {
         retval = gsd_byte_buffer_free(&handle->file_names.data);
         if (retval != GSD_SUCCESS)
-        {
+            {
             return retval;
+            }
         }
-    }
 
     retval = gsd_name_id_map_free(&handle->name_map);
     if (retval != GSD_SUCCESS)
-    {
+        {
         return retval;
-    }
+        }
 
     retval = gsd_index_buffer_free(&handle->file_index);
     if (retval != GSD_SUCCESS)
-    {
+        {
         return retval;
-    }
+        }
 
     if (handle->frame_index.reserved > 0)
-    {
+        {
         retval = gsd_index_buffer_free(&handle->frame_index);
         if (retval != GSD_SUCCESS)
-        {
+            {
             return retval;
+            }
         }
-    }
 
     if (handle->buffer_index.reserved > 0)
-    {
+        {
         retval = gsd_index_buffer_free(&handle->buffer_index);
         if (retval != GSD_SUCCESS)
-        {
+            {
             return retval;
+            }
         }
-    }
 
     if (handle->write_buffer.reserved > 0)
-    {
+        {
         retval = gsd_byte_buffer_free(&handle->write_buffer);
         if (retval != GSD_SUCCESS)
-        {
+            {
             return retval;
+            }
         }
-    }
 
     // keep a copy of the old header
     struct gsd_header old_header = handle->header;
@@ -1753,102 +1786,102 @@ int gsd_truncate(struct gsd_handle* handle)
                                  old_header.schema_version);
 
     if (retval != GSD_SUCCESS)
-    {
+        {
         return retval;
-    }
+        }
 
     return gsd_initialize_handle(handle);
-}
+    }
 
 int gsd_close(struct gsd_handle* handle)
-{
-    if (handle == NULL)
     {
+    if (handle == NULL)
+        {
         return GSD_ERROR_INVALID_ARGUMENT;
-    }
+        }
 
     // save the fd so we can use it after freeing the handle
     int fd = handle->fd;
 
     int retval = gsd_index_buffer_free(&handle->file_index);
     if (retval != GSD_SUCCESS)
-    {
+        {
         return retval;
-    }
+        }
 
     if (handle->frame_index.reserved > 0)
-    {
+        {
         retval = gsd_index_buffer_free(&handle->frame_index);
         if (retval != GSD_SUCCESS)
-        {
+            {
             return retval;
+            }
         }
-    }
 
     if (handle->buffer_index.reserved > 0)
-    {
+        {
         retval = gsd_index_buffer_free(&handle->buffer_index);
         if (retval != GSD_SUCCESS)
-        {
+            {
             return retval;
+            }
         }
-    }
 
     if (handle->write_buffer.reserved > 0)
-    {
+        {
         retval = gsd_byte_buffer_free(&handle->write_buffer);
         if (retval != GSD_SUCCESS)
-        {
+            {
             return retval;
+            }
         }
-    }
 
     retval = gsd_name_id_map_free(&handle->name_map);
     if (retval != GSD_SUCCESS)
-    {
+        {
         return retval;
-    }
+        }
 
     if (handle->frame_names.data.reserved > 0)
-    {
+        {
         handle->frame_names.n_names = 0;
         retval = gsd_byte_buffer_free(&handle->frame_names.data);
         if (retval != GSD_SUCCESS)
-        {
+            {
             return retval;
+            }
         }
-    }
 
     if (handle->file_names.data.reserved > 0)
-    {
+        {
         handle->file_names.n_names = 0;
         retval = gsd_byte_buffer_free(&handle->file_names.data);
         if (retval != GSD_SUCCESS)
-        {
+            {
             return retval;
+            }
         }
-    }
 
     // close the file
     retval = close(fd);
     if (retval != 0)
-    {
+        {
         return GSD_ERROR_IO;
-    }
+        }
 
     return GSD_SUCCESS;
-}
+    }
 
 int gsd_end_frame(struct gsd_handle* handle)
-{
+    {
     if (handle == NULL)
-    {
+        {
         return GSD_ERROR_INVALID_ARGUMENT;
-    }
+        }
     if (handle->open_flags == GSD_OPEN_READONLY)
-    {
+        {
         return GSD_ERROR_FILE_MUST_BE_WRITABLE;
-    }
+        }
 
     // increment the frame counter
     handle->cur_frame++;
@@ -1856,32 +1889,39 @@ int gsd_end_frame(struct gsd_handle* handle)
     // flush the namelist buffer
     int retval = gsd_flush_name_buffer(handle);
     if (retval != GSD_SUCCESS)
-    {
+        {
         return retval;
-    }
+        }
 
     // flush the write buffer
     retval = gsd_flush_write_buffer(handle);
     if (retval != GSD_SUCCESS)
-    {
+        {
         return retval;
-    }
+        }
+
+    // sync the data before writing the index
+    retval = fsync(handle->fd);
+    if (retval != 0)
+        {
+        return GSD_ERROR_IO;
+        }
 
     // write the frame index to the file
     if (handle->frame_index.size > 0)
-    {
+        {
         // ensure there is enough space in the index
         if ((handle->file_index.size + handle->frame_index.size) > handle->file_index.reserved)
-        {
+            {
             gsd_expand_file_index(handle, handle->file_index.size + handle->frame_index.size);
-        }
+            }
 
         // sort the index before writing
         retval = gsd_index_buffer_sort(&handle->frame_index);
         if (retval != 0)
-        {
+            {
             return retval;
-        }
+            }
 
         // write the frame index entries to the file
         int64_t write_pos = handle->header.index_location
@@ -1892,9 +1932,9 @@ int gsd_end_frame(struct gsd_handle* handle)
             = gsd_io_pwrite_retry(handle->fd, handle->frame_index.data, bytes_to_write, write_pos);
 
         if (bytes_written == -1 || bytes_written != bytes_to_write)
-        {
+            {
             return GSD_ERROR_IO;
-        }
+            }
 
 #if !GSD_USE_MMAP
         // add the entries to the file index
@@ -1908,10 +1948,10 @@ int gsd_end_frame(struct gsd_handle* handle)
 
         // clear the frame index
         handle->frame_index.size = 0;
-    }
+        }
 
     return GSD_SUCCESS;
-}
+    }
 
 int gsd_write_chunk(struct gsd_handle* handle,
                     const char* name,
@@ -1920,41 +1960,41 @@ int gsd_write_chunk(struct gsd_handle* handle,
                     uint32_t M,
                     uint8_t flags,
                     const void* data)
-{
+    {
     // validate input
     if (N > 0 && data == NULL)
-    {
+        {
         return GSD_ERROR_INVALID_ARGUMENT;
-    }
+        }
     if (M == 0)
-    {
+        {
         return GSD_ERROR_INVALID_ARGUMENT;
-    }
+        }
     if (handle->open_flags == GSD_OPEN_READONLY)
-    {
+        {
         return GSD_ERROR_FILE_MUST_BE_WRITABLE;
-    }
+        }
     if (flags != 0)
-    {
+        {
         return GSD_ERROR_INVALID_ARGUMENT;
-    }
+        }
 
     uint16_t id = gsd_name_id_map_find(&handle->name_map, name);
     if (id == UINT16_MAX)
-    {
+        {
         // not found, append to the index
         int retval = gsd_append_name(&id, handle, name);
         if (retval != GSD_SUCCESS)
-        {
+            {
             return retval;
-        }
+            }
 
         if (id == UINT16_MAX)
-        {
+            {
             // this should never happen
             return GSD_ERROR_NAMELIST_FULL;
+            }
         }
-    }
 
     struct gsd_index_entry entry;
     // populate fields in the entry's data
@@ -1967,13 +2007,13 @@ int gsd_write_chunk(struct gsd_handle* handle,
     size_t size = N * M * gsd_sizeof_type(type);
 
     // decide whether to write this chunk to the buffer or straight to disk
-    if (size < handle->write_buffer.reserved / 2)
-    {
-        // flush the buffer if this entry won't fit
-        if (size > (handle->write_buffer.reserved - handle->write_buffer.size))
+    if (size < GSD_MAXIMUM_WRITE_BUFFER_SIZE / 2)
         {
+        // flush the buffer if this entry won't fit
+        if (size > (GSD_MAXIMUM_WRITE_BUFFER_SIZE - handle->write_buffer.size))
+            {
             gsd_flush_write_buffer(handle);
-        }
+            }
 
         entry.location = handle->write_buffer.size;
 
@@ -1982,31 +2022,31 @@ int gsd_write_chunk(struct gsd_handle* handle,
 
         int retval = gsd_index_buffer_add(&handle->buffer_index, &index_entry);
         if (retval != GSD_SUCCESS)
-        {
+            {
             return retval;
-        }
+            }
         *index_entry = entry;
 
         // add the data to the write buffer
         if (size > 0)
-        {
+            {
             retval = gsd_byte_buffer_append(&handle->write_buffer, data, size);
             if (retval != GSD_SUCCESS)
-            {
+                {
                 return retval;
+                }
             }
         }
-    }
     else
-    {
+        {
         // add an entry to the frame index
         struct gsd_index_entry* index_entry;
 
         int retval = gsd_index_buffer_add(&handle->frame_index, &index_entry);
         if (retval != GSD_SUCCESS)
-        {
+            {
             return retval;
-        }
+            }
         *index_entry = entry;
 
         // find the location at the end of the file for the chunk
@@ -2015,55 +2055,51 @@ int gsd_write_chunk(struct gsd_handle* handle,
         // write the data
         ssize_t bytes_written = gsd_io_pwrite_retry(handle->fd, data, size, index_entry->location);
         if (bytes_written == -1 || bytes_written != size)
-        {
+            {
             return GSD_ERROR_IO;
-        }
+            }
 
         // update the file_size in the handle
         handle->file_size += bytes_written;
-    }
+        }
 
     return GSD_SUCCESS;
-}
+    }
 
 uint64_t gsd_get_nframes(struct gsd_handle* handle)
-{
-    if (handle == NULL)
     {
+    if (handle == NULL)
+        {
         return 0;
-    }
+        }
     return handle->cur_frame;
-}
+    }
 
 const struct gsd_index_entry*
 gsd_find_chunk(struct gsd_handle* handle, uint64_t frame, const char* name)
-{
+    {
     if (handle == NULL)
-    {
+        {
         return NULL;
-    }
+        }
     if (name == NULL)
-    {
+        {
         return NULL;
-    }
+        }
     if (frame >= gsd_get_nframes(handle))
-    {
+        {
         return NULL;
-    }
-    if (handle->open_flags == GSD_OPEN_APPEND)
-    {
-        return NULL;
-    }
+        }
 
     // find the id for the given name
     uint16_t match_id = gsd_name_id_map_find(&handle->name_map, name);
     if (match_id == UINT16_MAX)
-    {
+        {
         return NULL;
-    }
+        }
 
     if (handle->header.gsd_version >= gsd_make_version(2, 0))
-    {
+        {
         // gsd 2.0 files sort the entire index
         // binary search for the index entry
         ssize_t L = 0;
@@ -2073,43 +2109,43 @@ gsd_find_chunk(struct gsd_handle* handle, uint64_t frame, const char* name)
         T.id = match_id;
 
         while (L <= R)
-        {
+            {
             size_t m = (L + R) / 2;
             int cmp = gsd_cmp_index_entry(handle->file_index.data + m, &T);
             if (cmp == -1)
-            {
+                {
                 L = m + 1;
-            }
+                }
             else if (cmp == 1)
-            {
+                {
                 R = m - 1;
-            }
+                }
             else
-            {
+                {
                 return &(handle->file_index.data[m]);
+                }
             }
         }
-    }
     else
-    {
+        {
         // gsd 1.0 file: use binary search to find the frame and linear search to find the entry
         size_t L = 0;
         size_t R = handle->file_index.size;
 
         // progressively narrow the search window by halves
         do
-        {
+            {
             size_t m = (L + R) / 2;
 
             if (frame < handle->file_index.data[m].frame)
-            {
+                {
                 R = m;
-            }
+                }
             else
-            {
+                {
                 L = m;
-            }
-        } while ((R - L) > 1);
+                }
+            } while ((R - L) > 1);
 
         // this finds L = the rightmost index with the desired frame
         int64_t cur_index;
@@ -2117,213 +2153,209 @@ gsd_find_chunk(struct gsd_handle* handle, uint64_t frame, const char* name)
         // search all index entries with the matching frame
         for (cur_index = L; (cur_index >= 0) && (handle->file_index.data[cur_index].frame == frame);
              cur_index--)
-        {
+            {
             // if the frame matches, check the id
             if (match_id == handle->file_index.data[cur_index].id)
-            {
+                {
                 return &(handle->file_index.data[cur_index]);
+                }
             }
         }
-    }
 
     // if we got here, we didn't find the specified chunk
     return NULL;
-}
+    }
 
 int gsd_read_chunk(struct gsd_handle* handle, void* data, const struct gsd_index_entry* chunk)
-{
+    {
     if (handle == NULL)
-    {
+        {
         return GSD_ERROR_INVALID_ARGUMENT;
-    }
+        }
     if (data == NULL)
-    {
+        {
         return GSD_ERROR_INVALID_ARGUMENT;
-    }
+        }
     if (chunk == NULL)
-    {
+        {
         return GSD_ERROR_INVALID_ARGUMENT;
-    }
-    if (handle->open_flags == GSD_OPEN_APPEND)
-    {
-        return GSD_ERROR_FILE_MUST_BE_READABLE;
-    }
+        }
 
     size_t size = chunk->N * chunk->M * gsd_sizeof_type((enum gsd_type)chunk->type);
     if (size == 0)
-    {
+        {
         return GSD_ERROR_FILE_CORRUPT;
-    }
+        }
     if (chunk->location == 0)
-    {
+        {
         return GSD_ERROR_FILE_CORRUPT;
-    }
+        }
 
     // validate that we don't read past the end of the file
     if ((chunk->location + size) > (uint64_t)handle->file_size)
-    {
+        {
         return GSD_ERROR_FILE_CORRUPT;
-    }
+        }
 
     ssize_t bytes_read = gsd_io_pread_retry(handle->fd, data, size, chunk->location);
     if (bytes_read == -1 || bytes_read != size)
-    {
+        {
         return GSD_ERROR_IO;
-    }
+        }
 
     return GSD_SUCCESS;
-}
+    }
 
 size_t gsd_sizeof_type(enum gsd_type type)
-{
+    {
     size_t val = 0;
     if (type == GSD_TYPE_UINT8)
-    {
+        {
         val = sizeof(uint8_t);
-    }
+        }
     else if (type == GSD_TYPE_UINT16)
-    {
+        {
         val = sizeof(uint16_t);
-    }
+        }
     else if (type == GSD_TYPE_UINT32)
-    {
+        {
         val = sizeof(uint32_t);
-    }
+        }
     else if (type == GSD_TYPE_UINT64)
-    {
+        {
         val = sizeof(uint64_t);
-    }
+        }
     else if (type == GSD_TYPE_INT8)
-    {
+        {
         val = sizeof(int8_t);
-    }
+        }
     else if (type == GSD_TYPE_INT16)
-    {
+        {
         val = sizeof(int16_t);
-    }
+        }
     else if (type == GSD_TYPE_INT32)
-    {
+        {
         val = sizeof(int32_t);
-    }
+        }
     else if (type == GSD_TYPE_INT64)
-    {
+        {
         val = sizeof(int64_t);
-    }
+        }
     else if (type == GSD_TYPE_FLOAT)
-    {
+        {
         val = sizeof(float);
-    }
+        }
     else if (type == GSD_TYPE_DOUBLE)
-    {
+        {
         val = sizeof(double);
-    }
+        }
     else
-    {
+        {
         return 0;
-    }
+        }
     return val;
-}
+    }
 
 const char*
 gsd_find_matching_chunk_name(struct gsd_handle* handle, const char* match, const char* prev)
-{
+    {
     if (handle == NULL)
-    {
+        {
         return NULL;
-    }
+        }
     if (match == NULL)
-    {
+        {
         return NULL;
-    }
+        }
     if (handle->file_names.n_names == 0)
-    {
+        {
         return NULL;
-    }
+        }
 
     // return nothing found if the name buffer is corrupt
     if (handle->file_names.data.data[handle->file_names.data.reserved - 1] != 0)
-    {
+        {
         return NULL;
-    }
+        }
 
     // determine search start index
     const char* search_str;
     if (prev == NULL)
-    {
+        {
         search_str = handle->file_names.data.data;
-    }
+        }
     else
-    {
+        {
         // return not found if prev is not in range
         if (prev < handle->file_names.data.data)
-        {
+            {
             return NULL;
-        }
+            }
         if (prev >= (handle->file_names.data.data + handle->file_names.data.reserved))
-        {
+            {
             return NULL;
-        }
+            }
 
         if (handle->header.gsd_version < gsd_make_version(2, 0))
-        {
+            {
             search_str = prev + GSD_NAME_SIZE;
-        }
+            }
         else
-        {
+            {
             search_str = prev + strlen(prev) + 1;
+            }
         }
-    }
 
     size_t match_len = strlen(match);
 
     while (search_str < (handle->file_names.data.data + handle->file_names.data.reserved))
-    {
-        if (search_str[0] != 0 && 0 == strncmp(match, search_str, match_len))
         {
+        if (search_str[0] != 0 && 0 == strncmp(match, search_str, match_len))
+            {
             return search_str;
-        }
+            }
 
         if (handle->header.gsd_version < gsd_make_version(2, 0))
-        {
+            {
             search_str += GSD_NAME_SIZE;
-        }
+            }
         else
-        {
+            {
             search_str += strlen(search_str) + 1;
+            }
         }
-    }
 
     // searched past the end of the list, return NULL
     return NULL;
-}
+    }
 
 int gsd_upgrade(struct gsd_handle* handle)
-{
+    {
     if (handle == NULL)
-    {
+        {
         return GSD_ERROR_INVALID_ARGUMENT;
-    }
+        }
     if (handle->open_flags == GSD_OPEN_READONLY)
-    {
+        {
         return GSD_ERROR_INVALID_ARGUMENT;
-    }
+        }
     if (handle->frame_index.size > 0 || handle->frame_names.n_names > 0)
-    {
+        {
         return GSD_ERROR_INVALID_ARGUMENT;
-    }
+        }
 
     if (handle->header.gsd_version < gsd_make_version(2, 0))
-    {
-        if (handle->file_index.size > 0)
         {
+        if (handle->file_index.size > 0)
+            {
             // make a copy of the file index
             struct gsd_index_buffer buf;
             gsd_util_zero_memory(&buf, sizeof(struct gsd_index_buffer));
             int retval = gsd_index_buffer_allocate(&buf, handle->file_index.size);
             if (retval != GSD_SUCCESS)
-            {
+                {
                 return retval;
-            }
+                }
             memcpy(buf.data,
                    handle->file_index.data,
                    sizeof(struct gsd_index_entry) * handle->file_index.size);
@@ -2332,10 +2364,10 @@ int gsd_upgrade(struct gsd_handle* handle)
             // sort the copy and write it back out to the file
             retval = gsd_index_buffer_sort(&buf);
             if (retval != GSD_SUCCESS)
-            {
+                {
                 gsd_index_buffer_free(&buf);
                 return retval;
-            }
+                }
 
             ssize_t bytes_written = gsd_io_pwrite_retry(handle->fd,
                                                         buf.data,
@@ -2343,53 +2375,53 @@ int gsd_upgrade(struct gsd_handle* handle)
                                                         handle->header.index_location);
 
             if (bytes_written == -1 || bytes_written != sizeof(struct gsd_index_entry) * buf.size)
-            {
+                {
                 gsd_index_buffer_free(&buf);
                 return GSD_ERROR_IO;
-            }
+                }
 
             retval = gsd_index_buffer_free(&buf);
             if (retval != GSD_SUCCESS)
-            {
+                {
                 return retval;
-            }
+                }
 
             // sync the updated index
             retval = fsync(handle->fd);
             if (retval != 0)
-            {
+                {
                 return GSD_ERROR_IO;
+                }
             }
-        }
 
         if (handle->file_names.n_names > 0)
-        {
+            {
             // compact the name list without changing its size or position on the disk
             struct gsd_byte_buffer new_name_buf;
             gsd_util_zero_memory(&new_name_buf, sizeof(struct gsd_byte_buffer));
             int retval = gsd_byte_buffer_allocate(&new_name_buf, handle->file_names.data.reserved);
             if (retval != GSD_SUCCESS)
-            {
+                {
                 return retval;
-            }
+                }
 
             const char* name = gsd_find_matching_chunk_name(handle, "", NULL);
             while (name != NULL)
-            {
+                {
                 retval = gsd_byte_buffer_append(&new_name_buf, name, strlen(name) + 1);
                 if (retval != GSD_SUCCESS)
-                {
+                    {
                     gsd_byte_buffer_free(&new_name_buf);
                     return retval;
-                }
+                    }
                 name = gsd_find_matching_chunk_name(handle, "", name);
-            }
+                }
 
             if (new_name_buf.reserved != handle->file_names.data.reserved)
-            {
+                {
                 gsd_byte_buffer_free(&new_name_buf);
                 return GSD_ERROR_FILE_CORRUPT;
-            }
+                }
 
             // write the new names out to disk
             ssize_t bytes_written = gsd_io_pwrite_retry(handle->fd,
@@ -2398,28 +2430,28 @@ int gsd_upgrade(struct gsd_handle* handle)
                                                         handle->header.namelist_location);
 
             if (bytes_written == -1 || bytes_written != new_name_buf.reserved)
-            {
+                {
                 gsd_byte_buffer_free(&new_name_buf);
                 return GSD_ERROR_IO;
-            }
+                }
 
             // swap in the re-organized name buffer
             retval = gsd_byte_buffer_free(&handle->file_names.data);
             if (retval != GSD_SUCCESS)
-            {
+                {
                 gsd_byte_buffer_free(&new_name_buf);
                 return retval;
-            }
+                }
             handle->file_names.data = new_name_buf;
 
             // sync the updated name list
             retval = fsync(handle->fd);
             if (retval != 0)
-            {
+                {
                 gsd_byte_buffer_free(&new_name_buf);
                 return GSD_ERROR_IO;
+                }
             }
-        }
 
         // label the file as a v2.0 file
         handle->header.gsd_version = gsd_make_version(GSD_CURRENT_FILE_VERSION, 0);
@@ -2428,33 +2460,33 @@ int gsd_upgrade(struct gsd_handle* handle)
         ssize_t bytes_written
             = gsd_io_pwrite_retry(handle->fd, &(handle->header), sizeof(struct gsd_header), 0);
         if (bytes_written != sizeof(struct gsd_header))
-        {
+            {
             return GSD_ERROR_IO;
-        }
+            }
 
         // sync the updated header
         int retval = fsync(handle->fd);
         if (retval != 0)
-        {
+            {
             return GSD_ERROR_IO;
-        }
+            }
 
         // remap the file index
         retval = gsd_index_buffer_free(&handle->file_index);
         if (retval != 0)
-        {
+            {
             return retval;
-        }
+            }
 
         retval = gsd_index_buffer_map(&handle->file_index, handle);
         if (retval != 0)
-        {
+            {
             return retval;
+            }
         }
-    }
 
     return GSD_SUCCESS;
-}
+    }
 
 // undefine windows wrapper macros
 #ifdef _WIN32

--- a/hoomd/extern/gsd.h
+++ b/hoomd/extern/gsd.h
@@ -1,6 +1,5 @@
-// Copyright (c) 2016-2020 The Regents of the University of Michigan
-// This file is part of the General Simulation Data (GSD) project, released under the BSD 2-Clause
-// License.
+// Copyright (c) 2016-2023 The Regents of the University of Michigan
+// Part of GSD, released under the BSD 2-Clause License.
 
 #ifndef GSD_H
 #define GSD_H
@@ -10,582 +9,586 @@
 #include <string.h>
 
 #ifdef __cplusplus
-extern "C" {
+extern "C"
+    {
 #endif
 
-/*! \file gsd.h
-    \brief Declare GSD data types and C API
-*/
-
-/// Identifiers for the gsd data chunk element types
-enum gsd_type
-{
-    /// Unsigned 8-bit integer.
-    GSD_TYPE_UINT8 = 1,
-
-    /// Unsigned 16-bit integer.
-    GSD_TYPE_UINT16,
-
-    /// Unsigned 32-bit integer.
-    GSD_TYPE_UINT32,
-
-    /// Unsigned 53-bit integer.
-    GSD_TYPE_UINT64,
-
-    /// Signed 8-bit integer.
-    GSD_TYPE_INT8,
-
-    /// Signed 16-bit integer.
-    GSD_TYPE_INT16,
-
-    /// Signed 32-bit integer.
-    GSD_TYPE_INT32,
-
-    /// Signed 64-bit integer.
-    GSD_TYPE_INT64,
-
-    /// 32-bit floating point number.
-    GSD_TYPE_FLOAT,
-
-    /// 64-bit floating point number.
-    GSD_TYPE_DOUBLE
-};
-
-/// Flag for GSD file open options
-enum gsd_open_flag
-{
-    /// Open for both reading and writing
-    GSD_OPEN_READWRITE = 1,
-
-    /// Open only for reading
-    GSD_OPEN_READONLY,
-
-    /// Open only for writing
-    GSD_OPEN_APPEND
-};
-
-/// Error return values
-enum gsd_error
-{
-    /// Success.
-    GSD_SUCCESS = 0,
-
-    /// IO error. Check ``errno`` for details
-    GSD_ERROR_IO = -1,
-
-    /// Invalid argument passed to function.
-    GSD_ERROR_INVALID_ARGUMENT = -2,
-
-    /// The file is not a GSD file.
-    GSD_ERROR_NOT_A_GSD_FILE = -3,
-
-    /// The GSD file version cannot be read.
-    GSD_ERROR_INVALID_GSD_FILE_VERSION = -4,
-
-    /// The GSD file is corrupt.
-    GSD_ERROR_FILE_CORRUPT = -5,
-
-    /// GSD failed to allocated memory.
-    GSD_ERROR_MEMORY_ALLOCATION_FAILED = -6,
-
-    /// The GSD file cannot store any additional unique data chunk names.
-    GSD_ERROR_NAMELIST_FULL = -7,
-
-    /** This API call requires that the GSD file opened in with the mode GSD_OPEN_APPEND or
-        GSD_OPEN_READWRITE.
+    /*! \file gsd.h
+        \brief Declare GSD data types and C API
     */
-    GSD_ERROR_FILE_MUST_BE_WRITABLE = -8,
 
-    /** This API call requires that the GSD file opened the mode GSD_OPEN_READ or
-        GSD_OPEN_READWRITE.
+    /// Identifiers for the gsd data chunk element types
+    enum gsd_type
+        {
+        /// Unsigned 8-bit integer.
+        GSD_TYPE_UINT8 = 1,
+
+        /// Unsigned 16-bit integer.
+        GSD_TYPE_UINT16,
+
+        /// Unsigned 32-bit integer.
+        GSD_TYPE_UINT32,
+
+        /// Unsigned 53-bit integer.
+        GSD_TYPE_UINT64,
+
+        /// Signed 8-bit integer.
+        GSD_TYPE_INT8,
+
+        /// Signed 16-bit integer.
+        GSD_TYPE_INT16,
+
+        /// Signed 32-bit integer.
+        GSD_TYPE_INT32,
+
+        /// Signed 64-bit integer.
+        GSD_TYPE_INT64,
+
+        /// 32-bit floating point number.
+        GSD_TYPE_FLOAT,
+
+        /// 64-bit floating point number.
+        GSD_TYPE_DOUBLE
+        };
+
+    /// Flag for GSD file open options
+    enum gsd_open_flag
+        {
+        /// Open for both reading and writing
+        GSD_OPEN_READWRITE = 1,
+
+        /// Open only for reading
+        GSD_OPEN_READONLY,
+
+        /// Open only for writing
+        GSD_OPEN_APPEND
+        };
+
+    /// Error return values
+    enum gsd_error
+        {
+        /// Success.
+        GSD_SUCCESS = 0,
+
+        /// IO error. Check ``errno`` for details
+        GSD_ERROR_IO = -1,
+
+        /// Invalid argument passed to function.
+        GSD_ERROR_INVALID_ARGUMENT = -2,
+
+        /// The file is not a GSD file.
+        GSD_ERROR_NOT_A_GSD_FILE = -3,
+
+        /// The GSD file version cannot be read.
+        GSD_ERROR_INVALID_GSD_FILE_VERSION = -4,
+
+        /// The GSD file is corrupt.
+        GSD_ERROR_FILE_CORRUPT = -5,
+
+        /// GSD failed to allocated memory.
+        GSD_ERROR_MEMORY_ALLOCATION_FAILED = -6,
+
+        /// The GSD file cannot store any additional unique data chunk names.
+        GSD_ERROR_NAMELIST_FULL = -7,
+
+        /** This API call requires that the GSD file opened in with the mode GSD_OPEN_APPEND or
+            GSD_OPEN_READWRITE.
+        */
+        GSD_ERROR_FILE_MUST_BE_WRITABLE = -8,
+
+        /** This API call requires that the GSD file opened the mode GSD_OPEN_READ or
+            GSD_OPEN_READWRITE.
+        */
+        GSD_ERROR_FILE_MUST_BE_READABLE = -9,
+        };
+
+    enum
+        {
+        /** v1 file: Size of a GSD name in memory. v2 file: The name buffer size is a multiple of
+            GSD_NAME_SIZE.
+        */
+        GSD_NAME_SIZE = 64
+        };
+
+    enum
+        {
+        /// Reserved bytes in the header structure
+        GSD_RESERVED_BYTES = 80
+        };
+
+    /** GSD file header
+
+        The in-memory and on-disk storage of the GSD file header. Stored in the first 256 bytes of
+        the file.
+
+        @warning All members are **read-only** to the caller.
     */
-    GSD_ERROR_FILE_MUST_BE_READABLE = -9,
-};
+    struct gsd_header
+        {
+        /// Magic number marking that this is a GSD file.
+        uint64_t magic;
 
-enum
-{
-    /** v1 file: Size of a GSD name in memory. v2 file: The name buffer size is a multiple of
-        GSD_NAME_SIZE.
+        /// Location of the chunk index in the file.
+        uint64_t index_location;
+
+        /// Number of index entries that will fit in the space allocated.
+        uint64_t index_allocated_entries;
+
+        /// Location of the name list in the file.
+        uint64_t namelist_location;
+
+        /// Number of bytes in the namelist divided by GSD_NAME_SIZE.
+        uint64_t namelist_allocated_entries;
+
+        /// Schema version: from gsd_make_version().
+        uint32_t schema_version;
+
+        /// GSD file format version from gsd_make_version().
+        uint32_t gsd_version;
+
+        /// Name of the application that generated this file.
+        char application[GSD_NAME_SIZE];
+
+        /// Name of data schema.
+        char schema[GSD_NAME_SIZE];
+
+        /// Reserved for future use.
+        char reserved[GSD_RESERVED_BYTES];
+        };
+
+    /** Index entry
+
+        An index entry for a single chunk of data.
+
+        @warning All members are **read-only** to the caller.
     */
-    GSD_NAME_SIZE = 64
-};
+    struct gsd_index_entry
+        {
+        /// Frame index of the chunk.
+        uint64_t frame;
 
-enum
-{
-    /// Reserved bytes in the header structure
-    GSD_RESERVED_BYTES = 80
-};
+        /// Number of rows in the chunk.
+        uint64_t N;
 
-/** GSD file header
+        /// Location of the chunk in the file.
+        int64_t location;
 
-    The in-memory and on-disk storage of the GSD file header. Stored in the first 256 bytes of the
-    file.
+        /// Number of columns in the chunk.
+        uint32_t M;
 
-    @warning All members are **read-only** to the caller.
-*/
-struct gsd_header
-{
-    /// Magic number marking that this is a GSD file.
-    uint64_t magic;
+        /// Index of the chunk name in the name list.
+        uint16_t id;
 
-    /// Location of the chunk index in the file.
-    uint64_t index_location;
+        /// Data type of the chunk: one of gsd_type.
+        uint8_t type;
 
-    /// Number of index entries that will fit in the space allocated.
-    uint64_t index_allocated_entries;
+        /// Flags (for internal use).
+        uint8_t flags;
+        };
 
-    /// Location of the name list in the file.
-    uint64_t namelist_location;
+    /** Name/id mapping
 
-    /// Number of bytes in the namelist divided by GSD_NAME_SIZE.
-    uint64_t namelist_allocated_entries;
+        A string name paired with an ID. Used for storing sorted name/id mappings in a hash map.
+    */
+    struct gsd_name_id_pair
+        {
+        /// Pointer to name (actual name storage is allocated in gsd_handle)
+        char* name;
 
-    /// Schema version: from gsd_make_version().
-    uint32_t schema_version;
+        /// Next name/id pair with the same hash
+        struct gsd_name_id_pair* next;
 
-    /// GSD file format version from gsd_make_version().
-    uint32_t gsd_version;
+        /// Entry id
+        uint16_t id;
+        };
 
-    /// Name of the application that generated this file.
-    char application[GSD_NAME_SIZE];
+    /** Name/id hash map
 
-    /// Name of data schema.
-    char schema[GSD_NAME_SIZE];
+        A hash map of string names to integer identifiers.
+    */
+    struct gsd_name_id_map
+        {
+        /// Name/id mappings
+        struct gsd_name_id_pair* v;
 
-    /// Reserved for future use.
-    char reserved[GSD_RESERVED_BYTES];
-};
+        /// Number of entries in the mapping
+        size_t size;
+        };
 
-/** Index entry
+    /** Array of index entries
 
-    An index entry for a single chunk of data.
+        May point to a mapped location of index entries in the file or an in-memory buffer.
+    */
+    struct gsd_index_buffer
+        {
+        /// Indices in the buffer
+        struct gsd_index_entry* data;
 
-    @warning All members are **read-only** to the caller.
-*/
-struct gsd_index_entry
-{
-    /// Frame index of the chunk.
-    uint64_t frame;
+        /// Number of entries in the buffer
+        size_t size;
 
-    /// Number of rows in the chunk.
-    uint64_t N;
+        /// Number of entries available in the buffer
+        size_t reserved;
 
-    /// Location of the chunk in the file.
-    int64_t location;
+        /// Pointer to mapped data (NULL if not mapped)
+        void* mapped_data;
 
-    /// Number of columns in the chunk.
-    uint32_t M;
+        /// Number of bytes mapped
+        size_t mapped_len;
+        };
 
-    /// Index of the chunk name in the name list.
-    uint16_t id;
+    /** Byte buffer
 
-    /// Data type of the chunk: one of gsd_type.
-    uint8_t type;
+        Used to buffer of small data chunks held for a buffered write at the end of a frame. Also
+        used to hold the names.
+    */
+    struct gsd_byte_buffer
+        {
+        /// Data
+        char* data;
 
-    /// Flags (for internal use).
-    uint8_t flags;
-};
+        /// Number of bytes in the buffer
+        size_t size;
 
-/** Name/id mapping
+        /// Number of bytes available in the buffer
+        size_t reserved;
+        };
 
-    A string name paired with an ID. Used for storing sorted name/id mappings in a hash map.
-*/
-struct gsd_name_id_pair
-{
-    /// Pointer to name (actual name storage is allocated in gsd_handle)
-    char* name;
+    /** Name buffer
 
-    /// Next name/id pair with the same hash
-    struct gsd_name_id_pair* next;
+        Holds a list of string names in order separated by NULL terminators. In v1 files, each name
+        is 64 bytes. In v2 files, only one NULL terminator is placed between each name.
+    */
+    struct gsd_name_buffer
+        {
+        /// Data
+        struct gsd_byte_buffer data;
 
-    /// Entry id
-    uint16_t id;
-};
+        /// Number of names in the list
+        size_t n_names;
+        };
 
-/** Name/id hash map
+    /** File handle
 
-    A hash map of string names to integer identifiers.
-*/
-struct gsd_name_id_map
-{
-    /// Name/id mappings
-    struct gsd_name_id_pair* v;
+        A handle to an open GSD file.
 
-    /// Number of entries in the mapping
-    size_t size;
-};
+        This handle is obtained when opening a GSD file and is passed into every method that
+        operates on the file.
 
-/** Array of index entries
+        @warning All members are **read-only** to the caller.
+    */
+    struct gsd_handle
+        {
+        /// File descriptor
+        int fd;
 
-    May point to a mapped location of index entries in the file or an in-memory buffer.
-*/
-struct gsd_index_buffer
-{
-    /// Indices in the buffer
-    struct gsd_index_entry* data;
+        /// The file header
+        struct gsd_header header;
 
-    /// Number of entries in the buffer
-    size_t size;
+        /// Mapped data chunk index
+        struct gsd_index_buffer file_index;
 
-    /// Number of entries available in the buffer
-    size_t reserved;
+        /// Index entries to append to the current frame
+        struct gsd_index_buffer frame_index;
 
-    /// Pointer to mapped data (NULL if not mapped)
-    void* mapped_data;
+        /// Buffered index entries to append to the current frame
+        struct gsd_index_buffer buffer_index;
 
-    /// Number of bytes mapped
-    size_t mapped_len;
-};
+        /// Buffered write data
+        struct gsd_byte_buffer write_buffer;
 
-/** Byte buffer
+        /// List of names stored in the file
+        struct gsd_name_buffer file_names;
 
-    Used to buffer of small data chunks held for a buffered write at the end of a frame. Also
-    used to hold the names.
-*/
-struct gsd_byte_buffer
-{
-    /// Data
-    char* data;
+        /// List of names added in the current frame
+        struct gsd_name_buffer frame_names;
 
-    /// Number of bytes in the buffer
-    size_t size;
+        /// The index of the last frame in the file
+        uint64_t cur_frame;
 
-    /// Number of bytes available in the buffer
-    size_t reserved;
-};
+        /// Size of the file (in bytes)
+        int64_t file_size;
 
-/** Name buffer
+        /// Flags passed to gsd_open() when opening this handle
+        enum gsd_open_flag open_flags;
 
-    Holds a list of string names in order separated by NULL terminators. In v1 files, each name is
-    64 bytes. In v2 files, only one NULL terminator is placed between each name.
-*/
-struct gsd_name_buffer
-{
-    /// Data
-    struct gsd_byte_buffer data;
+        /// Access the names in the namelist
+        struct gsd_name_id_map name_map;
+        };
 
-    /// Number of names in the list
-    size_t n_names;
-};
+    /** Specify a version
 
-/** File handle
+        @param major major version
+        @param minor minor version
 
-    A handle to an open GSD file.
+        @return a packed version number aaaa.bbbb suitable for storing in a gsd file version entry.
+    */
+    uint32_t gsd_make_version(unsigned int major, unsigned int minor);
 
-    This handle is obtained when opening a GSD file and is passed into every method that operates
-    on the file.
+    /** Create a GSD file
 
-    @warning All members are **read-only** to the caller.
-*/
-struct gsd_handle
-{
-    /// File descriptor
-    int fd;
+        @param fname File name (UTF-8 encoded).
+        @param application Generating application name (truncated to 63 chars).
+        @param schema Schema name for data to be written in this GSD file (truncated to 63 chars).
+        @param schema_version Version of the scheme data to be written (make with
+        gsd_make_version()).
 
-    /// The file header
-    struct gsd_header header;
+        @post Create an empty gsd file in a file of the given name. Overwrite any existing file at
+        that location.
 
-    /// Mapped data chunk index
-    struct gsd_index_buffer file_index;
+        The generated gsd file is not opened. Call gsd_open() to open it for writing.
 
-    /// Index entries to append to the current frame
-    struct gsd_index_buffer frame_index;
+        @return
+          - GSD_SUCCESS (0) on success. Negative value on failure:
+          - GSD_ERROR_IO: IO error (check errno).
+    */
+    int gsd_create(const char* fname,
+                   const char* application,
+                   const char* schema,
+                   uint32_t schema_version);
 
-    /// Buffered index entries to append to the current frame
-    struct gsd_index_buffer buffer_index;
+    /** Create and open a GSD file
 
-    /// Buffered write data
-    struct gsd_byte_buffer write_buffer;
+        @param handle Handle to open.
+        @param fname File name (UTF-8 encoded).
+        @param application Generating application name (truncated to 63 chars).
+        @param schema Schema name for data to be written in this GSD file (truncated to 63 chars).
+        @param schema_version Version of the scheme data to be written (make with
+            gsd_make_version()).
+        @param flags Either GSD_OPEN_READWRITE, or GSD_OPEN_APPEND.
+        @param exclusive_create Set to non-zero to force exclusive creation of the file.
 
-    /// List of names stored in the file
-    struct gsd_name_buffer file_names;
+        @post Create an empty gsd file with the given name. Overwrite any existing file at that
+        location.
 
-    /// List of names added in the current frame
-    struct gsd_name_buffer frame_names;
+        Open the generated gsd file in *handle*.
 
-    /// The index of the last frame in the file
-    uint64_t cur_frame;
+        The file descriptor is closed if there when an error opening the file.
 
-    /// Size of the file (in bytes)
-    int64_t file_size;
+        @return
+          - GSD_SUCCESS (0) on success. Negative value on failure:
+          - GSD_ERROR_IO: IO error (check errno).
+          - GSD_ERROR_NOT_A_GSD_FILE: Not a GSD file.
+          - GSD_ERROR_INVALID_GSD_FILE_VERSION: Invalid GSD file version.
+          - GSD_ERROR_FILE_CORRUPT: Corrupt file.
+          - GSD_ERROR_MEMORY_ALLOCATION_FAILED: Unable to allocate memory.
+    */
+    int gsd_create_and_open(struct gsd_handle* handle,
+                            const char* fname,
+                            const char* application,
+                            const char* schema,
+                            uint32_t schema_version,
+                            enum gsd_open_flag flags,
+                            int exclusive_create);
 
-    /// Flags passed to gsd_open() when opening this handle
-    enum gsd_open_flag open_flags;
+    /** Open a GSD file
 
-    /// Access the names in the namelist
-    struct gsd_name_id_map name_map;
-};
+        @param handle Handle to open.
+        @param fname File name to open (UTF-8 encoded).
+        @param flags Either GSD_OPEN_READWRITE, GSD_OPEN_READONLY, or GSD_OPEN_APPEND.
 
-/** Specify a version
+        @pre The file name *fname* is a GSD file.
 
-    @param major major version
-    @param minor minor version
+        @post Open a GSD file and populates the handle for use by API calls.
 
-    @return a packed version number aaaa.bbbb suitable for storing in a gsd file version entry.
-*/
-uint32_t gsd_make_version(unsigned int major, unsigned int minor);
+        The file descriptor is closed if there is an error opening the file.
 
-/** Create a GSD file
+        @return
+          - GSD_SUCCESS (0) on success. Negative value on failure:
+          - GSD_ERROR_IO: IO error (check errno).
+          - GSD_ERROR_NOT_A_GSD_FILE: Not a GSD file.
+          - GSD_ERROR_INVALID_GSD_FILE_VERSION: Invalid GSD file version.
+          - GSD_ERROR_FILE_CORRUPT: Corrupt file.
+          - GSD_ERROR_MEMORY_ALLOCATION_FAILED: Unable to allocate memory.
+    */
+    int gsd_open(struct gsd_handle* handle, const char* fname, enum gsd_open_flag flags);
 
-    @param fname File name.
-    @param application Generating application name (truncated to 63 chars).
-    @param schema Schema name for data to be written in this GSD file (truncated to 63 chars).
-    @param schema_version Version of the scheme data to be written (make with gsd_make_version()).
+    /** Truncate a GSD file
+
+        @param handle Open GSD file to truncate.
 
-    @post Create an empty gsd file in a file of the given name. Overwrite any existing file at that
-    location.
+        After truncating, a file will have no frames and no data chunks. The file size will be that
+        of a newly created gsd file. The application, schema, and schema version metadata will be
+        kept. Truncate does not close and reopen the file, so it is suitable for writing restart
+        files on Lustre file systems without any metadata access.
 
-    The generated gsd file is not opened. Call gsd_open() to open it for writing.
+        @return
+          - GSD_SUCCESS (0) on success. Negative value on failure:
+          - GSD_ERROR_IO: IO error (check errno).
+          - GSD_ERROR_NOT_A_GSD_FILE: Not a GSD file.
+          - GSD_ERROR_INVALID_GSD_FILE_VERSION: Invalid GSD file version.
+          - GSD_ERROR_FILE_CORRUPT: Corrupt file.
+          - GSD_ERROR_MEMORY_ALLOCATION_FAILED: Unable to allocate memory.
+    */
+    int gsd_truncate(struct gsd_handle* handle);
 
-    @return
-      - GSD_SUCCESS (0) on success. Negative value on failure:
-      - GSD_ERROR_IO: IO error (check errno).
-*/
-int gsd_create(const char* fname,
-               const char* application,
-               const char* schema,
-               uint32_t schema_version);
+    /** Close a GSD file
 
-/** Create and open a GSD file
+        @param handle GSD file to close.
 
-    @param handle Handle to open.
-    @param fname File name.
-    @param application Generating application name (truncated to 63 chars).
-    @param schema Schema name for data to be written in this GSD file (truncated to 63 chars).
-    @param schema_version Version of the scheme data to be written (make with gsd_make_version()).
-    @param flags Either GSD_OPEN_READWRITE, or GSD_OPEN_APPEND.
-    @param exclusive_create Set to non-zero to force exclusive creation of the file.
+        @pre *handle* was opened by gsd_open().
+        @pre gsd_end_frame() has been called since the last call to gsd_write_chunk().
 
-    @post Create an empty gsd file with the given name. Overwrite any existing file at that
-    location.
+        @post The file is closed.
+        @post *handle* is freed and can no longer be used.
+
+        @warning Ensure that all gsd_write_chunk() calls are committed with gsd_end_frame() before
+        closing the file.
+
+        @return
+          - GSD_SUCCESS (0) on success. Negative value on failure:
+          - GSD_ERROR_IO: IO error (check errno).
+          - GSD_ERROR_INVALID_ARGUMENT: *handle* is NULL.
+    */
+    int gsd_close(struct gsd_handle* handle);
 
-    Open the generated gsd file in *handle*.
+    /** Commit the current frame and increment the frame counter.
 
-    The file descriptor is closed if there when an error opening the file.
+        @param handle Handle to an open GSD file
 
-    @return
-      - GSD_SUCCESS (0) on success. Negative value on failure:
-      - GSD_ERROR_IO: IO error (check errno).
-      - GSD_ERROR_NOT_A_GSD_FILE: Not a GSD file.
-      - GSD_ERROR_INVALID_GSD_FILE_VERSION: Invalid GSD file version.
-      - GSD_ERROR_FILE_CORRUPT: Corrupt file.
-      - GSD_ERROR_MEMORY_ALLOCATION_FAILED: Unable to allocate memory.
-*/
-int gsd_create_and_open(struct gsd_handle* handle,
-                        const char* fname,
-                        const char* application,
-                        const char* schema,
-                        uint32_t schema_version,
-                        enum gsd_open_flag flags,
-                        int exclusive_create);
+        @pre *handle* was opened by gsd_open().
+        @pre gsd_write_chunk() has been called at least once since the last call to gsd_end_frame().
 
-/** Open a GSD file
+        @post The current frame counter is increased by 1 and cached indexes are written to disk.
 
-    @param handle Handle to open.
-    @param fname File name to open.
-    @param flags Either GSD_OPEN_READWRITE, GSD_OPEN_READONLY, or GSD_OPEN_APPEND.
+        @return
+          - GSD_SUCCESS (0) on success. Negative value on failure:
+          - GSD_ERROR_IO: IO error (check errno).
+          - GSD_ERROR_INVALID_ARGUMENT: *handle* is NULL.
+          - GSD_ERROR_FILE_MUST_BE_WRITABLE: The file was opened read-only.
+          - GSD_ERROR_MEMORY_ALLOCATION_FAILED: Unable to allocate memory.
+    */
+    int gsd_end_frame(struct gsd_handle* handle);
 
-    @pre The file name *fname* is a GSD file.
+    /** Write a data chunk to the current frame
 
-    @post Open a GSD file and populates the handle for use by API calls.
+        @param handle Handle to an open GSD file.
+        @param name Name of the data chunk.
+        @param type type ID that identifies the type of data in *data*.
+        @param N Number of rows in the data.
+        @param M Number of columns in the data.
+        @param flags set to 0, non-zero values reserved for future use.
+        @param data Data buffer.
 
-    The file descriptor is closed if there is an error opening the file.
+        @pre *handle* was opened by gsd_open().
+        @pre *name* is a unique name for data chunks in the given frame.
+        @pre data is allocated and contains at least `N * M * gsd_sizeof_type(type)` bytes.
 
-    @return
-      - GSD_SUCCESS (0) on success. Negative value on failure:
-      - GSD_ERROR_IO: IO error (check errno).
-      - GSD_ERROR_NOT_A_GSD_FILE: Not a GSD file.
-      - GSD_ERROR_INVALID_GSD_FILE_VERSION: Invalid GSD file version.
-      - GSD_ERROR_FILE_CORRUPT: Corrupt file.
-      - GSD_ERROR_MEMORY_ALLOCATION_FAILED: Unable to allocate memory.
-*/
-int gsd_open(struct gsd_handle* handle, const char* fname, enum gsd_open_flag flags);
-
-/** Truncate a GSD file
-
-    @param handle Open GSD file to truncate.
-
-    After truncating, a file will have no frames and no data chunks. The file size will be that of a
-    newly created gsd file. The application, schema, and schema version metadata will be kept.
-    Truncate does not close and reopen the file, so it is suitable for writing restart files on
-    Lustre file systems without any metadata access.
+        @post The given data chunk is written to the end of the file and its location is updated in
+        the in-memory index.
 
-    @return
-      - GSD_SUCCESS (0) on success. Negative value on failure:
-      - GSD_ERROR_IO: IO error (check errno).
-      - GSD_ERROR_NOT_A_GSD_FILE: Not a GSD file.
-      - GSD_ERROR_INVALID_GSD_FILE_VERSION: Invalid GSD file version.
-      - GSD_ERROR_FILE_CORRUPT: Corrupt file.
-      - GSD_ERROR_MEMORY_ALLOCATION_FAILED: Unable to allocate memory.
-*/
-int gsd_truncate(struct gsd_handle* handle);
+        @note If the GSD file is version 1.0, the chunk name is truncated to 63 bytes. GSD version
+        2.0 files support arbitrarily long names.
 
-/** Close a GSD file
+        @note *N* == 0 is allowed. When *N* is 0, *data* may be NULL.
 
-    @param handle GSD file to close.
+        @return
+          - GSD_SUCCESS (0) on success. Negative value on failure:
+          - GSD_ERROR_IO: IO error (check errno).
+          - GSD_ERROR_INVALID_ARGUMENT: *handle* is NULL, *N* == 0, *M* == 0, *type* is invalid, or
+            *flags* != 0.
+          - GSD_ERROR_FILE_MUST_BE_WRITABLE: The file was opened read-only.
+          - GSD_ERROR_NAMELIST_FULL: The file cannot store any additional unique chunk names.
+          - GSD_ERROR_MEMORY_ALLOCATION_FAILED: failed to allocate memory.
+    */
+    int gsd_write_chunk(struct gsd_handle* handle,
+                        const char* name,
+                        enum gsd_type type,
+                        uint64_t N,
+                        uint32_t M,
+                        uint8_t flags,
+                        const void* data);
 
-    @pre *handle* was opened by gsd_open().
-    @pre gsd_end_frame() has been called since the last call to gsd_write_chunk().
+    /** Find a chunk in the GSD file
 
-    @post The file is closed.
-    @post *handle* is freed and can no longer be used.
-
-    @warning Ensure that all gsd_write_chunk() calls are committed with gsd_end_frame() before
-    closing the file.
-
-    @return
-      - GSD_SUCCESS (0) on success. Negative value on failure:
-      - GSD_ERROR_IO: IO error (check errno).
-      - GSD_ERROR_INVALID_ARGUMENT: *handle* is NULL.
-*/
-int gsd_close(struct gsd_handle* handle);
+        @param handle Handle to an open GSD file
+        @param frame Frame to look for chunk
+        @param name Name of the chunk to find
 
-/** Commit the current frame and increment the frame counter.
+        @pre *handle* was opened by gsd_open() in read or readwrite mode.
 
-    @param handle Handle to an open GSD file
+        The found entry contains size and type metadata and can be passed to gsd_read_chunk() to
+        read the data.
 
-    @pre *handle* was opened by gsd_open().
-    @pre gsd_write_chunk() has been called at least once since the last call to gsd_end_frame().
+        @return A pointer to the found chunk, or NULL if not found.
+    */
+    const struct gsd_index_entry*
+    gsd_find_chunk(struct gsd_handle* handle, uint64_t frame, const char* name);
 
-    @post The current frame counter is increased by 1 and cached indexes are written to disk.
+    /** Read a chunk from the GSD file
 
-    @return
-      - GSD_SUCCESS (0) on success. Negative value on failure:
-      - GSD_ERROR_IO: IO error (check errno).
-      - GSD_ERROR_INVALID_ARGUMENT: *handle* is NULL.
-      - GSD_ERROR_FILE_MUST_BE_WRITABLE: The file was opened read-only.
-      - GSD_ERROR_MEMORY_ALLOCATION_FAILED: Unable to allocate memory.
-*/
-int gsd_end_frame(struct gsd_handle* handle);
+        @param handle Handle to an open GSD file.
+        @param data Data buffer to read into.
+        @param chunk Chunk to read.
 
-/** Write a data chunk to the current frame
+        @pre *handle* was opened in read or readwrite mode.
+        @pre *chunk* was found by gsd_find_chunk().
+        @pre *data* points to an allocated buffer with at least `N * M * gsd_sizeof_type(type)`
+       bytes.
 
-    @param handle Handle to an open GSD file.
-    @param name Name of the data chunk.
-    @param type type ID that identifies the type of data in *data*.
-    @param N Number of rows in the data.
-    @param M Number of columns in the data.
-    @param flags set to 0, non-zero values reserved for future use.
-    @param data Data buffer.
+        @return
+          - GSD_SUCCESS (0) on success. Negative value on failure:
+          - GSD_ERROR_IO: IO error (check errno).
+          - GSD_ERROR_INVALID_ARGUMENT: *handle* is NULL, *data* is NULL, or *chunk* is NULL.
+          - GSD_ERROR_FILE_MUST_BE_READABLE: The file was opened in append mode.
+          - GSD_ERROR_FILE_CORRUPT: The GSD file is corrupt.
+    */
+    int gsd_read_chunk(struct gsd_handle* handle, void* data, const struct gsd_index_entry* chunk);
 
-    @pre *handle* was opened by gsd_open().
-    @pre *name* is a unique name for data chunks in the given frame.
-    @pre data is allocated and contains at least `N * M * gsd_sizeof_type(type)` bytes.
+    /** Get the number of frames in the GSD file
 
-    @post The given data chunk is written to the end of the file and its location is updated in the
-    in-memory index.
+        @param handle Handle to an open GSD file
 
-    @note If the GSD file is version 1.0, the chunk name is truncated to 63 bytes. GSD version
-    2.0 files support arbitrarily long names.
+        @pre *handle* was opened by gsd_open().
 
-    @note *N* == 0 is allowed. When *N* is 0, *data* may be NULL.
+        @return The number of frames in the file, or 0 on error.
+    */
+    uint64_t gsd_get_nframes(struct gsd_handle* handle);
 
-    @return
-      - GSD_SUCCESS (0) on success. Negative value on failure:
-      - GSD_ERROR_IO: IO error (check errno).
-      - GSD_ERROR_INVALID_ARGUMENT: *handle* is NULL, *N* == 0, *M* == 0, *type* is invalid, or
-        *flags* != 0.
-      - GSD_ERROR_FILE_MUST_BE_WRITABLE: The file was opened read-only.
-      - GSD_ERROR_NAMELIST_FULL: The file cannot store any additional unique chunk names.
-      - GSD_ERROR_MEMORY_ALLOCATION_FAILED: failed to allocate memory.
-*/
-int gsd_write_chunk(struct gsd_handle* handle,
-                    const char* name,
-                    enum gsd_type type,
-                    uint64_t N,
-                    uint32_t M,
-                    uint8_t flags,
-                    const void* data);
+    /** Query size of a GSD type ID.
 
-/** Find a chunk in the GSD file
+        @param type Type ID to query.
 
-    @param handle Handle to an open GSD file
-    @param frame Frame to look for chunk
-    @param name Name of the chunk to find
+        @return Size of the given type in bytes, or 0 for an unknown type ID.
+    */
+    size_t gsd_sizeof_type(enum gsd_type type);
 
-    @pre *handle* was opened by gsd_open() in read or readwrite mode.
+    /** Search for chunk names in a gsd file.
 
-    The found entry contains size and type metadata and can be passed to gsd_read_chunk() to read
-    the data.
+        @param handle Handle to an open GSD file.
+        @param match String to match.
+        @param prev Search starting point.
 
-    @return A pointer to the found chunk, or NULL if not found.
-*/
-const struct gsd_index_entry*
-gsd_find_chunk(struct gsd_handle* handle, uint64_t frame, const char* name);
+        @pre *handle* was opened by gsd_open()
+        @pre *prev* was returned by a previous call to gsd_find_matching_chunk_name()
 
-/** Read a chunk from the GSD file
+        To find the first matching chunk name, pass NULL for prev. Pass in the previous found string
+        to find the next after that, and so on. Chunk names match if they begin with the string in
+        *match*. Chunk names returned by this function may be present in at least one frame.
 
-    @param handle Handle to an open GSD file.
-    @param data Data buffer to read into.
-    @param chunk Chunk to read.
+        @return Pointer to a string, NULL if no more matching chunks are found found, or NULL if
+        *prev* is invalid
+    */
+    const char*
+    gsd_find_matching_chunk_name(struct gsd_handle* handle, const char* match, const char* prev);
 
-    @pre *handle* was opened in read or readwrite mode.
-    @pre *chunk* was found by gsd_find_chunk().
-    @pre *data* points to an allocated buffer with at least `N * M * gsd_sizeof_type(type)` bytes.
+    /** Upgrade a GSD file to the latest specification.
 
-    @return
-      - GSD_SUCCESS (0) on success. Negative value on failure:
-      - GSD_ERROR_IO: IO error (check errno).
-      - GSD_ERROR_INVALID_ARGUMENT: *handle* is NULL, *data* is NULL, or *chunk* is NULL.
-      - GSD_ERROR_FILE_MUST_BE_READABLE: The file was opened in append mode.
-      - GSD_ERROR_FILE_CORRUPT: The GSD file is corrupt.
-*/
-int gsd_read_chunk(struct gsd_handle* handle, void* data, const struct gsd_index_entry* chunk);
+        @param handle Handle to an open GSD file
 
-/** Get the number of frames in the GSD file
+        @pre *handle* was opened by gsd_open() with a writable mode.
+        @pre There are no pending data to write to the file in gsd_end_frame()
 
-    @param handle Handle to an open GSD file
-
-    @pre *handle* was opened by gsd_open().
-
-    @return The number of frames in the file, or 0 on error.
-*/
-uint64_t gsd_get_nframes(struct gsd_handle* handle);
-
-/** Query size of a GSD type ID.
-
-    @param type Type ID to query.
-
-    @return Size of the given type in bytes, or 0 for an unknown type ID.
-*/
-size_t gsd_sizeof_type(enum gsd_type type);
-
-/** Search for chunk names in a gsd file.
-
-    @param handle Handle to an open GSD file.
-    @param match String to match.
-    @param prev Search starting point.
-
-    @pre *handle* was opened by gsd_open()
-    @pre *prev* was returned by a previous call to gsd_find_matching_chunk_name()
-
-    To find the first matching chunk name, pass NULL for prev. Pass in the previous found string to
-    find the next after that, and so on. Chunk names match if they begin with the string in *match*.
-    Chunk names returned by this function may be present in at least one frame.
-
-    @return Pointer to a string, NULL if no more matching chunks are found found, or NULL if *prev*
-    is invalid
-*/
-const char*
-gsd_find_matching_chunk_name(struct gsd_handle* handle, const char* match, const char* prev);
-
-/** Upgrade a GSD file to the latest specification.
-
-    @param handle Handle to an open GSD file
-
-    @pre *handle* was opened by gsd_open() with a writable mode.
-    @pre There are no pending data to write to the file in gsd_end_frame()
-
-    @return
-      - GSD_SUCCESS (0) on success. Negative value on failure:
-      - GSD_ERROR_IO: IO error (check errno).
-      - GSD_ERROR_INVALID_ARGUMENT: *handle* is NULL
-      - GSD_ERROR_FILE_MUST_BE_WRITABLE: The file was opened in read-only mode.
-*/
-int gsd_upgrade(struct gsd_handle* handle);
+        @return
+          - GSD_SUCCESS (0) on success. Negative value on failure:
+          - GSD_ERROR_IO: IO error (check errno).
+          - GSD_ERROR_INVALID_ARGUMENT: *handle* is NULL
+          - GSD_ERROR_FILE_MUST_BE_WRITABLE: The file was opened in read-only mode.
+    */
+    int gsd_upgrade(struct gsd_handle* handle);
 
 #ifdef __cplusplus
-}
+    }
 #endif
 
 #endif // #ifndef GSD_H


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should be based on *trunk-patch*. -->
<!-- Backwards compatible new features should be based on *trunk-minor*. -->
<!-- Incompatible API changes should be based on *trunk-major*. -->

## Description

<!-- Describe your changes in detail. -->
Copy `gsd.c` and `gsd.h` from the forthcoming gsd 2.8.1 release.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Notable changes include:
 * A reduction in memory usage - https://github.com/glotzerlab/gsd/pull/231.
 * Fixes to help prevent corrupt gsd fiiles - https://github.com/glotzerlab/gsd/pull/232.

The changes also include a major *clang-format* reformatting, making this PR's diff difficult to read.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
GSD unit test pass. GSD performance benchmarks show an acceptable reduction in performance.

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
Fixed: 

* Reduce likelihood  of data corruption when writing GSD files.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
