### PR TITLE
Attempt to workaround MPI_Init error on Frontier.

### DIFF
--- a/hoomd/module.cc
+++ b/hoomd/module.cc
@@ -95,6 +95,10 @@ char env_enable_mpi_cuda[] = "MV2_USE_CUDA=1";
 //! Initialize the MPI environment
 int initialize_mpi()
     {
+    #ifdef ENABLE_HIP
+    hipInit(0);
+    #endif
+
     // initialize MPI if it has not been initialized by another program
     int external_init = 0;
     MPI_Initialized(&external_init);

--- a/hoomd/module.cc
+++ b/hoomd/module.cc
@@ -95,7 +95,7 @@ char env_enable_mpi_cuda[] = "MV2_USE_CUDA=1";
 //! Initialize the MPI environment
 int initialize_mpi()
     {
-    #ifdef ENABLE_HIP
+    #if defined(__HIP_PLATFORM_HCC__) && defined(ENABLE_HIP)
     hipInit(0);
     #endif
 

--- a/hoomd/module.cc
+++ b/hoomd/module.cc
@@ -95,9 +95,9 @@ char env_enable_mpi_cuda[] = "MV2_USE_CUDA=1";
 //! Initialize the MPI environment
 int initialize_mpi()
     {
-    #if defined(__HIP_PLATFORM_HCC__) && defined(ENABLE_HIP)
+#if defined(__HIP_PLATFORM_HCC__) && defined(ENABLE_HIP)
     hipInit(0);
-    #endif
+#endif
 
     // initialize MPI if it has not been initialized by another program
     int external_init = 0;


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should be based on *trunk-patch*. -->
<!-- Backwards compatible new features should be based on *trunk-minor*. -->
<!-- Incompatible API changes should be based on *trunk-major*. -->

## Description

<!-- Describe your changes in detail. -->
Call `hipInit(0)` before `MPI_Init`.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Avoid errors on Frontier. See https://docs.olcf.ornl.gov/systems/frontier_user_guide.html#olcfdev-1655-occasional-seg-fault-during-mpi-init

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
Tests on `cheme-hodges` pass.

@SchoeniPhlippsn will see if this resolves the issue on Frontier.

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
* Work around occasional ``MPI_Init`` failures on Frontier.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
