### PR TITLE
Refactor gamma distribution.

### DIFF
--- a/hoomd/RandomNumbers.h
+++ b/hoomd/RandomNumbers.h
@@ -418,7 +418,7 @@ template<typename Real> class SpherePointGenerator
         do
             {
             u = UniformDistribution<Real>(Real(-1.0), Real(1.0))(rng);
-            one_minus_u2 = 1.0f - u * u;
+            one_minus_u2 = Real(1.0) - u * u;
             } while (one_minus_u2 < Real(0.0));
 
         // project onto the sphere surface

--- a/hoomd/RandomNumbers.h
+++ b/hoomd/RandomNumbers.h
@@ -449,6 +449,8 @@ template<typename Real> class SpherePointGenerator
  *      Mathematical Software (TOMS), vol. 26, issue 3, Sept. 2000, 363--372.
  *      https://doi.org/10.1145/358407.358414
  *
+ * WARNING: This implementation assumes alpha > 1.
+ *
  * \tparam Real Precision of the random number
  */
 template<typename Real> class GammaDistribution
@@ -487,18 +489,18 @@ template<typename Real> class GammaDistribution
             do
                 {
                 x = m_normal(rng);
-                v = 1.0f + m_c * x;
+                v = Real(1.0) + m_c * x;
                 } while (v <= Real(0.));
             v = v * v * v;
 
             // draw uniform and perform cheap squeeze test first
             const Real x2 = x * x;
             Real u = detail::generate_canonical<Real>(rng);
-            if (u < 1.0f - 0.0331f * x2 * x2)
+            if (u < Real(1.0) - Real(0.0331) * x2 * x2)
                 break;
 
             // otherwise, do expensive log comparison
-            if (fast::log(u) < 0.5f * x2 + m_d * (1.0f - v + fast::log(v)))
+            if (fast::log(u) < Real(0.5) * x2 + m_d * (Real(1.0) - v + fast::log(v)))
                 break;
             }
 

--- a/hoomd/test/random_numbers_test.cc
+++ b/hoomd/test/random_numbers_test.cc
@@ -245,14 +245,26 @@ UP_TEST(normal_float_test)
     check_moments(gen, 500000, mean, var, exkurtosis, skew, 0.01);
     }
 
-//! Test case for GammaDistribution -- double
-UP_TEST(gamma_double_test)
+//! Test case for GammaDistribution -- double (small alpha)
+UP_TEST(gamma_double_small_alpha_test)
     {
     double alpha = 2.5, b = 2.0;
     double mean = alpha * b, var = alpha * b * b, skew = 2.0 / sqrt(alpha),
            exkurtosis = 6.0 / alpha;
     hoomd::GammaDistribution<double> gen(alpha, b);
     check_moments(gen, 5000000, mean, var, skew, exkurtosis, 0.01);
+    }
+//! Test case for GammaDistribution -- double (large N)
+UP_TEST(gamma_double_large_alpha_test)
+    {
+    double alpha = 1000.0, b = 2.0;
+    double mean = alpha * b, var = alpha * b * b, skew = 2.0 / sqrt(alpha),
+           exkurtosis = 6.0 / alpha;
+    hoomd::GammaDistribution<double> gen(alpha, b);
+
+    // Test with reduced tolerance. The skew and kurtosis computations suffer from round-off
+    // errors for large alpha. Can lower tolerance when check_moments implements kahan summation.
+    check_moments(gen, 5000000, mean, var, skew, exkurtosis, 0.05, false);
     }
 //! Test case for GammaDistribution -- float
 UP_TEST(gamma_float_test)


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should be based on *trunk-patch*. -->
<!-- Backwards compatible new features should be based on *trunk-minor*. -->
<!-- Incompatible API changes should be based on *trunk-major*. -->

## Description

<!-- Describe your changes in detail. -->
* Replace floating point literals with explicit Real constants in random number generation.
* Test gamma distribution with a larger alpha.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
After getting some surprising results from the Bussi thermostat (which turned out to be a poor seed choice), I reviewed the GammaDistribution code. I found no errors in the code, but there were floating point literals. I replaced these with Real casted literals to ensure there are no unintended conversions. This should be a no-op for double precision Real as the compiler would have upcasted implicitly. 

In Bussi, GammaDistribution is used with alpha=ndof/2, so I added a unit test to cover something more reasonable. I had to lower the tolerance because the `sample_x3` used in the skew computation goes to 1e10 and suffers from round off error in the accumulation. A better solution would be fix the skew computation with kahan summation or another method, but I do not have time for that right now.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
Existing tests pass. *hoomd-validation* simulations using Bussi produce the expected K distribution.

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

Internal change, no change log necessary.

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
