### PR TITLE
Always show NVRTC errors.

### DIFF
--- a/hoomd/extern/jitify.hpp
+++ b/hoomd/extern/jitify.hpp
@@ -2934,11 +2934,11 @@ inline void load_program(std::string const& cuda_source,
       }
       std::string& parent_source = (*program_sources)[include_parent];
       parent_source = detail::comment_out_code_line(line_num, parent_source);
-#if JITIFY_PRINT_LOG
+// #if JITIFY_PRINT_LOG
       std::cout << include_parent << "(" << line_num
                 << "): warning: " << include_name << ": [jitify] File not found"
                 << std::endl;
-#endif
+// #endif
     }
   }
   if (ret != NVRTC_SUCCESS) {

--- a/hoomd/extern/jitify.hpp
+++ b/hoomd/extern/jitify.hpp
@@ -2889,7 +2889,7 @@ inline void load_program(std::string const& cuda_source,
 #endif
       // There was a non include-related compilation error
       // TODO: How to handle error?
-      throw std::runtime_error("Runtime compilation failed");
+      throw std::runtime_error("Runtime compilation failed:\n" + log);
     }
 
     bool is_included_with_quotes = false;


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should be based on *trunk-patch*. -->
<!-- Backwards compatible new features should be based on *trunk-minor*. -->
<!-- Incompatible API changes should be based on *trunk-major*. -->

## Description

<!-- Describe your changes in detail. -->
Always show errors generated by NVRTC. Also, update to the latest `jitify.hpp`.

## Motivation and context

This helps users (and mailing list readers) identify errors in user patch code. Previously, users needed to recompile with `ENABLE_DEBUG_JIT=on` to see this information. `ENABLE_DEBUG_JIT` still exists and adds additional details. This PR aims to cover the basic error information needed and show it only on error.

Yes, we could manage our own fork of `jitify` and use it a submodule. However doing so would require 10x the effort of making these 3 lines of changes.

<!--- Why is this change required? What problem does it solve? -->

## How has this been tested?

I temporarily moved `warp_scan.cuh`, ran a test script that previously worked, and got this output:
```
hoomd/WarpTools.cuh(27): warning: cub/warp/warp_scan.cuh: [jitify] File not found
Traceback (most recent call last):
  File "/home/joaander/test/test-patch-user.py", line 20, in <module>
    simulation.run(0)
  File "/home/joaander/build/hoomd/hoomd/simulation.py", line 461, in run
    self.operations._schedule()
  File "/home/joaander/build/hoomd/hoomd/operations.py", line 180, in _schedule
    self.integrator._attach(sim)
  File "/home/joaander/build/hoomd/hoomd/operation.py", line 310, in _attach
    self._attach_hook()
  File "/home/joaander/build/hoomd/hoomd/hpmc/integrate.py", line 420, in _attach_hook
    self._pair_potential._attach(self._simulation)
  File "/home/joaander/build/hoomd/hoomd/operation.py", line 310, in _attach
    self._attach_hook()
  File "/home/joaander/build/hoomd/hoomd/hpmc/pair/user.py", line 269, in _attach_hook
    self._cpp_obj = _jit.PatchEnergyJITGPU(
RuntimeError: Runtime compilation failed:
hoomd/WarpTools.cuh(428): error: qualified name is not allowed

hoomd/WarpTools.cuh(428): error: explicit type is missing ("int" assumed)

hoomd/WarpTools.cuh(428): error: expected a ";"

hoomd/WarpTools.cuh(430): error: name followed by "::" must be a class or namespace name

4 errors detected in the compilation of "default_program".
```
<!--- Please describe in detail how you tested your changes. -->

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
Changed:

* Improved error messages with NVRTC compiled code.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
