### PR TITLE
Prevent ValueError when importing HOOMD in a non-main thread.

### DIFF
--- a/hoomd/__init__.py
+++ b/hoomd/__init__.py
@@ -104,4 +104,7 @@ sys.excepthook = _hoomd_sys_excepthook
 
 # Install a SIGTERM handler that gracefully exits, allowing open files to flush
 # buffered writes and close.
-signal.signal(signal.SIGTERM, lambda n, f: sys.exit(1))
+try:
+    signal.signal(signal.SIGTERM, lambda n, f: sys.exit(1))
+except ValueError:
+    pass

--- a/hoomd/__init__.py
+++ b/hoomd/__init__.py
@@ -103,7 +103,9 @@ def _hoomd_sys_excepthook(type, value, traceback):
 sys.excepthook = _hoomd_sys_excepthook
 
 # Install a SIGTERM handler that gracefully exits, allowing open files to flush
-# buffered writes and close.
+# buffered writes and close. Catch ValueError and pass as there is no way to
+# determine if this is the main interpreter running the main thread prior to
+# the call.
 try:
     signal.signal(signal.SIGTERM, lambda n, f: sys.exit(1))
 except ValueError:

--- a/hoomd/snapshot.py
+++ b/hoomd/snapshot.py
@@ -43,11 +43,11 @@ class Snapshot:
         communicator (Communicator): MPI communicator to be used when accessing
             the snapshot.
 
-    See `State` and `gsd.hoomd.Snapshot` for detailed documentation on the
+    See `State` and `gsd.hoomd.Frame` for detailed documentation on the
     components of `Snapshot`.
 
     Note:
-        `Snapshot` is duck-type compatible with `gsd.hoomd.Snapshot` except
+        `Snapshot` is duck-type compatible with `gsd.hoomd.Frame` except
         that arrays in `Snapshot` are not assignable. You can edit their
         contents: e.g. ``snapshot.particles.typeid[:] == 0``.
 
@@ -387,7 +387,7 @@ class Snapshot:
 
     @classmethod
     def from_gsd_snapshot(cls, gsd_snap, communicator):
-        """Constructs a `hoomd.Snapshot` from a `gsd.hoomd.Snapshot` object.
+        """Constructs a `hoomd.Snapshot` from a ``gsd.hoomd.Snapshot`` object.
 
         .. deprecated:: 4.0.0
 


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should be based on *trunk-patch*. -->
<!-- Backwards compatible new features should be based on *trunk-minor*. -->
<!-- Incompatible API changes should be based on *trunk-major*. -->

## Description

<!-- Describe your changes in detail. -->

See https://github.com/glotzerlab/gsd/pull/258 for details.

## Change log

<!-- Propose a change log entry. -->
```
*Fixed:*

* Prevent ``ValueError: signal only works in main thread of the main interpreter`` when importing
  gsd in a non-main thread.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
