### PR TITLE
Fix plugin bond

### DIFF
--- a/hoomd/md/angle.py
+++ b/hoomd/md/angle.py
@@ -51,6 +51,10 @@ class Angle(Force):
         for `isinstance` or `issubclass` checks.
     """
 
+    # Module where the C++ class is defined. Reassign this when developing an
+    # external plugin.
+    _ext_module = _md
+
     def __init__(self):
         super().__init__()
 
@@ -61,9 +65,9 @@ class Angle(Force):
 
         # create the c++ mirror class
         if isinstance(self._simulation.device, hoomd.device.CPU):
-            cpp_cls = getattr(_md, self._cpp_class_name)
+            cpp_cls = getattr(self._ext_module, self._cpp_class_name)
         else:
-            cpp_cls = getattr(_md, self._cpp_class_name + "GPU")
+            cpp_cls = getattr(self._ext_module, self._cpp_class_name + "GPU")
 
         self._cpp_obj = cpp_cls(self._simulation.state._cpp_sys_def)
 

--- a/hoomd/md/bond.py
+++ b/hoomd/md/bond.py
@@ -52,15 +52,19 @@ class Bond(Force):
         for `isinstance` or `issubclass` checks.
     """
 
+    # Module where the C++ class is defined. Reassign this when developing an
+    # external plugin.
+    _ext_module = _md
+
     def __init__(self):
         super().__init__()
 
     def _attach_hook(self):
         """Create the c++ mirror class."""
         if isinstance(self._simulation.device, hoomd.device.CPU):
-            cpp_cls = getattr(_md, self._cpp_class_name)
+            cpp_cls = getattr(self._ext_module, self._cpp_class_name)
         else:
-            cpp_cls = getattr(_md, self._cpp_class_name + "GPU")
+            cpp_cls = getattr(self._ext_module, self._cpp_class_name + "GPU")
 
         self._cpp_obj = cpp_cls(self._simulation.state._cpp_sys_def)
 

--- a/hoomd/md/bond.py
+++ b/hoomd/md/bond.py
@@ -247,6 +247,10 @@ class Table(Bond):
         width (int): Number of points in the table.
     """
 
+    # Module where the C++ class is defined. Reassign this when developing an
+    # external plugin.
+    _ext_module = _md
+
     def __init__(self, width):
         super().__init__()
         param_dict = hoomd.data.parameterdicts.ParameterDict(width=int)
@@ -266,9 +270,9 @@ class Table(Bond):
     def _attach_hook(self):
         """Create the c++ mirror class."""
         if isinstance(self._simulation.device, hoomd.device.CPU):
-            cpp_cls = _md.BondTablePotential
+            cpp_cls = self._ext_module.BondTablePotential
         else:
-            cpp_cls = _md.BondTablePotentialGPU
+            cpp_cls = self._ext_module.BondTablePotentialGPU
 
         self._cpp_obj = cpp_cls(self._simulation.state._cpp_sys_def, self.width)
 

--- a/hoomd/md/bond.py
+++ b/hoomd/md/bond.py
@@ -247,10 +247,6 @@ class Table(Bond):
         width (int): Number of points in the table.
     """
 
-    # Module where the C++ class is defined. Reassign this when developing an
-    # external plugin.
-    _ext_module = _md
-
     def __init__(self, width):
         super().__init__()
         param_dict = hoomd.data.parameterdicts.ParameterDict(width=int)

--- a/hoomd/md/dihedral.py
+++ b/hoomd/md/dihedral.py
@@ -60,6 +60,10 @@ class Dihedral(Force):
         for `isinstance` or `issubclass` checks.
     """
 
+    # Module where the C++ class is defined. Reassign this when developing an
+    # external plugin.
+    _ext_module = _md
+
     def __init__(self):
         super().__init__()
 
@@ -72,9 +76,9 @@ class Dihedral(Force):
 
         # create the c++ mirror class
         if isinstance(self._simulation.device, hoomd.device.CPU):
-            cpp_class = getattr(_md, self._cpp_class_name)
+            cpp_class = getattr(self._ext_module, self._cpp_class_name)
         else:
-            cpp_class = getattr(_md, self._cpp_class_name + "GPU")
+            cpp_class = getattr(self._ext_module, self._cpp_class_name + "GPU")
 
         self._cpp_obj = cpp_class(self._simulation.state._cpp_sys_def)
 

--- a/hoomd/md/improper.py
+++ b/hoomd/md/improper.py
@@ -37,8 +37,7 @@ and similarly for virials.
 """
 
 import hoomd
-from hoomd import md  # required because hoomd.md is not yet available
-
+from hoomd.md import _md
 
 class Improper(md.force.Force):
     """Base class improper force.
@@ -49,6 +48,10 @@ class Improper(md.force.Force):
         This class should not be instantiated by users. The class can be used
         for `isinstance` or `issubclass` checks.
     """
+
+    # Module where the C++ class is defined. Reassign this when developing an
+    # external plugin.
+    _ext_module = _md
 
     def __init__(self):
         super().__init__()
@@ -62,9 +65,9 @@ class Improper(md.force.Force):
 
         # Instantiate the c++ implementation.
         if isinstance(self._simulation.device, hoomd.device.CPU):
-            cpp_class = getattr(hoomd.md._md, self._cpp_class_name)
+            cpp_class = getattr(self._ext_module, self._cpp_class_name)
         else:
-            cpp_class = getattr(hoomd.md._md, self._cpp_class_name + "GPU")
+            cpp_class = getattr(self._ext_module, self._cpp_class_name + "GPU")
 
         self._cpp_obj = cpp_class(self._simulation.state._cpp_sys_def)
 

--- a/hoomd/md/improper.py
+++ b/hoomd/md/improper.py
@@ -40,6 +40,7 @@ import hoomd
 from hoomd import md
 from hoomd.md import _md
 
+
 class Improper(md.force.Force):
     """Base class improper force.
 

--- a/hoomd/md/improper.py
+++ b/hoomd/md/improper.py
@@ -37,6 +37,7 @@ and similarly for virials.
 """
 
 import hoomd
+from hoomd import md
 from hoomd.md import _md
 
 class Improper(md.force.Force):

--- a/hoomd/md/special_pair.py
+++ b/hoomd/md/special_pair.py
@@ -55,6 +55,10 @@ class SpecialPair(Force):
         for `isinstance` or `issubclass` checks.
     """
 
+    # Module where the C++ class is defined. Reassign this when developing an
+    # external plugin.
+    _ext_module = _md
+
     def __init__(self):
         super().__init__()
 
@@ -65,9 +69,9 @@ class SpecialPair(Force):
 
         # create the c++ mirror class
         if isinstance(self._simulation.device, hoomd.device.CPU):
-            cpp_cls = getattr(_md, self._cpp_class_name)
+            cpp_cls = getattr(self._ext_module, self._cpp_class_name)
         else:
-            cpp_cls = getattr(_md, self._cpp_class_name + "GPU")
+            cpp_cls = getattr(self._ext_module, self._cpp_class_name + "GPU")
         self._cpp_obj = cpp_cls(self._simulation.state._cpp_sys_def)
 
 

--- a/sphinx-doc/credits.rst
+++ b/sphinx-doc/credits.rst
@@ -17,7 +17,7 @@ The following people have contributed to the to HOOMD-blue:
 * Andrew Schultz, University at Buffalo
 * Andrew Mark, Max Planck Institute
 * Andrey Kazennov, Joint Institute for High Temperatures of RAS
-* Antonia Statt, Universit of Illinois
+* Antonia Statt, University of Illinois
 * Antonio Osorio, University of Michigan
 * Avisek Das, University of Michigan
 * Axel Kohlmeyer, Temple University

--- a/sphinx-doc/credits.rst
+++ b/sphinx-doc/credits.rst
@@ -17,6 +17,7 @@ The following people have contributed to the to HOOMD-blue:
 * Andrew Schultz, University at Buffalo
 * Andrew Mark, Max Planck Institute
 * Andrey Kazennov, Joint Institute for High Temperatures of RAS
+* Antonia Statt, Universit of Illinois
 * Antonio Osorio, University of Michigan
 * Avisek Das, University of Michigan
 * Axel Kohlmeyer, Temple University


### PR DESCRIPTION
## Description

A simple bug fix that allows bond potentials to be developed in external plugins in the same way pair potentials are. 

## Motivation and context

Without this fix, an external plugin with a new bond potential will compile but fail to find the bond when run, i.e. the link will still be to `hoomd.md.bond` instead of `external_plugin_name.bond`. The simple fix is to add the same "_ext_module = _md" logic as is present in the pair potential class, see [here](https://github.com/glotzerlab/hoomd-blue/blob/efbeae37947a739146f8e7fc1da151db34366db5/hoomd/md/pair/pair.py#L65). 

Resolves #1591

## How has this been tested?

Tested via small "example_plugin" with a test bond implementation. No major changes to the code, so all other tests and functionalities are unaffected.  No changes to documentation aside from adding contributor name. 

## Change log

```
Fix: Bond potentials can now be implemented via external plugins 
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
