### PR TITLE
Fix virial pressure documentation.

### DIFF
--- a/hoomd/md/compute.py
+++ b/hoomd/md/compute.py
@@ -80,11 +80,11 @@ class ThermodynamicQuantities(Compute):
 
         .. math::
 
-            W_\\mathrm{isotropic} = & \\frac{1}{D} \\left(
+            W_\\mathrm{isotropic} = & \\left(
             W_{\\mathrm{net},\\mathrm{additional}}^{xx}
             + W_{\\mathrm{net},\\mathrm{additional}}^{yy}
             + W_{\\mathrm{net},\\mathrm{additional}}^{zz} \\right) \\\\
-            + & \\frac{1}{D} \\sum_{i \\in \\mathrm{filter}}
+            + & \\sum_{i \\in \\mathrm{filter}}
             \\left( W_\\mathrm{{net},i}^{xx}
             + W_\\mathrm{{net},i}^{yy}
             + W_\\mathrm{{net},i}^{zz}
@@ -106,14 +106,14 @@ class ThermodynamicQuantities(Compute):
         (:math:`P^{xx}`, :math:`P^{xy}`, :math:`P^{xz}`, :math:`P^{yy}`,
         :math:`P^{yz}`, :math:`P^{zz}`):
 
-          .. math::
+        .. math::
 
-              P^{kl} = \\frac{1}{V} \\left(
-              W_{\\mathrm{net},\\mathrm{additional}}^{kl}
-              + \\sum_{i \\in \\mathrm{filter}} m_i
-              \\cdot v_i^k \\cdot v_i^l +
-              W_{\\mathrm{net},i}^{kl}
-              \\right),
+            P^{kl} = \\frac{1}{V} \\left(
+            W_{\\mathrm{net},\\mathrm{additional}}^{kl}
+            + \\sum_{i \\in \\mathrm{filter}} m_i
+            \\cdot v_i^k \\cdot v_i^l +
+            W_{\\mathrm{net},i}^{kl}
+            \\right),
 
         where the net virial terms are computed by `hoomd.md.Integrator` over
         all of the forces in `hoomd.md.Integrator.forces`, :math:`v_i^k` is the


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should be based on *trunk-patch*. -->
<!-- Backwards compatible new features should be based on *trunk-minor*. -->
<!-- Incompatible API changes should be based on *trunk-major*. -->

## Description

* Remove extra factor of 1/D from W_isotropic. This factor is present in the previous equation: P = ... W/D
* Move the pressure tensor equation out of the definition list.

<!-- Describe your changes in detail. -->

## Motivation and context

Correctly document HOOMD-blue's computations.
<!--- Why is this change required? What problem does it solve? -->

## How has this been tested?

I rendered the documentation locally.

<!--- Please describe in detail how you tested your changes. -->

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
Fixed:

* Correct equations in virial pressure documentation.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
