### PR TITLE
Fix compilation error with LLVM 16.

### DIFF
--- a/hoomd/hpmc/ClangCompiler.cc
+++ b/hoomd/hpmc/ClangCompiler.cc
@@ -67,7 +67,9 @@ ClangCompiler::ClangCompiler()
     llvm::initializeAnalysis(Registry);
     llvm::initializeTransformUtils(Registry);
     llvm::initializeInstCombine(Registry);
+#if LLVM_VERSION_MAJOR < 16
     llvm::initializeInstrumentation(Registry);
+#endif
     llvm::initializeTarget(Registry);
     }
 


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should be based on *trunk-patch*. -->
<!-- Backwards compatible new features should be based on *trunk-minor*. -->
<!-- Incompatible API changes should be based on *trunk-major*. -->

## Description

<!-- Describe your changes in detail. -->
Fix compile errors with LLVM 16.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Allow users to compile HOOMD-blue against LLVM 16.

<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves #1540 

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
Tested locally with a LLVM 16 install provided by homebrew.

CI tests do not include LLVM16. Ubuntu 22.04 does not have a package: https://packages.ubuntu.com/search?keywords=clang-16&searchon=names&suite=all&section=all
Will add LLVM 16 test next year with Ubuntu 24.04.

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
Added:

* Support LLVM 16.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
