### PR TITLE
Account for grid shift in HPMC external fields

### DIFF
--- a/hoomd/BoxResizeUpdater.cc
+++ b/hoomd/BoxResizeUpdater.cc
@@ -115,6 +115,12 @@ void BoxResizeUpdater::update(uint64_t timestep)
         // scale the particle positions (if we have been asked to)
         // move the particles to be inside the new box
         scaleAndWrapParticles(cur_box, new_box);
+
+        // scale the origin
+        Scalar3 old_origin = m_pdata->getOrigin();
+        Scalar3 fractional_old_origin = cur_box.makeFraction(old_origin);
+        Scalar3 new_origin = new_box.makeCoordinates(fractional_old_origin);
+        m_pdata->translateOrigin(new_origin - old_origin);
         }
     }
 

--- a/hoomd/hpmc/ExternalField.h
+++ b/hoomd/hpmc/ExternalField.h
@@ -33,7 +33,8 @@ class ExternalField : public Compute
     virtual double calculateDeltaE(uint64_t timestep,
                                    const Scalar4* const position_old,
                                    const Scalar4* const orientation_old,
-                                   const BoxDim& box_old)
+                                   const BoxDim& box_old,
+                                   const Scalar3& origin_old)
         {
         return 0;
         }

--- a/hoomd/hpmc/ExternalFieldComposite.h
+++ b/hoomd/hpmc/ExternalFieldComposite.h
@@ -40,7 +40,8 @@ template<class Shape> class ExternalFieldMonoComposite : public ExternalFieldMon
     double calculateDeltaE(uint64_t timestep,
                            const Scalar4* const position_old,
                            const Scalar4* const orientation_old,
-                           const BoxDim& box_old)
+                           const BoxDim& box_old,
+                           const Scalar3& origin_old)
         {
         throw(std::runtime_error("ExternalFieldMonoComposite::calculateDeltaE is not implemented"));
         return double(0.0);

--- a/hoomd/hpmc/ExternalFieldHarmonic.h
+++ b/hoomd/hpmc/ExternalFieldHarmonic.h
@@ -259,7 +259,8 @@ template<class Shape> class ExternalFieldHarmonic : public ExternalFieldMono<Sha
     double calculateDeltaE(uint64_t timestep,
                            const Scalar4* const position_old_arg,
                            const Scalar4* const orientation_old_arg,
-                           const BoxDim& box_old) override
+                           const BoxDim& box_old,
+                           const Scalar3& origin_old) override
         {
         ArrayHandle<Scalar4> h_pos(m_pdata->getPositions(),
                                    access_location::host,

--- a/hoomd/hpmc/ExternalFieldJIT.h
+++ b/hoomd/hpmc/ExternalFieldJIT.h
@@ -131,7 +131,8 @@ template<class Shape> class ExternalFieldJIT : public hpmc::ExternalFieldMono<Sh
     virtual double calculateDeltaE(uint64_t timestep,
                                    const Scalar4* const position_old_arg,
                                    const Scalar4* const orientation_old_arg,
-                                   const BoxDim& box_old)
+                                   const BoxDim& box_old,
+                                   const Scalar3& origin_old)
         {
         ArrayHandle<Scalar4> h_postype(this->m_pdata->getPositions(),
                                        access_location::host,
@@ -167,7 +168,7 @@ template<class Shape> class ExternalFieldJIT : public hpmc::ExternalFieldMono<Sh
             vec3<Scalar> pos_i = vec3<Scalar>(postype_i) - vec3<Scalar>(this->m_pdata->getOrigin());
             box_new.wrap(pos_i, image);
             image = make_int3(0, 0, 0);
-            vec3<Scalar> old_pos_i = vec3<Scalar>(*(position_old + i));
+            vec3<Scalar> old_pos_i = vec3<Scalar>(*(position_old + i)) - vec3<Scalar>(origin_old);
             box_old.wrap(old_pos_i, image);
             dE += energy(box_new,
                          typ_i,

--- a/hoomd/hpmc/ExternalFieldWall.h
+++ b/hoomd/hpmc/ExternalFieldWall.h
@@ -632,7 +632,8 @@ template<class Shape> class ExternalFieldWall : public ExternalFieldMono<Shape>
     double calculateDeltaE(uint64_t timestep,
                            const Scalar4* const position_old,
                            const Scalar4* const orientation_old,
-                           const BoxDim& box_old)
+                           const BoxDim& box_old,
+                           const Scalar3& origin_old)
         {
         unsigned int numOverlaps = countOverlaps(0, false);
         if (numOverlaps > 0)

--- a/hoomd/hpmc/IntegratorHPMC.cc
+++ b/hoomd/hpmc/IntegratorHPMC.cc
@@ -153,6 +153,12 @@ bool IntegratorHPMC::attemptBoxResize(uint64_t timestep, const BoxDim& new_box)
 
     m_pdata->setGlobalBox(new_box);
 
+    // scale the origin
+    Scalar3 old_origin = m_pdata->getOrigin();
+    Scalar3 fractional_old_origin = curBox.makeFraction(old_origin);
+    Scalar3 new_origin = new_box.makeCoordinates(fractional_old_origin);
+    m_pdata->translateOrigin(new_origin - old_origin);
+
     // we have moved particles, communicate those changes
     this->communicate(false);
 

--- a/hoomd/hpmc/UpdaterQuickCompress.cc
+++ b/hoomd/hpmc/UpdaterQuickCompress.cc
@@ -64,6 +64,8 @@ void UpdaterQuickCompress::performBoxScale(uint64_t timestep)
     auto new_box = getNewBox(timestep);
     auto old_box = m_pdata->getGlobalBox();
 
+    Scalar3 old_origin = m_pdata->getOrigin();
+
     // Make a backup copy of position data
     unsigned int N_backup = m_pdata->getN();
         {
@@ -77,6 +79,8 @@ void UpdaterQuickCompress::performBoxScale(uint64_t timestep)
         }
 
     m_mc->attemptBoxResize(timestep, new_box);
+    Scalar3 new_origin = m_pdata->getOrigin();
+    Scalar3 origin_shift = new_origin - old_origin;
 
     auto n_overlaps = m_mc->countOverlaps(false);
     if (n_overlaps > m_max_overlaps_per_particle * m_pdata->getNGlobal())
@@ -90,6 +94,7 @@ void UpdaterQuickCompress::performBoxScale(uint64_t timestep)
         assert(N == N_backup);
         memcpy(h_pos.data, h_pos_backup.data, sizeof(Scalar4) * N);
         m_pdata->setGlobalBox(old_box);
+        m_pdata->translateOrigin(-origin_shift);
 
         // we have moved particles, communicate those changes
         m_mc->communicate(false);

--- a/hoomd/hpmc/pytest/test_external_user.py
+++ b/hoomd/hpmc/pytest/test_external_user.py
@@ -213,12 +213,12 @@ def test_gravity(device, simulation_factory, lattice_snapshot_factory):
 
     # expand box and add gravity field
     old_box = sim.state.box
-    new_box = hoomd.Box(Lx=1.5 * old_box.Lx,
-                        Ly=1.5 * old_box.Ly,
-                        Lz=20 * old_box.Lz)
+    new_box = hoomd.Box(Lx=3 * old_box.Lx,
+                        Ly=3 * old_box.Ly,
+                        Lz=5 * old_box.Lz)
     sim.state.set_box(new_box)
     ext = hoomd.hpmc.external.user.CPPExternalPotential(
-        code="return 1000*r_i.z;")
+        code="return 1000*r_i.z*r_i.z;")
     mc.external_potential = ext
     sim.operations.integrator = mc
 
@@ -233,5 +233,6 @@ def test_gravity(device, simulation_factory, lattice_snapshot_factory):
     snapshot = sim.state.get_snapshot()
     if snapshot.communicator.rank == 0:
         new_avg_z = np.mean(snapshot.particles.position[:, 2])
-        assert new_avg_z < old_avg_z
+        assert abs(new_avg_z) < 0.5
+        assert np.ptp(snapshot.particles.position[:, 2]) < 1
     assert ext.energy < old_energy

--- a/hoomd/hpmc/pytest/test_external_user.py
+++ b/hoomd/hpmc/pytest/test_external_user.py
@@ -212,7 +212,7 @@ def test_z_bias(device, simulation_factory, lattice_snapshot_factory):
     mc.shape['A'] = dict(diameter=1)
     mc.nselect = 1
 
-    # expand box and add gravity field
+    # expand box and add external field
     old_box = sim.state.box
     new_box = hoomd.Box(Lx=3 * old_box.Lx, Ly=3 * old_box.Ly, Lz=3 * old_box.Lz)
     sim.state.set_box(new_box)

--- a/hoomd/hpmc/pytest/test_external_user.py
+++ b/hoomd/hpmc/pytest/test_external_user.py
@@ -213,9 +213,7 @@ def test_gravity(device, simulation_factory, lattice_snapshot_factory):
 
     # expand box and add gravity field
     old_box = sim.state.box
-    new_box = hoomd.Box(Lx=3 * old_box.Lx,
-                        Ly=3 * old_box.Ly,
-                        Lz=5 * old_box.Lz)
+    new_box = hoomd.Box(Lx=3 * old_box.Lx, Ly=3 * old_box.Ly, Lz=5 * old_box.Lz)
     sim.state.set_box(new_box)
     ext = hoomd.hpmc.external.user.CPPExternalPotential(
         code="return 1000*r_i.z*r_i.z;")
@@ -223,8 +221,6 @@ def test_gravity(device, simulation_factory, lattice_snapshot_factory):
     sim.operations.integrator = mc
 
     snapshot = sim.state.get_snapshot()
-    if snapshot.communicator.rank == 0:
-        old_avg_z = np.mean(snapshot.particles.position[:, 2])
     sim.run(0)
     old_energy = ext.energy
 

--- a/hoomd/update/box_resize.py
+++ b/hoomd/update/box_resize.py
@@ -27,9 +27,9 @@ class BoxResize(Updater):
         L_{x}' &= \\lambda L_{2x} + (1 - \\lambda) L_{1x} \\\\
         L_{y}' &= \\lambda L_{2y} + (1 - \\lambda) L_{1y} \\\\
         L_{z}' &= \\lambda L_{2z} + (1 - \\lambda) L_{1z} \\\\
-        xy' &= \\lambda xy_{2} + (1 - \\lambda) xy_{2} \\\\
-        xz' &= \\lambda xz_{2} + (1 - \\lambda) xz_{2} \\\\
-        yz' &= \\lambda yz_{2} + (1 - \\lambda) yz_{2} \\\\
+        xy' &= \\lambda xy_{2} + (1 - \\lambda) xy_{1} \\\\
+        xz' &= \\lambda xz_{2} + (1 - \\lambda) xz_{1} \\\\
+        yz' &= \\lambda yz_{2} + (1 - \\lambda) yz_{1} \\\\
         \\end{align*}
 
     Where `box1` is :math:`(L_{1x}, L_{1y}, L_{1z}, xy_1, xz_1, yz_1)`,


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should be based on *trunk-patch*. -->
<!-- Backwards compatible new features should be based on *trunk-minor*. -->
<!-- Incompatible API changes should be based on *trunk-major*. -->

## Description

Account for grid shift in member functions of C++ class `ExternalFieldJIT`.

## Motivation and context

Fixes a bug.

<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves #1562 

## How has this been tested?

I updated the `test_gravity` unit test to be more robust. I have also observed the correct behavior in the simulation mentioned in #1562. 

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
- Fix bug in hpmc.external.user.CPPExternalPotential
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
