### PR TITLE
Documentation fixes

### DIFF
--- a/INSTALLING.rst
+++ b/INSTALLING.rst
@@ -30,11 +30,16 @@ Install the ``hoomd`` package from the conda-forge_ channel into a conda environ
 package. Override this and force the GPU enabled package installation with::
 
     $ export CONDA_OVERRIDE_CUDA="12.0"
-    $ conda install "hoomd=4.0.1=*gpu*"
+    $ conda install "hoomd=4.0.1=*gpu*" "cuda-version=12.0"
 
 Similarly, you can force CPU only package installation with::
 
     $ conda install "hoomd=4.0.1=*cpu*"
+
+.. note::
+
+    CUDA 11.2 compatible packages are also available. Replace "12.0" with "11.2" above when
+    installing HOOMD-blue on systems with CUDA 11 compatible drivers.
 
 .. note::
 

--- a/INSTALLING.rst
+++ b/INSTALLING.rst
@@ -29,7 +29,7 @@ Install the ``hoomd`` package from the conda-forge_ channel into a conda environ
 ``conda`` auto-detects whether your system has a GPU and attempts to install the appropriate
 package. Override this and force the GPU enabled package installation with::
 
-    $ export CONDA_OVERRIDE_CUDA="11.2"
+    $ export CONDA_OVERRIDE_CUDA="12.0"
     $ conda install "hoomd=4.0.1=*gpu*"
 
 Similarly, you can force CPU only package installation with::

--- a/hoomd/data/local_access.py
+++ b/hoomd/data/local_access.py
@@ -129,7 +129,7 @@ class ParticleLocalAccessBase(_LocalAccess):
         net_torque ((N_particles, 3) `hoomd.data.array` object of ``float``):
             Net torque on particle
             :math:`[\\mathrm{force} \\cdot \\mathrm{length}]`.
-        net_virial ((N_particles, 3) `hoomd.data.array` object of ``float``):
+        net_virial ((N_particles, 6) `hoomd.data.array` object of ``float``):
             Net virial on particle :math:`[\\mathrm{energy}]`.
         net_energy ((N_particles,) `hoomd.data.array` object of ``float``):
             Net energy of a particle :math:`[\\mathrm{energy}]`.


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should be based on *trunk-patch*. -->
<!-- Backwards compatible new features should be based on *trunk-minor*. -->
<!-- Incompatible API changes should be based on *trunk-major*. -->

## Description

<!-- Describe your changes in detail. -->
* Recommend installing CUDA 12.0 builds from conda-forge.
* Fix typo in net_virial documentation.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
* CUDA 12 builds are now available on conda-forge thanks to the efforts of @bdice. The installation documentation should recommend installing the latest version available.
* The `net_virial` documentation incorrectly identified the shape of the array.

## Change log

<!-- Propose a change log entry. -->
```
Fixed:

* Improved documentation.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
