### PR TITLE
Fix barostat warning.

### DIFF
--- a/hoomd/md/TwoStepConstantPressure.cc
+++ b/hoomd/md/TwoStepConstantPressure.cc
@@ -51,8 +51,7 @@ TwoStepConstantPressure::TwoStepConstantPressure(std::shared_ptr<SystemDefinitio
 
     if (m_flags == 0)
         {
-        m_exec_conf->msg->warning()
-            << "ConstantPressure: No box degrees of freedom." << std::endl;
+        m_exec_conf->msg->warning() << "ConstantPressure: No box degrees of freedom." << std::endl;
         }
 
     bool is_two_dimensions = m_sysdef->getNDimensions() == 2;

--- a/hoomd/md/TwoStepConstantPressure.cc
+++ b/hoomd/md/TwoStepConstantPressure.cc
@@ -46,12 +46,14 @@ TwoStepConstantPressure::TwoStepConstantPressure(std::shared_ptr<SystemDefinitio
     : IntegrationMethodTwoStep(sysdef, group), m_S(S), m_tauS(tauS), m_ndof(0), m_gamma(gamma),
       m_thermostat(thermostat), m_thermo_full_step(thermo_full_step), m_rescale_all(false)
     {
-    if (m_flags == 0)
-        m_exec_conf->msg->warning()
-            << "integrate.npt: No barostat couplings specified." << std::endl;
-
     setCouple(couple);
     setFlags(flags);
+
+    if (m_flags == 0)
+        {
+        m_exec_conf->msg->warning()
+            << "ConstantPressure: No box degrees of freedom." << std::endl;
+        }
 
     bool is_two_dimensions = m_sysdef->getNDimensions() == 2;
     m_V = m_pdata->getGlobalBox().getVolume(is_two_dimensions); // volume


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should be based on *trunk-patch*. -->
<!-- Backwards compatible new features should be based on *trunk-minor*. -->
<!-- Incompatible API changes should be based on *trunk-major*. -->

## Description

<!-- Describe your changes in detail. -->
Correctly warn users when `m_flags==0`.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Before this change, `ConstantPressure` always gives this warning, regardless of the value of `box_dof`:
```
*Warning*: integrate.npt: No barostat couplings specified.
```

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
I have not tested this yet. The change should clearly fix the problem, as now `m_flags` is checked after it is set by `setFlags`.

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.