### PR TITLE
Improve conda-forge installation documentation.

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -12,6 +12,8 @@ values =
 	beta
 	rc
 
+[bumpversion:file:INSTALLING.rst]
+
 [bumpversion:file:BUILDING.rst]
 
 [bumpversion:file:CMakeLists.txt]

--- a/INSTALLING.rst
+++ b/INSTALLING.rst
@@ -24,18 +24,18 @@ Conda package
 **HOOMD-blue** is available on conda-forge_ on the *linux-64*, *osx-64*, and *osx-arm64* platforms.
 Install the ``hoomd`` package from the conda-forge_ channel into a conda environment::
 
-    $ conda install -c conda-forge hoomd
+    $ conda install hoomd=4.0.0
 
 Recent versions of ``conda`` auto-detect whether your system has a GPU and installs the appropriate
 package. Override this and force GPU package installation with::
 
-    $ conda install -c conda-forge "hoomd=*=*gpu*"
+    $ conda install "hoomd=4.0.0=*gpu*"
 
 .. note::
 
     To use :ref:`run time compilation` on **macOS**, install the ``compilers`` package::
 
-        $ conda install -c conda-forge compilers
+        $ conda install compilers
 
     Without this package you will get *file not found* errors when HOOMD-blue performs the run time
     compilation.
@@ -43,7 +43,9 @@ package. Override this and force GPU package installation with::
 .. tip::
 
     Use mambaforge_, miniforge_ or miniconda_ instead of the full Anaconda distribution to avoid
-    package conflicts with conda-forge_ packages.
+    package conflicts with conda-forge_ packages. When using miniconda_, follow the conda-forge_
+    instructions to configure the channel selection so that all packages are installed from
+    the conda-forge_ channel.
 
 .. _mambaforge: https://github.com/conda-forge/miniforge
 .. _miniforge: https://github.com/conda-forge/miniforge

--- a/INSTALLING.rst
+++ b/INSTALLING.rst
@@ -26,10 +26,15 @@ Install the ``hoomd`` package from the conda-forge_ channel into a conda environ
 
     $ conda install hoomd=4.0.0
 
-Recent versions of ``conda`` auto-detect whether your system has a GPU and installs the appropriate
-package. Override this and force GPU package installation with::
+``conda`` auto-detects whether your system has a GPU and attempts to install the appropriate
+package. Override this and force the GPU enabled package installation with::
 
+    $ export CONDA_OVERRIDE_CUDA="11.2"
     $ conda install "hoomd=4.0.0=*gpu*"
+
+Similarly, you can force CPU only package installation with::
+
+    $ conda install "hoomd=4.0.0=*cpu*"
 
 .. note::
 
@@ -43,9 +48,9 @@ package. Override this and force GPU package installation with::
 .. tip::
 
     Use mambaforge_, miniforge_ or miniconda_ instead of the full Anaconda distribution to avoid
-    package conflicts with conda-forge_ packages. When using miniconda_, follow the conda-forge_
-    instructions to configure the channel selection so that all packages are installed from
-    the conda-forge_ channel.
+    package conflicts with conda-forge_ packages. When using miniconda_, follow the instructions
+    provided in the conda-forge_ documentation to configure the channel selection so that all
+    packages are installed from the conda-forge_ channel.
 
 .. _mambaforge: https://github.com/conda-forge/miniforge
 .. _miniforge: https://github.com/conda-forge/miniforge


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should be based on *trunk-patch*. -->
<!-- Backwards compatible new features should be based on *trunk-minor*. -->
<!-- Incompatible API changes should be based on *trunk-major*. -->

## Description

<!-- Describe your changes in detail. -->
Recommend that users request specific versions of hoomd. Also make it more explicit that a properly configured conda-forge environment is required.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
On one systems I recently tested, `conda install hoomd` offers hoomd 2.9.7. Some users have reported similar behavior on the mailing list.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
I tested installing both CPU and GPU hoomd builds on a mambaforge environment on NCSA delta. `mamba install` resolves the environment very quickly, then often sadly fails with an error in the install phase. The `conda install` commands in the docs work, though they require several minutes of iteration through "Solving environment":
```
conda install "hoomd=4.0.0=*gpu*"
Collecting package metadata (current_repodata.json): done
Solving environment: unsuccessful initial attempt using frozen solve. Retrying with flexible solve.
Solving environment: unsuccessful attempt using repodata from current_repodata.json, retrying with next repodata source.
Collecting package metadata (repodata.json): done
Solving environment: done
```

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
Fixed:

* The recommended conda install commands find the documented version.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
