### PR TITLE
Support gsd 3.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
     name: Build release tarball
     runs-on: ubuntu-latest
     container:
-      image: glotzerlab/ci:2023.03-ubuntu20.04
+      image: glotzerlab/ci:2023.05-ubuntu20.04
 
     steps:
       - name: Checkout

--- a/.github/workflows/templates/workflow.yml
+++ b/.github/workflows/templates/workflow.yml
@@ -1,5 +1,5 @@
 <% block name %><% endblock %>
-<% set container_prefix="glotzerlab/ci:2023.03" %>
+<% set container_prefix="glotzerlab/ci:2023.05" %>
 
 <% block concurrency %>
 concurrency:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,7 +59,7 @@ jobs:
     name: Build [${{ join(matrix.config, '_') }}]
     runs-on: ${{ matrix.build_runner }}
     container:
-      image: glotzerlab/ci:2023.03-${{ matrix.config[0] }}
+      image: glotzerlab/ci:2023.05-${{ matrix.config[0] }}
     strategy:
       matrix:
         include:
@@ -168,7 +168,7 @@ jobs:
     needs: build
     runs-on: ${{ matrix.test_runner }}
     container:
-      image: glotzerlab/ci:2023.03-${{ matrix.config[0] }}
+      image: glotzerlab/ci:2023.05-${{ matrix.config[0] }}
       options: ${{ matrix.test_docker_options }} -e CUDA_VISIBLE_DEVICES
     strategy:
       matrix:
@@ -229,7 +229,7 @@ jobs:
     needs: build
     runs-on: ${{ matrix.test_runner }}
     container:
-      image: glotzerlab/ci:2023.03-${{ matrix.config[0] }}
+      image: glotzerlab/ci:2023.05-${{ matrix.config[0] }}
       options: ${{ matrix.test_docker_options }} -e CUDA_VISIBLE_DEVICES
     strategy:
       matrix:
@@ -283,7 +283,7 @@ jobs:
     needs: build
     runs-on: ${{ matrix.test_runner }}
     container:
-      image: glotzerlab/ci:2023.03-${{ matrix.config[0] }}
+      image: glotzerlab/ci:2023.05-${{ matrix.config[0] }}
       options: ${{ matrix.test_docker_options }} -e CUDA_VISIBLE_DEVICES
     strategy:
       matrix:
@@ -334,7 +334,7 @@ jobs:
     name: Build [${{ join(matrix.config, '_') }}]
     runs-on: ${{ matrix.build_runner }}
     container:
-      image: glotzerlab/ci:2023.03-${{ matrix.config[0] }}
+      image: glotzerlab/ci:2023.05-${{ matrix.config[0] }}
     strategy:
       matrix:
         include:
@@ -445,7 +445,7 @@ jobs:
     needs: build_release
     runs-on: ${{ matrix.test_runner }}
     container:
-      image: glotzerlab/ci:2023.03-${{ matrix.config[0] }}
+      image: glotzerlab/ci:2023.05-${{ matrix.config[0] }}
       options: ${{ matrix.test_docker_options }} -e CUDA_VISIBLE_DEVICES
     strategy:
       matrix:
@@ -512,7 +512,7 @@ jobs:
     needs: build_release
     runs-on: ${{ matrix.test_runner }}
     container:
-      image: glotzerlab/ci:2023.03-${{ matrix.config[0] }}
+      image: glotzerlab/ci:2023.05-${{ matrix.config[0] }}
       options: ${{ matrix.test_docker_options }} -e CUDA_VISIBLE_DEVICES
     strategy:
       matrix:

--- a/hoomd/md/pytest/test_gsd.py
+++ b/hoomd/md/pytest/test_gsd.py
@@ -93,7 +93,7 @@ def test_write(simulation_factory, hoomd_snapshot, tmp_path):
     sim = simulation_factory(hoomd_snapshot)
     hoomd.write.GSD.write(state=sim.state, mode='wb', filename=str(filename))
     if hoomd_snapshot.communicator.rank == 0:
-        with gsd.hoomd.open(name=filename, mode='rb') as traj:
+        with gsd.hoomd.open(name=filename, mode='r') as traj:
             assert len(traj) == 1
             assert_equivalent_snapshots(traj[0], hoomd_snapshot)
 
@@ -114,7 +114,7 @@ def test_write_gsd_trigger(create_md_sim, tmp_path):
     gsd_writer.flush()
 
     if sim.device.communicator.rank == 0:
-        with gsd.hoomd.open(name=filename, mode='rb') as traj:
+        with gsd.hoomd.open(name=filename, mode='r') as traj:
             assert [frame.configuration.step for frame in traj] == [5, 15, 25]
 
 
@@ -149,7 +149,7 @@ def test_write_gsd_mode(create_md_sim, hoomd_snapshot, tmp_path,
         if snap.communicator.rank == 0:
             snap_list.append(snap)
     if sim.device.communicator.rank == 0:
-        with gsd.hoomd.open(name=filename, mode='rb') as traj:
+        with gsd.hoomd.open(name=filename, mode='r') as traj:
             for gsd_snap, hoomd_snap in zip(traj[5:], snap_list):
                 assert_equivalent_snapshots(gsd_snap, hoomd_snap)
 
@@ -186,7 +186,7 @@ def test_write_gsd_mode(create_md_sim, hoomd_snapshot, tmp_path,
     gsd_writer.flush()
 
     if sim.device.communicator.rank == 0:
-        with gsd.hoomd.open(name=filename_xb, mode='rb') as traj:
+        with gsd.hoomd.open(name=filename_xb, mode='r') as traj:
             assert len(traj) == len(snapshot_list)
             for gsd_snap, hoomd_snap in zip(traj, snapshot_list):
                 assert_equivalent_snapshots(gsd_snap, hoomd_snap)
@@ -208,7 +208,7 @@ def test_write_gsd_filter(create_md_sim, tmp_path):
     sim.run(3)
 
     if sim.device.communicator.rank == 0:
-        with gsd.hoomd.open(name=filename, mode='rb') as traj:
+        with gsd.hoomd.open(name=filename, mode='r') as traj:
             for frame in traj:
                 assert frame.particles.N == 0
 
@@ -229,7 +229,7 @@ def test_write_gsd_truncate(create_md_sim, tmp_path):
     snapshot = sim.state.get_snapshot()
 
     if snapshot.communicator.rank == 0:
-        with gsd.hoomd.open(name=filename, mode='rb') as traj:
+        with gsd.hoomd.open(name=filename, mode='r') as traj:
             for gsd_snap in traj:
                 assert_equivalent_snapshots(gsd_snap, snapshot)
 
@@ -258,7 +258,7 @@ def test_write_gsd_dynamic(simulation_factory, create_md_sim, tmp_path):
     gsd_writer.flush()
 
     if sim.device.communicator.rank == 0:
-        with gsd.hoomd.open(name=filename, mode='rb') as traj:
+        with gsd.hoomd.open(name=filename, mode='r') as traj:
             for step in range(5):
                 np.testing.assert_allclose(traj[step].particles.position,
                                            position_list[step],
@@ -293,7 +293,7 @@ def test_write_gsd_dynamic(simulation_factory, create_md_sim, tmp_path):
     gsd_writer.flush()
 
     if sim.device.communicator.rank == 0:
-        with gsd.hoomd.open(name=filename, mode='rb') as traj:
+        with gsd.hoomd.open(name=filename, mode='r') as traj:
             for step in range(5):
                 np.testing.assert_allclose(traj[step].particles.velocity,
                                            velocity_list[step],
@@ -327,7 +327,7 @@ def test_write_gsd_dynamic(simulation_factory, create_md_sim, tmp_path):
     gsd_writer.flush()
 
     if sim.device.communicator.rank == 0:
-        with gsd.hoomd.open(name=filename, mode='rb') as traj:
+        with gsd.hoomd.open(name=filename, mode='r') as traj:
             for step in range(5, 10):
                 np.testing.assert_allclose(traj[step].particles.mass,
                                            N_particles * [0.8],
@@ -365,7 +365,7 @@ def test_write_gsd_dynamic(simulation_factory, create_md_sim, tmp_path):
     gsd_writer.flush()
 
     if sim.device.communicator.rank == 0:
-        with gsd.hoomd.open(name=filename, mode='rb') as traj:
+        with gsd.hoomd.open(name=filename, mode='r') as traj:
             assert traj[-1].bonds.N == 3
 
 
@@ -395,7 +395,7 @@ def test_write_gsd_log(create_md_sim, tmp_path):
     gsd_writer.flush()
 
     if sim.device.communicator.rank == 0:
-        with gsd.hoomd.open(name=filename, mode='rb') as traj:
+        with gsd.hoomd.open(name=filename, mode='r') as traj:
             for s in range(5):
                 e = traj[s].log[
                     'md/compute/ThermodynamicQuantities/kinetic_energy']
@@ -455,7 +455,7 @@ def test_write_gsd_finegrained_dynamic(simulation_factory, hoomd_snapshot,
     gsd_writer.flush()
 
     if sim.device.communicator.rank == 0:
-        with gsd.fl.open(name=filename, mode='rb') as f:
+        with gsd.fl.open(name=filename, mode='r') as f:
             for field in dynamic_fields:
                 if field == dynamic_field:
                     assert f.chunk_exists(frame=1, name=field)
@@ -504,7 +504,7 @@ def test_write_gsd_finegrained_dynamic_alldefault(simulation_factory,
     gsd_writer.flush()
 
     if sim.device.communicator.rank == 0:
-        with gsd.fl.open(name=filename, mode='rb') as f:
+        with gsd.fl.open(name=filename, mode='r') as f:
             assert f.nframes == 2
 
             for field in dynamic_fields:
@@ -528,7 +528,7 @@ def test_write_gsd_no_dynamic(simulation_factory, hoomd_snapshot, tmp_path):
     gsd_writer.flush()
 
     if sim.device.communicator.rank == 0:
-        with gsd.fl.open(name=filename, mode='rb') as f:
+        with gsd.fl.open(name=filename, mode='r') as f:
             assert f.nframes == 2
 
             assert f.chunk_exists(frame=0, name='configuration/step')

--- a/hoomd/pytest/test_simulation.py
+++ b/hoomd/pytest/test_simulation.py
@@ -30,7 +30,7 @@ class SleepUpdater(hoomd.custom.Action):
         return hoomd.update.CustomUpdater(1, cls())
 
 
-def make_gsd_snapshot(hoomd_snapshot):
+def make_gsd_frame(hoomd_snapshot):
     s = gsd.hoomd.Frame()
     for attr in dir(hoomd_snapshot):
         if attr[0] != '_' and attr not in [
@@ -216,7 +216,7 @@ def test_state_from_gsd(device, simulation_factory, lattice_snapshot_factory,
     snapshot_dict[0] = snap
 
     if device.communicator.rank == 0:
-        f.append(make_gsd_snapshot(snap))
+        f.append(make_gsd_frame(snap))
 
     box = sim.state.box
     for step in range(1, nsteps):
@@ -226,7 +226,7 @@ def test_state_from_gsd(device, simulation_factory, lattice_snapshot_factory,
                   particle_type)
 
         if device.communicator.rank == 0:
-            f.append(make_gsd_snapshot(snap))
+            f.append(make_gsd_frame(snap))
             snapshot_dict[step] = snap
         else:
             snapshot_dict[step] = None
@@ -265,7 +265,7 @@ def test_state_from_gsd_box_dims(device, simulation_factory,
     checks = range(3)
     if device.communicator.rank == 0:
         for step in checks:
-            f.append(modify_gsd_snap(make_gsd_snapshot(snap)))
+            f.append(modify_gsd_snap(make_gsd_frame(snap)))
         f.close()
 
     for step in checks:
@@ -278,7 +278,7 @@ def test_state_from_gsd_box_dims(device, simulation_factory,
 
 
 @skip_gsd
-def test_state_from_gsd_snapshot(simulation_factory, lattice_snapshot_factory,
+def test_state_from_gsd_frame(simulation_factory, lattice_snapshot_factory,
                                  device, state_args, tmp_path):
     snap_params, nsteps = state_args
 
@@ -286,7 +286,7 @@ def test_state_from_gsd_snapshot(simulation_factory, lattice_snapshot_factory,
         lattice_snapshot_factory(n=snap_params[0],
                                  particle_types=snap_params[1]))
     snap = sim.state.get_snapshot()
-    snap = make_gsd_snapshot(snap)
+    snap = make_gsd_frame(snap)
     gsd_snapshot_list = [snap]
     box = sim.state.box
     for _ in range(1, nsteps):
@@ -294,7 +294,7 @@ def test_state_from_gsd_snapshot(simulation_factory, lattice_snapshot_factory,
         snap = update_positions(sim.state.get_snapshot())
         set_types(snap, random_inds(snap_params[0]), snap_params[1],
                   particle_type)
-        snap = make_gsd_snapshot(snap)
+        snap = make_gsd_frame(snap)
         gsd_snapshot_list.append(snap)
 
     for snap in gsd_snapshot_list:

--- a/hoomd/pytest/test_simulation.py
+++ b/hoomd/pytest/test_simulation.py
@@ -279,7 +279,7 @@ def test_state_from_gsd_box_dims(device, simulation_factory,
 
 @skip_gsd
 def test_state_from_gsd_frame(simulation_factory, lattice_snapshot_factory,
-                                 device, state_args, tmp_path):
+                              device, state_args, tmp_path):
     snap_params, nsteps = state_args
 
     sim = simulation_factory(

--- a/hoomd/pytest/test_simulation.py
+++ b/hoomd/pytest/test_simulation.py
@@ -31,7 +31,7 @@ class SleepUpdater(hoomd.custom.Action):
 
 
 def make_gsd_snapshot(hoomd_snapshot):
-    s = gsd.hoomd.Snapshot()
+    s = gsd.hoomd.Frame()
     for attr in dir(hoomd_snapshot):
         if attr[0] != '_' and attr not in [
                 'exists', 'replicate', 'communicator'
@@ -206,7 +206,7 @@ def test_state_from_gsd(device, simulation_factory, lattice_snapshot_factory,
     d.mkdir()
     filename = d / "temporary_test_file.gsd"
     if device.communicator.rank == 0:
-        f = gsd.hoomd.open(name=filename, mode='wb+')
+        f = gsd.hoomd.open(name=filename, mode='w')
 
     sim = simulation_factory(
         lattice_snapshot_factory(n=snap_params[0],
@@ -256,7 +256,7 @@ def test_state_from_gsd_box_dims(device, simulation_factory,
     d.mkdir()
     filename = d / "temporary_test_file.gsd"
     if device.communicator.rank == 0:
-        f = gsd.hoomd.open(name=filename, mode='wb+')
+        f = gsd.hoomd.open(name=filename, mode='w')
 
     sim = simulation_factory(
         lattice_snapshot_factory(n=10, particle_types=["A", "B"], dimensions=2))

--- a/hoomd/pytest/test_snapshot.py
+++ b/hoomd/pytest/test_snapshot.py
@@ -5,7 +5,7 @@ from hoomd.snapshot import Snapshot
 from hoomd import Box
 import numpy
 import pytest
-from hoomd.pytest.test_simulation import make_gsd_snapshot
+from hoomd.pytest.test_simulation import make_gsd_frame
 try:
     import gsd.hoomd  # noqa: F401 - need to know if the import fails
     skip_gsd = False
@@ -400,14 +400,14 @@ def test_constraints(s):
 
 
 @skip_gsd
-def test_from_gsd_snapshot_empty(s, device):
-    gsd_snap = make_gsd_snapshot(s)
-    hoomd_snap = Snapshot.from_gsd_snapshot(gsd_snap, device.communicator)
+def test_from_gsd_frame_empty(s, device):
+    gsd_snap = make_gsd_frame(s)
+    hoomd_snap = Snapshot.from_gsd_frame(gsd_snap, device.communicator)
     assert_equivalent_snapshots(gsd_snap, hoomd_snap)
 
 
 @skip_gsd
-def test_from_gsd_snapshot_populated(s, device):
+def test_from_gsd_frame_populated(s, device):
     if s.communicator.rank == 0:
         s.configuration.box = [10, 12, 7, 0.1, 0.4, 0.2]
         for section in ('particles', 'bonds', 'angles', 'dihedrals',
@@ -437,8 +437,8 @@ def test_from_gsd_snapshot_populated(s, device):
             else:
                 attr[:] = numpy.random.randint(3, size=attr.shape)
 
-    gsd_snap = make_gsd_snapshot(s)
-    hoomd_snap = Snapshot.from_gsd_snapshot(gsd_snap, device.communicator)
+    gsd_snap = make_gsd_frame(s)
+    hoomd_snap = Snapshot.from_gsd_frame(gsd_snap, device.communicator)
     assert_equivalent_snapshots(gsd_snap, hoomd_snap)
 
 

--- a/hoomd/simulation.py
+++ b/hoomd/simulation.py
@@ -210,8 +210,8 @@ class Simulation(metaclass=Loggable):
         """Create the simulation state from a `Snapshot`.
 
         Args:
-            snapshot (Snapshot or gsd.hoomd.Snapshot): Snapshot to initialize
-                the state from. A `gsd.hoomd.Snapshot` will first be
+            snapshot (Snapshot or gsd.hoomd.Frame): Snapshot to initialize
+                the state from. A `gsd.hoomd.Frame` will first be
                 converted to a `hoomd.Snapshot`.
 
             domain_decomposition (tuple): Choose how to distribute the state
@@ -246,7 +246,12 @@ class Simulation(metaclass=Loggable):
             # snapshot is hoomd.Snapshot
             self._state = State(self, snapshot, domain_decomposition)
         elif _match_class_path(snapshot, 'gsd.hoomd.Snapshot'):
-            # snapshot is gsd.hoomd.Snapshot
+            # snapshot is gsd.hoomd.Snapshot (gsd 2.x)
+            snapshot = Snapshot.from_gsd_snapshot(snapshot,
+                                                  self._device.communicator)
+            self._state = State(self, snapshot, domain_decomposition)
+        elif _match_class_path(snapshot, 'gsd.hoomd.Frame'):
+            # snapshot is gsd.hoomd.Frame (gsd 3.x)
             snapshot = Snapshot.from_gsd_snapshot(snapshot,
                                                   self._device.communicator)
             self._state = State(self, snapshot, domain_decomposition)

--- a/hoomd/simulation.py
+++ b/hoomd/simulation.py
@@ -245,19 +245,20 @@ class Simulation(metaclass=Loggable):
         if isinstance(snapshot, Snapshot):
             # snapshot is hoomd.Snapshot
             self._state = State(self, snapshot, domain_decomposition)
+        elif _match_class_path(snapshot, 'gsd.hoomd.Frame'):
+            # snapshot is gsd.hoomd.Frame (gsd 2.8+, 3.x)
+            snapshot = Snapshot.from_gsd_frame(snapshot,
+                                               self._device.communicator)
+            self._state = State(self, snapshot, domain_decomposition)
         elif _match_class_path(snapshot, 'gsd.hoomd.Snapshot'):
             # snapshot is gsd.hoomd.Snapshot (gsd 2.x)
             snapshot = Snapshot.from_gsd_snapshot(snapshot,
                                                   self._device.communicator)
             self._state = State(self, snapshot, domain_decomposition)
-        elif _match_class_path(snapshot, 'gsd.hoomd.Frame'):
-            # snapshot is gsd.hoomd.Frame (gsd 3.x)
-            snapshot = Snapshot.from_gsd_snapshot(snapshot,
-                                                  self._device.communicator)
-            self._state = State(self, snapshot, domain_decomposition)
         else:
             raise TypeError(
-                "Snapshot must be a hoomd.Snapshot or gsd.hoomd.Snapshot.")
+                "Snapshot must be a hoomd.Snapshot, gsd.hoomd.Snapshot, "
+                "or gsd.hoomd.Frame")
 
         step = 0
         if self.timestep is not None:

--- a/hoomd/snapshot.py
+++ b/hoomd/snapshot.py
@@ -5,6 +5,7 @@
 
 import hoomd
 from hoomd import _hoomd
+import warnings
 
 
 class _ConfigurationData:
@@ -323,11 +324,11 @@ class Snapshot:
         self._cpp_obj._broadcast_box(self.communicator.cpp_mpi_conf)
 
     @classmethod
-    def from_gsd_snapshot(cls, gsd_snap, communicator):
-        """Constructs a `hoomd.Snapshot` from a `gsd.hoomd.Snapshot` object.
+    def from_gsd_frame(cls, gsd_snap, communicator):
+        """Constructs a `hoomd.Snapshot` from a `gsd.hoomd.Frame` object.
 
         Args:
-            gsd_snap (gsd.hoomd.Snapshot): The gsd snapshot to convert to a
+            gsd_snap (gsd.hoomd.Frame): The gsd frame to convert to a
                 `hoomd.Snapshot`.
             communicator (hoomd.communicator.Communicator): The MPI communicator
                 to use for the snapshot. This prevents the snapshot from being
@@ -338,7 +339,7 @@ class Snapshot:
             the system state from a GSD file.
 
         Note:
-            `from_gsd_snapshot` only accesses the ``gsd_snap`` argument on rank
+            `from_gsd_frame` only accesses the ``gsd_snap`` argument on rank
             0. In MPI simulations, avoid duplicating memory and file reads by
             reading GSD files only on rank 0 and passing ``gsd_snap=None`` on
             other ranks.
@@ -383,3 +384,15 @@ class Snapshot:
 
         snap._broadcast_box()
         return snap
+
+    @classmethod
+    def from_gsd_snapshot(cls, gsd_snap, communicator):
+        """Constructs a `hoomd.Snapshot` from a `gsd.hoomd.Snapshot` object.
+
+        .. deprecated:: 4.0.0
+
+            Use `from_gsd_frame`.
+        """
+        warnings.warn("gsd.hoomd.Snapshot is deprecated, use gsd.hoomd.Frame",
+                      FutureWarning)
+        return cls.from_gsd_frame(gsd_snap, communicator)

--- a/sphinx-doc/deprecated.rst
+++ b/sphinx-doc/deprecated.rst
@@ -4,83 +4,17 @@
 Deprecated
 ==========
 
-Features deprecated in v3.x may be removed in a future v4.0.0 release.
+Features deprecated in HOOMD 4.x may be removed in a future 5.0.0 release.
 
 HOOMD may issue `FutureWarning` messages to provide warnings for breaking changes in the next major
 release. Use Python's warnings module to silence warnings which may not be correctable until the
 next major release. Use this filter: ``ignore::FutureWarning:hoomd``. See Python's `warnings`
 documentation for more information on warning filters.
 
-.. note::
+4.x
+---
 
-    Where noted, suggested replacements will be first available with v4.0.0 and there  will be no
-    releases with overlapping support for the two APIs.
+* ``hoomd.snapshot.from_gsd_snapshot`` (since 4.0.0).
 
-v3.x
-----
+  * Use `hoomd.Snapshot.from_gsd_frame`.
 
-* Particle diameters (since v3.0.0).
-
-  * Use potentials such as `md.pair.ExpandedLJ`.
-
-* ``hoomd.md.pair.aniso.ALJ.mode`` parameter (since v3.1.0).
-
-  * ``mode`` has no effect since v3.0.0.
-
-* ``hoomd.md.pair.aniso.Dipole.mode`` parameter (since v3.1.0)
-
-  * ``mode`` has no effect since v3.0.0.
-
-* ``hoomd.device.GPU.memory_traceback`` parameter (since v3.4.0)
-
-  * ``memory_traceback`` has no effect since v3.0.0.
-
-* ``hoomd.md.dihedral.Harmonic`` (since v3.7.0).
-
-  * Use `hoomd.md.dihedral.Periodic`.
-
-* ``ENABLE_MPI_CUDA`` CMake option (since v3.7.0).
-* ``fix_cudart_rpath`` CMake macro (since v3.7.0).
-* ``charges`` key in `Rigid.body <hoomd.md.constrain.Rigid.body>` (since v3.7.0).
-
-  * Pass charges to `Rigid.create_bodies <hoomd.md.constrain.Rigid.create_bodies>` or set in system state.
-
-* ``diameters`` key in `Rigid.body <hoomd.md.constrain.Rigid.body>` (since v3.7.0).
-
-  * Set diameters in system state.
-
-* ``hoomd.md.methods.NVE`` (since v3.8.0).
-
-  * Use ``hoomd.md.methods.ConstantVolume`` with ``thermostat=None`` (available in >=4.0.0).
-
-* ``hoomd.md.methods.NVT`` (since v3.8.0).
-
-  * Use ``hoomd.md.methods.ConstantVolume`` with a ``hoomd.md.methods.thermostats.MTTK`` thermostat (available in >=4.0.0).
-
-* ``hoomd.md.methods.Berendsen`` (since v3.8.0).
-
-  * Use ``hoomd.md.methods.ConstantVolume`` with a ``hoomd.md.methods.thermostats.Berendsen`` thermostat (available in >=4.0.0).
-
-* ``hoomd.md.methods.NPH`` (since v3.8.0).
-
-  * Use ``hoomd.md.methods.ConstantPressure` with ``thermostat=None`` (available in >=4.0.0).
-
-* ``hoomd.md.methods.NPT`` (since v3.8.0).
-
-  * Use ``hoomd.md.methods.ConstantPressure`` with a ``hoomd.md.methods.thermostats.MTTK`` thermostat (available in >=4.0.0).
-
-* ``log`` attribute and constructor parameter in `hoomd.write.GSD`.
-
-  * Use ``logger``.
-
-* ``hoomd.md.pair.Gauss`` (since v3.10.0)
-
-  * Use `hoomd.md.pair.Gaussian`.
-
-* ``msg_file`` property and argument to ``Device`` and subclasses (since v3.10.0)
-
-  * Use `message_filename <hoomd.device.Device.message_filename>`.
-
-* ``sdf`` property of `hoomd.hpmc.compute.SDF` (since v3.11.0)
-
-  * Use `sdf_compression <hoomd.hpmc.compute.SDF>`

--- a/sphinx-doc/deprecated.rst
+++ b/sphinx-doc/deprecated.rst
@@ -17,4 +17,3 @@ documentation for more information on warning filters.
 * ``hoomd.snapshot.from_gsd_snapshot`` (since 4.0.0).
 
   * Use `hoomd.Snapshot.from_gsd_frame`.
-


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should be based on *trunk-patch*. -->
<!-- Backwards compatible new features should be based on *trunk-minor*. -->
<!-- Incompatible API changes should be based on *trunk-major*. -->

## Description

<!-- Describe your changes in detail. -->
* Update unit tests to support GSD 3.
* Test with gsd 2.9 and ensure that there are no deprecation warnings.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Tests will fail with GSD 3 as these deprecated modes will be removed.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
Unit tests pass locally with no gsd deprecation warnings.

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

```
Added:

* `hoomd.Snapshot.from_gsd_frame` - convert a `gsd.hoomd.Frame` object to `hoomd.Snapshot`.

Deprecated:

* ``hoomd.Snapshot.from_gsd_snapshot`` - use `hoomd.Snapshot.from_gsd_frame`.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
