### PR TITLE
Flush GSD buffers on exit.

### DIFF
--- a/hoomd/GSDDumpWriter.cc
+++ b/hoomd/GSDDumpWriter.cc
@@ -206,6 +206,7 @@ void GSDDumpWriter::flush()
     {
     if (m_exec_conf->isRoot())
         {
+        m_exec_conf->msg->notice(5) << "GSD: flush gsd file " << m_fname << endl;
         int retval = gsd_flush(&m_handle);
         GSDUtils::checkError(retval, m_fname);
         }

--- a/hoomd/__init__.py
+++ b/hoomd/__init__.py
@@ -94,6 +94,7 @@ _default_excepthook = sys.excepthook
 
 def _hoomd_sys_excepthook(type, value, traceback):
     """Override Python's excepthook to abort MPI runs."""
+    write.gsd._flush_open_gsd_writers()
     _default_excepthook(type, value, traceback)
     sys.stderr.flush()
     _hoomd.abort_mpi(communicator._current_communicator.cpp_mpi_conf, 1)

--- a/hoomd/write/gsd.py
+++ b/hoomd/write/gsd.py
@@ -44,6 +44,12 @@ def _array_to_strings(value):
         return value
 
 
+def _finalize_gsd(weak_writer, cpp_obj):
+    """Finalize a GSD writer."""
+    _open_gsd_writers.remove(weak_writer)
+    cpp_obj.flush()
+
+
 class GSD(Writer):
     r"""Write simulation trajectories in the GSD format.
 
@@ -222,8 +228,8 @@ class GSD(Writer):
         # Maintain a list of open gsd writers
         weak_writer = weakref.ref(self)
         _open_gsd_writers.append(weak_writer)
-        self._finalizer = weakref.finalize(self, _open_gsd_writers.remove,
-                                           weak_writer)
+        self._finalizer = weakref.finalize(self, _finalize_gsd, weak_writer,
+                                           self._cpp_obj),
 
     @staticmethod
     def write(state, filename, filter=All(), mode='wb', logger=None):


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should be based on *trunk-patch*. -->
<!-- Backwards compatible new features should be based on *trunk-minor*. -->
<!-- Incompatible API changes should be based on *trunk-major*. -->

## Description

<!-- Describe your changes in detail. -->
Maintain a list of active GSD writers. Use an `atexit` method to flush them on exit. Also flush the files in the exception handler to attempt to keep data before calling MPI_Abort.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Due to #1457 or a related issue, GSD files may not flush **even when the program cleanly exits**. Explicit is better than implicit, so forcibly flushing the GSD files at exit ensures as much data as possible is written. 

Note: We may be able to solve #1457 using some `weakref` objects to break cycles.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
Existing unit tests pass. Examined the length of `_open_gsd_writers` with and without the `finalizer` object and got the expected results.

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

Not needed. Fixing a new feature in this release.

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
