### PR TITLE
feat: Add __len__ to Burst writer

### DIFF
--- a/hoomd/GSDDequeWriter.cc
+++ b/hoomd/GSDDequeWriter.cc
@@ -74,6 +74,11 @@ int GSDDequeWriter::getMaxQueueSize() const
     return m_queue_size;
     }
 
+size_t GSDDequeWriter::getCurrentQueueSize() const
+    {
+    return m_frame_queue.size();
+    }
+
 void GSDDequeWriter::setMaxQueueSize(int new_max_size)
     {
     m_queue_size = new_max_size;
@@ -107,6 +112,7 @@ void export_GSDDequeWriter(pybind11::module& m)
         .def_property("max_burst_size",
                       &GSDDequeWriter::getMaxQueueSize,
                       &GSDDequeWriter::setMaxQueueSize)
+        .def("__len__", &GSDDequeWriter::getCurrentQueueSize)
         .def("dump", &GSDDequeWriter::dump);
     }
     } // namespace detail

--- a/hoomd/GSDDequeWriter.h
+++ b/hoomd/GSDDequeWriter.h
@@ -36,6 +36,8 @@ class PYBIND11_EXPORT GSDDequeWriter : public GSDDumpWriter
     int getMaxQueueSize() const;
     void setMaxQueueSize(int new_max_size);
 
+    size_t getCurrentQueueSize() const;
+
     protected:
     int m_queue_size;
     std::deque<GSDDumpWriter::GSDFrame> m_frame_queue;

--- a/hoomd/md/pytest/test_burst_writer.py
+++ b/hoomd/md/pytest/test_burst_writer.py
@@ -128,6 +128,23 @@ def test_write_on_start(sim, tmp_path):
         sim.run(0)
 
 
+def test_len(sim, tmp_path):
+    filename = tmp_path / "temporary_test_file.gsd"
+
+    burst_trigger = hoomd.trigger.Periodic(period=2, phase=1)
+    burst_writer = hoomd.write.Burst(trigger=burst_trigger,
+                                     filename=filename,
+                                     mode='wb',
+                                     dynamic=['property', 'momentum'],
+                                     max_burst_size=3,
+                                     write_at_start=True)
+    sim.operations.writers.append(burst_writer)
+    sim.run(8)
+    assert (burst_writer) == 3
+    burst_writer.dump()
+    assert (burst_writer) == 0
+
+
 def test_burst_dump(sim, tmp_path):
     filename = tmp_path / "temporary_test_file.gsd"
 

--- a/hoomd/md/pytest/test_burst_writer.py
+++ b/hoomd/md/pytest/test_burst_writer.py
@@ -140,9 +140,9 @@ def test_len(sim, tmp_path):
                                      write_at_start=True)
     sim.operations.writers.append(burst_writer)
     sim.run(8)
-    assert (burst_writer) == 3
+    assert len(burst_writer) == 3
     burst_writer.dump()
-    assert (burst_writer) == 0
+    assert len(burst_writer) == 0
 
 
 def test_burst_dump(sim, tmp_path):

--- a/hoomd/write/gsd_burst.py
+++ b/hoomd/write/gsd_burst.py
@@ -104,3 +104,9 @@ class Burst(GSD):
         """
         if self._attached:
             self._cpp_obj.dump()
+
+    def __len__(self):
+        """Get the current length of the internal frame buffer."""
+        if self._attached:
+            return len(self._cpp_obj)
+        return 0


### PR DESCRIPTION
## Description
Adds a `__len__` method to `Burst`.

## Motivation and context

This is useful for custom actions which use `Burst`.

## How has this been tested?
Added a new test.

## Change log

<!-- Propose a change log entry. -->
```
``hoomd.write.Burst`` now has a ``__len__`` method.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
