### PR TITLE
More explicit attachment errors.

### DIFF
--- a/hoomd/operation.py
+++ b/hoomd/operation.py
@@ -307,8 +307,8 @@ class _HOOMDBaseObject(_HOOMDGetSetAttrBase,
             self._apply_typeparam_dict(self._cpp_obj, self._simulation)
         except Exception as err:
             raise type(err)(
-                f"Object of type {type(self)} could not be setup for "
-                f"simulating.") from err
+                f"Error applying parameters for object of type {type(self)}."
+                ) from err
         self._post_attach_hook()
 
     @property

--- a/hoomd/operation.py
+++ b/hoomd/operation.py
@@ -302,8 +302,13 @@ class _HOOMDBaseObject(_HOOMDGetSetAttrBase,
         except hoomd.error.SimulationDefinitionError as err:
             self._use_count -= 1
             raise err
-        self._apply_param_dict()
-        self._apply_typeparam_dict(self._cpp_obj, self._simulation)
+        try:
+            self._apply_param_dict()
+            self._apply_typeparam_dict(self._cpp_obj, self._simulation)
+        except Exception as err:
+            raise hoomd.error.SimulationDefinitionError(
+                f"Object of type {type(self)} could not be setup for "
+                f"simulating.") from err
         self._post_attach_hook()
 
     @property

--- a/hoomd/operation.py
+++ b/hoomd/operation.py
@@ -306,7 +306,7 @@ class _HOOMDBaseObject(_HOOMDGetSetAttrBase,
             self._apply_param_dict()
             self._apply_typeparam_dict(self._cpp_obj, self._simulation)
         except Exception as err:
-            raise hoomd.error.SimulationDefinitionError(
+            raise type(err)(
                 f"Object of type {type(self)} could not be setup for "
                 f"simulating.") from err
         self._post_attach_hook()

--- a/hoomd/operation.py
+++ b/hoomd/operation.py
@@ -308,7 +308,7 @@ class _HOOMDBaseObject(_HOOMDGetSetAttrBase,
         except Exception as err:
             raise type(err)(
                 f"Error applying parameters for object of type {type(self)}."
-                ) from err
+            ) from err
         self._post_attach_hook()
 
     @property


### PR DESCRIPTION
## Description
Add an error message when any object fails to attach to a simulation with the class name.

## Motivation and context
This will significantly aid debugging by providing necessary information at attachment about what is causing the problem. Despite the `ParameterDict` and `TypeparameterDict` infrastructure, there are times where pybind11 will raise an error without much context making debugging very difficult. This can be seen in multiple mailing list questions.

## How has this been tested?

We don't normally test error messages, and so I did not here. A test can be added if desired.

## Change log

<!-- Propose a change log entry. -->
```
Added:
+ More descriptive error messages when calling `Simulation.run`.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
