### PR TITLE
Fix Circular References

### DIFF
--- a/hoomd/conftest.py
+++ b/hoomd/conftest.py
@@ -426,7 +426,9 @@ def _check_obj_attr_compatibility(a, b):
     filtered_differences = set(different_keys)
     for key in different_keys:
         if key in a._reserved_default_attrs:
-            default = a._reserved_default_attrs[key]()
+            default = a._reserved_default_attrs[key]
+            if callable(default):
+                default = default()
             if getattr(a, key, default) == getattr(b, key, default):
                 filtered_differences.remove(key)
                 continue

--- a/hoomd/data/syncedlist.py
+++ b/hoomd/data/syncedlist.py
@@ -215,7 +215,7 @@ class SyncedList(MutableSequence):
 
     @property
     def _simulation(self):
-        sim = self.__simulation
+        sim = self._simulation_
         if sim is not None:
             sim = sim()
             if sim is not None:
@@ -225,7 +225,7 @@ class SyncedList(MutableSequence):
     def _simulation(self, simulation):
         if simulation is not None:
             simulation = weakref.ref(simulation)
-        self.__simulation = simulation
+        self._simulation_ = simulation
 
     def _sync(self, simulation, synced_list):
         """Attach all list items and update for automatic attachment."""
@@ -260,7 +260,7 @@ class SyncedList(MutableSequence):
     def __getstate__(self):
         """Get state for pickling."""
         state = copy(self.__dict__)
-        state['_simulation'] = None
+        state['_simulation_'] = None
         state.pop('_synced_list', None)
         return state
 

--- a/hoomd/data/syncedlist.py
+++ b/hoomd/data/syncedlist.py
@@ -5,6 +5,7 @@
 
 from collections.abc import MutableSequence
 from copy import copy
+import weakref
 
 from hoomd.data.typeconverter import _BaseConverter, TypeConverter
 
@@ -211,6 +212,20 @@ class SyncedList(MutableSequence):
         except ValueError as verr:
             raise ValueError(f"Validation failed: {verr.args[0]}") from verr
         return processed_value
+
+    @property
+    def _simulation(self):
+        sim = self.__simulation
+        if sim is not None:
+            sim = sim()
+            if sim is not None:
+                return sim
+
+    @_simulation.setter
+    def _simulation(self, simulation):
+        if simulation is not None:
+            simulation = weakref.ref(simulation)
+        self.__simulation = simulation
 
     def _sync(self, simulation, synced_list):
         """Attach all list items and update for automatic attachment."""

--- a/hoomd/data/syncedlist.py
+++ b/hoomd/data/syncedlist.py
@@ -71,6 +71,7 @@ class SyncedList(MutableSequence):
                  callable_class=False,
                  attach_members=True):
         self._attach_members = attach_members
+        self._simulation_ = None
         if to_synced_list is None:
             to_synced_list = identity
 

--- a/hoomd/data/syncedlist.py
+++ b/hoomd/data/syncedlist.py
@@ -220,6 +220,8 @@ class SyncedList(MutableSequence):
             sim = sim()
             if sim is not None:
                 return sim
+            else:
+                self._unsync()
 
     @_simulation.setter
     def _simulation(self, simulation):

--- a/hoomd/logging.py
+++ b/hoomd/logging.py
@@ -14,13 +14,14 @@ See Also:
     Tutorial: :doc:`tutorial/04-Custom-Actions-In-Python/00-index`
 """
 
-from copy import deepcopy
+import copy
 from enum import Flag, auto
 from itertools import count
 from functools import reduce, wraps
 import weakref
 
-from hoomd.util import dict_map, _SafeNamespaceDict
+import hoomd
+from hoomd.util import _SafeNamespaceDict
 from hoomd.error import DataAccessError
 from collections.abc import Sequence
 
@@ -348,7 +349,7 @@ class Loggable(type):
             # or one of its subclasses.
             if issubclass(type(base_cls), Loggable):
                 inherited_loggables.update({
-                    name: deepcopy(quantity).update_cls(new_cls)
+                    name: copy.deepcopy(quantity).update_cls(new_cls)
                     for name, quantity in base_cls._export_dict.items()
                 })
         return inherited_loggables
@@ -480,6 +481,13 @@ def log(func=None,
         return helper(func)
 
 
+class _InvalidLogEntryType():
+    pass
+
+
+_InvalidLogEntry = _InvalidLogEntryType()
+
+
 class _LoggerEntry:
     """Stores the information for an entry in a `Logger`.
 
@@ -547,6 +555,10 @@ class _LoggerEntry:
 
     @obj.setter
     def obj(self, new_obj):
+        if not isinstance(new_obj,
+                          (hoomd.operation.Operation, hoomd.Simulation)):
+            self._obj = new_obj
+            return
         try:
             self._obj = weakref.ref(new_obj)
         except TypeError:
@@ -555,9 +567,9 @@ class _LoggerEntry:
     def __call__(self):
         obj = self.obj
         if obj is None:
-            return (None, self.category.name)
+            return _InvalidLogEntry
         try:
-            attr = getattr(self.obj, self.attr)
+            attr = getattr(obj, self.attr)
         except DataAccessError:
             attr = None
 
@@ -572,6 +584,12 @@ class _LoggerEntry:
         return all(
             getattr(self, attr) == getattr(other, attr)
             for attr in ['obj', 'attr', 'category'])
+
+    def __getstate__(self):
+        state = copy.copy(self.__dict__)
+        # Remove weak reference
+        state["_obj"] = self.obj
+        return state
 
 
 class Logger(_SafeNamespaceDict):
@@ -834,12 +852,25 @@ class Logger(_SafeNamespaceDict):
         Returns:
             dict: A nested dictionary of the current logged quantities. The end
             values are (value, category) pairs which hold the value along
-            with its associated `LoggerCategories` category
-            represented as a string (to get the
-            `LoggerCategories` enum value use
-            ``LoggerCategories[category]``.
+            with its associated `LoggerCategories` category represented as a
+            string (to get the `LoggerCategories` enum value use
+            ``LoggerCategories[category]``).
         """
-        return dict_map(self._dict, lambda x: x())
+        # Use namespace dict to correctly nest log values.
+        data = _SafeNamespaceDict()
+        # We remove all keys where the reference to the object has become
+        # invalid.
+        remove_keys = []
+        for key, entry in self.items():
+            log_value = entry()
+            if log_value is _InvalidLogEntry:
+                remove_keys.append(key)
+                continue
+            data[key] = log_value
+        if len(remove_keys) > 0:
+            for key in remove_keys:
+                del self[key]
+        return data._dict
 
     def _contains_obj(self, namespace, obj):
         """Evaluates based on identity."""

--- a/hoomd/operation.py
+++ b/hoomd/operation.py
@@ -52,8 +52,9 @@ class _HOOMDGetSetAttrBase:
 
     def __getattr__(self, attr):
         if attr in self._reserved_default_attrs:
-            default = self._reserved_default_attrs[attr]
-            value = default() if callable(default) else default
+            value = self._reserved_default_attrs[attr]
+            if callable(value):
+                value = value()
             object.__setattr__(self, attr, value)
             return value
         elif attr in self._param_dict:

--- a/hoomd/operation.py
+++ b/hoomd/operation.py
@@ -223,16 +223,23 @@ class _HOOMDBaseObject(_HOOMDGetSetAttrBase,
     # expected as _use_count may not equal 0.
     _remove_for_pickling = ('_simulation_', '_cpp_obj', "_use_count")
 
-    def _detach(self):
+    def _detach(self, force=False):
         """Decrement attach count and destroy C++ object if count == 0.
 
         This method is not designed to be overwritten, but handles the necessary
         detaching procedures for all `_HOOMDBaseObject` subclasses.
 
+        Args:
+            force (`bool`, optional): Whether to ignore ``_use_count`` or not.
+                Defaults to ``False``. When ``True`` the object will remove all
+                C++ connections regardless of usage elsewhere.
+
         Note:
             Use `~._detach_hook` in subclasses to provide custom detaching
             logic.
         """
+        if force:
+            self._use_count = 0
         if self._use_count == 0:
             return self
         self._use_count -= 1
@@ -320,6 +327,8 @@ class _HOOMDBaseObject(_HOOMDGetSetAttrBase,
             sim = sim()  # grab weakref
             if sim is not None:
                 return sim
+            else:
+                self._detach(force=True)
 
     @_simulation.setter
     def _simulation(self, simulation):

--- a/hoomd/operation.py
+++ b/hoomd/operation.py
@@ -208,7 +208,7 @@ class _HOOMDBaseObject(_HOOMDGetSetAttrBase,
     _reserved_default_attrs = {
         **_HOOMDGetSetAttrBase._reserved_default_attrs,
         '_cpp_obj': None,
-        '__simulation': None,
+        '_simulation_': None,
         '_dependents': list,
         '_dependencies': list,
         # Keeps track of the number of times _attach is called to avoid
@@ -217,11 +217,11 @@ class _HOOMDBaseObject(_HOOMDGetSetAttrBase,
     }
 
     _skip_for_equality = {
-        '_cpp_obj', '_dependents', '_dependencies', '_simulation', "_use_count"
+        '_cpp_obj', '_dependents', '_dependencies', '_simulation_', "_use_count"
     }
     # _use_count must be included or attaching and detaching won't work as
     # expected as _use_count may not equal 0.
-    _remove_for_pickling = ('__simulation', '_cpp_obj', "_use_count")
+    _remove_for_pickling = ('_simulation_', '_cpp_obj', "_use_count")
 
     def _detach(self):
         """Decrement attach count and destroy C++ object if count == 0.
@@ -315,7 +315,7 @@ class _HOOMDBaseObject(_HOOMDGetSetAttrBase,
     @property
     def _simulation(self):
         """Get/set reference to weakly referenced simulation."""
-        sim = self.__simulation
+        sim = self._simulation_
         if sim is not None:
             sim = sim()  # grab weakref
             if sim is not None:
@@ -325,7 +325,7 @@ class _HOOMDBaseObject(_HOOMDGetSetAttrBase,
     def _simulation(self, simulation):
         if simulation is not None:
             simulation = weakref.ref(simulation)
-        self.__simulation = simulation
+        self._simulation_ = simulation
 
     def _apply_param_dict(self):
         self._param_dict._attach(self._cpp_obj)

--- a/hoomd/operations.py
+++ b/hoomd/operations.py
@@ -11,6 +11,7 @@ added and removed from a `Simulation`.
 # Operations also automatically handles attaching and detaching (creating and
 # destroying C++ objects) for all hoomd operations.
 
+import weakref
 from collections.abc import Collection
 from copy import copy
 from itertools import chain
@@ -321,3 +322,17 @@ class Operations(Collection):
         state['_simulation'] = None
         state['_scheduled'] = False
         return state
+
+    @property
+    def _simulation(self):
+        sim = self._simulation_
+        if sim is not None:
+            sim = sim()
+            if sim is not None:
+                return sim
+
+    @_simulation.setter
+    def _simulation(self, sim):
+        if sim is not None:
+            sim = weakref.ref(sim)
+        self._simulation_ = sim

--- a/hoomd/pytest/test_logging.py
+++ b/hoomd/pytest/test_logging.py
@@ -4,8 +4,9 @@
 from hoomd.conftest import pickling_check
 from pytest import raises, fixture, mark
 from hoomd.logging import (_LoggerQuantity, _NamespaceFilter,
-                           _SafeNamespaceDict, Logger, dict_map, Loggable,
+                           _SafeNamespaceDict, Logger, Loggable,
                            LoggerCategories, log)
+from hoomd.util import dict_map
 
 
 class DummyNamespace:

--- a/hoomd/pytest/test_operation.py
+++ b/hoomd/pytest/test_operation.py
@@ -115,7 +115,7 @@ def test_apply_param_dict(full_op):
 def attached(full_op):
     cp = deepcopy(full_op)
     op = test_apply_param_dict(cp)
-    op._simulation = 1
+    op._simulation = DummySimulation()
     return op
 
 

--- a/hoomd/pytest/test_operation.py
+++ b/hoomd/pytest/test_operation.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2009-2023 The Regents of the University of Michigan.
 # Part of HOOMD-blue, released under the BSD 3-Clause License.
 
+import hoomd
 from hoomd.conftest import pickling_check
 from hoomd.data.typeparam import TypeParameter
 from hoomd.data.parameterdicts import TypeParameterDict
@@ -142,3 +143,24 @@ def test_detach(attached):
 def test_pickling(full_op, attached):
     pickling_check(full_op)
     pickling_check(attached)
+
+
+def test_operation_lifetime(simulation_factory, two_particle_snapshot_factory):
+
+    def drop_sim(attach=False):
+        sim = simulation_factory(two_particle_snapshot_factory())
+        # Use operation available regardless of build
+        box_resize = hoomd.update.BoxResize(10, hoomd.Box.cube(4),
+                                            hoomd.Box.cube(5),
+                                            hoomd.variant.Ramp(0, 1, 0, 10_000))
+        sim.operations.updaters.append(box_resize)
+        if attach:
+            sim.run(0)
+        return box_resize
+
+    box_resize = drop_sim()
+    assert box_resize._simulation is None
+
+    box_resize = drop_sim(True)
+    assert box_resize._simulation is None
+    assert box_resize._cpp_obj is None

--- a/hoomd/pytest/test_syncedlist.py
+++ b/hoomd/pytest/test_syncedlist.py
@@ -3,7 +3,9 @@
 
 import numpy as np
 import pytest
-from hoomd.conftest import BaseListTest, pickling_check
+
+import hoomd
+from hoomd.conftest import (BaseListTest, pickling_check)
 from hoomd.pytest.dummy import DummyOperation, DummySimulation
 from hoomd.data.syncedlist import SyncedList
 
@@ -64,7 +66,9 @@ class TestSyncedList(BaseListTest):
         list_ = SyncedList(validation=item_cls, attach_members=attach_items)
         if attached:
             self._synced_list = []
-            list_._sync(DummySimulation(), self._synced_list)
+            # have to store reference since SyncedList only stores weak ref.
+            self.__simulation = DummySimulation()
+            list_._sync(self.__simulation, self._synced_list)
         return list_
 
     def is_equal(self, a, b):
@@ -148,3 +152,24 @@ class TestSyncedList(BaseListTest):
     def test_pickling(self, populated_collection):
         test_list, _ = populated_collection
         pickling_check(test_list)
+
+    def test_sim_weakref(self, simulation_factory,
+                         two_particle_snapshot_factory):
+
+        def drop_sim(attach=False):
+            sim = simulation_factory(two_particle_snapshot_factory())
+            # Use operation available regardless of build
+            box_resize = hoomd.update.BoxResize(
+                10, hoomd.Box.cube(4), hoomd.Box.cube(5),
+                hoomd.variant.Ramp(0, 1, 0, 10_000))
+            sim.operations.updaters.append(box_resize)
+            if attach:
+                sim.run(0)
+            return sim.operations.updaters
+
+        synced_list = drop_sim()
+        assert synced_list._simulation is None
+
+        synced_list = drop_sim(True)
+        assert synced_list._simulation is None
+        assert not synced_list._synced

--- a/hoomd/simulation.py
+++ b/hoomd/simulation.py
@@ -461,6 +461,10 @@ class Simulation(metaclass=Loggable):
 
         self._cpp_sys.run(steps_int, write_at_start)
 
+    def __del__(self):
+        """Clean up dangling references to simulation."""
+        self._operations._unschedule()
+
 
 def _match_class_path(obj, *matches):
     return any(cls.__module__ + '.' + cls.__name__ in matches

--- a/hoomd/state.py
+++ b/hoomd/state.py
@@ -7,6 +7,7 @@
 particle positions, system bonds).
 
 """
+import weakref
 from collections import defaultdict
 
 from . import _hoomd
@@ -686,3 +687,17 @@ class State:
             len(particle_data.getDomainDecomposition().getCumulativeFractions(
                 dir)) - 1 for dir in range(3)
         ])
+
+    @property
+    def _simulation(self):
+        sim = self._simulation_
+        if sim is not None:
+            sim = sim()
+            if sim is not None:
+                return sim
+
+    @_simulation.setter
+    def _simulation(self, sim):
+        if sim is not None:
+            sim = weakref.ref(sim)
+        self._simulation_ = sim

--- a/hoomd/util.py
+++ b/hoomd/util.py
@@ -5,7 +5,6 @@
 
 import io
 from collections.abc import Iterable, Mapping, MutableMapping
-from copy import deepcopy
 
 
 def _to_camel_case(string):
@@ -250,9 +249,6 @@ class _SafeNamespaceDict(_NamespaceDict):
                            "replacing.".format(namespace))
         else:
             super().__setitem__(namespace, value)
-
-    def __getitem__(self, namespace):
-        return deepcopy(super().__getitem__(namespace))
 
 
 class GPUNotAvailableError(NotImplementedError):


### PR DESCRIPTION
## Description

This fixes memory leaks associated with using a logger and perhaps other parts of HOOMD's interface using `weakref`. Why this is necessary, I don't know. I think it may have something to do with a C++ object holding a reference to a Python object which holds a reference to the C++ object, but that is purely conjecture.

This moves simulation references to weak references generally and moves the logger to use weak references for objects expected to live beyond the call. Unfortunately simply always wrapping leads to cases like
```python
logger[("new", "loggable")] = (lambda : 42, "scalar")
```
not working since the only reference to the function is in the logger. Similarly and perhaps more damningly,

```python
def add_quantities(logger):
    log_quantities = LogValues()
    logger["A"] = (log_quantities, "A")
    logger["B"] = (log_quantities, "B")
    logger["C"] = (log_quantities, "C")
```

would not work
<!-- Describe your changes in detail. -->

## Motivation and context

This is to fix multiple issues we have had with the garbage collector such as #1457.
<!--- Why is this change required? What problem does it solve? -->

<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves #1457

## How has this been tested?

Existing tests pass which ensures the same behavior as before (well tests will pass when I make this not a draft).
<!--- Please describe in detail how you tested your changes. -->

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
Fixed: Potential memory leaks.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
