### PR TITLE
Further improve GSD performance.

### DIFF
--- a/hoomd/GSDDumpWriter.cc
+++ b/hoomd/GSDDumpWriter.cc
@@ -54,8 +54,7 @@ GSDDumpWriter::GSDDumpWriter(std::shared_ptr<SystemDefinition> sysdef,
                              std::shared_ptr<ParticleGroup> group,
                              std::string mode,
                              bool truncate)
-    : Analyzer(sysdef, trigger), m_fname(fname), m_mode(mode), m_truncate(truncate),
-      m_group(group)
+    : Analyzer(sysdef, trigger), m_fname(fname), m_mode(mode), m_truncate(truncate), m_group(group)
     {
     m_exec_conf->msg->notice(5) << "Constructing GSDDumpWriter: " << m_fname << " " << mode << " "
                                 << truncate << endl;
@@ -1524,8 +1523,8 @@ void export_GSDDumpWriter(pybind11::module& m)
                       &GSDDumpWriter::setWriteDiameter)
         .def("flush", &GSDDumpWriter::flush)
         .def_property("maximum_write_buffer_size",
-                &GSDDumpWriter::getMaximumWriteBufferSize,
-                &GSDDumpWriter::setMaximumWriteBufferSize);
+                      &GSDDumpWriter::getMaximumWriteBufferSize,
+                      &GSDDumpWriter::setMaximumWriteBufferSize);
     }
 
     } // end namespace detail

--- a/hoomd/GSDDumpWriter.cc
+++ b/hoomd/GSDDumpWriter.cc
@@ -206,7 +206,8 @@ void GSDDumpWriter::flush()
     {
     if (m_exec_conf->isRoot())
         {
-        gsd_flush(&m_handle);
+        int retval = gsd_flush(&m_handle);
+        GSDUtils::checkError(retval, m_fname);
         }
     }
 
@@ -214,7 +215,12 @@ void GSDDumpWriter::setMaximumWriteBufferSize(uint64_t size)
     {
     if (m_exec_conf->isRoot())
         {
-        gsd_set_maximum_write_buffer_size(&m_handle, size);
+        int retval = gsd_set_maximum_write_buffer_size(&m_handle, size);
+        GSDUtils::checkError(retval, m_fname);
+
+        // Scale the index buffer entires to write with the write buffer.
+        retval = gsd_set_index_entries_to_buffer(&m_handle, size / 256);
+        GSDUtils::checkError(retval, m_fname);
         }
     }
 

--- a/hoomd/GSDDumpWriter.cc
+++ b/hoomd/GSDDumpWriter.cc
@@ -201,6 +201,19 @@ void GSDDumpWriter::setDynamic(pybind11::object dynamic)
         }
     }
 
+void GSDDumpWriter::flush()
+    {
+    if (m_exec_conf->isRoot())
+        {
+        if (!m_is_initialized)
+            {
+            throw std::runtime_error("GSD file is not open.");
+            }
+
+        gsd_flush(&m_handle);
+        }
+    }
+
 //! Initializes the output file for writing
 void GSDDumpWriter::initFileIO()
     {
@@ -1502,7 +1515,8 @@ void export_GSDDumpWriter(pybind11::module& m)
                                { return gsd->getGroup()->getFilter(); })
         .def_property("write_diameter",
                       &GSDDumpWriter::getWriteDiameter,
-                      &GSDDumpWriter::setWriteDiameter);
+                      &GSDDumpWriter::setWriteDiameter)
+        .def("flush", &GSDDumpWriter::flush);
     }
 
     } // end namespace detail

--- a/hoomd/GSDDumpWriter.h
+++ b/hoomd/GSDDumpWriter.h
@@ -127,6 +127,12 @@ class PYBIND11_EXPORT GSDDumpWriter : public Analyzer
     /// Flush the write buffer
     void flush();
 
+    /// Set the maximum write buffer size (in bytes)
+    void setMaximumWriteBufferSize(uint64_t size);
+
+    /// Get the maximum write buffer size (in bytes)
+    uint64_t getMaximumWriteBufferSize();
+
     protected:
     /// Flags for dynamic/default bitsets.
     struct gsd_flag
@@ -199,7 +205,6 @@ class PYBIND11_EXPORT GSDDumpWriter : public Analyzer
     std::string m_fname;           //!< The file name we are writing to
     std::string m_mode;            //!< The file open mode
     bool m_truncate = false;       //!< True if we should truncate the file on every analyze()
-    bool m_is_initialized = false; //!< True if the file is open
     bool m_write_topology = false; //!< True if topology should be written
     bool m_write_diameter = false; //!< True if the diameter attribute should be written
     gsd_handle m_handle;           //!< Handle to the file

--- a/hoomd/GSDDumpWriter.h
+++ b/hoomd/GSDDumpWriter.h
@@ -124,6 +124,9 @@ class PYBIND11_EXPORT GSDDumpWriter : public Analyzer
         m_write_diameter = write_diameter;
         }
 
+    /// Flush the write buffer
+    void flush();
+
     protected:
     /// Flags for dynamic/default bitsets.
     struct gsd_flag

--- a/hoomd/__init__.py
+++ b/hoomd/__init__.py
@@ -29,10 +29,18 @@ methods, and variables in the API.
 
 See Also:
     Tutorial: :doc:`tutorial/00-Introducing-HOOMD-blue/00-index`
+
+.. rubric:: Signal handling
+
+On import, `hoomd` installs a ``SIGTERM`` signal handler that calls `sys.exit`
+so that open gsd files have a chance to flush write buffers
+(`hoomd.write.GSD.flush`) when a user's process is terminated. Use
+`signal.signal` to adjust this behavior as needed.
 """
 import sys
 import pathlib
 import os
+import signal
 
 if ((pathlib.Path(__file__).parent / 'CMakeLists.txt').exists()
         and 'SPHINX' not in os.environ):
@@ -92,3 +100,7 @@ def _hoomd_sys_excepthook(type, value, traceback):
 
 
 sys.excepthook = _hoomd_sys_excepthook
+
+# Install a SIGTERM handler that gracefully exits, allowing open files to flush
+# buffered writes and close.
+signal.signal(signal.SIGTERM, lambda n, f: sys.exit(1))

--- a/hoomd/extern/gsd.c
+++ b/hoomd/extern/gsd.c
@@ -64,16 +64,16 @@ enum
     GSD_INITIAL_WRITE_BUFFER_SIZE = 1024
     };
 
-/// Maximum size of write buffer
+/// Default maximum size of write buffer
 enum
     {
-    GSD_MAXIMUM_WRITE_BUFFER_SIZE = 16 * 1024 * 1024
+    GSD_DEFAULT_MAXIMUM_WRITE_BUFFER_SIZE = 64 * 1024 * 1024
     };
 
-/// Size of copy buffer
+/// Default number of index entries to buffer
 enum
     {
-    GSD_COPY_BUFFER_SIZE = 128 * 1024
+    GSD_DEFAULT_INDEX_ENTRIES_TO_BUFFER = 262144
     };
 
 /// Size of hash map
@@ -965,7 +965,13 @@ inline static int gsd_expand_file_index(struct gsd_handle* handle, size_t size_r
         }
 
     // allocate the copy buffer
-    char* buf = malloc(GSD_COPY_BUFFER_SIZE);
+    uint64_t copy_buffer_size
+        = GSD_DEFAULT_INDEX_ENTRIES_TO_BUFFER * sizeof(struct gsd_index_entry);
+    if (copy_buffer_size > size_old * sizeof(struct gsd_index_entry))
+        {
+        copy_buffer_size = size_old * sizeof(struct gsd_index_entry);
+        }
+    char* buf = malloc(copy_buffer_size);
 
     // write the current index to the end of the file
     int64_t new_index_location = lseek(handle->fd, 0, SEEK_END);
@@ -974,8 +980,8 @@ inline static int gsd_expand_file_index(struct gsd_handle* handle, size_t size_r
     size_t old_index_bytes = size_old * sizeof(struct gsd_index_entry);
     while (total_bytes_written < old_index_bytes)
         {
-        size_t bytes_to_copy = GSD_COPY_BUFFER_SIZE;
-        if (old_index_bytes - total_bytes_written < GSD_COPY_BUFFER_SIZE)
+        size_t bytes_to_copy = copy_buffer_size;
+        if (old_index_bytes - total_bytes_written < copy_buffer_size)
             {
             bytes_to_copy = old_index_bytes - total_bytes_written;
             }
@@ -1006,13 +1012,13 @@ inline static int gsd_expand_file_index(struct gsd_handle* handle, size_t size_r
         }
 
     // fill the new index space with 0s
-    gsd_util_zero_memory(buf, GSD_COPY_BUFFER_SIZE);
+    gsd_util_zero_memory(buf, copy_buffer_size);
 
     size_t new_index_bytes = size_new * sizeof(struct gsd_index_entry);
     while (total_bytes_written < new_index_bytes)
         {
-        size_t bytes_to_copy = GSD_COPY_BUFFER_SIZE;
-        if (new_index_bytes - total_bytes_written < GSD_COPY_BUFFER_SIZE)
+        size_t bytes_to_copy = copy_buffer_size;
+        if (new_index_bytes - total_bytes_written < copy_buffer_size)
             {
             bytes_to_copy = new_index_bytes - total_bytes_written;
             }
@@ -1120,7 +1126,7 @@ inline static int gsd_flush_write_buffer(struct gsd_handle* handle)
     // reset write_buffer for new data
     handle->write_buffer.size = 0;
 
-    // move buffer_index entries to file_index
+    // Move buffer_index entries to frame_index.
     size_t i;
     for (i = 0; i < handle->buffer_index.size; i++)
         {
@@ -1590,6 +1596,10 @@ inline static int gsd_initialize_handle(struct gsd_handle* handle)
             }
         }
 
+    handle->pending_index_entries = 0;
+    handle->maximum_write_buffer_size = GSD_DEFAULT_MAXIMUM_WRITE_BUFFER_SIZE;
+    handle->index_entries_to_buffer = GSD_DEFAULT_INDEX_ENTRIES_TO_BUFFER;
+
     return GSD_SUCCESS;
     }
 
@@ -1800,10 +1810,21 @@ int gsd_close(struct gsd_handle* handle)
         return GSD_ERROR_INVALID_ARGUMENT;
         }
 
+    int retval;
+
+    if (handle->open_flags != GSD_OPEN_READONLY)
+        {
+        retval = gsd_flush(handle);
+        if (retval != GSD_SUCCESS)
+            {
+            return retval;
+            }
+        }
+
     // save the fd so we can use it after freeing the handle
     int fd = handle->fd;
 
-    int retval = gsd_index_buffer_free(&handle->file_index);
+    retval = gsd_index_buffer_free(&handle->file_index);
     if (retval != GSD_SUCCESS)
         {
         return retval;
@@ -1883,8 +1904,27 @@ int gsd_end_frame(struct gsd_handle* handle)
         return GSD_ERROR_FILE_MUST_BE_WRITABLE;
         }
 
-    // increment the frame counter
     handle->cur_frame++;
+    handle->pending_index_entries = 0;
+
+    if (handle->frame_index.size > 0 || handle->buffer_index.size > handle->index_entries_to_buffer)
+        {
+        return gsd_flush(handle);
+        }
+
+    return GSD_SUCCESS;
+    }
+
+int gsd_flush(struct gsd_handle* handle)
+    {
+    if (handle == NULL)
+        {
+        return GSD_ERROR_INVALID_ARGUMENT;
+        }
+    if (handle->open_flags == GSD_OPEN_READONLY)
+        {
+        return GSD_ERROR_FILE_MUST_BE_WRITABLE;
+        }
 
     // flush the namelist buffer
     int retval = gsd_flush_name_buffer(handle);
@@ -1907,13 +1947,20 @@ int gsd_end_frame(struct gsd_handle* handle)
         return GSD_ERROR_IO;
         }
 
-    // write the frame index to the file
-    if (handle->frame_index.size > 0)
+    // Write the frame index to the file, excluding the index entries that are part of the current
+    // frame.
+    if (handle->pending_index_entries > handle->frame_index.size)
+        {
+        return GSD_ERROR_INVALID_ARGUMENT;
+        }
+    uint64_t index_entries_to_write = handle->frame_index.size - handle->pending_index_entries;
+
+    if (index_entries_to_write > 0)
         {
         // ensure there is enough space in the index
-        if ((handle->file_index.size + handle->frame_index.size) > handle->file_index.reserved)
+        if ((handle->file_index.size + index_entries_to_write) > handle->file_index.reserved)
             {
-            gsd_expand_file_index(handle, handle->file_index.size + handle->frame_index.size);
+            gsd_expand_file_index(handle, handle->file_index.size + index_entries_to_write);
             }
 
         // sort the index before writing
@@ -1927,7 +1974,7 @@ int gsd_end_frame(struct gsd_handle* handle)
         int64_t write_pos = handle->header.index_location
                             + sizeof(struct gsd_index_entry) * handle->file_index.size;
 
-        size_t bytes_to_write = sizeof(struct gsd_index_entry) * handle->frame_index.size;
+        size_t bytes_to_write = sizeof(struct gsd_index_entry) * index_entries_to_write;
         ssize_t bytes_written
             = gsd_io_pwrite_retry(handle->fd, handle->frame_index.data, bytes_to_write, write_pos);
 
@@ -1940,14 +1987,24 @@ int gsd_end_frame(struct gsd_handle* handle)
         // add the entries to the file index
         memcpy(handle->file_index.data + handle->file_index.size,
                handle->frame_index.data,
-               sizeof(struct gsd_index_entry) * handle->frame_index.size);
+               sizeof(struct gsd_index_entry) * index_entries_to_write);
 #endif
 
         // update size of file index
-        handle->file_index.size += handle->frame_index.size;
+        handle->file_index.size += index_entries_to_write;
 
-        // clear the frame index
-        handle->frame_index.size = 0;
+        // Clear the frame index, keeping those in the current unfinished frame.
+        if (handle->pending_index_entries > 0)
+            {
+            for (uint64_t i = 0; i < handle->pending_index_entries; i++)
+                {
+                handle->frame_index.data[i]
+                    = handle->frame_index
+                          .data[handle->frame_index.size - handle->pending_index_entries];
+                }
+            }
+
+        handle->frame_index.size = handle->pending_index_entries;
         }
 
     return GSD_SUCCESS;
@@ -2007,10 +2064,10 @@ int gsd_write_chunk(struct gsd_handle* handle,
     size_t size = N * M * gsd_sizeof_type(type);
 
     // decide whether to write this chunk to the buffer or straight to disk
-    if (size < GSD_MAXIMUM_WRITE_BUFFER_SIZE / 2)
+    if (size < handle->maximum_write_buffer_size)
         {
         // flush the buffer if this entry won't fit
-        if (size > (GSD_MAXIMUM_WRITE_BUFFER_SIZE - handle->write_buffer.size))
+        if (size > (handle->maximum_write_buffer_size - handle->write_buffer.size))
             {
             gsd_flush_write_buffer(handle);
             }
@@ -2063,6 +2120,7 @@ int gsd_write_chunk(struct gsd_handle* handle,
         handle->file_size += bytes_written;
         }
 
+    handle->pending_index_entries++;
     return GSD_SUCCESS;
     }
 
@@ -2089,6 +2147,14 @@ gsd_find_chunk(struct gsd_handle* handle, uint64_t frame, const char* name)
     if (frame >= gsd_get_nframes(handle))
         {
         return NULL;
+        }
+    if (handle->open_flags != GSD_OPEN_READONLY)
+        {
+        int retval = gsd_flush(handle);
+        if (retval != GSD_SUCCESS)
+            {
+            return NULL;
+            }
         }
 
     // find the id for the given name
@@ -2180,6 +2246,14 @@ int gsd_read_chunk(struct gsd_handle* handle, void* data, const struct gsd_index
         {
         return GSD_ERROR_INVALID_ARGUMENT;
         }
+    if (handle->open_flags != GSD_OPEN_READONLY)
+        {
+        int retval = gsd_flush(handle);
+        if (retval != GSD_SUCCESS)
+            {
+            return retval;
+            }
+        }
 
     size_t size = chunk->N * chunk->M * gsd_sizeof_type((enum gsd_type)chunk->type);
     if (size == 0)
@@ -2270,6 +2344,14 @@ gsd_find_matching_chunk_name(struct gsd_handle* handle, const char* match, const
     if (handle->file_names.n_names == 0)
         {
         return NULL;
+        }
+    if (handle->open_flags != GSD_OPEN_READONLY)
+        {
+        int retval = gsd_flush(handle);
+        if (retval != GSD_SUCCESS)
+            {
+            return NULL;
+            }
         }
 
     // return nothing found if the name buffer is corrupt
@@ -2484,6 +2566,48 @@ int gsd_upgrade(struct gsd_handle* handle)
             return retval;
             }
         }
+
+    return GSD_SUCCESS;
+    }
+
+uint64_t gsd_get_maximum_write_buffer_size(struct gsd_handle* handle)
+    {
+    if (handle == NULL)
+        {
+        return 0;
+        }
+    return handle->maximum_write_buffer_size;
+    }
+
+int gsd_set_maximum_write_buffer_size(struct gsd_handle* handle, uint64_t size)
+    {
+    if (handle == NULL || size == 0)
+        {
+        return GSD_ERROR_INVALID_ARGUMENT;
+        }
+
+    handle->maximum_write_buffer_size = size;
+
+    return GSD_SUCCESS;
+    }
+
+uint64_t gsd_get_index_entries_to_buffer(struct gsd_handle* handle)
+    {
+    if (handle == NULL)
+        {
+        return 0;
+        }
+    return handle->index_entries_to_buffer;
+    }
+
+int gsd_set_index_entries_to_buffer(struct gsd_handle* handle, uint64_t number)
+    {
+    if (handle == NULL || number == 0)
+        {
+        return GSD_ERROR_INVALID_ARGUMENT;
+        }
+
+    handle->index_entries_to_buffer = number;
 
     return GSD_SUCCESS;
     }

--- a/hoomd/extern/gsd.c
+++ b/hoomd/extern/gsd.c
@@ -73,7 +73,7 @@ enum
 /// Default number of index entries to buffer
 enum
     {
-    GSD_DEFAULT_INDEX_ENTRIES_TO_BUFFER = 262144
+    GSD_DEFAULT_INDEX_ENTRIES_TO_BUFFER = 256 * 1024
     };
 
 /// Size of hash map

--- a/hoomd/md/pytest/test_gsd.py
+++ b/hoomd/md/pytest/test_gsd.py
@@ -111,6 +111,7 @@ def test_write_gsd_trigger(create_md_sim, tmp_path):
     sim.operations.writers.append(gsd_writer)
 
     sim.run(30)
+    gsd_writer.flush()
 
     if sim.device.communicator.rank == 0:
         with gsd.hoomd.open(name=filename, mode='rb') as traj:
@@ -182,6 +183,8 @@ def test_write_gsd_mode(create_md_sim, hoomd_snapshot, tmp_path,
         if snap.communicator.rank == 0:
             snapshot_list.append(snap)
 
+    gsd_writer.flush()
+
     if sim.device.communicator.rank == 0:
         with gsd.hoomd.open(name=filename_xb, mode='rb') as traj:
             assert len(traj) == len(snapshot_list)
@@ -252,6 +255,8 @@ def test_write_gsd_dynamic(simulation_factory, create_md_sim, tmp_path):
             velocity_list.append(snap.particles.velocity)
     N_particles = sim.state.N_particles
 
+    gsd_writer.flush()
+
     if sim.device.communicator.rank == 0:
         with gsd.hoomd.open(name=filename, mode='rb') as traj:
             for step in range(5):
@@ -285,6 +290,8 @@ def test_write_gsd_dynamic(simulation_factory, create_md_sim, tmp_path):
             velocity_list.append(snap.particles.velocity)
             angmom_list.append(snap.particles.angmom)
 
+    gsd_writer.flush()
+
     if sim.device.communicator.rank == 0:
         with gsd.hoomd.open(name=filename, mode='rb') as traj:
             for step in range(5):
@@ -316,6 +323,8 @@ def test_write_gsd_dynamic(simulation_factory, create_md_sim, tmp_path):
                                  dynamic=['property', 'attribute'])
     sim.operations.writers.append(gsd_writer)
     sim.run(5)
+
+    gsd_writer.flush()
 
     if sim.device.communicator.rank == 0:
         with gsd.hoomd.open(name=filename, mode='rb') as traj:
@@ -353,6 +362,8 @@ def test_write_gsd_dynamic(simulation_factory, create_md_sim, tmp_path):
     sim.operations.writers.append(gsd_writer)
     sim.run(1)
 
+    gsd_writer.flush()
+
     if sim.device.communicator.rank == 0:
         with gsd.hoomd.open(name=filename, mode='rb') as traj:
             assert traj[-1].bonds.N == 3
@@ -380,6 +391,8 @@ def test_write_gsd_log(create_md_sim, tmp_path):
     for _ in range(5):
         sim.run(1)
         kinetic_energy_list.append(thermo.kinetic_energy)
+
+    gsd_writer.flush()
 
     if sim.device.communicator.rank == 0:
         with gsd.hoomd.open(name=filename, mode='rb') as traj:
@@ -439,6 +452,8 @@ def test_write_gsd_finegrained_dynamic(simulation_factory, hoomd_snapshot,
 
     sim.run(2)
 
+    gsd_writer.flush()
+
     if sim.device.communicator.rank == 0:
         with gsd.fl.open(name=filename, mode='rb') as f:
             for field in dynamic_fields:
@@ -486,7 +501,11 @@ def test_write_gsd_finegrained_dynamic_alldefault(simulation_factory,
 
     sim.run(2)
 
+    gsd_writer.flush()
+
     if sim.device.communicator.rank == 0:
         with gsd.fl.open(name=filename, mode='rb') as f:
+            assert f.nframes == 2
+
             for field in dynamic_fields:
                 assert not f.chunk_exists(frame=1, name=field)

--- a/hoomd/md/pytest/test_gsd.py
+++ b/hoomd/md/pytest/test_gsd.py
@@ -161,8 +161,8 @@ def test_write_gsd_mode(create_md_sim, hoomd_snapshot, tmp_path,
                                      trigger=hoomd.trigger.Periodic(1),
                                      mode='xb',
                                      dynamic=['property', 'momentum'])
-        sim.operations.writers.append(gsd_writer)
         with pytest.raises(Exception):
+            sim.operations.writers.append(gsd_writer)
             sim.run(1)
 
     # test mode=xb creates a new file

--- a/hoomd/write/gsd.py
+++ b/hoomd/write/gsd.py
@@ -243,6 +243,14 @@ class GSD(Writer):
         self._logger = logger
         return self.logger
 
+    def flush(self):
+        """Flush the write buffer to the file."""
+        if not self._attached:
+            raise RuntimeError("The GSD file is unavailable until the"
+                               "simulation runs for 0 or more steps.")
+
+        self._cpp_obj.flush()
+
 
 def _iterable_is_incomplete(iterable):
     """Checks that any nested attribute has no instances of RequiredArg.

--- a/hoomd/write/gsd.py
+++ b/hoomd/write/gsd.py
@@ -147,6 +147,8 @@ class GSD(Writer):
         write_diameter (bool): When `False`, do not write
             ``particles/diameter``. Set to `True` to write non-default particle
             diameters.
+        maximum_write_buffer_size (int): Size (in bytes) to buffer in memory
+           before writing to the file.
     """
 
     def __init__(self,
@@ -188,6 +190,7 @@ class GSD(Writer):
                           truncate=bool(truncate),
                           dynamic=[dynamic_validation],
                           write_diameter=False,
+                          maximum_write_buffer_size=64 * 1024 * 1024,
                           _defaults=dict(filter=filter, dynamic=dynamic)))
 
         self._logger = None if logger is None else _GSDLogWriter(logger)

--- a/hoomd/write/gsd.py
+++ b/hoomd/write/gsd.py
@@ -225,6 +225,7 @@ class GSD(Writer):
         if logger is not None:
             writer.log_writer = _GSDLogWriter(logger)
         writer.analyze(state._simulation.timestep)
+        writer.flush()
 
     @property
     def logger(self):

--- a/sphinx-doc/migrating.rst
+++ b/sphinx-doc/migrating.rst
@@ -84,6 +84,10 @@ For some functionalities, you will need to update your scripts to use a new API:
   an always dynamic quantity. Users must include ``'property'``, ``'particles/position'`` and/or
   ``'particles/orientation'`` as needed in ``dynamic`` lists that contain other fields.
 
+* `hoomd.write.GSD` aggressively buffers output. Call `hoomd.write.GSD.flush` to write the buffer
+  to disk when opening a file for reading that is still open for writing. There is **no need** to
+  call ``flush`` in normal workflows when files are closed and then opened later for reading.
+
 Removed functionalities
 ^^^^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should be based on *trunk-patch*. -->
<!-- Backwards compatible new features should be based on *trunk-minor*. -->
<!-- Incompatible API changes should be based on *trunk-major*. -->

## Description

<!-- Describe your changes in detail. -->
Add write buffers to further improve GSD performance.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
See https://github.com/glotzerlab/gsd/pull/237.

Most users will not need to change the write buffer size. I make the API available so that users wishing to push the limits can increase the buffer size.

## How has this been tested?

* Existing unit tests pass after adding needed calls to flush().
* Will report on performance tests on Frontier.

TODO:
* [x] Test and update tutorial notebooks as needed.
<!--- Please describe in detail how you tested your changes. -->

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
Added:

* ``hoomd.write.GSD.maximum_write_buffer_size`` - Set the maximum size of the GSD write buffer.
* ``hoomd.write.GSD.flush`` - flush the write buffer of an open GSD file.
* On importing ``hoomd``, install a ``SIGTERM`` handler that calls ``sys.exit(1)``.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
