### PR TITLE
Fix release workflow.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,10 @@ on:
 env:
   name: hoomd
 
+defaults:
+  run:
+    shell: bash
+
 
 jobs:
   release:
@@ -53,17 +57,17 @@ jobs:
         run: echo "tag=$(echo ${GITHUB_REF} | sed  -e 's/refs\/tags\///g')" >> $GITHUB_ENV
 
       - name: Write version change log
-        run: .github/workflows/make-changelog-md.sh  ${tag} | tee ${GITHUB_WORKSPACE}/changelog.md
+        run: .github/workflows/make-changelog-md.sh  ${tag:1} | tee ${GITHUB_WORKSPACE}/changelog.md
         working-directory: code
 
       - name: Copy source
-        run: cp -R code ${name}-${tag}
+        run: cp -R code ${name}-${tag:1}
 
       - name: Remove .git
-        run: rm -rf ${name}-${tag}/.git && ls -laR ${name}-${tag}
+        run: rm -rf ${name}-${tag:1}/.git && ls -laR ${name}-${tag:1}
 
       - name: Tar source
-        run: tar -cvzf ${name}-${tag}.tar.gz ${name}-${tag}
+        run: tar -cvzf ${name}-${tag:1}.tar.gz ${name}-${tag:1}
 
       - name: Upload release files
         uses: actions/upload-artifact@v3.1.2

--- a/.github/workflows/templates/release.yml
+++ b/.github/workflows/templates/release.yml
@@ -12,6 +12,10 @@ name: GitHub Release
 <% block env %>
 env:
   name: hoomd
+
+defaults:
+  run:
+    shell: bash
 <% endblock %>
 <% block jobs %>
 jobs:
@@ -40,17 +44,17 @@ jobs:
         run: echo "tag=$(echo ${GITHUB_REF} | sed  -e 's/refs\/tags\///g')" >> $GITHUB_ENV
 
       - name: Write version change log
-        run: .github/workflows/make-changelog-md.sh  ${tag} | tee ${GITHUB_WORKSPACE}/changelog.md
+        run: .github/workflows/make-changelog-md.sh  ${tag:1} | tee ${GITHUB_WORKSPACE}/changelog.md
         working-directory: code
 
       - name: Copy source
-        run: cp -R code ${name}-${tag}
+        run: cp -R code ${name}-${tag:1}
 
       - name: Remove .git
-        run: rm -rf ${name}-${tag}/.git && ls -laR ${name}-${tag}
+        run: rm -rf ${name}-${tag:1}/.git && ls -laR ${name}-${tag:1}
 
       - name: Tar source
-        run: tar -cvzf ${name}-${tag}.tar.gz ${name}-${tag}
+        run: tar -cvzf ${name}-${tag:1}.tar.gz ${name}-${tag:1}
 
       - name: Upload release files
         uses: actions/upload-artifact@v3.1.2


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should be based on *trunk-patch*. -->
<!-- Backwards compatible new features should be based on *trunk-minor*. -->
<!-- Incompatible API changes should be based on *trunk-major*. -->

## Description

<!-- Describe your changes in detail. -->
Remove "v" prefix from version name.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
`v1.2.3` is not a semantic version (https://semver.org/#is-v123-a-semantic-version).

We will continue to use the `v` prefix on git tags, but release notes, e-mails, tarballs, etc.. should all refer to the correct semantic verison.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
Will inspect the pull request checks.

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
Changed:

* Package source in `hoomd-x.y.z.tar.gz` (previously `hoomd-vx.y.z.tar.gz`).
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
