### PR TITLE
Fix CMake error when using HIP.

### DIFF
--- a/CMake/hoomd/FindCUDALibs.cmake
+++ b/CMake/hoomd/FindCUDALibs.cmake
@@ -189,9 +189,10 @@ if (HIP_PLATFORM STREQUAL "nvcc")
     mark_as_advanced(CUDA_MEMCHECK_EXECUTABLE)
 endif()
 
-include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(CUDALibs
-  REQUIRED_VARS
-    ${REQUIRED_CUDA_LIB_VARS}
-    ${REQUIRED_HIP_LIB_VARS}
-)
+if (HIP_PLATFORM STREQUAL "nvcc")
+    include(FindPackageHandleStandardArgs)
+    find_package_handle_standard_args(CUDALibs
+      REQUIRED_VARS
+        ${REQUIRED_CUDA_LIB_VARS}
+    )
+endif()


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should be based on *trunk-patch*. -->
<!-- Backwards compatible new features should be based on *trunk-minor*. -->
<!-- Incompatible API changes should be based on *trunk-major*. -->

## Description

<!-- Describe your changes in detail. -->
Call `find_package_handle_standard_args` only when there are required libraries found.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Prior to this change, CMake reports an error that the `REQUIRED_VARS` argument is missing. Nowhere does this script set `REQUIRED_HIP_LIB_VARS`, so `${REQUIRED_HIP_LIB_VARS}` is the empty string.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
This branch builds on Frontier.

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
Fixed:

* CMake error when ``HOOMD_GPU_PLATFORM=HIP``.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
