### PR TITLE
Add Missing HPMC Headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,7 +105,7 @@ option(BUILD_METAL "Build the metal package" on)
 option(ENABLE_TBB "Enable support for Threading Building Blocks (TBB)" off)
 
 # Add list of plugins
-set(PLUGINS "example_plugins/pair_plugin;example_plugins/updater_plugin" CACHE STRING "List of plugin directories.")
+set(PLUGINS "example_plugins/pair_plugin;example_plugins/updater_plugin;example_plugins/shape_plugin" CACHE STRING "List of plugin directories.")
 
 # this needs to go before CUDA setup
 include (HOOMDHIPSetup)

--- a/example_plugins/CMakeLists.txt
+++ b/example_plugins/CMakeLists.txt
@@ -21,3 +21,4 @@ endif()
 # Add subdirectories
 add_subdirectory(updater_plugin)
 add_subdirectory(pair_plugin)
+add_subdirectory(shape_plugin)

--- a/example_plugins/shape_plugin/CMakeLists.txt
+++ b/example_plugins/shape_plugin/CMakeLists.txt
@@ -57,4 +57,4 @@ install(FILES ${files}
 copy_files_to_build("${files}" "${COMPONENT_NAME}" "*.py")
 
 # Python tests.
-add_subdirectory(pytest)
+#add_subdirectory(pytest)

--- a/example_plugins/shape_plugin/CMakeLists.txt
+++ b/example_plugins/shape_plugin/CMakeLists.txt
@@ -19,7 +19,9 @@ set(_${COMPONENT_NAME}_cu_sources
     )
 
 if (ENABLE_HIP)
-set(_cuda_sources ${_${COMPONENT_NAME}_cu_sources})
+set(_cuda_sources ${_${COMPONENT_NAME}_cu_sources}
+    kernels.cu
+    )
 endif (ENABLE_HIP)
 
 pybind11_add_module(_${COMPONENT_NAME} SHARED ${_${COMPONENT_NAME}_sources} ${_cuda_sources} NO_EXTRAS)

--- a/example_plugins/shape_plugin/CMakeLists.txt
+++ b/example_plugins/shape_plugin/CMakeLists.txt
@@ -1,0 +1,60 @@
+# Template CMakeLists.txt for plugins/components.
+
+set(COMPONENT_NAME shape_plugin)
+
+# Check that the HOOMD build configuration supports plugin dependencies
+if(NOT BUILD_HPMC)
+    message(WARNING "The HOOMD build configuration does not support HPMC. Skipping build of "
+            "plugin component ${COMPONENT_NAME}.")
+    return()
+endif()
+
+# Specify any C++ sources
+set(_${COMPONENT_NAME}_sources
+    module.cc
+    )
+
+# Specify any CUDA sources
+set(_${COMPONENT_NAME}_cu_sources
+    )
+
+if (ENABLE_HIP)
+set(_cuda_sources ${_${COMPONENT_NAME}_cu_sources})
+endif (ENABLE_HIP)
+
+pybind11_add_module(_${COMPONENT_NAME} SHARED ${_${COMPONENT_NAME}_sources} ${_cuda_sources} NO_EXTRAS)
+# Alias into the HOOMD namespace so that plugins and symlinked components both work.
+add_library(HOOMD::_${COMPONENT_NAME} ALIAS _${COMPONENT_NAME})
+
+if (APPLE)
+set_target_properties(_${COMPONENT_NAME} PROPERTIES INSTALL_RPATH "@loader_path/..;@loader_path")
+else()
+set_target_properties(_${COMPONENT_NAME} PROPERTIES INSTALL_RPATH "\$ORIGIN/..;\$ORIGIN")
+endif()
+
+# Link the library to its dependencies. Add or remove HOOMD extension modules (and/or external C++
+# libraries) as needed.
+target_link_libraries(_${COMPONENT_NAME}
+                      PUBLIC HOOMD::_hoomd
+                      PUBLIC HOOMD::_hpmc
+                      )
+
+# Install the library.
+install(TARGETS _${COMPONENT_NAME}
+        LIBRARY DESTINATION ${PYTHON_SITE_INSTALL_DIR}/${COMPONENT_NAME}
+        )
+
+################ Python only modules
+# Copy python modules to the build directory to make it a working python package. Any files that
+# should be copied to the install directory should be listed here.
+set(files
+    )
+
+install(FILES ${files}
+        DESTINATION ${PYTHON_SITE_INSTALL_DIR}/${COMPONENT_NAME}
+       )
+
+copy_files_to_build("${files}" "${COMPONENT_NAME}" "*.py")
+
+# Python tests.
+add_subdirectory(pytest)

--- a/example_plugins/shape_plugin/CMakeLists.txt
+++ b/example_plugins/shape_plugin/CMakeLists.txt
@@ -57,4 +57,4 @@ install(FILES ${files}
 copy_files_to_build("${files}" "${COMPONENT_NAME}" "*.py")
 
 # Python tests.
-#add_subdirectory(pytest)
+add_subdirectory(pytest)

--- a/example_plugins/shape_plugin/CMakeLists.txt
+++ b/example_plugins/shape_plugin/CMakeLists.txt
@@ -48,6 +48,8 @@ install(TARGETS _${COMPONENT_NAME}
 # Copy python modules to the build directory to make it a working python package. Any files that
 # should be copied to the install directory should be listed here.
 set(files
+    __init__.py
+    integrate.py
     )
 
 install(FILES ${files}

--- a/example_plugins/shape_plugin/ShapeMySphere.h
+++ b/example_plugins/shape_plugin/ShapeMySphere.h
@@ -8,10 +8,9 @@
 #include "hoomd/HOOMDMath.h"
 #include "hoomd/VectorMath.h"
 #include "hoomd/hpmc/HPMCMiscFunctions.h"
-#include "hoomd/hpmc/ShapeSphere.h"
 #include "hoomd/hpmc/Moves.h"
 #include "hoomd/hpmc/OBB.h"
-
+#include "hoomd/hpmc/ShapeSphere.h"
 
 #include <sstream>
 

--- a/example_plugins/shape_plugin/ShapeMySphere.h
+++ b/example_plugins/shape_plugin/ShapeMySphere.h
@@ -3,12 +3,12 @@
 
 #pragma once
 
-#include "hoomd/hpmc/Moves.h"
 #include "hoomd/AABB.h"
 #include "hoomd/BoxDim.h"
 #include "hoomd/HOOMDMath.h"
 #include "hoomd/VectorMath.h"
 #include "hoomd/hpmc/HPMCMiscFunctions.h"
+#include "hoomd/hpmc/Moves.h"
 #include "hoomd/hpmc/OBB.h"
 
 #include "hoomd/hpmc/Moves.h"
@@ -72,7 +72,6 @@ struct MySphereParams : ShapeParams
 
 #endif
     } __attribute__((aligned(32)));
-
 
 struct ShapeMySphere
     {
@@ -145,7 +144,6 @@ struct ShapeMySphere
     const MySphereParams& params;
     };
 
-
 //! MySphere-MySphere overlap
 /*! \param r_ab Vector defining the position of shape b relative to shape a (r_b - r_a)
     \param a first shape
@@ -175,10 +173,6 @@ DEVICE inline bool test_overlap<ShapeMySphere, ShapeMySphere>(const vec3<Scalar>
         return false;
         }
     }
-
-
-
-
 
     } // end namespace hpmc
     } // end namespace hoomd

--- a/example_plugins/shape_plugin/ShapeMySphere.h
+++ b/example_plugins/shape_plugin/ShapeMySphere.h
@@ -177,61 +177,8 @@ DEVICE inline bool test_overlap<ShapeMySphere, ShapeMySphere>(const vec3<Scalar>
     }
 
 
-//! sphere sweep distance
-/*! \param r_ab Vector defining the position of shape b relative to shape a (r_b - r_a)
-    \param a first shape
-    \param b second shape
-    \param err in/out variable incremented when error conditions occur in the overlap test
-    \returns true when *a* and *b* overlap, and false when they are disjoint
-
-    \ingroup shape
-*/
-DEVICE inline ShortReal sweep_distance(const vec3<Scalar>& r_ab,
-                                       const ShapeMySphere& a,
-                                       const ShapeMySphere& b,
-                                       const vec3<Scalar>& direction,
-                                       unsigned int& err,
-                                       vec3<Scalar>& collisionPlaneVector)
-    {
-    ShortReal sumR = a.params.radius + b.params.radius;
-    ShortReal distSQ = ShortReal(dot(r_ab, r_ab));
-
-    ShortReal d_parallel = ShortReal(dot(r_ab, direction));
-    if (d_parallel <= 0) // Moving apart
-        {
-        return -1.0;
-        };
-
-    ShortReal discriminant = sumR * sumR - distSQ + d_parallel * d_parallel;
-    if (discriminant < 0) // orthogonal distance larger than sum of radii
-        {
-        return -2.0;
-        };
-
-    ShortReal newDist = d_parallel - fast::sqrt(discriminant);
-
-    if (newDist > 0)
-        {
-        collisionPlaneVector = r_ab - direction * Scalar(newDist);
-        return newDist;
-        }
-    else
-        {
-        // Two particles overlapping [with negative sweepable distance]
-        collisionPlaneVector = r_ab;
-        return -10.0;
-        }
-    }
 
 
-#ifndef __HIPCC__
-template<> inline std::string getShapeSpec(const ShapeMySphere& sphere)
-    {
-    std::ostringstream shapedef;
-    shapedef << "{\"type\": \"MySphere\", \"radius\": " << sphere.params.radius << "}";
-    return shapedef.str();
-    }
-#endif
 
     } // end namespace hpmc
     } // end namespace hoomd

--- a/example_plugins/shape_plugin/ShapeMySphere.h
+++ b/example_plugins/shape_plugin/ShapeMySphere.h
@@ -8,10 +8,10 @@
 #include "hoomd/HOOMDMath.h"
 #include "hoomd/VectorMath.h"
 #include "hoomd/hpmc/HPMCMiscFunctions.h"
+#include "hoomd/hpmc/ShapeSphere.h"
 #include "hoomd/hpmc/Moves.h"
 #include "hoomd/hpmc/OBB.h"
 
-#include "hoomd/hpmc/Moves.h"
 
 #include <sstream>
 

--- a/example_plugins/shape_plugin/ShapeMySphere.h
+++ b/example_plugins/shape_plugin/ShapeMySphere.h
@@ -1,0 +1,240 @@
+// Copyright (c) 2009-2023 The Regents of the University of Michigan.
+// Part of HOOMD-blue, released under the BSD 3-Clause License.
+
+#pragma once
+
+#include "hoomd/hpmc/Moves.h"
+#include "hoomd/AABB.h"
+#include "hoomd/BoxDim.h"
+#include "hoomd/HOOMDMath.h"
+#include "hoomd/VectorMath.h"
+#include "hoomd/hpmc/HPMCMiscFunctions.h"
+#include "hoomd/hpmc/OBB.h"
+
+#include "hoomd/hpmc/Moves.h"
+
+#include <sstream>
+
+#include <stdexcept>
+
+#ifdef __HIPCC__
+#define DEVICE __device__
+#define HOSTDEVICE __host__ __device__
+#else
+#define DEVICE
+#define HOSTDEVICE
+#include <pybind11/pybind11.h>
+#endif
+
+namespace hoomd
+    {
+namespace hpmc
+    {
+
+struct MySphereParams : ShapeParams
+    {
+    /// The radius of the sphere
+    ShortReal radius;
+
+    /// True when move statistics should not be counted
+    bool ignore;
+
+    /// True when the shape may be oriented
+    bool isOriented;
+
+#ifdef ENABLE_HIP
+    /// Set CUDA memory hints
+    void set_memory_hint() const { }
+#endif
+
+#ifndef __HIPCC__
+
+    /// Default constructor
+    MySphereParams() { }
+
+    /// Construct from a Python dictionary
+    MySphereParams(pybind11::dict v, bool managed = false)
+        {
+        ignore = v["ignore_statistics"].cast<bool>();
+        radius = v["radius"].cast<ShortReal>();
+        isOriented = v["orientable"].cast<bool>();
+        }
+
+    /// Convert parameters to a python dictionary
+    pybind11::dict asDict()
+        {
+        pybind11::dict v;
+        v["radius"] = radius;
+        v["orientable"] = isOriented;
+        v["ignore_statistics"] = ignore;
+        return v;
+        }
+
+#endif
+    } __attribute__((aligned(32)));
+
+
+struct ShapeMySphere
+    {
+    /// Define the parameter type
+    typedef MySphereParams param_type;
+
+    /// Temporary storage for depletant insertion
+    typedef struct
+        {
+        } depletion_storage_type;
+
+    /// Construct a shape at a given orientation
+    DEVICE ShapeMySphere(const quat<Scalar>& _orientation, const param_type& _params)
+        : orientation(_orientation), params(_params)
+        {
+        }
+
+    /// Check if the shape may be rotated
+    DEVICE bool hasOrientation() const
+        {
+        return params.isOriented;
+        }
+
+    /// Check if this shape should be ignored in the move statistics
+    DEVICE bool ignoreStatistics() const
+        {
+        return params.ignore;
+        }
+
+    /// Get the circumsphere diameter of the shape
+    DEVICE ShortReal getCircumsphereDiameter() const
+        {
+        return params.radius * ShortReal(2.0);
+        }
+
+    /// Get the in-sphere radius of the shape
+    DEVICE ShortReal getInsphereRadius() const
+        {
+        return params.radius;
+        }
+
+    /// Return the bounding box of the shape in world coordinates
+    DEVICE hoomd::detail::AABB getAABB(const vec3<Scalar>& pos) const
+        {
+        return hoomd::detail::AABB(pos, params.radius);
+        }
+
+    /// Return a tight fitting OBB around the shape
+    DEVICE detail::OBB getOBB(const vec3<Scalar>& pos) const
+        {
+        return detail::OBB(pos, params.radius);
+        }
+
+    /// Returns true if this shape splits the overlap check over several threads of a warp using
+    /// threadIdx.x
+    HOSTDEVICE static bool isParallel()
+        {
+        return false;
+        }
+
+    /// Returns true if the overlap check supports sweeping both shapes by a sphere of given radius
+    HOSTDEVICE static bool supportsSweepRadius()
+        {
+        return true;
+        }
+
+    quat<Scalar> orientation; //!< Orientation of the sphere (unused)
+
+    /// MySphere parameters
+    const MySphereParams& params;
+    };
+
+
+//! MySphere-MySphere overlap
+/*! \param r_ab Vector defining the position of shape b relative to shape a (r_b - r_a)
+    \param a first shape
+    \param b second shape
+    \param err in/out variable incremented when error conditions occur in the overlap test
+    \returns true when *a* and *b* overlap, and false when they are disjoint
+
+    \ingroup shape
+*/
+template<>
+DEVICE inline bool test_overlap<ShapeMySphere, ShapeMySphere>(const vec3<Scalar>& r_ab,
+                                                              const ShapeMySphere& a,
+                                                              const ShapeMySphere& b,
+                                                              unsigned int& err)
+    {
+    vec3<ShortReal> dr(r_ab);
+
+    ShortReal rsq = dot(dr, dr);
+
+    ShortReal RaRb = a.params.radius + b.params.radius;
+    if (rsq < RaRb * RaRb)
+        {
+        return true;
+        }
+    else
+        {
+        return false;
+        }
+    }
+
+
+//! sphere sweep distance
+/*! \param r_ab Vector defining the position of shape b relative to shape a (r_b - r_a)
+    \param a first shape
+    \param b second shape
+    \param err in/out variable incremented when error conditions occur in the overlap test
+    \returns true when *a* and *b* overlap, and false when they are disjoint
+
+    \ingroup shape
+*/
+DEVICE inline ShortReal sweep_distance(const vec3<Scalar>& r_ab,
+                                       const ShapeMySphere& a,
+                                       const ShapeMySphere& b,
+                                       const vec3<Scalar>& direction,
+                                       unsigned int& err,
+                                       vec3<Scalar>& collisionPlaneVector)
+    {
+    ShortReal sumR = a.params.radius + b.params.radius;
+    ShortReal distSQ = ShortReal(dot(r_ab, r_ab));
+
+    ShortReal d_parallel = ShortReal(dot(r_ab, direction));
+    if (d_parallel <= 0) // Moving apart
+        {
+        return -1.0;
+        };
+
+    ShortReal discriminant = sumR * sumR - distSQ + d_parallel * d_parallel;
+    if (discriminant < 0) // orthogonal distance larger than sum of radii
+        {
+        return -2.0;
+        };
+
+    ShortReal newDist = d_parallel - fast::sqrt(discriminant);
+
+    if (newDist > 0)
+        {
+        collisionPlaneVector = r_ab - direction * Scalar(newDist);
+        return newDist;
+        }
+    else
+        {
+        // Two particles overlapping [with negative sweepable distance]
+        collisionPlaneVector = r_ab;
+        return -10.0;
+        }
+    }
+
+
+#ifndef __HIPCC__
+template<> inline std::string getShapeSpec(const ShapeMySphere& sphere)
+    {
+    std::ostringstream shapedef;
+    shapedef << "{\"type\": \"MySphere\", \"radius\": " << sphere.params.radius << "}";
+    return shapedef.str();
+    }
+#endif
+
+    } // end namespace hpmc
+    } // end namespace hoomd
+
+#undef DEVICE
+#undef HOSTDEVICE

--- a/example_plugins/shape_plugin/__init__.py
+++ b/example_plugins/shape_plugin/__init__.py
@@ -3,4 +3,4 @@
 
 """Example MC shape plugin."""
 
-from hoomd.shape_plugin import integrate
+from . import integrate

--- a/example_plugins/shape_plugin/__init__.py
+++ b/example_plugins/shape_plugin/__init__.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2009-2023 The Regents of the University of Michigan.
+# Part of HOOMD-blue, released under the BSD 3-Clause License.
 
 """Example MC shape plugin."""
 

--- a/example_plugins/shape_plugin/__init__.py
+++ b/example_plugins/shape_plugin/__init__.py
@@ -1,0 +1,4 @@
+
+"""Example MC shape plugin."""
+
+from hoomd.shape_plugin import integrate

--- a/example_plugins/shape_plugin/integrate.py
+++ b/example_plugins/shape_plugin/integrate.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2009-2023 The Regents of the University of Michigan.
+# Part of HOOMD-blue, released under the BSD 3-Clause License.
 
 """Example Shape Integrator."""
 
@@ -19,9 +21,14 @@ class MySphere(hpmc.integrate.HPMCIntegrator):
     _ext_module = _shape_plugin
     _cpp_cls = "IntegratorHPMCMonoMySphere"
 
-    def __init__(self, default_d=0.1, default_a=0.1, translation_move_probability=0.5, nselect=4):
+    def __init__(self,
+                 default_d=0.1,
+                 default_a=0.1,
+                 translation_move_probability=0.5,
+                 nselect=4):
         # initialize base class
-        super().__init__(default_d, default_a, translation_move_probability, nselect)
+        super().__init__(default_d, default_a, translation_move_probability,
+                         nselect)
 
         typeparam_shape = TypeParameter('shape',
                                         type_kind='particle_types',

--- a/example_plugins/shape_plugin/integrate.py
+++ b/example_plugins/shape_plugin/integrate.py
@@ -1,0 +1,29 @@
+import hoomd
+from hoomd import hpmc
+
+
+
+class MySphere(hpmc.integrate.HPMCIntegrator)
+    """Example shape integrator."""
+
+    # set static class data
+    _ext_module = _shape_plugin
+    _cpp_cls = "IntegratorHPMCMonoMySphere"
+
+    def __init__(self, default_d=0.1, default_a=0.1, translation_move_probability=0.5, nselect=4):
+        # initialize base class
+        super().__init__(default_d, default_a, translation_move_probability, nselect)
+
+        typeparam_shape = TypeParameter('shape',
+                                        type_kind='particle_types',
+                                        param_dict=TypeParameterDict(
+                                            radius=float,
+                                            ignore_statistics=False,
+                                            orientable=False,
+                                            len_keys=1))
+        self._add_typeparam(typeparam_shape)
+
+    @log(category='object', requires_run=True)
+    def type_shapes(self):
+        """list[dict]: Description of shapes in ``type_shapes`` format."""
+        return super()._return_type_shapes()

--- a/example_plugins/shape_plugin/integrate.py
+++ b/example_plugins/shape_plugin/integrate.py
@@ -4,7 +4,7 @@
 """Example Shape Integrator."""
 
 # Import the C++ module
-from hoomd.shape_plugin import _shape_plugin
+from . import _shape_plugin
 
 # Import the hoomd Python package and other necessary components
 from hoomd import hpmc

--- a/example_plugins/shape_plugin/integrate.py
+++ b/example_plugins/shape_plugin/integrate.py
@@ -3,7 +3,7 @@ from hoomd import hpmc
 from hoomd.shape_plugin import _shape_plugin
 
 
-class MySphere(hpmc.integrate.HPMCIntegrator)
+class MySphere(hpmc.integrate.HPMCIntegrator):
     """Example shape integrator."""
 
     # set static class data

--- a/example_plugins/shape_plugin/integrate.py
+++ b/example_plugins/shape_plugin/integrate.py
@@ -1,6 +1,6 @@
 import hoomd
 from hoomd import hpmc
-from . import _shape_plugin
+from hoomd.shape_plugin import _shape_plugin
 
 
 class MySphere(hpmc.integrate.HPMCIntegrator)

--- a/example_plugins/shape_plugin/integrate.py
+++ b/example_plugins/shape_plugin/integrate.py
@@ -1,6 +1,15 @@
+
+"""Example Shape Integrator."""
+
+# Import the C++ module
+from hoomd.shape_plugin import _shape_plugin
+
+# Import the hoomd Python package and other necessary components
 import hoomd
 from hoomd import hpmc
-from hoomd.shape_plugin import _shape_plugin
+from hoomd.logging import log
+from hoomd.data.parameterdicts import TypeParameterDict
+from hoomd.data.typeparam import TypeParameter
 
 
 class MySphere(hpmc.integrate.HPMCIntegrator):

--- a/example_plugins/shape_plugin/integrate.py
+++ b/example_plugins/shape_plugin/integrate.py
@@ -1,6 +1,6 @@
 import hoomd
 from hoomd import hpmc
-
+from . import _shape_plugin
 
 
 class MySphere(hpmc.integrate.HPMCIntegrator)

--- a/example_plugins/shape_plugin/integrate.py
+++ b/example_plugins/shape_plugin/integrate.py
@@ -7,7 +7,6 @@
 from hoomd.shape_plugin import _shape_plugin
 
 # Import the hoomd Python package and other necessary components
-import hoomd
 from hoomd import hpmc
 from hoomd.logging import log
 from hoomd.data.parameterdicts import TypeParameterDict

--- a/example_plugins/shape_plugin/kernels.cu
+++ b/example_plugins/shape_plugin/kernels.cu
@@ -2,14 +2,14 @@
 // Part of HOOMD-blue, released under the BSD 3-Clause License.
 
 #include "ShapeMySphere.h"
-#include "hoomd/hpmc/IntegratorHPMCMonoGPU.cuh"
 #include "hoomd/hpmc/ComputeFreeVolumeGPU.cuh"
-#include "hoomd/hpmc/IntegratorHPMCMonoGPUMoves.cuh"
+#include "hoomd/hpmc/IntegratorHPMCMonoGPU.cuh"
 #include "hoomd/hpmc/IntegratorHPMCMonoGPUDepletants.cuh"
-#include "hoomd/hpmc/UpdaterClustersGPU.cuh"
-#include "hoomd/hpmc/UpdaterClustersGPUDepletants.cuh"
 #include "hoomd/hpmc/IntegratorHPMCMonoGPUDepletantsAuxilliaryPhase1.cuh"
 #include "hoomd/hpmc/IntegratorHPMCMonoGPUDepletantsAuxilliaryPhase2.cuh"
+#include "hoomd/hpmc/IntegratorHPMCMonoGPUMoves.cuh"
+#include "hoomd/hpmc/UpdaterClustersGPU.cuh"
+#include "hoomd/hpmc/UpdaterClustersGPUDepletants.cuh"
 
 namespace hoomd
     {
@@ -19,47 +19,44 @@ namespace detail
     {
 template hipError_t
 gpu_hpmc_free_volume<ShapeMySphere>(const hpmc_free_volume_args_t& args,
-                                         const typename ShapeMySphere::param_type* d_params);
+                                    const typename ShapeMySphere::param_type* d_params);
     }
 namespace gpu
     {
 template void hpmc_gen_moves<ShapeMySphere>(const hpmc_args_t& args,
-                                                 const ShapeMySphere::param_type* params);
+                                            const ShapeMySphere::param_type* params);
 
 template void hpmc_narrow_phase<ShapeMySphere>(const hpmc_args_t& args,
-                                                    const ShapeMySphere::param_type* params);
+                                               const ShapeMySphere::param_type* params);
 
-template void
-hpmc_insert_depletants<ShapeMySphere>(const hpmc_args_t& args,
-                                           const hpmc_implicit_args_t& implicit_args,
-                                           const ShapeMySphere::param_type* params);
+template void hpmc_insert_depletants<ShapeMySphere>(const hpmc_args_t& args,
+                                                    const hpmc_implicit_args_t& implicit_args,
+                                                    const ShapeMySphere::param_type* params);
 
 template void hpmc_update_pdata<ShapeMySphere>(const hpmc_update_args_t& args,
-                                                    const ShapeMySphere::param_type* params);
+                                               const ShapeMySphere::param_type* params);
 
-template void
-hpmc_cluster_overlaps<ShapeMySphere>(const cluster_args_t& args,
-                                          const ShapeMySphere::param_type* params);
+template void hpmc_cluster_overlaps<ShapeMySphere>(const cluster_args_t& args,
+                                                   const ShapeMySphere::param_type* params);
 
-template void
-hpmc_clusters_depletants<ShapeMySphere>(const cluster_args_t& args,
-                                             const hpmc_implicit_args_t& implicit_args,
-                                             const ShapeMySphere::param_type* params);
+template void hpmc_clusters_depletants<ShapeMySphere>(const cluster_args_t& args,
+                                                      const hpmc_implicit_args_t& implicit_args,
+                                                      const ShapeMySphere::param_type* params);
 
 template void transform_particles<ShapeMySphere>(const clusters_transform_args_t& args,
-                                                      const ShapeMySphere::param_type* params);
+                                                 const ShapeMySphere::param_type* params);
 
 template void
 hpmc_depletants_auxilliary_phase1<ShapeMySphere>(const hpmc_args_t& args,
-                                                      const hpmc_implicit_args_t& implicit_args,
-                                                      const hpmc_auxilliary_args_t& auxilliary_args,
-                                                      const ShapeMySphere::param_type* params);
+                                                 const hpmc_implicit_args_t& implicit_args,
+                                                 const hpmc_auxilliary_args_t& auxilliary_args,
+                                                 const ShapeMySphere::param_type* params);
 
 template void
 hpmc_depletants_auxilliary_phase2<ShapeMySphere>(const hpmc_args_t& args,
-                                                      const hpmc_implicit_args_t& implicit_args,
-                                                      const hpmc_auxilliary_args_t& auxilliary_args,
-                                                      const ShapeMySphere::param_type* params);
+                                                 const hpmc_implicit_args_t& implicit_args,
+                                                 const hpmc_auxilliary_args_t& auxilliary_args,
+                                                 const ShapeMySphere::param_type* params);
     } // namespace gpu
 
     } // end namespace hpmc

--- a/example_plugins/shape_plugin/kernels.cu
+++ b/example_plugins/shape_plugin/kernels.cu
@@ -1,0 +1,66 @@
+// Copyright (c) 2009-2023 The Regents of the University of Michigan.
+// Part of HOOMD-blue, released under the BSD 3-Clause License.
+
+#include "ShapeMySphere.h"
+#include "hoomd/hpmc/IntegratorHPMCMonoGPU.cuh"
+#include "hoomd/hpmc/ComputeFreeVolumeGPU.cuh"
+#include "hoomd/hpmc/IntegratorHPMCMonoGPUMoves.cuh"
+#include "hoomd/hpmc/IntegratorHPMCMonoGPUDepletants.cuh"
+#include "hoomd/hpmc/UpdaterClustersGPU.cuh"
+#include "hoomd/hpmc/UpdaterClustersGPUDepletants.cuh"
+#include "hoomd/hpmc/IntegratorHPMCMonoGPUDepletantsAuxilliaryPhase1.cuh"
+#include "hoomd/hpmc/IntegratorHPMCMonoGPUDepletantsAuxilliaryPhase2.cuh"
+
+namespace hoomd
+    {
+namespace hpmc
+    {
+namespace detail
+    {
+template hipError_t
+gpu_hpmc_free_volume<ShapeMySphere>(const hpmc_free_volume_args_t& args,
+                                         const typename ShapeMySphere::param_type* d_params);
+    }
+namespace gpu
+    {
+template void hpmc_gen_moves<ShapeMySphere>(const hpmc_args_t& args,
+                                                 const ShapeMySphere::param_type* params);
+
+template void hpmc_narrow_phase<ShapeMySphere>(const hpmc_args_t& args,
+                                                    const ShapeMySphere::param_type* params);
+
+template void
+hpmc_insert_depletants<ShapeMySphere>(const hpmc_args_t& args,
+                                           const hpmc_implicit_args_t& implicit_args,
+                                           const ShapeMySphere::param_type* params);
+
+template void hpmc_update_pdata<ShapeMySphere>(const hpmc_update_args_t& args,
+                                                    const ShapeMySphere::param_type* params);
+
+template void
+hpmc_cluster_overlaps<ShapeMySphere>(const cluster_args_t& args,
+                                          const ShapeMySphere::param_type* params);
+
+template void
+hpmc_clusters_depletants<ShapeMySphere>(const cluster_args_t& args,
+                                             const hpmc_implicit_args_t& implicit_args,
+                                             const ShapeMySphere::param_type* params);
+
+template void transform_particles<ShapeMySphere>(const clusters_transform_args_t& args,
+                                                      const ShapeMySphere::param_type* params);
+
+template void
+hpmc_depletants_auxilliary_phase1<ShapeMySphere>(const hpmc_args_t& args,
+                                                      const hpmc_implicit_args_t& implicit_args,
+                                                      const hpmc_auxilliary_args_t& auxilliary_args,
+                                                      const ShapeMySphere::param_type* params);
+
+template void
+hpmc_depletants_auxilliary_phase2<ShapeMySphere>(const hpmc_args_t& args,
+                                                      const hpmc_implicit_args_t& implicit_args,
+                                                      const hpmc_auxilliary_args_t& auxilliary_args,
+                                                      const ShapeMySphere::param_type* params);
+    } // namespace gpu
+
+    } // end namespace hpmc
+    } // end namespace hoomd

--- a/example_plugins/shape_plugin/module.cc
+++ b/example_plugins/shape_plugin/module.cc
@@ -2,28 +2,31 @@
 // Part of HOOMD-blue, released under the BSD 3-Clause License.
 
 // Include the defined classes that are to be exported to python
-#include "ComputeFreeVolume.h"
-#include "IntegratorHPMC.h"
-#include "IntegratorHPMCMono.h"
-#include "IntegratorHPMCMonoNEC.h"
+#include "hoomd/hpmc/ComputeFreeVolume.h"
+#include "hoomd/hpmc/IntegratorHPMC.h"
+#include "hoomd/hpmc/IntegratorHPMCMono.h"
+#include "hoomd/hpmc/IntegratorHPMCMonoNEC.h"
 
-#include "ComputeSDF.h"
+#include "hoomd/hpmc/ComputeSDF.h"
+#include "hoomd/hpmc/ShapeUnion.h"
+
+#include "hoomd/hpmc/ExternalField.h"
+#include "hoomd/hpmc/ExternalFieldComposite.h"
+#include "hoomd/hpmc/ExternalFieldHarmonic.h"
+#include "hoomd/hpmc/ExternalFieldWall.h"
+
+#include "hoomd/hpmc/UpdaterClusters.h"
+#include "hoomd/hpmc/UpdaterMuVT.h"
+
 #include "ShapeMySphere.h"
-#include "ShapeUnion.h"
-
-#include "ExternalField.h"
-#include "ExternalFieldComposite.h"
-#include "ExternalFieldHarmonic.h"
-#include "ExternalFieldWall.h"
-
-#include "UpdaterClusters.h"
-#include "UpdaterMuVT.h"
 
 #ifdef ENABLE_HIP
-#include "ComputeFreeVolumeGPU.h"
-#include "IntegratorHPMCMonoGPU.h"
-#include "UpdaterClustersGPU.h"
+#include "hoomd/hpmc/ComputeFreeVolumeGPU.h"
+#include "hoomd/hpmc/IntegratorHPMCMonoGPU.h"
+#include "hoomd/hpmc/UpdaterClustersGPU.h"
 #endif
+
+using namespace hoomd::hpmc::detail;
 
 namespace hoomd
     {
@@ -53,6 +56,7 @@ PYBIND11_MODULE(_shape_plugin, m)
     export_ComputeFreeVolumeGPU<ShapeMySphere>(m, "ComputeFreeVolumeMySphereGPU");
     export_UpdaterClustersGPU<ShapeMySphere>(m, "UpdaterClustersMySphereGPU");
 #endif
+    }
 
     } // namespace hpmc
     } // namespace hoomd

--- a/example_plugins/shape_plugin/module.cc
+++ b/example_plugins/shape_plugin/module.cc
@@ -5,7 +5,6 @@
 #include "hoomd/hpmc/ComputeFreeVolume.h"
 #include "hoomd/hpmc/IntegratorHPMC.h"
 #include "hoomd/hpmc/IntegratorHPMCMono.h"
-#include "hoomd/hpmc/IntegratorHPMCMonoNEC.h"
 
 #include "hoomd/hpmc/ComputeSDF.h"
 #include "hoomd/hpmc/ShapeUnion.h"
@@ -36,7 +35,6 @@ namespace hpmc
 PYBIND11_MODULE(_shape_plugin, m)
     {
     export_IntegratorHPMCMono<ShapeMySphere>(m, "IntegratorHPMCMonoMySphere");
-    export_IntegratorHPMCMonoNEC<ShapeMySphere>(m, "IntegratorHPMCMonoNECMySphere");
     export_ComputeFreeVolume<ShapeMySphere>(m, "ComputeFreeVolumeMySphere");
     export_ComputeSDF<ShapeMySphere>(m, "ComputeSDFMySphere");
     export_UpdaterMuVT<ShapeMySphere>(m, "UpdaterMuVTMySphere");

--- a/example_plugins/shape_plugin/module.cc
+++ b/example_plugins/shape_plugin/module.cc
@@ -1,0 +1,58 @@
+// Copyright (c) 2009-2023 The Regents of the University of Michigan.
+// Part of HOOMD-blue, released under the BSD 3-Clause License.
+
+// Include the defined classes that are to be exported to python
+#include "ComputeFreeVolume.h"
+#include "IntegratorHPMC.h"
+#include "IntegratorHPMCMono.h"
+#include "IntegratorHPMCMonoNEC.h"
+
+#include "ComputeSDF.h"
+#include "ShapeMySphere.h"
+#include "ShapeUnion.h"
+
+#include "ExternalField.h"
+#include "ExternalFieldComposite.h"
+#include "ExternalFieldHarmonic.h"
+#include "ExternalFieldWall.h"
+
+#include "UpdaterClusters.h"
+#include "UpdaterMuVT.h"
+
+#ifdef ENABLE_HIP
+#include "ComputeFreeVolumeGPU.h"
+#include "IntegratorHPMCMonoGPU.h"
+#include "UpdaterClustersGPU.h"
+#endif
+
+namespace hoomd
+    {
+namespace hpmc
+    {
+//! Export the base HPMCMono integrators
+PYBIND11_MODULE(_shape_plugin, m)
+    {
+    export_IntegratorHPMCMono<ShapeMySphere>(m, "IntegratorHPMCMonoMySphere");
+    export_IntegratorHPMCMonoNEC<ShapeMySphere>(m, "IntegratorHPMCMonoNECMySphere");
+    export_ComputeFreeVolume<ShapeMySphere>(m, "ComputeFreeVolumeMySphere");
+    export_ComputeSDF<ShapeMySphere>(m, "ComputeSDFMySphere");
+    export_UpdaterMuVT<ShapeMySphere>(m, "UpdaterMuVTMySphere");
+    export_UpdaterClusters<ShapeMySphere>(m, "UpdaterClustersMySphere");
+
+    export_ExternalFieldInterface<ShapeMySphere>(m, "ExternalFieldMySphere");
+    export_HarmonicField<ShapeMySphere>(m, "ExternalFieldHarmonicMySphere");
+    export_ExternalFieldComposite<ShapeMySphere>(m, "ExternalFieldCompositeMySphere");
+    export_ExternalFieldWall<ShapeMySphere>(m, "WallMySphere");
+
+    pybind11::class_<MySphereParams, std::shared_ptr<MySphereParams>>(m, "MySphereParams")
+        .def(pybind11::init<pybind11::dict>())
+        .def("asDict", &MySphereParams::asDict);
+
+#ifdef ENABLE_HIP
+    export_IntegratorHPMCMonoGPU<ShapeMySphere>(m, "IntegratorHPMCMonoMySphereGPU");
+    export_ComputeFreeVolumeGPU<ShapeMySphere>(m, "ComputeFreeVolumeMySphereGPU");
+    export_UpdaterClustersGPU<ShapeMySphere>(m, "UpdaterClustersMySphereGPU");
+#endif
+
+    } // namespace hpmc
+    } // namespace hoomd

--- a/example_plugins/shape_plugin/pytest/CMakeLists.txt
+++ b/example_plugins/shape_plugin/pytest/CMakeLists.txt
@@ -1,0 +1,11 @@
+# List all files that include python tests
+set(files __init__.py
+          test_mysphere.py)
+
+# Copy tests to the install directory
+install(FILES ${files}
+        DESTINATION ${PYTHON_SITE_INSTALL_DIR}/shape_plugin/pytest
+        )
+
+# Copy tests to the build directory for testing prior to installation
+copy_files_to_build("${files}" "shape_plugin_pytest" "*.py")

--- a/example_plugins/shape_plugin/pytest/__init__.py
+++ b/example_plugins/shape_plugin/pytest/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) 2009-2023 The Regents of the University of Michigan.
+# Part of HOOMD-blue, released under the BSD 3-Clause License.
+
+"""Unit and validation tests."""

--- a/example_plugins/shape_plugin/pytest/test_mysphere.py
+++ b/example_plugins/shape_plugin/pytest/test_mysphere.py
@@ -1,5 +1,13 @@
 from hoomd import shape_plugin
+from hoomd.conftest import two_particle_snapshot_factory
 
 
-def test_make_mysphere():
-    intgrator = shape_plugin.integrate.MySphere()
+def test_attach(simulation_factory, two_particle_snapshot_factory):
+    mc = shape_plugin.integrate.MySphere()
+    mc.shape["A"] = dict(radius=0.5)
+    mc.d["A"] = 0.1
+    mc.a["A"] = 0.1
+    sim = simulation_factory(two_particle_snapshot_factory())
+    sim.operations.integrator = mc
+
+    sim.run(0)

--- a/example_plugins/shape_plugin/pytest/test_mysphere.py
+++ b/example_plugins/shape_plugin/pytest/test_mysphere.py
@@ -2,7 +2,6 @@
 # Part of HOOMD-blue, released under the BSD 3-Clause License.
 
 from hoomd import shape_plugin
-from hoomd.conftest import two_particle_snapshot_factory
 
 
 def test_attach(simulation_factory, two_particle_snapshot_factory):

--- a/example_plugins/shape_plugin/pytest/test_mysphere.py
+++ b/example_plugins/shape_plugin/pytest/test_mysphere.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2009-2023 The Regents of the University of Michigan.
+# Part of HOOMD-blue, released under the BSD 3-Clause License.
+
 from hoomd import shape_plugin
 from hoomd.conftest import two_particle_snapshot_factory
 

--- a/example_plugins/shape_plugin/pytest/test_mysphere.py
+++ b/example_plugins/shape_plugin/pytest/test_mysphere.py
@@ -1,0 +1,5 @@
+from hoomd import shape_plugin
+
+
+def test_make_mysphere():
+    intgrator = shape_plugin.integrate.MySphere()

--- a/hoomd/hpmc/CMakeLists.txt
+++ b/hoomd/hpmc/CMakeLists.txt
@@ -44,14 +44,20 @@ set(_hpmc_sources   module.cc
                     )
 
 set(_hpmc_headers
+    ClangCompiler.h
     ComputeFreeVolumeGPU.cuh
     ComputeFreeVolumeGPU.h
     ComputeFreeVolume.h
     ComputeSDF.h
+    EvalFactory.h
+    Evaluator.cuh
+    EvaluatorUnionGPU.cuh
     ExternalFieldComposite.h
     ExternalField.h
     ExternalFieldHarmonic.h
+    ExternalFieldJIT.h
     ExternalFieldWall.h
+    GPUEvalFactory.h
     GSDHPMCSchema.h
     GPUHelpers.cuh
     GPUTree.h
@@ -66,14 +72,19 @@ set(_hpmc_headers
     IntegratorHPMCMonoGPUDepletantsAuxilliaryPhase1.cuh
     IntegratorHPMCMonoGPUDepletantsAuxilliaryPhase2.cuh
     IntegratorHPMCMonoGPUDepletantsAuxilliaryTypes.cuh
-    IntegratorHPMCMonoGPUJIT.inc
     IntegratorHPMCMonoGPU.h
+    IntegratorHPMCMonoNEC.h
     IntegratorHPMCMono.h
+    KaleidoscopeJIT.h
     MinkowskiMath.h
     modules.h
     Moves.h
     OBB.h
     OBBTree.h
+    PatchEnergyJIT.h
+    PatchEnergyJITGPU.h
+    PatchEnergyJITUnion.h
+    PatchEnergyJITUnionGPU.h
     ShapeConvexPolygon.h
     ShapeConvexPolyhedron.h
     ShapeEllipsoid.h
@@ -86,15 +97,19 @@ set(_hpmc_headers
     ShapeSpheropolyhedron.h
     ShapeSphinx.h
     ShapeUnion.h
+    ShapeUtils.h
     SphinxOverlap.h
+    UpdaterBoxMC.h
     UpdaterClusters.h
     UpdaterClustersGPU.cuh
+    UpdaterClustersGPU.h
     UpdaterClustersGPUDepletants.cuh
     UpdaterMuVT.h
     UpdaterQuickCompress.h
     UpdaterShape.h
     XenoCollide2D.h
     XenoCollide3D.h
+    XenoSweep3D.h
     )
 
 set(_hpmc_cu_sources IntegratorHPMCMonoGPU.cu

--- a/hoomd/hpmc/CMakeLists.txt
+++ b/hoomd/hpmc/CMakeLists.txt
@@ -59,6 +59,7 @@ set(_hpmc_headers
     HPMCMiscFunctions.h
     IntegratorHPMC.h
     IntegratorHPMCMonoGPU.cuh
+    IntegratorHPMCMonoGPUJIT.inc
     IntegratorHPMCMonoGPUMoves.cuh
     IntegratorHPMCMonoGPUTypes.cuh
     IntegratorHPMCMonoGPUDepletants.cuh

--- a/hoomd/hpmc/CMakeLists.txt
+++ b/hoomd/hpmc/CMakeLists.txt
@@ -44,20 +44,14 @@ set(_hpmc_sources   module.cc
                     )
 
 set(_hpmc_headers
-    ClangCompiler.h
     ComputeFreeVolumeGPU.cuh
     ComputeFreeVolumeGPU.h
     ComputeFreeVolume.h
     ComputeSDF.h
-    EvalFactory.h
-    Evaluator.cuh
-    EvaluatorUnionGPU.cuh
     ExternalFieldComposite.h
     ExternalField.h
     ExternalFieldHarmonic.h
-    ExternalFieldJIT.h
     ExternalFieldWall.h
-    GPUEvalFactory.h
     GSDHPMCSchema.h
     GPUHelpers.cuh
     GPUTree.h
@@ -75,16 +69,11 @@ set(_hpmc_headers
     IntegratorHPMCMonoGPU.h
     IntegratorHPMCMonoNEC.h
     IntegratorHPMCMono.h
-    KaleidoscopeJIT.h
     MinkowskiMath.h
     modules.h
     Moves.h
     OBB.h
     OBBTree.h
-    PatchEnergyJIT.h
-    PatchEnergyJITGPU.h
-    PatchEnergyJITUnion.h
-    PatchEnergyJITUnionGPU.h
     ShapeConvexPolygon.h
     ShapeConvexPolyhedron.h
     ShapeEllipsoid.h

--- a/hoomd/hpmc/IntegratorHPMCMonoGPU.cu
+++ b/hoomd/hpmc/IntegratorHPMCMonoGPU.cu
@@ -149,17 +149,17 @@ __global__ void hpmc_check_convergence(const unsigned int* d_trial_move_type,
     } // end namespace kernel
 
 //! Driver for kernel::hpmc_excell()
-void hpmc_excell(unsigned int* d_excell_idx,
-                 unsigned int* d_excell_size,
-                 const Index2D& excli,
-                 const unsigned int* d_cell_idx,
-                 const unsigned int* d_cell_size,
-                 const unsigned int* d_cell_adj,
-                 const Index3D& ci,
-                 const Index2D& cli,
-                 const Index2D& cadji,
-                 const unsigned int ngpu,
-                 const unsigned int block_size)
+void __attribute__((visibility("default"))) hpmc_excell(unsigned int* d_excell_idx,
+                                                        unsigned int* d_excell_size,
+                                                        const Index2D& excli,
+                                                        const unsigned int* d_cell_idx,
+                                                        const unsigned int* d_cell_size,
+                                                        const unsigned int* d_cell_adj,
+                                                        const Index3D& ci,
+                                                        const Index2D& cli,
+                                                        const Index2D& cadji,
+                                                        const unsigned int ngpu,
+                                                        const unsigned int block_size)
     {
     assert(d_excell_idx);
     assert(d_excell_size);
@@ -196,12 +196,12 @@ void hpmc_excell(unsigned int* d_excell_idx,
     }
 
 //! Kernel driver for kernel::hpmc_shift()
-void hpmc_shift(Scalar4* d_postype,
-                int3* d_image,
-                const unsigned int N,
-                const BoxDim& box,
-                const Scalar3 shift,
-                const unsigned int block_size)
+void __attribute__((visibility("default"))) hpmc_shift(Scalar4* d_postype,
+                                                       int3* d_image,
+                                                       const unsigned int N,
+                                                       const BoxDim& box,
+                                                       const Scalar3 shift,
+                                                       const unsigned int block_size)
     {
     assert(d_postype);
     assert(d_image);
@@ -225,13 +225,14 @@ void hpmc_shift(Scalar4* d_postype,
     hipDeviceSynchronize();
     }
 
-void hpmc_check_convergence(const unsigned int* d_trial_move_type,
-                            const unsigned int* d_reject_out_of_cell,
-                            unsigned int* d_reject_in,
-                            unsigned int* d_reject_out,
-                            unsigned int* d_condition,
-                            const GPUPartition& gpu_partition,
-                            const unsigned int block_size)
+void __attribute__((visibility("default")))
+hpmc_check_convergence(const unsigned int* d_trial_move_type,
+                       const unsigned int* d_reject_out_of_cell,
+                       unsigned int* d_reject_in,
+                       unsigned int* d_reject_out,
+                       unsigned int* d_condition,
+                       const GPUPartition& gpu_partition,
+                       const unsigned int block_size)
     {
     // determine the maximum block size and clamp the input block size down
     int max_block_size;

--- a/hoomd/hpmc/IntegratorHPMCMonoGPUDepletants.cu
+++ b/hoomd/hpmc/IntegratorHPMCMonoGPUDepletants.cu
@@ -164,18 +164,19 @@ __global__ void hpmc_depletants_accept(const uint16_t seed,
 
     } // end namespace kernel
 
-void generate_num_depletants(const uint16_t seed,
-                             const uint64_t timestep,
-                             const unsigned int select,
-                             const unsigned int rank,
-                             const unsigned int depletant_type_a,
-                             const Scalar* d_lambda,
-                             const Scalar4* d_postype,
-                             unsigned int* d_n_depletants,
-                             const unsigned int block_size,
-                             const hipStream_t* streams,
-                             const GPUPartition& gpu_partition,
-                             const unsigned int ntypes)
+void __attribute__((visibility("default")))
+generate_num_depletants(const uint16_t seed,
+                        const uint64_t timestep,
+                        const unsigned int select,
+                        const unsigned int rank,
+                        const unsigned int depletant_type_a,
+                        const Scalar* d_lambda,
+                        const Scalar4* d_postype,
+                        unsigned int* d_n_depletants,
+                        const unsigned int block_size,
+                        const hipStream_t* streams,
+                        const GPUPartition& gpu_partition,
+                        const unsigned int ntypes)
     {
     // determine the maximum block size and clamp the input block size down
     unsigned int max_block_size;
@@ -209,20 +210,21 @@ void generate_num_depletants(const uint16_t seed,
         }
     }
 
-void generate_num_depletants_ntrial(const Scalar4* d_vel,
-                                    const Scalar4* d_trial_vel,
-                                    const unsigned int ntrial,
-                                    const unsigned int depletant_type_a,
-                                    const Scalar* d_lambda,
-                                    const Scalar4* d_postype,
-                                    unsigned int* d_n_depletants,
-                                    const unsigned int N_local,
-                                    const bool add_ghosts,
-                                    const unsigned int n_ghosts,
-                                    const GPUPartition& gpu_partition,
-                                    const unsigned int block_size,
-                                    const hipStream_t* streams,
-                                    const unsigned int ntypes)
+void __attribute__((visibility("default")))
+generate_num_depletants_ntrial(const Scalar4* d_vel,
+                               const Scalar4* d_trial_vel,
+                               const unsigned int ntrial,
+                               const unsigned int depletant_type_a,
+                               const Scalar* d_lambda,
+                               const Scalar4* d_postype,
+                               unsigned int* d_n_depletants,
+                               const unsigned int N_local,
+                               const bool add_ghosts,
+                               const unsigned int n_ghosts,
+                               const GPUPartition& gpu_partition,
+                               const unsigned int block_size,
+                               const hipStream_t* streams,
+                               const unsigned int ntypes)
     {
     // determine the maximum block size and clamp the input block size down
     unsigned int max_block_size;
@@ -268,11 +270,12 @@ void generate_num_depletants_ntrial(const Scalar4* d_vel,
         }
     }
 
-void get_max_num_depletants(unsigned int* d_n_depletants,
-                            unsigned int* max_n_depletants,
-                            const hipStream_t* streams,
-                            const GPUPartition& gpu_partition,
-                            CachedAllocator& alloc)
+void __attribute__((visibility("default")))
+get_max_num_depletants(unsigned int* d_n_depletants,
+                       unsigned int* max_n_depletants,
+                       const hipStream_t* streams,
+                       const GPUPartition& gpu_partition,
+                       CachedAllocator& alloc)
     {
     assert(d_n_depletants);
     thrust::device_ptr<unsigned int> n_depletants(d_n_depletants);
@@ -293,14 +296,15 @@ void get_max_num_depletants(unsigned int* d_n_depletants,
     }
 
 //! Compute the max # of depletants per particle, trial insertion, and configuration
-void get_max_num_depletants_ntrial(const unsigned int ntrial,
-                                   unsigned int* d_n_depletants,
-                                   unsigned int* max_n_depletants,
-                                   const bool add_ghosts,
-                                   const unsigned int n_ghosts,
-                                   const hipStream_t* streams,
-                                   const GPUPartition& gpu_partition,
-                                   CachedAllocator& alloc)
+void __attribute__((visibility("default")))
+get_max_num_depletants_ntrial(const unsigned int ntrial,
+                              unsigned int* d_n_depletants,
+                              unsigned int* max_n_depletants,
+                              const bool add_ghosts,
+                              const unsigned int n_ghosts,
+                              const hipStream_t* streams,
+                              const GPUPartition& gpu_partition,
+                              CachedAllocator& alloc)
     {
     assert(d_n_depletants);
     thrust::device_ptr<unsigned int> n_depletants(d_n_depletants);
@@ -326,14 +330,15 @@ void get_max_num_depletants_ntrial(const unsigned int ntrial,
         }
     }
 
-void reduce_counters(const unsigned int ngpu,
-                     const unsigned int pitch,
-                     const hpmc_counters_t* d_per_device_counters,
-                     hpmc_counters_t* d_counters,
-                     const unsigned int implicit_pitch,
-                     const hpmc_implicit_counters_t* d_per_device_implicit_counters,
-                     hpmc_implicit_counters_t* d_implicit_counters,
-                     const unsigned int ntypes)
+void __attribute__((visibility("default")))
+reduce_counters(const unsigned int ngpu,
+                const unsigned int pitch,
+                const hpmc_counters_t* d_per_device_counters,
+                hpmc_counters_t* d_counters,
+                const unsigned int implicit_pitch,
+                const hpmc_implicit_counters_t* d_per_device_implicit_counters,
+                hpmc_implicit_counters_t* d_implicit_counters,
+                const unsigned int ntypes)
     {
     hipLaunchKernelGGL(kernel::hpmc_reduce_counters,
                        1,
@@ -350,18 +355,19 @@ void reduce_counters(const unsigned int ngpu,
                        ntypes);
     }
 
-void hpmc_depletants_accept(const uint16_t seed,
-                            const uint64_t timestep,
-                            const unsigned int select,
-                            const unsigned int rank,
-                            const int* d_deltaF_int,
-                            const unsigned int deltaF_pitch,
-                            const Scalar* d_fugacity,
-                            const unsigned int* d_ntrial,
-                            unsigned int* d_reject_out,
-                            const GPUPartition& gpu_partition,
-                            const unsigned int block_size,
-                            const unsigned int ntypes)
+void __attribute__((visibility("default")))
+hpmc_depletants_accept(const uint16_t seed,
+                       const uint64_t timestep,
+                       const unsigned int select,
+                       const unsigned int rank,
+                       const int* d_deltaF_int,
+                       const unsigned int deltaF_pitch,
+                       const Scalar* d_fugacity,
+                       const unsigned int* d_ntrial,
+                       unsigned int* d_reject_out,
+                       const GPUPartition& gpu_partition,
+                       const unsigned int block_size,
+                       const unsigned int ntypes)
     {
     // determine the maximum block size and clamp the input block size down
     unsigned int max_block_size;

--- a/hoomd/hpmc/UpdaterClustersGPU.cu
+++ b/hoomd/hpmc/UpdaterClustersGPU.cu
@@ -75,11 +75,11 @@ struct pair_less : public thrust::binary_function<uint2, uint2, bool>
         }
     };
 
-void get_num_neighbors(const unsigned int* d_nneigh,
-                       unsigned int* d_nneigh_scan,
-                       unsigned int& nneigh_total,
-                       const GPUPartition& gpu_partition,
-                       CachedAllocator& alloc)
+void __attribute__((visibility("default"))) get_num_neighbors(const unsigned int* d_nneigh,
+                                                              unsigned int* d_nneigh_scan,
+                                                              unsigned int& nneigh_total,
+                                                              const GPUPartition& gpu_partition,
+                                                              CachedAllocator& alloc)
     {
     assert(d_nneigh);
     thrust::device_ptr<const unsigned int> nneigh(d_nneigh);
@@ -187,14 +187,15 @@ __global__ void flip_clusters(Scalar4* d_postype,
 
     } // end namespace kernel
 
-void concatenate_adjacency_list(const unsigned int* d_adjacency,
-                                const unsigned int* d_nneigh,
-                                const unsigned int* d_nneigh_scan,
-                                const unsigned int maxn,
-                                uint2* d_adjacency_out,
-                                const GPUPartition& gpu_partition,
-                                const unsigned int block_size,
-                                const unsigned int group_size)
+void __attribute__((visibility("default")))
+concatenate_adjacency_list(const unsigned int* d_adjacency,
+                           const unsigned int* d_nneigh,
+                           const unsigned int* d_nneigh_scan,
+                           const unsigned int maxn,
+                           uint2* d_adjacency_out,
+                           const GPUPartition& gpu_partition,
+                           const unsigned int block_size,
+                           const unsigned int group_size)
     {
     // determine the maximum block size and clamp the input block size down
     int max_block_size;
@@ -236,18 +237,18 @@ void concatenate_adjacency_list(const unsigned int* d_adjacency,
         }
     }
 
-void flip_clusters(Scalar4* d_postype,
-                   Scalar4* d_orientation,
-                   int3* d_image,
-                   const Scalar4* d_postype_backup,
-                   const Scalar4* d_orientation_backup,
-                   const int3* d_image_backup,
-                   const int* d_components,
-                   float flip_probability,
-                   uint16_t seed,
-                   uint64_t timestep,
-                   const GPUPartition& gpu_partition,
-                   const unsigned int block_size)
+void __attribute__((visibility("default"))) flip_clusters(Scalar4* d_postype,
+                                                          Scalar4* d_orientation,
+                                                          int3* d_image,
+                                                          const Scalar4* d_postype_backup,
+                                                          const Scalar4* d_orientation_backup,
+                                                          const int3* d_image_backup,
+                                                          const int* d_components,
+                                                          float flip_probability,
+                                                          uint16_t seed,
+                                                          uint64_t timestep,
+                                                          const GPUPartition& gpu_partition,
+                                                          const unsigned int block_size)
     {
     // determine the maximum block size and clamp the input block size down
     int max_block_size;

--- a/hoomd/hpmc/UpdaterClustersGPU.cuh
+++ b/hoomd/hpmc/UpdaterClustersGPU.cuh
@@ -117,13 +117,13 @@ struct cluster_args_t
     const hipStream_t* streams;           //!< kernel streams
     };
 
-void connected_components(uint2* d_adj,
-                          unsigned int N,
-                          const unsigned int n_elements,
-                          int* d_components,
-                          unsigned int& num_components,
-                          const hipDeviceProp_t& dev_prop,
-                          CachedAllocator& alloc);
+void __attribute__((visibility("default"))) connected_components(uint2* d_adj,
+                                                                 unsigned int N,
+                                                                 const unsigned int n_elements,
+                                                                 int* d_components,
+                                                                 unsigned int& num_components,
+                                                                 const hipDeviceProp_t& dev_prop,
+                                                                 CachedAllocator& alloc);
 
 void get_num_neighbors(const unsigned int* d_nneigh,
                        unsigned int* d_nneigh_scan,

--- a/hoomd/hpmc/integrate.py
+++ b/hoomd/hpmc/integrate.py
@@ -346,6 +346,7 @@ class HPMCIntegrator(Integrator):
 
     .. rubric:: Attributes
     """
+    _ext_module = _hpmc
     _remove_for_pickling = Integrator._remove_for_pickling + ('_cpp_cell',)
     _skip_for_equality = Integrator._skip_for_equality | {'_cpp_cell'}
     _cpp_cls = None
@@ -402,14 +403,14 @@ class HPMCIntegrator(Integrator):
         if (isinstance(self._simulation.device, hoomd.device.GPU)
                 and (self._cpp_cls + 'GPU') in _hpmc.__dict__):
             self._cpp_cell = _hoomd.CellListGPU(sys_def)
-            self._cpp_obj = getattr(_hpmc,
+            self._cpp_obj = getattr(_ext_module,
                                     self._cpp_cls + 'GPU')(sys_def,
                                                            self._cpp_cell)
         else:
             if isinstance(self._simulation.device, hoomd.device.GPU):
                 self._simulation.device._cpp_msg.warning(
                     "Falling back on CPU. No GPU implementation for shape.\n")
-            self._cpp_obj = getattr(_hpmc, self._cpp_cls)(sys_def)
+            self._cpp_obj = getattr(_ext_module, self._cpp_cls)(sys_def)
             self._cpp_cell = None
 
         if self._external_potential is not None:

--- a/hoomd/hpmc/integrate.py
+++ b/hoomd/hpmc/integrate.py
@@ -403,14 +403,14 @@ class HPMCIntegrator(Integrator):
         if (isinstance(self._simulation.device, hoomd.device.GPU)
                 and (self._cpp_cls + 'GPU') in _hpmc.__dict__):
             self._cpp_cell = _hoomd.CellListGPU(sys_def)
-            self._cpp_obj = getattr(_ext_module,
+            self._cpp_obj = getattr(self._ext_module,
                                     self._cpp_cls + 'GPU')(sys_def,
                                                            self._cpp_cell)
         else:
             if isinstance(self._simulation.device, hoomd.device.GPU):
                 self._simulation.device._cpp_msg.warning(
                     "Falling back on CPU. No GPU implementation for shape.\n")
-            self._cpp_obj = getattr(_ext_module, self._cpp_cls)(sys_def)
+            self._cpp_obj = getattr(self._ext_module, self._cpp_cls)(sys_def)
             self._cpp_cell = None
 
         if self._external_potential is not None:


### PR DESCRIPTION
## Description

This PR adds some headers which are in hoomd's source, but do not get installed with hoomd.

## Motivation and context

Many of HPMC's headers do not get installed with hoomd, preventing users from building hpmc-based plugins.

## How has this been tested?

I have not tested this locally yet, but will soon.

## Change log

<!-- Propose a change log entry. -->
```
- All of HPMC's headers are now installed with hoomd.
```

## Checklist:

- [ ] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.rst).
- [ ] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [ ] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
