### PR TITLE
Improve error handling.

### DIFF
--- a/hoomd/CellList.cc
+++ b/hoomd/CellList.cc
@@ -567,9 +567,10 @@ bool CellList::checkConditions()
         ArrayHandle<unsigned int> h_tag(m_pdata->getTags(),
                                         access_location::host,
                                         access_mode::read);
-        m_exec_conf->msg->errorAllRanks()
-            << "Particle with unique tag " << h_tag.data[n] << " has NaN for its position." << endl;
-        throw runtime_error("Error computing cell list");
+
+        ostringstream s;
+        s << "Particle with unique tag " << h_tag.data[n] << " has NaN for its position." << endl;
+        throw runtime_error(s.str());
         }
 
     // detect particles leaving box errors
@@ -588,18 +589,18 @@ bool CellList::checkConditions()
         Scalar3 lo = m_pdata->getBox().getLo();
         Scalar3 hi = m_pdata->getBox().getHi();
 
-        m_exec_conf->msg->errorAllRanks()
-            << "Particle with unique tag " << h_tag.data[n]
-            << " is no longer in the simulation box." << std::endl
-            << std::endl
-            << "Cartesian coordinates: " << std::endl
-            << "x: " << h_pos.data[n].x << " y: " << h_pos.data[n].y << " z: " << h_pos.data[n].z
-            << std::endl
-            << "Fractional coordinates: " << std::endl
-            << "f.x: " << f.x << " f.y: " << f.y << " f.z: " << f.z << std::endl
-            << "Local box lo: (" << lo.x << ", " << lo.y << ", " << lo.z << ")" << std::endl
-            << "          hi: (" << hi.x << ", " << hi.y << ", " << hi.z << ")" << std::endl;
-        throw runtime_error("Error computing cell list");
+        ostringstream s;
+        s << "Particle with unique tag " << h_tag.data[n] << " is no longer in the simulation box."
+          << std::endl
+          << std::endl
+          << "Cartesian coordinates: " << std::endl
+          << "x: " << h_pos.data[n].x << " y: " << h_pos.data[n].y << " z: " << h_pos.data[n].z
+          << std::endl
+          << "Fractional coordinates: " << std::endl
+          << "f.x: " << f.x << " f.y: " << f.y << " f.z: " << f.z << std::endl
+          << "Local box lo: (" << lo.x << ", " << lo.y << ", " << lo.z << ")" << std::endl
+          << "          hi: (" << hi.x << ", " << hi.y << ", " << hi.z << ")" << std::endl;
+        throw runtime_error(s.str());
         }
 
     return result;

--- a/hoomd/ExecutionConfiguration.cc
+++ b/hoomd/ExecutionConfiguration.cc
@@ -141,10 +141,8 @@ ExecutionConfiguration::ExecutionConfiguration(executionMode mode,
         {
         if (!m_concurrent && gpu_id.size() > 1)
             {
-            msg->errorAllRanks() << "Multi-GPU execution requested, but not all GPUs support "
-                                    "concurrent managed access"
-                                 << endl;
-            throw runtime_error("Error initializing execution configuration");
+            throw runtime_error("Multi-GPU execution requested, but not all GPUs support "
+                                "concurrent managed access");
             }
 
 #ifndef ALWAYS_USE_MANAGED_MEMORY
@@ -278,12 +276,11 @@ void ExecutionConfiguration::handleHIPError(hipError_t err,
         if (strlen(file) > strlen(HOOMD_SOURCE_DIR))
             file += strlen(HOOMD_SOURCE_DIR);
 
-        // print an error message
-        msg->errorAllRanks() << string(hipGetErrorString(err)) << " before " << file << ":" << line
-                             << endl;
+        std::ostringstream s;
+        s << "HIP Error: " << string(hipGetErrorString(err)) << " before " << file << ":" << line;
 
         // throw an error exception
-        throw(runtime_error("HIP Error"));
+        throw(runtime_error(s.str()));
         }
     }
 
@@ -483,7 +480,6 @@ void ExecutionConfiguration::setupStats()
             cudaError_t error = cudaGetDeviceProperties(&cuda_prop, m_gpu_id[idev]);
             if (error != cudaSuccess)
                 {
-                msg->errorAllRanks() << "" << endl;
                 throw runtime_error("Failed to get device properties: "
                                     + string(cudaGetErrorString(error)));
                 }

--- a/hoomd/ExecutionConfiguration.cc
+++ b/hoomd/ExecutionConfiguration.cc
@@ -110,11 +110,16 @@ ExecutionConfiguration::ExecutionConfiguration(executionMode mode,
             {
             // if we found a local rank, use that to select the GPU
             gpu_id.push_back((local_rank % dev_count));
+
+            ostringstream s;
+            s << "Selected GPU " << gpu_id[0] << " by MPI rank." << endl;
+            msg->collectiveNoticeStr(4, s.str());
             }
 
         if (!gpu_id.size())
             {
             // auto-detect a single GPU
+            msg->collectiveNoticeStr(4, "Asking the driver to choose a GPU.\n");
             initializeGPU(-1);
             }
         else
@@ -135,6 +140,15 @@ ExecutionConfiguration::ExecutionConfiguration(executionMode mode,
 #endif
 
     setupStats();
+
+    s.clear();
+    s << "Device is running on ";
+    for (const auto& device_description : m_active_device_descriptions)
+        {
+        s << device_description << " ";
+        }
+    s << endl;
+    msg->collectiveNoticeStr(3, s.str());
 
 #if defined(ENABLE_HIP)
     if (exec_mode == GPU)

--- a/hoomd/ExecutionConfiguration.cc
+++ b/hoomd/ExecutionConfiguration.cc
@@ -291,12 +291,12 @@ void ExecutionConfiguration::handleHIPError(hipError_t err,
             file += strlen(HOOMD_SOURCE_DIR);
 
         std::ostringstream s;
-        #ifdef __HIP_PLATFORM_NVCC__
+#ifdef __HIP_PLATFORM_NVCC__
         cudaError_t cuda_error = cudaPeekAtLastError();
         s << "CUDA Error: " << string(cudaGetErrorString(cuda_error));
-        #else
+#else
         s << "HIP Error: " << string(hipGetErrorString(err));
-        #endif
+#endif
         s << " before " << file << ":" << line;
 
         // throw an error exception

--- a/hoomd/ExecutionConfiguration.h
+++ b/hoomd/ExecutionConfiguration.h
@@ -210,8 +210,6 @@ class PYBIND11_EXPORT ExecutionConfiguration
     /// Compute capability of the GPU formatted as a tuple (major, minor)
     std::pair<unsigned int, unsigned int> getComputeCapability(unsigned int igpu = 0) const;
 
-    //! Handle cuda error message
-    void handleCUDAError(hipError_t err, const char* file, unsigned int line) const;
     //! Handle hip error message
     void handleHIPError(hipError_t err, const char* file, unsigned int line) const;
 #endif
@@ -418,7 +416,7 @@ class PYBIND11_EXPORT ExecutionConfiguration
 #if defined(ENABLE_HIP)
 #define CHECK_CUDA_ERROR()                                                            \
         {                                                                             \
-        hipError_t err_sync = hipGetLastError();                                      \
+        hipError_t err_sync = hipPeekAtLastError();                                   \
         this->m_exec_conf->handleHIPError(err_sync, __FILE__, __LINE__);              \
         auto gpu_map = this->m_exec_conf->getGPUIds();                                \
         for (int idev = this->m_exec_conf->getNumActiveGPUs() - 1; idev >= 0; --idev) \

--- a/hoomd/GPUArray.h
+++ b/hoomd/GPUArray.h
@@ -975,8 +975,6 @@ template<class T> void GPUArray<T>::allocate()
     int retval = posix_memalign(&host_ptr, 32, m_num_elements * sizeof(T));
     if (retval != 0)
         {
-        if (m_exec_conf)
-            m_exec_conf->msg->errorAllRanks() << "Error allocating aligned memory" << std::endl;
         throw std::bad_alloc();
         }
 
@@ -1345,8 +1343,6 @@ template<class T> T* GPUArray<T>::resizeHostArray(size_t num_elements)
     int retval = posix_memalign((void**)&h_tmp, 32, num_elements * sizeof(T));
     if (retval != 0)
         {
-        if (m_exec_conf)
-            m_exec_conf->msg->errorAllRanks() << "Error allocating aligned memory" << std::endl;
         throw std::bad_alloc();
         }
 
@@ -1411,8 +1407,6 @@ T* GPUArray<T>::resize2DHostArray(size_t pitch, size_t new_pitch, size_t height,
     int retval = posix_memalign((void**)&h_tmp, 32, size);
     if (retval != 0)
         {
-        if (m_exec_conf)
-            m_exec_conf->msg->errorAllRanks() << "Error allocating aligned memory" << std::endl;
         throw std::bad_alloc();
         }
 

--- a/hoomd/GPUFlags.h
+++ b/hoomd/GPUFlags.h
@@ -226,8 +226,7 @@ template<class T> void GPUFlags<T>::allocate()
             int retval = posix_memalign(&ptr, getpagesize(), sizeof(T));
             if (retval != 0)
                 {
-                m_exec_conf->msg->errorAllRanks() << "Error allocating aligned memory" << std::endl;
-                throw std::runtime_error("Error allocating GPUArray.");
+                throw std::runtime_error("Error allocating aligned memory.");
                 }
             h_data = (T*)ptr;
             hipHostRegister(h_data, sizeof(T), hipHostRegisterMapped);
@@ -245,8 +244,7 @@ template<class T> void GPUFlags<T>::allocate()
             int retval = posix_memalign(&ptr, getpagesize(), sizeof(T));
             if (retval != 0)
                 {
-                m_exec_conf->msg->errorAllRanks() << "Error allocating aligned memory" << std::endl;
-                throw std::runtime_error("Error allocating GPUArray.");
+                throw std::runtime_error("Error allocating aligned memory.");
                 }
             h_data = (T*)ptr;
             hipHostRegister(h_data, sizeof(T), hipHostRegisterDefault);

--- a/hoomd/hpmc/IntegratorHPMCMono.h
+++ b/hoomd/hpmc/IntegratorHPMCMono.h
@@ -1638,8 +1638,7 @@ void IntegratorHPMCMono<Shape>::growAABBList(unsigned int N)
         int retval = posix_memalign((void**)&m_aabbs, 32, N*sizeof(hoomd::detail::AABB));
         if (retval != 0)
             {
-            m_exec_conf->msg->errorAllRanks() << "Error allocating aligned memory" << std::endl;
-            throw std::runtime_error("Error allocating AABB memory");
+            throw std::runtime_error("Error allocating aligned memory.");
             }
         }
     }

--- a/hoomd/md/BondTablePotential.cc
+++ b/hoomd/md/BondTablePotential.cc
@@ -284,8 +284,7 @@ void BondTablePotential::computeForces(uint64_t timestep)
             }
         else
             {
-            m_exec_conf->msg->errorAllRanks() << "Table bond out of bounds" << endl;
-            throw std::runtime_error("Error in bond calculation");
+            throw std::runtime_error("Table bond out of bounds.");
             }
         }
     }

--- a/hoomd/md/BondTablePotentialGPU.cc
+++ b/hoomd/md/BondTablePotentialGPU.cc
@@ -108,8 +108,7 @@ void BondTablePotentialGPU::computeForces(uint64_t timestep)
 
         if (h_flags.data[0])
             {
-            m_exec_conf->msg->errorAllRanks() << endl << "Table bond out of bounds" << endl << endl;
-            throw std::runtime_error("Error in bond calculation");
+            throw std::runtime_error("Table bond out of bounds.");
             }
         }
     m_tuner->end();

--- a/hoomd/md/ForceCompositeGPU.cc
+++ b/hoomd/md/ForceCompositeGPU.cc
@@ -218,10 +218,10 @@ void ForceCompositeGPU::computeForces(uint64_t timestep)
 
     if (flag.x)
         {
-        m_exec_conf->msg->errorAllRanks() << "constrain.rigid(): Composite particle with body tag "
-                                          << flag.x - 1 << " incomplete" << std::endl
-                                          << std::endl;
-        throw std::runtime_error("Error computing composite particle forces.\n");
+        std::ostringstream s;
+        s << "Composite particle with body tag " << flag.x - 1 << " incomplete" << std::endl
+          << std::endl;
+        throw std::runtime_error(s.str());
         }
 
     m_tuner_force->end();
@@ -394,11 +394,11 @@ void ForceCompositeGPU::updateCompositeParticles(uint64_t timestep)
         unsigned int body_id = h_body.data[idx];
         unsigned int tag = h_tag.data[idx];
 
-        m_exec_conf->msg->errorAllRanks()
-            << "constrain.rigid(): Particle " << tag << " part of composite body " << body_id
-            << " is missing central particle" << std::endl
-            << std::endl;
-        throw std::runtime_error("Error while updating constituent particles");
+        std::ostringstream s;
+        s << "Particle " << tag << " part of composite body " << body_id
+          << " is missing central particle" << std::endl
+          << std::endl;
+        throw std::runtime_error(s.str());
         }
 
     if (flag.y)
@@ -410,10 +410,10 @@ void ForceCompositeGPU::updateCompositeParticles(uint64_t timestep)
         unsigned int idx = flag.y - 1;
         unsigned int body_id = h_body.data[idx];
 
-        m_exec_conf->msg->errorAllRanks() << "constrain.rigid(): Composite particle with body id "
-                                          << body_id << " incomplete" << std::endl
-                                          << std::endl;
-        throw std::runtime_error("Error while updating constituent particles");
+        std::ostringstream s;
+        s << "Composite particle with body id " << body_id << " incomplete" << std::endl
+          << std::endl;
+        throw std::runtime_error(s.str());
         }
     }
 

--- a/hoomd/md/NeighborListTree.cc
+++ b/hoomd/md/NeighborListTree.cc
@@ -243,11 +243,11 @@ void NeighborListTree::buildTree()
             ArrayHandle<unsigned int> h_tag(m_pdata->getTags(),
                                             access_location::host,
                                             access_mode::read);
-            m_exec_conf->msg->errorAllRanks()
-                << "nlist.tree(): Particle " << h_tag.data[i] << " is out of bounds "
-                << "(x: " << my_pos.x << ", y: " << my_pos.y << ", z: " << my_pos.z
-                << ", fx: " << f.x << ", fy: " << f.y << ", fz:" << f.z << ")" << endl;
-            throw runtime_error("Error updating neighborlist");
+            ostringstream s;
+            s << "Particle " << h_tag.data[i] << " is out of bounds "
+              << "(x: " << my_pos.x << ", y: " << my_pos.y << ", z: " << my_pos.z << ", fx: " << f.x
+              << ", fy: " << f.y << ", fz:" << f.z << ")" << endl;
+            throw runtime_error(s.str());
             return;
             }
 

--- a/hoomd/test/test_global_array.cc
+++ b/hoomd/test/test_global_array.cc
@@ -105,7 +105,7 @@ UP_TEST(GlobalArray_transfer_tests)
         UP_ASSERT(d_handle.data != NULL);
 
         gpu_fill_test_pattern(d_handle.data, gpu_array.getNumElements());
-        hipError_t err_sync = hipGetLastError();
+        hipError_t err_sync = hipPeekAtLastError();
         exec_conf->handleHIPError(err_sync, __FILE__, __LINE__);
         }
 
@@ -127,7 +127,7 @@ UP_TEST(GlobalArray_transfer_tests)
         UP_ASSERT(d_handle.data != NULL);
 
         gpu_add_one(d_handle.data, gpu_array.getNumElements());
-        hipError_t err_sync = hipGetLastError();
+        hipError_t err_sync = hipPeekAtLastError();
         exec_conf->handleHIPError(err_sync, __FILE__, __LINE__);
         }
 
@@ -146,7 +146,7 @@ UP_TEST(GlobalArray_transfer_tests)
         UP_ASSERT(d_handle.data != NULL);
 
         gpu_add_one(d_handle.data, gpu_array.getNumElements());
-        hipError_t err_sync = hipGetLastError();
+        hipError_t err_sync = hipPeekAtLastError();
         exec_conf->handleHIPError(err_sync, __FILE__, __LINE__);
         }
 

--- a/hoomd/test/test_global_array.cu
+++ b/hoomd/test/test_global_array.cu
@@ -41,7 +41,7 @@ hipError_t gpu_add_one(int* d_data, size_t num)
     hipLaunchKernelGGL((gpu_add_one_kernel), dim3(grid), dim3(threads), 0, 0, d_data, num);
 
     hipDeviceSynchronize();
-    return hipGetLastError();
+    return hipPeekAtLastError();
     }
 
 /*! \param d_data Device pointer to the array where the data is held
@@ -79,7 +79,7 @@ hipError_t gpu_fill_test_pattern(int* d_data, size_t num)
                        num);
 
     hipDeviceSynchronize();
-    return hipGetLastError();
+    return hipPeekAtLastError();
     }
 
     } // end namespace test

--- a/hoomd/test/test_gpu_array.cc
+++ b/hoomd/test/test_gpu_array.cc
@@ -107,7 +107,7 @@ UP_TEST(GPUArray_transfer_tests)
         UP_ASSERT(d_handle.data != NULL);
 
         gpu_fill_test_pattern(d_handle.data, gpu_array.getNumElements());
-        hipError_t err_sync = hipGetLastError();
+        hipError_t err_sync = hipPeekAtLastError();
         exec_conf->handleHIPError(err_sync, __FILE__, __LINE__);
         }
 
@@ -130,7 +130,7 @@ UP_TEST(GPUArray_transfer_tests)
         UP_ASSERT(d_handle.data != NULL);
 
         gpu_add_one(d_handle.data, gpu_array.getNumElements());
-        hipError_t err_sync = hipGetLastError();
+        hipError_t err_sync = hipPeekAtLastError();
         exec_conf->handleHIPError(err_sync, __FILE__, __LINE__);
         }
 
@@ -154,7 +154,7 @@ UP_TEST(GPUArray_transfer_tests)
         UP_ASSERT(d_handle.data != NULL);
 
         gpu_add_one(d_handle.data, gpu_array.getNumElements());
-        hipError_t err_sync = hipGetLastError();
+        hipError_t err_sync = hipPeekAtLastError();
         exec_conf->handleHIPError(err_sync, __FILE__, __LINE__);
         }
 
@@ -173,7 +173,7 @@ UP_TEST(GPUArray_transfer_tests)
         UP_ASSERT(d_handle.data != NULL);
 
         gpu_add_one(d_handle.data, gpu_array.getNumElements());
-        hipError_t err_sync = hipGetLastError();
+        hipError_t err_sync = hipPeekAtLastError();
         exec_conf->handleHIPError(err_sync, __FILE__, __LINE__);
         }
 
@@ -192,7 +192,7 @@ UP_TEST(GPUArray_transfer_tests)
         UP_ASSERT(d_handle.data != NULL);
 
         gpu_add_one(d_handle.data, gpu_array.getNumElements());
-        hipError_t err_sync = hipGetLastError();
+        hipError_t err_sync = hipPeekAtLastError();
         exec_conf->handleHIPError(err_sync, __FILE__, __LINE__);
         }
 

--- a/hoomd/test/test_gpu_array.cu
+++ b/hoomd/test/test_gpu_array.cu
@@ -41,7 +41,7 @@ hipError_t gpu_add_one(int* d_data, size_t num)
     hipLaunchKernelGGL((gpu_add_one_kernel), dim3(grid), dim3(threads), 0, 0, d_data, num);
 
     hipDeviceSynchronize();
-    return hipGetLastError();
+    return hipPeekAtLastError();
     }
 
 /*! \param d_data Device pointer to the array where the data is held
@@ -79,7 +79,7 @@ hipError_t gpu_fill_test_pattern(int* d_data, size_t num)
                        num);
 
     hipDeviceSynchronize();
-    return hipGetLastError();
+    return hipPeekAtLastError();
     }
 
     } // end namespace test


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should be based on *trunk-patch*. -->
<!-- Backwards compatible new features should be based on *trunk-minor*. -->
<!-- Incompatible API changes should be based on *trunk-major*. -->

## Description

<!-- Describe your changes in detail. -->
* Format error messages in the exception description.
* Add additional notice messages to `ExecutionConfiguration.`
* Provide detailed error messages from CUDA.

## Motivation and context

This completes some missing conversions motivated in #1174.

With the new notice messages, we can ask users to run:
```
hoomd.device.GPU(notice_level=4)
```
to get detailed troubleshooting information.

`hipGetErrorString` is broken, it almost always returns "Unknown error".

## How has this been tested?

I ran minimal tests locally, including ones where I forced `handleHIPError` to process an error value.
<!--- Please describe in detail how you tested your changes. -->

Working before this change (notice_level=4):
```
notice(3): Found local rank in: OMPI_COMM_WORLD_LOCAL_RANK
```

Working after this change (notice_level=4):
```
notice(3): Found local rank in: OMPI_COMM_WORLD_LOCAL_RANK
notice(4): Rank 0: Selected GPU 0 by MPI rank.
notice(4): Rank 1: Selected GPU 1 by MPI rank.
notice(4): Rank 2: Selected GPU 0 by MPI rank.
notice(4): Rank 3: Selected GPU 1 by MPI rank.
notice(3): Rank 0: Device is running on [0]      NVIDIA RTX A5000  64 SM_8.6 @ 01.7 GHz, 24245 MiB DRAM 
notice(3): Rank 1: Device is running on [1]      NVIDIA RTX A5000  64 SM_8.6 @ 01.7 GHz, 24247 MiB DRAM 
notice(3): Rank 2: Device is running on [0]      NVIDIA RTX A5000  64 SM_8.6 @ 01.7 GHz, 24245 MiB DRAM 
notice(3): Rank 3: Device is running on [1]      NVIDIA RTX A5000  64 SM_8.6 @ 01.7 GHz, 24247 MiB DRAM 
```

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->
Error before this change:
```
notice(3): Found local rank in: OMPI_COMM_WORLD_LOCAL_RANK
Traceback (most recent call last):
  File "/home/joaander/build/hoomd/test.py", line 5, in <module>
    device = hoomd.device.auto_select(communicator=communicator, notice_level=4)
  File "/home/joaander/build/hoomd/hoomd/device.py", line 438, in auto_select
    return GPU(None, None, communicator, message_filename, notice_level)
  File "/home/joaander/build/hoomd/hoomd/device.py", line 296, in __init__
    self._cpp_exec_conf = _hoomd.ExecutionConfiguration(
RuntimeError: HIP Error
```

Error after this change:
```
notice(3): Found local rank in: OMPI_COMM_WORLD_LOCAL_RANK
Traceback (most recent call last):
  File "/home/joaander/build/hoomd/test.py", line 4, in <module>
notice(4): Rank 0: Selected GPU 0 by MPI rank.
notice(4): Rank 1: Selected GPU 1 by MPI rank.
notice(4): Rank 2: Selected GPU 0 by MPI rank.
notice(4): Rank 3: Selected GPU 1 by MPI rank.
    device = hoomd.device.auto_select(communicator=communicator, notice_level=4)
  File "/home/joaander/build/hoomd/hoomd/device.py", line 438, in auto_select
    return GPU(None, None, communicator, message_filename, notice_level)
  File "/home/joaander/build/hoomd/hoomd/device.py", line 296, in __init__
    self._cpp_exec_conf = _hoomd.ExecutionConfiguration(
RuntimeError: CUDA Error: CUDA-capable device(s) is/are busy or unavailable before /hoomd/ExecutionConfiguration.cc:368
```

## Change log

<!-- Propose a change log entry. -->
```
Fixed:

- Provide full CUDA error message when possible (`#1581 <https://github.com/glotzerlab/hoomd-blue/pull/1581>`__).
- Notice level 4 gives additional GPU initialization details (`#1581 <https://github.com/glotzerlab/hoomd-blue/pull/1581>`__).
- Show particle out of bounds error messages in exception description (`#1581 <https://github.com/glotzerlab/hoomd-blue/pull/1581>`__).
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
