### PR TITLE
Warn about GSD buffering behaivior.

### DIFF
--- a/hoomd/write/gsd.py
+++ b/hoomd/write/gsd.py
@@ -138,6 +138,12 @@ class GSD(Writer):
     When you set a category string (``'property'``, ``'momentum'``,
     ``'attribute'``), `GSD` makes all the category member's fields dynamic.
 
+    Warning:
+        `GSD` buffers writes in memory. Abnormal exits (e.g. ``kill``,
+        ``scancel``, reaching walltime limits) may cause loss of data. Ensure
+        that your scripts exit cleanly and call `flush()` as needed to write
+        buffered frames to the file.
+
     See Also:
         See the `GSD documentation <https://gsd.readthedocs.io/>`__, `GSD HOOMD
         Schema <https://gsd.readthedocs.io/en/stable/schema-hoomd.html>`__, and
@@ -280,7 +286,18 @@ class GSD(Writer):
         return self.logger
 
     def flush(self):
-        """Flush the write buffer to the file."""
+        """Flush the write buffer to the file.
+
+        Example::
+
+            gsd_writer.flush()
+
+        Flush all write buffers::
+
+            for writer in simulation.operations.writers:
+                if hasattr(writer, 'flush'):
+                    writer.flush()
+        """
         if not self._attached:
             raise RuntimeError("The GSD file is unavailable until the"
                                "simulation runs for 0 or more steps.")


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should be based on *trunk-patch*. -->
<!-- Backwards compatible new features should be based on *trunk-minor*. -->
<!-- Incompatible API changes should be based on *trunk-major*. -->

## Description

<!-- Describe your changes in detail. -->
Add warnings in the documentation regarding GSD's buffering behavior. Also provide examples on using `flush`.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Write buffering dramatically improves performance and reduces file corruption, but users might experience unexpected data loss with scripts that exit abnormally.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
I viewed the documentation locally.

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

No change log necessary, part of the GSD improvements in HOOMD-blue 4.0.0.

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
