### PR TITLE
Fix MPI_Allreduce.

### DIFF
--- a/hoomd/md/IntegrationMethodTwoStep.cc
+++ b/hoomd/md/IntegrationMethodTwoStep.cc
@@ -117,7 +117,7 @@ void IntegrationMethodTwoStep::validateGroup()
                                             access_location::host,
                                             access_mode::read);
 
-    bool error = false;
+    unsigned int error = 0;
     for (unsigned int gidx = 0; gidx < m_group->getNumMembers(); gidx++)
         {
         unsigned int i = h_group_index.data[gidx];
@@ -126,7 +126,7 @@ void IntegrationMethodTwoStep::validateGroup()
 
         if (body < MIN_FLOPPY && body != tag)
             {
-            error = true;
+            error = 1;
             }
         }
 
@@ -136,7 +136,7 @@ void IntegrationMethodTwoStep::validateGroup()
         MPI_Allreduce(MPI_IN_PLACE,
                       &error,
                       1,
-                      MPI_CXX_BOOL,
+                      MPI_UNSIGNED,
                       MPI_LOR,
                       this->m_exec_conf->getMPICommunicator());
         }


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should be based on *trunk-patch*. -->
<!-- Backwards compatible new features should be based on *trunk-minor*. -->
<!-- Incompatible API changes should be based on *trunk-major*. -->

## Description

<!-- Describe your changes in detail. -->
Use `MPI_UNSINGED` in place of `MPI_CXX_BOOL` in `MPI_Allreduce`.

## Motivation and context

Users report this error on Frontier:
```
aborting job:
Fatal error in PMPI_Allreduce: Invalid datatype, error stack:
PMPI_Allreduce(497): MPI_Allreduce(sbuf=MPI_IN_PLACE, rbuf=0x7fffffff35af, count=1, datatype=MPI_DATATYPE_NULL, op=MPI_LOR, comm=comm=0x84000001) failed
PMPI_Allreduce(440): Datatype for argument datatype is a null datatype
```

## How has this been tested?

@DomFijan will test on Frontier.
<!--- Please describe in detail how you tested your changes. -->

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

```
* Fix error with ``MPI_Allreduce`` on OLCF Frontier.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
