### PR TITLE
Setup sybil

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
     name: Build release tarball
     runs-on: ubuntu-latest
     container:
-      image: glotzerlab/ci:2023.05-ubuntu20.04
+      image: glotzerlab/ci:2023.06-ubuntu20.04
 
     steps:
       - name: Checkout

--- a/.github/workflows/templates/workflow.yml
+++ b/.github/workflows/templates/workflow.yml
@@ -1,5 +1,5 @@
 <% block name %><% endblock %>
-<% set container_prefix="glotzerlab/ci:2023.05" %>
+<% set container_prefix="glotzerlab/ci:2023.06" %>
 
 <% block concurrency %>
 concurrency:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,7 +59,7 @@ jobs:
     name: Build [${{ join(matrix.config, '_') }}]
     runs-on: ${{ matrix.build_runner }}
     container:
-      image: glotzerlab/ci:2023.05-${{ matrix.config[0] }}
+      image: glotzerlab/ci:2023.06-${{ matrix.config[0] }}
     strategy:
       matrix:
         include:
@@ -168,7 +168,7 @@ jobs:
     needs: build
     runs-on: ${{ matrix.test_runner }}
     container:
-      image: glotzerlab/ci:2023.05-${{ matrix.config[0] }}
+      image: glotzerlab/ci:2023.06-${{ matrix.config[0] }}
       options: ${{ matrix.test_docker_options }} -e CUDA_VISIBLE_DEVICES
     strategy:
       matrix:
@@ -229,7 +229,7 @@ jobs:
     needs: build
     runs-on: ${{ matrix.test_runner }}
     container:
-      image: glotzerlab/ci:2023.05-${{ matrix.config[0] }}
+      image: glotzerlab/ci:2023.06-${{ matrix.config[0] }}
       options: ${{ matrix.test_docker_options }} -e CUDA_VISIBLE_DEVICES
     strategy:
       matrix:
@@ -283,7 +283,7 @@ jobs:
     needs: build
     runs-on: ${{ matrix.test_runner }}
     container:
-      image: glotzerlab/ci:2023.05-${{ matrix.config[0] }}
+      image: glotzerlab/ci:2023.06-${{ matrix.config[0] }}
       options: ${{ matrix.test_docker_options }} -e CUDA_VISIBLE_DEVICES
     strategy:
       matrix:
@@ -334,7 +334,7 @@ jobs:
     name: Build [${{ join(matrix.config, '_') }}]
     runs-on: ${{ matrix.build_runner }}
     container:
-      image: glotzerlab/ci:2023.05-${{ matrix.config[0] }}
+      image: glotzerlab/ci:2023.06-${{ matrix.config[0] }}
     strategy:
       matrix:
         include:
@@ -445,7 +445,7 @@ jobs:
     needs: build_release
     runs-on: ${{ matrix.test_runner }}
     container:
-      image: glotzerlab/ci:2023.05-${{ matrix.config[0] }}
+      image: glotzerlab/ci:2023.06-${{ matrix.config[0] }}
       options: ${{ matrix.test_docker_options }} -e CUDA_VISIBLE_DEVICES
     strategy:
       matrix:
@@ -512,7 +512,7 @@ jobs:
     needs: build_release
     runs-on: ${{ matrix.test_runner }}
     container:
-      image: glotzerlab/ci:2023.05-${{ matrix.config[0] }}
+      image: glotzerlab/ci:2023.06-${{ matrix.config[0] }}
       options: ${{ matrix.test_docker_options }} -e CUDA_VISIBLE_DEVICES
     strategy:
       matrix:

--- a/hoomd/conftest.py
+++ b/hoomd/conftest.py
@@ -49,7 +49,9 @@ pytest_collect_file = sybil.Sybil(
     # Despite being documented as fnmatch syntax, in practice patterns matches
     # whole relative paths. TODO:when all code examples function, search
     # *.py, */*.py, */*/*.py, ... as many levels deep as needed.
-    patterns=['md/methods/methods.py'],
+    patterns=['md/methods/methods.py',
+              'md/methods/thermostats.py',
+              ],
     setup=setup_sybil_tests,
     fixtures=[]
 ).pytest()

--- a/hoomd/conftest.py
+++ b/hoomd/conftest.py
@@ -41,18 +41,19 @@ def setup_sybil_tests(namespace):
     # Allow documentation tests to use numpy.
     namespace['numpy'] = numpy
 
-    # Rename tmp_path to path to not confuse users with `path / 'file.ext'`
-    # namespace['path'] = namespace['tmp_path']
+    namespace['gpu_not_available'] = _n_available_gpu == 0
 
 
 pytest_collect_file = sybil.Sybil(
     parsers=[
         sybil.parsers.rest.PythonCodeBlockParser(),
+        sybil.parsers.rest.SkipParser(),
     ],
     # Despite being documented as fnmatch syntax, in practice patterns matches
     # whole relative paths. TODO:when all code examples function, search
     # *.py, */*.py, */*/*.py, ... as many levels deep as needed.
     patterns=[
+        'device.py',
         'md/methods/methods.py',
         'md/methods/thermostats.py',
     ],

--- a/hoomd/conftest.py
+++ b/hoomd/conftest.py
@@ -14,6 +14,9 @@ import hoomd
 import atexit
 import os
 import numpy
+import sybil
+import sybil.parsers.rest
+
 from hoomd.logging import LoggerCategories
 from hoomd.snapshot import Snapshot
 from hoomd import Simulation
@@ -31,6 +34,25 @@ if hoomd.version.gpu_enabled and (_n_available_gpu > 0 or _github_actions):
         devices.pop(0)
 
     devices.append(hoomd.device.GPU)
+
+
+def setup_sybil_tests(namespace):
+    """Sybil setup function."""
+    # Allow documentation tests to call pytest.skip when needed.
+    namespace['pytest'] = pytest
+
+
+pytest_collect_file = sybil.Sybil(
+    parsers=[
+        sybil.parsers.rest.PythonCodeBlockParser(),
+    ],
+    # Despite being documented as fnmatch syntax, in practice patterns matches
+    # whole relative paths. TODO:when all code examples function, search
+    # *.py, */*.py, */*/*.py, ... as many levels deep as needed.
+    patterns=['md/methods/methods.py'],
+    setup=setup_sybil_tests,
+    fixtures=[]
+).pytest()
 
 
 @pytest.fixture(scope='session', params=devices)

--- a/hoomd/conftest.py
+++ b/hoomd/conftest.py
@@ -38,8 +38,11 @@ if hoomd.version.gpu_enabled and (_n_available_gpu > 0 or _github_actions):
 
 def setup_sybil_tests(namespace):
     """Sybil setup function."""
-    # Allow documentation tests to call pytest.skip when needed.
-    namespace['pytest'] = pytest
+    # Allow documentation tests to use numpy.
+    namespace['numpy'] = numpy
+
+    # Rename tmp_path to path to not confuse users with `path / 'file.ext'`
+    # namespace['path'] = namespace['tmp_path']
 
 
 pytest_collect_file = sybil.Sybil(
@@ -54,7 +57,7 @@ pytest_collect_file = sybil.Sybil(
         'md/methods/thermostats.py',
     ],
     setup=setup_sybil_tests,
-    fixtures=[]).pytest()
+    fixtures=['tmp_path']).pytest()
 
 
 @pytest.fixture(scope='session', params=devices)

--- a/hoomd/conftest.py
+++ b/hoomd/conftest.py
@@ -49,12 +49,12 @@ pytest_collect_file = sybil.Sybil(
     # Despite being documented as fnmatch syntax, in practice patterns matches
     # whole relative paths. TODO:when all code examples function, search
     # *.py, */*.py, */*/*.py, ... as many levels deep as needed.
-    patterns=['md/methods/methods.py',
-              'md/methods/thermostats.py',
-              ],
+    patterns=[
+        'md/methods/methods.py',
+        'md/methods/thermostats.py',
+    ],
     setup=setup_sybil_tests,
-    fixtures=[]
-).pytest()
+    fixtures=[]).pytest()
 
 
 @pytest.fixture(scope='session', params=devices)

--- a/hoomd/device.py
+++ b/hoomd/device.py
@@ -33,7 +33,7 @@ See Also:
 
 .. invisible-code-block: python
 
-    # Rename tmp_path to path to avoid giving the users the wrong signal.
+    # Rename pytest's tmp_path fixture for clarity.
     path = tmp_path
 """
 

--- a/hoomd/device.py
+++ b/hoomd/device.py
@@ -16,13 +16,13 @@ with many `hoomd.Simulation` objects.
 
 .. code-block:: python
 
-    cpu = hoomd.device.CPU()
+    device = hoomd.device.CPU()
 
 .. skip: next if(gpu_not_available)
 
 .. code-block:: python
 
-    gpu = hoomd.device.GPU()
+    device = hoomd.device.GPU()
 
 Tip:
     Reuse `Device` objects when possible. There is a non-negligible overhead
@@ -53,7 +53,7 @@ class NoticeFile:
 
     .. code-block:: python
 
-        notice_file = hoomd.device.NoticeFile(device=cpu)
+        notice_file = hoomd.device.NoticeFile(device=device)
 
     Note:
         Use this in combination with `Device.message_filename` to combine notice
@@ -154,7 +154,7 @@ class Device:
 
         .. code-block:: python
 
-            cpu.notice_level = 4
+            device.notice_level = 4
         """
         return self._cpp_msg.getNoticeLevel()
 
@@ -180,11 +180,11 @@ class Device:
 
         .. code-block:: python
 
-            cpu.message_filename = str(path / 'messages.log')
+            device.message_filename = str(path / 'messages.log')
 
         .. code-block:: python
 
-            cpu.message_filename = None
+            device.message_filename = None
 
         Note:
             All MPI ranks within a given partition must open the same file.
@@ -192,7 +192,7 @@ class Device:
             other ranks. Different partitions may open separate files. For
             example:
 
-            .. skip: next if(cpu.communicator.num_ranks % 2 != 0)
+            .. skip: next if(device.communicator.num_ranks != 2)
 
             .. code-block:: python
 
@@ -248,7 +248,7 @@ class Device:
 
         .. code-block:: python
 
-            cpu.notice('Message')
+            device.notice('Message')
 
         Hint:
             Use `notice` instead of `print` to write status messages and your

--- a/hoomd/device.py
+++ b/hoomd/device.py
@@ -12,12 +12,29 @@ User scripts may instantiate multiple `Device` objects and use each with a
 different `hoomd.Simulation` object. One `Device` object may also be shared
 with many `hoomd.Simulation` objects.
 
+.. rubric:: Examples:
+
+.. code-block:: python
+
+    cpu = hoomd.device.CPU()
+
+.. skip: next if(gpu_not_available)
+
+.. code-block:: python
+
+    gpu = hoomd.device.GPU()
+
 Tip:
     Reuse `Device` objects when possible. There is a non-negligible overhead
     to creating each `Device`, especially on the GPU.
 
 See Also:
     `hoomd.Simulation`
+
+.. invisible-code-block: python
+
+    # Rename tmp_path to path to avoid giving the users the wrong signal.
+    path = tmp_path
 """
 
 import contextlib
@@ -31,6 +48,12 @@ class NoticeFile:
     Args:
         device (`Device`): The `Device` object.
         level (int): Message notice level. Default value is 1.
+
+    .. rubric:: Example:
+
+    .. code-block:: python
+
+        notice_file = hoomd.device.NoticeFile(device=cpu)
 
     Note:
         Use this in combination with `Device.message_filename` to combine notice
@@ -48,6 +71,12 @@ class NoticeFile:
 
         Args:
             message (str): Message to write.
+
+        .. rubric:: Example:
+
+        .. code-block:: python
+
+            notice_file.write('Message\\n')
         """
         self._buff += message
 
@@ -120,6 +149,12 @@ class Device:
         default level of 2 shows messages that the developers expect most users
         will want to see. Set the level lower to reduce verbosity or as high as
         10 to get extremely verbose debugging messages.
+
+        .. rubric:: Example:
+
+        .. code-block:: python
+
+            cpu.notice_level = 4
         """
         return self._cpp_msg.getNoticeLevel()
 
@@ -141,18 +176,30 @@ class Device:
         Set `message_filename` to `None` to use the system's ``stdout`` and
         ``stderr``.
 
+        .. rubric:: Examples:
+
+        .. code-block:: python
+
+            cpu.message_filename = str(path / 'messages.log')
+
+        .. code-block:: python
+
+            cpu.message_filename = None
+
         Note:
             All MPI ranks within a given partition must open the same file.
             To ensure this, the given file name on rank 0 is broadcast to the
             other ranks. Different partitions may open separate files. For
             example:
 
-            .. code::
+            .. skip: next if(cpu.communicator.num_ranks % 2 != 0)
+
+            .. code-block:: python
 
                 communicator = hoomd.communicator.Communicator(
                     ranks_per_partition=2)
                 filename = f'messages.{communicator.partition}'
-                device = hoomd.device.GPU(communicator=communicator,
+                device = hoomd.device.CPU(communicator=communicator,
                                           message_filename=filename)
         """
         return self._message_filename
@@ -196,6 +243,12 @@ class Device:
 
         Write the given message string to the output defined by
         `message_filename` on MPI rank 0 when `notice_level` >= ``level``.
+
+        .. rubric:: Example:
+
+        .. code-block:: python
+
+            cpu.notice('Message')
 
         Hint:
             Use `notice` instead of `print` to write status messages and your
@@ -276,6 +329,14 @@ class GPU(Device):
         that all GPUs support concurrent managed memory access and have high
         bandwidth interconnects.
 
+    .. rubric:: Example:
+
+    .. skip: next if(gpu_not_available)
+
+    .. code-block:: python
+
+        gpu = hoomd.device.GPU()
+
     """
 
     def __init__(
@@ -307,6 +368,14 @@ class GPU(Device):
         When `False` (the default), error messages from the GPU may not be
         noticed immediately. Set to `True` to increase the accuracy of the GPU
         error messages at the cost of significantly reduced performance.
+
+        .. rubric:: Example:
+
+        .. skip: next if(gpu_not_available)
+
+        .. code-block:: python
+
+            gpu.gpu_error_checking = True
         """
         return self._cpp_exec_conf.isCUDAErrorCheckingEnabled()
 
@@ -361,10 +430,15 @@ class GPU(Device):
         context manager and continue the simulation for a time. Profiling stops
         when the context manager closes.
 
-        Example::
+        .. rubric:: Example:
 
-            with device.enable_profiling():
-                sim.run(1000)
+        .. skip: next if(gpu_not_available)
+
+        .. code-block:: python
+
+            simulation = hoomd.util.make_example_simulation(device=gpu)
+            with gpu.enable_profiling():
+                simulation.run(1000)
         """
         try:
             self._cpp_exec_conf.hipProfileStart()
@@ -392,6 +466,12 @@ class CPU(Device):
     .. rubric:: MPI
 
     In MPI execution environments, create a `CPU` device on every rank.
+
+    .. rubric:: Example:
+
+    .. code-block:: python
+
+        cpu = hoomd.device.CPU()
     """
 
     def __init__(
@@ -432,6 +512,12 @@ def auto_select(
 
     Returns:
         Instance of `GPU` if availabile, otherwise `CPU`.
+
+    .. rubric:: Example:
+
+    .. code-block:: python
+
+        device = hoomd.device.auto_select()
     """
     # Set class according to C++ object
     if len(GPU.get_available_devices()) > 0:

--- a/hoomd/device.py
+++ b/hoomd/device.py
@@ -33,7 +33,7 @@ See Also:
 
 .. invisible-code-block: python
 
-    # Rename pytest's tmp_path fixture for clarity.
+    # Rename pytest's tmp_path fixture for clarity in the documentation.
     path = tmp_path
 """
 

--- a/hoomd/md/methods/__init__.py
+++ b/hoomd/md/methods/__init__.py
@@ -15,6 +15,15 @@ Thermostatted methods require usage of a thermostat, see
 .. rubric:: Integration methods with constraints
 
 For methods that constrain motion to a manifold see `hoomd.md.methods.rattle`.
+
+.. rubric:: Preparation
+
+Create a `hoomd.md.Integrator` to accept an integration method (or methods):
+
+.. code-block:: python
+
+    simulation = hoomd.util.make_example_simulation()
+    simulation.operations.integrator = hoomd.md.Integrator(dt=0.001)
 """
 
 from . import rattle

--- a/hoomd/md/methods/__init__.py
+++ b/hoomd/md/methods/__init__.py
@@ -15,21 +15,6 @@ Thermostatted methods require usage of a thermostat, see
 .. rubric:: Integration methods with constraints
 
 For methods that constrain motion to a manifold see `hoomd.md.methods.rattle`.
-
-.. rubric:: Preparation
-
-Create a `hoomd.md.Integrator` to accept an integration method (or methods):
-
-.. code-block:: python
-
-    simulation = hoomd.util.make_example_simulation()
-    simulation.operations.integrator = hoomd.md.Integrator(dt=0.001)
-
-Create a `hoomd.logging.Logger` that will be used in the examples below:
-
-.. code-block:: python
-
-    logger = hoomd.logging.Logger()
 """
 
 from . import rattle

--- a/hoomd/md/methods/__init__.py
+++ b/hoomd/md/methods/__init__.py
@@ -24,6 +24,12 @@ Create a `hoomd.md.Integrator` to accept an integration method (or methods):
 
     simulation = hoomd.util.make_example_simulation()
     simulation.operations.integrator = hoomd.md.Integrator(dt=0.001)
+
+Create a `hoomd.logging.Logger` that will be used in the examples below:
+
+.. code-block:: python
+
+    logger = hoomd.logging.Logger()
 """
 
 from . import rattle

--- a/hoomd/md/methods/methods.py
+++ b/hoomd/md/methods/methods.py
@@ -9,7 +9,7 @@
     simulation.operations.integrator = hoomd.md.Integrator(dt=0.001)
     logger = hoomd.logging.Logger()
 
-    # Rename tmp_path to path to avoid giving the users the wrong signal.
+    # Rename pytest's tmp_path fixture for clarity in the documentation.
     path = tmp_path
 """
 

--- a/hoomd/md/methods/methods.py
+++ b/hoomd/md/methods/methods.py
@@ -7,6 +7,7 @@
 
     simulation = hoomd.util.make_example_simulation()
     simulation.operations.integrator = hoomd.md.Integrator(dt=0.001)
+    logger = hoomd.logging.Logger()
 """
 
 from hoomd.md import _md
@@ -123,6 +124,16 @@ class ConstantVolume(Thermostatted):
 
         thermostat (hoomd.md.methods.thermostats.Thermostat): Temperature
             control for the integrator.
+
+            .. rubric:: Examples:
+
+            .. code-block:: python
+
+                nvt.thermostat.kT = 1.0
+
+            .. code-block:: python
+
+                nvt.thermostat = hoomd.md.methods.thermostats.Bussi(kT=0.5)
 
     .. _Kamberaj 2005: http://dx.doi.org/10.1063/1.1906216
     """
@@ -287,7 +298,7 @@ class ConstantPressure(Thermostatted):
         Set `gamma` = 0 to obtain the same MTK equations of motion used in
         HOOMD-blue releases prior to 4.0.0.
 
-    .. rubric:: Examples
+    .. rubric:: Examples:
 
     NPH integrator with cubic symmetry:
 
@@ -363,6 +374,8 @@ class ConstantPressure(Thermostatted):
             :math:`[S_{xx}, S_{yy}, S_{zz}, S_{yz}, S_{xz}, S_{xy}]`
             :math:`[\mathrm{pressure}]`.
 
+            .. rubric:: Examples:
+
             .. code-block:: python
 
                 npt.S = 4.0
@@ -377,12 +390,16 @@ class ConstantPressure(Thermostatted):
         tauS (float): Coupling constant for the barostat
             :math:`[\mathrm{time}]`.
 
+            .. rubric:: Example:
+
             .. code-block:: python
 
                 npt.tauS = 2.0
 
         couple (str): Couplings of diagonal elements of the stress tensor,
             can be 'none', 'xy', 'xz', 'yz', or 'xyz'.
+
+            .. rubric:: Example:
 
             .. code-block:: python
 
@@ -391,12 +408,16 @@ class ConstantPressure(Thermostatted):
         box_dof(list[bool]): Box degrees of freedom with six boolean elements in
             the order [x, y, z, xy, xz, yz].
 
+            .. rubric:: Example:
+
             .. code-block:: python
 
                 npt.box_dof = [False, False, True, False, False, False]
 
         rescale_all (bool): When True, rescale all particles, not only those
             selected by the filter.
+
+            .. rubric:: Example:
 
             .. code-block:: python
 
@@ -412,6 +433,8 @@ class ConstantPressure(Thermostatted):
 
             Save and restore the barostat degrees of freedom when continuing
             simulations:
+
+            .. rubric:: Examples:
 
             .. code-block:: python
 
@@ -531,7 +554,14 @@ class ConstantPressure(Thermostatted):
     @hoomd.logging.log(requires_run=True)
     def barostat_energy(self):
         """Energy the barostat contributes to the Hamiltonian \
-        :math:`[\\mathrm{energy}]`."""
+        :math:`[\\mathrm{energy}]`.
+
+        .. rubric:: Example:
+
+        .. code-block:: python
+
+            logger.add(obj=npt, quantities=['barostat_energy'])
+        """
         return self._cpp_obj.getBarostatEnergy(self._simulation.timestep)
 
 
@@ -555,7 +585,7 @@ class DisplacementCapped(ConstantVolume):
     degrees of freedom using modified microcanoncial dynamics. See `NVE` for the
     basis of the algorithm.
 
-    .. rubric:: Example
+    .. rubric:: Example:
 
     .. code-block:: python
 
@@ -658,7 +688,7 @@ class Langevin(Method):
     The attributes `gamma` and `gamma_r` set the translational and rotational
     damping coefficients, respectivley, by particle type.
 
-    .. rubric:: Example
+    .. rubric:: Example:
 
     .. code-block:: python
 
@@ -674,6 +704,8 @@ class Langevin(Method):
         kT (hoomd.variant.Variant): Temperature of the
             simulation :math:`[\mathrm{energy}]`.
 
+            .. rubric:: Examples:
+
             .. code-block:: python
 
                 langevin.kT = 1.0
@@ -688,6 +720,8 @@ class Langevin(Method):
         tally_reservoir_energy (bool): When True, track the energy exchange
             between the thermal reservoir and the particles.
 
+            .. rubric:: Example:
+
             .. code-block:: python
 
                 langevin.tally_reservoir_energy = True
@@ -696,6 +730,8 @@ class Langevin(Method):
             coefficient for each particle type
             :math:`[\mathrm{mass} \cdot \mathrm{time}^{-1}]`.
 
+            .. rubric:: Example:
+
             .. code-block:: python
 
                 langevin.gamma['A'] = 0.5
@@ -703,6 +739,8 @@ class Langevin(Method):
         gamma_r (TypeParameter[``particle type``,[`float`, `float` , `float`]]):
             The rotational drag coefficient tensor for each particle type
             :math:`[\mathrm{time}^{-1}]`.
+
+            .. rubric:: Example:
 
             .. code-block:: python
 
@@ -762,6 +800,13 @@ class Langevin(Method):
         """Energy absorbed by the reservoir :math:`[\\mathrm{energy}]`.
 
         Set `tally_reservoir_energy` to `True` to track the reservoir energy.
+
+        .. rubric:: Example:
+
+        .. code-block:: python
+
+            langevin.tally_reservoir_energy = True
+            logger.add(obj=langevin, quantities=['reservoir_energy'])
 
         Warning:
             When continuing a simulation, the energy of the reservoir will be
@@ -864,7 +909,7 @@ class Brownian(Method):
     The attributes `gamma` and `gamma_r` set the translational and rotational
     damping coefficients, respectivley, by particle type.
 
-    .. rubric:: Example
+    .. rubric:: Example:
 
     .. code-block:: python
 
@@ -878,6 +923,8 @@ class Brownian(Method):
 
         kT (hoomd.variant.Variant): Temperature of the simulation
             :math:`[\mathrm{energy}]`.
+
+            .. rubric:: Examples:
 
             .. code-block:: python
 
@@ -894,6 +941,8 @@ class Brownian(Method):
             coefficient for each particle type
             :math:`[\mathrm{mass} \cdot \mathrm{time}^{-1}]`.
 
+            .. rubric:: Example:
+
             .. code-block:: python
 
                 brownian.gamma['A'] = 0.5
@@ -901,6 +950,8 @@ class Brownian(Method):
         gamma_r (TypeParameter[``particle type``,[`float`, `float` , `float`]]):
             The rotational drag coefficient tensor for each particle type
             :math:`[\mathrm{time}^{-1}]`.
+
+            .. rubric:: Example:
 
             .. code-block:: python
 
@@ -1012,7 +1063,7 @@ class OverdampedViscous(Method):
         non-zero moments of inertia to enable the integration of rotational
         degrees of freedom.
 
-    .. rubric:: Example
+    .. rubric:: Example:
 
     .. code-block:: python
 
@@ -1028,6 +1079,8 @@ class OverdampedViscous(Method):
             coefficient for each particle type
             :math:`[\mathrm{mass} \cdot \mathrm{time}^{-1}]`.
 
+            .. rubric:: Example:
+
             .. code-block:: python
 
                 overdamped_viscous.gamma['A'] = 0.5
@@ -1036,6 +1089,8 @@ class OverdampedViscous(Method):
         gamma_r (TypeParameter[``particle type``,[`float`, `float` , `float`]]):
             The rotational drag coefficient tensor for each particle type
             :math:`[\mathrm{time}^{-1}]`.
+
+            .. rubric:: Example:
 
             .. code-block:: python
 

--- a/hoomd/md/methods/methods.py
+++ b/hoomd/md/methods/methods.py
@@ -850,7 +850,7 @@ class Brownian(Method):
     Warning:
 
         This numerical method has errors in :math:`O(\delta t)`, which is much
-        larger than the errors of the other integration methods which are in
+        larger than the errors of most other integration methods which are in
         :math:`O(\delta t^2)`. As a consequence, expect to use much smaller
         values of :math:`\delta t` with `Brownian` compared to e.g. `Langevin`
         or `ConstantVolume`.
@@ -986,30 +986,39 @@ class OverdampedViscous(Method):
     where :math:`\vec{F}_\mathrm{C} = \vec{F}_\mathrm{net}` is the net force on
     the particle from all forces (`hoomd.md.Integrator.forces`) and constraints
     (`hoomd.md.Integrator.constraints`), :math:`\gamma` is the translational
-    drag coefficient (`gamma`) :math:`\vec{v}` is the particle's velocity,
-    :math:`d` is the dimensionality of the system, :math:`\tau_\mathrm{C}^i` is
-    the i-th component of the net torque from all forces and constraints, and
-    :math:`\gamma_r^i` is the i-th component of the rotational drag coefficient
-    (`gamma_r`).
+    drag coefficient (`gamma`), :math:`\vec{v}` is the particle's velocity,
+    :math:`\tau_\mathrm{C}^i` is the i-th component of the net torque from all
+    forces and constraints, and :math:`\gamma_r^i` is the i-th component of the
+    rotational drag coefficient (`gamma_r`).
 
     The attributes `gamma` and `gamma_r` set the translational and rotational
     damping coefficients, respectivley, by particle type.
 
+    Warning:
+
+        This numerical method has errors in :math:`O(\delta t)`, which is much
+        larger than the errors of most other integration methods which are in
+        :math:`O(\delta t^2)`. As a consequence, expect to use much smaller
+        values of :math:`\delta t` with `Brownian` compared to e.g. `Langevin`
+        or `ConstantVolume`.
+
     Tip:
         `OverdampedViscous` can be used to simulate systems of athermal active
-        matter, such as athermal Active Brownian Particles.
+        matter.
 
     Note:
-        Even though `OverdampedViscous` models systems in the limit that
-        :math:`m` and moment of inertia :math:`I` go to 0, you must still set
+        `OverdampedViscous` models systems in the limit that :math:`m` and
+        moment of inertia :math:`I` go to 0. However, you must still set
         non-zero moments of inertia to enable the integration of rotational
         degrees of freedom.
 
-    Examples::
+    .. rubric:: Example
 
-        odv = hoomd.md.methods.OverdampedViscous(filter=hoomd.filter.All())
-        odv.gamma.default = 2.0
-        odv.gamma_r.default = [1.0, 2.0, 3.0]
+    .. code-block:: python
+
+        overdamped_viscous = hoomd.md.methods.OverdampedViscous(
+            filter=hoomd.filter.All())
+        simulation.operations.integrator.methods = [overdamped_viscous]
 
     Attributes:
         filter (hoomd.filter.filter_like): Subset of particles to apply this
@@ -1019,9 +1028,18 @@ class OverdampedViscous(Method):
             coefficient for each particle type
             :math:`[\mathrm{mass} \cdot \mathrm{time}^{-1}]`.
 
+            .. code-block:: python
+
+                overdamped_viscous.gamma['A'] = 0.5
+
+
         gamma_r (TypeParameter[``particle type``,[`float`, `float` , `float`]]):
             The rotational drag coefficient tensor for each particle type
             :math:`[\mathrm{time}^{-1}]`.
+
+            .. code-block:: python
+
+                overdamped_viscous.gamma_r['A'] = [1.0, 2.0, 3.0]
     """
 
     def __init__(

--- a/hoomd/md/methods/methods.py
+++ b/hoomd/md/methods/methods.py
@@ -86,15 +86,15 @@ class ConstantVolume(Thermostatted):
 
         thermostat (hoomd.md.methods.thermostats.Thermostat): Thermostat to
             control temperature. Setting this to ``None`` yields constant energy
-            (NVE) dynamics. Defaults to ``None``.
+            (NVE, microcanonical) dynamics. Defaults to ``None``.
 
     `ConstantVolume` numerically integrates the translational degrees of freedom
     using Velocity-Verlet and the rotational degrees of freedom with a scheme
     based on `Kamberaj 2005`_.
 
-    When set, the `thermostat` rescales the particle velocities to model an
-    isothermal ensemble. Use no thermostat (``thermostat = None``) to perform
-    constant energy integration.
+    When set, the `thermostat` rescales the particle velocities to model a
+    canonical (NVT) ensemble. Use no thermostat (``thermostat = None``) to
+    perform constant energy integration.
 
     See Also:
         `hoomd.md.methods.thermostats`.
@@ -200,8 +200,8 @@ class ConstantPressure(Thermostatted):
     freedom of the system held at constant pressure with a barostat. The
     barostat introduces additional degrees of freedom in the Hamiltonian that
     couple with box parameters. Use a thermostat to model an isothermal-isobaric
-    ensemble. Use no thermostat (``thermostat = None``) to model a
-    isoenthalpic-isobaric ensemble.
+    (NPT) ensemble. Use no thermostat (``thermostat = None``) to model a
+    isoenthalpic-isobaric (NPH) ensemble.
 
     See Also:
         `hoomd.md.methods.thermostats`.
@@ -538,9 +538,8 @@ class ConstantPressure(Thermostatted):
 class DisplacementCapped(ConstantVolume):
     r"""Newtonian dynamics with a cap on the maximum displacement per time step.
 
-    The method employs a maximum displacement allowed each time step. This
-    method can be helpful to relax a system with too much overlaps without
-    "blowing up" the system.
+    The method limits particle motion to a maximum displacement allowed each
+    time step which may be helpful to relax a high energy initial condition.
 
     Warning:
         This method does not conserve energy or momentum.
@@ -556,19 +555,26 @@ class DisplacementCapped(ConstantVolume):
     degrees of freedom using modified microcanoncial dynamics. See `NVE` for the
     basis of the algorithm.
 
-    Examples::
+    .. rubric:: Example
 
-        relaxer = hoomd.md.methods.DisplacementCapped(
-            filter=hoomd.filter.All(), maximum_displacement=1e-3)
-        integrator = hoomd.md.Integrator(
-            dt=0.005, methods=[relaxer], forces=[lj])
+    .. code-block:: python
+
+        displacement_capped = hoomd.md.methods.DisplacementCapped(
+            filter=hoomd.filter.All(),
+            maximum_displacement=1e-3)
+        simulation.operations.integrator.methods = [displacement_capped]
 
     Attributes:
         filter (hoomd.filter.filter_like): Subset of particles on which to
             apply this method.
+
         maximum_displacement (hoomd.variant.variant_like): The maximum
             displacement allowed for a particular timestep
             :math:`[\mathrm{length}]`.
+
+            .. code-block:: python
+
+                displacement_capped.maximum_displacement = 1e-5
     """
 
     def __init__(self, filter,

--- a/hoomd/md/methods/methods.py
+++ b/hoomd/md/methods/methods.py
@@ -89,8 +89,8 @@ class ConstantVolume(Thermostatted):
             apply this method.
 
         thermostat (hoomd.md.methods.thermostats.Thermostat): Thermostat to
-            control temperature. Setting this to ``None`` yields constant energy
-            (NVE, microcanonical) dynamics. Defaults to ``None``.
+            control temperature. Setting this to ``None`` samples a constant
+            energy (NVE, microcanonical) dynamics. Defaults to ``None``.
 
     `ConstantVolume` numerically integrates the translational degrees of freedom
     using Velocity-Verlet and the rotational degrees of freedom with a scheme
@@ -181,7 +181,7 @@ class ConstantPressure(Thermostatted):
             this method.
 
         thermostat (hoomd.md.methods.thermostats.Thermostat): Thermostat to
-            control temperature. Setting this to ``None`` yields constant
+            control temperature. Setting this to ``None`` samples a constant
             enthalpy (NPH) integration.
 
         S (tuple[variant.variant_like, ...] or variant.variant_like):
@@ -928,7 +928,6 @@ class Brownian(Method):
     .. code-block:: python
 
         brownian = hoomd.md.methods.Brownian(filter=hoomd.filter.All(), kT=1.5)
-        simulation.operations.integrator.dt = 0.0001
         simulation.operations.integrator.methods = [brownian]
 
     Attributes:

--- a/hoomd/md/methods/methods.py
+++ b/hoomd/md/methods/methods.py
@@ -8,6 +8,9 @@
     simulation = hoomd.util.make_example_simulation()
     simulation.operations.integrator = hoomd.md.Integrator(dt=0.001)
     logger = hoomd.logging.Logger()
+
+    # Rename tmp_path to path to avoid giving the users the wrong signal.
+    path = tmp_path
 """
 
 from hoomd.md import _md
@@ -436,15 +439,26 @@ class ConstantPressure(Thermostatted):
 
             .. rubric:: Examples:
 
-            .. code-block:: python
-
-                saved_barostat_dof = npt.barostat_dof
-                # Save to a file.
+            Save before exiting:
 
             .. code-block:: python
 
-                # Load from the file on next execution.
-                npt.barostat_dof = saved_barostat_dof
+                numpy.save(file=path / 'barostat_dof.npy',
+                           arr=npt.barostat_dof)
+
+            Load when continuing:
+
+            .. code-block:: python
+
+                npt = hoomd.md.methods.ConstantPressure(
+                    filter=hoomd.filter.All(),
+                    tauS=1.0,
+                    S=2.0,
+                    couple="xyz",
+                    thermostat=hoomd.md.methods.thermostats.Bussi(kT=1.5))
+                simulation.operations.integrator.methods = [npt]
+
+                npt.barostat_dof = numpy.load(file=path / 'barostat_dof.npy')
     """
 
     def __init__(self,

--- a/hoomd/md/methods/methods.py
+++ b/hoomd/md/methods/methods.py
@@ -78,45 +78,51 @@ class Thermostatted(Method):
 
 
 class ConstantVolume(Thermostatted):
-    r"""Constant volume, constant temperature dynamics.
+    r"""Constant volume dynamics.
 
     Args:
         filter (hoomd.filter.filter_like): Subset of particles on which to
             apply this method.
 
-        thermostat (hoomd.md.methods.thermostats.Thermostat): thermostat use do
-            to control temperature. Setting this to ``None`` produces NVE
-            dynamics. Defaults to ``None``
+        thermostat (hoomd.md.methods.thermostats.Thermostat): Thermostat to
+            control temperature. Setting this to ``None`` yields constant energy
+            (NVE) dynamics. Defaults to ``None``.
 
-    `ConstantVolume` `Langevin` numerically integrates the translational degrees
-    of freedom using Velocity-Verlet and the rotational degrees of freedom with
-    a scheme based on `Kamberaj 2005`_.
+    `ConstantVolume` numerically integrates the translational degrees of freedom
+    using Velocity-Verlet and the rotational degrees of freedom with a scheme
+    based on `Kamberaj 2005`_.
 
-    When set, the `thermostat` rescales the particle velocities to control the
-    temperature of the system. When `thermostat` = `None`, perform constant
-    energy integration.
+    When set, the `thermostat` rescales the particle velocities to model an
+    isothermal ensemble. Use no thermostat (``thermostat = None``) to perform
+    constant energy integration.
 
     See Also:
-        `hoomd.md.methods.thermostats` for the available thermostats.
+        `hoomd.md.methods.thermostats`.
 
-    Examples::
+    .. rubric Examples
 
-        # NVE integration
+    NVE integration:
+
+    .. code-block:: python
+
         nve = hoomd.md.methods.ConstantVolume(filter=hoomd.filter.All())
-        integrator = hoomd.md.Integrator(dt=0.005, methods=[nve], forces=[lj])
+        simulation.operations.integrator.methods = [nve]
 
-        # NVT integration using Bussi thermostat
-        bussi = hoomd.md.methods.thermostats.Bussi(kT=1.0)
-        nvt = hoomd.md.methods.ConstantVolume(filter=hoomd.filter.All(),
-                                            thermostat=bussi)
-        integrator = hoomd.md.Integrator(dt=0.005, methods=[nvt], forces=[lj])
+    NVT integration:
+
+    .. code-block:: python
+
+        nvt = hoomd.md.methods.ConstantVolume(
+            filter=hoomd.filter.All(),
+            thermostat=hoomd.md.methods.thermostats.Bussi(kT=1.5))
+        simulation.operations.integrator.methods = [nvt]
 
     Attributes:
         filter (hoomd.filter.filter_like): Subset of particles on which to apply
             this method.
 
         thermostat (hoomd.md.methods.thermostats.Thermostat): Temperature
-            control for the integrator
+            control for the integrator.
 
     .. _Kamberaj 2005: http://dx.doi.org/10.1063/1.1906216
     """
@@ -160,7 +166,7 @@ class ConstantPressure(Thermostatted):
         filter (hoomd.filter.filter_like): Subset of particles on which to apply
             this method.
 
-        thermostat (hoomd.md.methods.thermostats.Thermostat): Thermostat used to
+        thermostat (hoomd.md.methods.thermostats.Thermostat): Thermostat to
             control temperature. Setting this to ``None`` yields constant
             enthalpy (NPH) integration.
 
@@ -194,11 +200,11 @@ class ConstantPressure(Thermostatted):
     freedom of the system held at constant pressure with a barostat. The
     barostat introduces additional degrees of freedom in the Hamiltonian that
     couple with box parameters. Use a thermostat to model an isothermal-isobaric
-    ensemble. Use no thermostat (`thermostat` = `None`) to model a
+    ensemble. Use no thermostat (``thermostat = None``) to model a
     isoenthalpic-isobaric ensemble.
 
     See Also:
-        `hoomd.md.methods.thermostats` for the available thermostats.
+        `hoomd.md.methods.thermostats`.
 
     The barostat tensor is :math:`\nu_{\mathrm{ij}}`. Access these quantities
     using `barostat_dof`.

--- a/hoomd/md/methods/thermostats.py
+++ b/hoomd/md/methods/thermostats.py
@@ -31,7 +31,7 @@ Important:
 
 .. invisible-code-block: python
 
-    # Rename tmp_path to path to avoid giving the users the wrong signal.
+    # Rename pytest's tmp_path fixture for clarity in the documentation.
     path = tmp_path
 
     logger = hoomd.logging.Logger()

--- a/hoomd/md/methods/thermostats.py
+++ b/hoomd/md/methods/thermostats.py
@@ -39,6 +39,11 @@ Important:
         simulation.state.thermalize_particle_momenta(
             filter=hoomd.filter.All(),
             kT=1.5)
+
+.. invisible-code-block: python
+
+    # Rename tmp_path to path to avoid giving the users the wrong signal.
+    path = tmp_path
 """
 
 from hoomd.md import _md
@@ -143,15 +148,24 @@ class MTTK(Thermostat):
 
             .. rubric:: Examples:
 
-            .. code-block:: python
-
-                saved_translational_dof = mttk.translational_dof
-                # Save to a file.
+            Save before exiting:
 
             .. code-block:: python
 
-                # Load from the file on next execution.
-                mttk.translational_dof = saved_translational_dof
+                numpy.save(file=path / 'translational_dof.npy',
+                           arr=mttk.translational_dof)
+
+            Load when continuing:
+
+            .. code-block:: python
+
+                mttk = hoomd.md.methods.thermostats.MTTK(kT=1.5,
+                    tau=simulation.operations.integrator.dt*100)
+                simulation.operations.integrator.methods[0].thermostat = mttk
+
+                mttk.translational_dof = numpy.load(
+                    file=path / 'translational_dof.npy')
+
 
         rotational_dof (tuple[float, float]): Additional degrees
             of freedom for the rotational thermostat (:math:`\xi_\mathrm{rot}`,
@@ -162,15 +176,23 @@ class MTTK(Thermostat):
 
             .. rubric:: Examples:
 
-            .. code-block:: python
-
-                saved_rotational_dof = mttk.rotational_dof
-                # Save to a file.
+            Save before exiting:
 
             .. code-block:: python
 
-                # Load from the file on next execution.
-                mttk.rotational_dof = saved_rotational_dof
+                numpy.save(file=path / 'rotational_dof.npy',
+                           arr=mttk.rotational_dof)
+
+            Load when continuing:
+
+            .. code-block:: python
+
+                mttk = hoomd.md.methods.thermostats.MTTK(kT=1.5,
+                    tau=simulation.operations.integrator.dt*100)
+                simulation.operations.integrator.methods[0].thermostat = mttk
+
+                mttk.rotational_dof = numpy.load(
+                    file=path / 'rotational_dof.npy')
     """
 
     def __init__(self, kT, tau):

--- a/hoomd/md/methods/thermostats.py
+++ b/hoomd/md/methods/thermostats.py
@@ -302,23 +302,36 @@ class Berendsen(Thermostat):
         \frac{dT_\mathrm{cur}}{dt} = \frac{T - T_\mathrm{cur}}{\tau}
 
     .. attention::
-        `Berendsen` does not yield a proper canonical ensemble
+        `Berendsen` does **NOT** sample the correct distribution of kinetic
+        energies.
 
     See Also:
         `Berendsen et. al. 1984 <http://dx.doi.org/10.1063/1.448118>`_.
 
-    Example::
+    .. rubric:: Example:
 
-        # NVT integration using Berendsen thermostat
-        dt = 0.005
-        berendsen = hoomd.md.methods.thermostats.Berendsen(kT=1.0, tau=dt*100)
-        nvt = hoomd.md.methods.ConstantVolume(filter=hoomd.filter.All(),
-                                            thermostat=berendsen)
-        integrator = hoomd.md.Integrator(dt=dt, methods=[nvt])
+    .. code-block:: python
+
+        berendsen = hoomd.md.methods.thermostats.Berendsen(kT=1.5,
+            tau=simulation.operations.integrator.dt * 10_000)
+        simulation.operations.integrator.methods[0].thermostat = berendsen
 
     Attributes:
         kT (hoomd.variant.variant_like): Temperature of the simulation.
             :math:`[energy]`
+
+            .. rubric:: Examples:
+
+            .. code-block:: python
+
+                berendsen.kT = 1.0
+
+            .. code-block:: python
+
+                berendsen.kT = hoomd.variant.Ramp(A=1.0,
+                                                  B=2.0,
+                                                  t_start=0,
+                                                  t_ramp=1_000_000)
 
         tau (float): Time constant of thermostat. :math:`[time]`
     """

--- a/hoomd/md/methods/thermostats.py
+++ b/hoomd/md/methods/thermostats.py
@@ -6,24 +6,13 @@
 The thermostat classes are for use with `hoomd.md.methods.ConstantVolume` and
 `hoomd.md.methods.ConstantPressure`.
 
-.. rubric:: Preparation
-
-Create a `hoomd.md.Integrator` and `hoomd.md.methods.ConstantVolume` (for
-example) to accept the thermostats:
-
-.. code-block:: python
+.. invisible-code-block: python
 
     simulation = hoomd.util.make_example_simulation()
     constant_volume = hoomd.md.methods.ConstantVolume(filter=hoomd.filter.All())
     simulation.operations.integrator = hoomd.md.Integrator(
         dt=0.001,
         methods=[constant_volume])
-
-Create a `hoomd.logging.Logger` that will be used in the examples below:
-
-.. code-block:: python
-
-    logger = hoomd.logging.Logger()
 
 Important:
     Ensure that your initial condition includes non-zero particle velocities and
@@ -44,6 +33,8 @@ Important:
 
     # Rename tmp_path to path to avoid giving the users the wrong signal.
     path = tmp_path
+
+    logger = hoomd.logging.Logger()
 """
 
 from hoomd.md import _md

--- a/hoomd/md/methods/thermostats.py
+++ b/hoomd/md/methods/thermostats.py
@@ -106,7 +106,7 @@ class MTTK(Thermostat):
 
         mttk = hoomd.md.methods.thermostats.MTTK(kT=1.5,
             tau=simulation.operations.integrator.dt*100)
-        constant_volume.thermostat = mttk
+        simulation.operations.integrator.methods[0].thermostat = mttk
 
     Attributes:
         kT (hoomd.variant.variant_like): Temperature set point for the
@@ -249,17 +249,29 @@ class Bussi(Thermostat):
     See Also:
         `Bussi et. al. 2007 <https://doi.org/10.1063/1.2408420>`_.
 
-    Example::
+    .. rubric:: Example:
 
-        # NVT integration using Bussi thermostat
-        bussi = hoomd.md.methods.thermostats.Bussi(kT=1.0)
-        nvt = hoomd.md.methods.ConstantVolume(filter=hoomd.filter.All(),
-                                            thermostat=bussi)
-        integrator = hoomd.md.Integrator(dt=0.005, methods=[nvt])
+    .. code-block:: python
+
+        bussi = hoomd.md.methods.thermostats.Bussi(kT=1.5)
+        simulation.operations.integrator.methods[0].thermostat = bussi
 
     Attributes:
         kT (hoomd.variant.variant_like): Temperature set point
             for the thermostat :math:`[\mathrm{energy}]`.
+
+            .. rubric:: Examples:
+
+            .. code-block:: python
+
+                bussi.kT = 1.0
+
+            .. code-block:: python
+
+                bussi.kT = hoomd.variant.Ramp(A=1.0,
+                                              B=2.0,
+                                              t_start=0,
+                                              t_ramp=1_000_000)
     """
 
     def __init__(self, kT):

--- a/hoomd/pytest/test_logging.py
+++ b/hoomd/pytest/test_logging.py
@@ -6,7 +6,7 @@ from pytest import raises, fixture, mark
 from hoomd.logging import (_LoggerQuantity, _NamespaceFilter,
                            _SafeNamespaceDict, Logger, Loggable,
                            LoggerCategories, log)
-from hoomd.util import dict_map
+from hoomd.util import _dict_map
 
 
 class DummyNamespace:
@@ -170,7 +170,7 @@ def test_dict_map(base_dict, expected_mapped_dict):
     def func(x):
         return 1
 
-    mapped_dict = dict_map(base_dict, func)
+    mapped_dict = _dict_map(base_dict, func)
     assert mapped_dict == expected_mapped_dict
 
 

--- a/hoomd/write/gsd.py
+++ b/hoomd/write/gsd.py
@@ -6,7 +6,7 @@
 from collections.abc import Mapping, Collection
 from hoomd.trigger import Periodic
 from hoomd import _hoomd
-from hoomd.util import dict_flatten
+from hoomd.util import _dict_flatten
 from hoomd.data.typeconverter import OnlyFrom, RequiredArg
 from hoomd.filter import ParticleFilter, All
 from hoomd.data.parameterdicts import ParameterDict
@@ -360,7 +360,7 @@ class _GSDLogWriter:
     def log(self):
         """Get the flattened dictionary for consumption by GSD object."""
         log = dict()
-        for key, value in dict_flatten(self.logger.log()).items():
+        for key, value in _dict_flatten(self.logger.log()).items():
             if 'state' in key and _iterable_is_incomplete(value[0]):
                 pass
             log_value, type_category = value

--- a/hoomd/write/table.py
+++ b/hoomd/write/table.py
@@ -14,7 +14,7 @@ from hoomd.custom.custom_action import _InternalAction
 from hoomd.logging import LoggerCategories, Logger
 from hoomd.data.parameterdicts import ParameterDict
 from hoomd.data.typeconverter import OnlyTypes
-from hoomd.util import dict_flatten
+from hoomd.util import _dict_flatten
 from hoomd.custom import Action
 
 
@@ -241,7 +241,7 @@ class _TableInternal(_InternalAction):
         """Get a flattened dict for writing to output."""
         return {
             key: value[0]
-            for key, value in dict_flatten(self.logger.log()).items()
+            for key, value in _dict_flatten(self.logger.log()).items()
         }
 
     def _update_headers(self, new_keys):

--- a/sphinx-doc/module-hoomd-util.rst
+++ b/sphinx-doc/module-hoomd-util.rst
@@ -1,0 +1,30 @@
+.. Copyright (c) 2009-2023 The Regents of the University of Michigan.
+.. Part of HOOMD-blue, released under the BSD 3-Clause License.
+
+hoomd.util
+----------
+
+.. py:currentmodule:: hoomd.util
+
+.. rubric:: Overview
+
+.. autosummary::
+    :nosignatures:
+
+    GPUNotAvailableError
+    dict_filter
+    dict_flatten
+    dict_fold
+    dict_map
+    make_example_simulation
+
+.. rubric:: Details
+
+.. automodule:: hoomd.util
+    :synopsis: Utilities
+    :members: GPUNotAvailableError,
+              dict_filter,
+              dict_flatten,
+              dict_fold,
+              dict_map,
+              make_example_simulation

--- a/sphinx-doc/module-hoomd-util.rst
+++ b/sphinx-doc/module-hoomd-util.rst
@@ -12,10 +12,6 @@ hoomd.util
     :nosignatures:
 
     GPUNotAvailableError
-    dict_filter
-    dict_flatten
-    dict_fold
-    dict_map
     make_example_simulation
 
 .. rubric:: Details
@@ -23,8 +19,4 @@ hoomd.util
 .. automodule:: hoomd.util
     :synopsis: Utilities
     :members: GPUNotAvailableError,
-              dict_filter,
-              dict_flatten,
-              dict_fold,
-              dict_map,
               make_example_simulation

--- a/sphinx-doc/module-md-methods.rst
+++ b/sphinx-doc/module-md-methods.rst
@@ -37,7 +37,7 @@ md.methods
 .. rubric:: Modules
 
 .. toctree::
-   :maxdepth: 3
+   :maxdepth: 1
 
    module-md-methods-thermostats
    module-md-methods-rattle

--- a/sphinx-doc/package-hoomd.rst
+++ b/sphinx-doc/package-hoomd.rst
@@ -47,6 +47,7 @@ hoomd
    module-hoomd-triggers
    module-hoomd-tune
    module-hoomd-update
+   module-hoomd-util
    module-hoomd-variant
    module-hoomd-version
    module-hoomd-wall

--- a/sphinx-doc/style.rst
+++ b/sphinx-doc/style.rst
@@ -49,7 +49,8 @@ Documentation
 
 Python code should be documented with docstrings and added to the Sphinx
 documentation index in ``doc/``. Docstrings should follow `Google style`_
-formatting for use in `Napoleon`_.
+formatting for use in `Napoleon`_, with explicit Sphinx directives where necessary to obtain the
+proper formatting in the final HTML output.
 
 .. _Google Style: https://www.sphinx-doc.org/en/master/usage/extensions/example_google.html#example-google
 .. _Napoleon: https://www.sphinx-doc.org/en/master/usage/extensions/napoleon.html
@@ -63,6 +64,19 @@ When referencing classes, methods, and properties in documentation, use ``name``
 in the local scope (class method or property, or classes in the same module). For classes outside
 the module, use the fully qualified name (e.g. ``numpy.ndarray`` or
 ``hoomd.md.compute.ThermodynamicQuantities``).
+
+Provide code examples for all classes, methods, properties, etc... as appropriate. To the best
+extent possible, structure the example so that a majority of users can copy and paste the example
+into their script and set parameters to values reasonable for a wide range of simulations.
+Add files with your examples in the Sybil configuration in ``conftest.py`` and Sybil will test
+them. Document examples in this format so Sybil will parse them::
+
+    .. rubric:: Example:
+
+    .. code-block:: python
+
+        obj = MyObject(parameters ...)
+        ... more example code ...
 
 C++/CUDA
 --------

--- a/sphinx-doc/testing.rst
+++ b/sphinx-doc/testing.rst
@@ -32,11 +32,19 @@ Requirements
 The following Python packages are required to execute tests. Some tests will be skipped when
 optional requirements are missing.
 
-- gsd (optional)
-- mpi4py (optional)
-- pytest
-- rowan (optional)
-- CuPy (optional)
+- `CuPy`_ (optional)
+- `gsd`_ (optional)
+- `mpi4py`_ (optional)
+- `pytest`_
+- `rowan`_ (optional)
+- `sybil`_
+
+.. _CuPy: https://cupy.dev/
+.. _gsd: https://gsd.readthedocs.io/
+.. _mpi4py: https://mpi4py.readthedocs.io/
+.. _pytest: https://docs.pytest.org/
+.. _rowan: https://rowan.readthedocs.io/
+.. _sybil: https://sybil.readthedocs.io/
 
 Running tests
 -------------


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should be based on *trunk-patch*. -->
<!-- Backwards compatible new features should be based on *trunk-minor*. -->
<!-- Incompatible API changes should be based on *trunk-major*. -->

## Description

<!-- Describe your changes in detail. -->
Add Sybil documentation example tests to `methods.py` and `thermostats.py`.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Users wish to copy and paste example code from the documentation. Sybil tests those snippets to ensure that they work now and in the future.

These tests currently run both in serial and MPI. That may be helpful. However future examples we write might only work in MPI and/or only in serial (or only on the GPU or only on the CPU). `pytest.skip` works within these blocks, however Sybil generates each code block as a separate test. Users will see the `pytest.skip` logic in tests that need to be skipped in some configurations. If we were to add `pytest.skip` in a hidden code block, it would only skip that block and not the next. The `skip: next if` syntax may be a solution to this, I just found it and have not yet tried it: https://sybil.readthedocs.io/en/latest/rest.html#skipping-examples

In my testing, Sybil only parses ``.. code-block::`` sphinx directives and not literals ``Example::``. This format makes the raw docstring more verbose (for users of ``help()``), but the HTML output is as expected:
```
.. rubric:: Example:

.. code-block:: python

    example code
```

Note that the package-level example code the users sees in `module-md-methods.html` comes from `md/methods/__init__.py`, but the example code that Sybil runs in the namespace of all the MD methods is in `md/methods/methods.py`. This is because `__init__.py` imports from `methods.py` to create a different canonical namespace for the methods while Sybil runs all examples in the context of a document (a single .py file).

This pull request adds documentation for previously undocumented methods in `hoomd.util`. Should these be documented, or should they remain hidden?
* `dict_map`
* `dict_fold`
* `dict_flatten`
* `dict_filter`
* `GPUNotAvailableError`

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
* I have tested this locally and ensured that all code blocks are indeed being tested.
* I have examined the generated html docs and ensured that the formatting is consistent and readable.

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
Added:

* Tested example code snippets in select modules.
* ``hoomd.util.make_example_simulation`` - create an example Simulation object.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
