### PR TITLE
added `default_gamma` and `default_gamma_r` arguments to rattle methods

### DIFF
--- a/hoomd/md/methods/rattle.py
+++ b/hoomd/md/methods/rattle.py
@@ -503,8 +503,6 @@ class OverdampedViscous(MethodRATTLE):
             manifold_constraint=sphere,
             default_gamma=1.0,
             default_gamma_r=(1.0, 1.0, 1.0))
-        integrator = hoomd.md.Integrator(
-            dt=0.001, methods=[odv_rattle], forces=None)
         simulation.operations.integrator.methods = [odv_rattle]
 
     Attributes:

--- a/hoomd/md/methods/rattle.py
+++ b/hoomd/md/methods/rattle.py
@@ -271,11 +271,12 @@ class Langevin(MethodRATTLE):
     def __init__(self,
                  filter,
                  kT,
+                 manifold_constraint,
                  default_gamma=1.0,
                  default_gamma_r=(1.0, 1.0, 1.0),
                  tally_reservoir_energy=False,
                  tolerance=0.000001,
-                 manifold_constraint):
+    ):
 
         # store metadata
         param_dict = ParameterDict(
@@ -392,9 +393,9 @@ class Brownian(MethodRATTLE):
             self,
             filter,
             kT,
+            manifold_constraint,
             default_gamma=1.0,
             default_gamma_r=(1.0, 1.0, 1.0),
-            manifold_constraint,
             tolerance=1e-6
     ):
 
@@ -506,9 +507,9 @@ class OverdampedViscous(MethodRATTLE):
     def __init__(
             self,
             filter,
+            manifold_constraint,
             default_gamma=1.0,
             default_gamma_r=(1.0, 1.0, 1.0),
-            manifold_constraint,
             tolerance=1e-6
     ):
         # store metadata

--- a/hoomd/md/methods/rattle.py
+++ b/hoomd/md/methods/rattle.py
@@ -286,14 +286,16 @@ class Langevin(MethodRATTLE):
             :math:`[\mathrm{time}^{-1}]`.
     """
 
-    def __init__(self,
-                 filter,
-                 kT,
-                 manifold_constraint,
-                 tally_reservoir_energy=False,
-                 tolerance=0.000001,
-                 default_gamma=1.0,
-                 default_gamma_r=(1.0, 1.0, 1.0),):
+    def __init__(
+            self,
+            filter,
+            kT,
+            manifold_constraint,
+            tally_reservoir_energy=False,
+            tolerance=0.000001,
+            default_gamma=1.0,
+            default_gamma_r=(1.0, 1.0, 1.0),
+    ):
 
         # store metadata
         param_dict = ParameterDict(

--- a/hoomd/md/methods/rattle.py
+++ b/hoomd/md/methods/rattle.py
@@ -223,7 +223,7 @@ class Langevin(MethodRATTLE):
         tally_reservoir_energy (bool): If true, the energy exchange
             between the thermal reservoir and the particles is tracked. Total
             energy conservation can then be monitored by adding
-            ``langevin_reservoir_energy_groiupname`` to the logged quantities.
+            ``langevin_reservoir_energy_groupname`` to the logged quantities.
             Defaults to False :math:`[\mathrm{energy}]`.
 
         tolerance (float): Defines the tolerated error particles are allowed

--- a/hoomd/md/methods/rattle.py
+++ b/hoomd/md/methods/rattle.py
@@ -290,10 +290,10 @@ class Langevin(MethodRATTLE):
                  filter,
                  kT,
                  manifold_constraint,
-                 default_gamma=1.0,
-                 default_gamma_r=(1.0, 1.0, 1.0),
                  tally_reservoir_energy=False,
-                 tolerance=0.000001):
+                 tolerance=0.000001,
+                 default_gamma=1.0,
+                 default_gamma_r=(1.0, 1.0, 1.0),):
 
         # store metadata
         param_dict = ParameterDict(

--- a/hoomd/md/methods/rattle.py
+++ b/hoomd/md/methods/rattle.py
@@ -206,6 +206,12 @@ class Langevin(MethodRATTLE):
         kT (hoomd.variant.variant_like): Temperature of the simulation
             :math:`[\mathrm{energy}]`.
 
+        default_gamma (float): Default drag coefficient for all particle types
+            :math:`[\mathrm{mass} \cdot \mathrm{time}^{-1}]`.
+
+        default_gamma_r ([`float`, `float`, `float`]): Default rotational drag
+            coefficient tensor for all particles :math:`[\mathrm{time}^{-1}]`.
+
         manifold_constraint (hoomd.md.manifold.Manifold): Manifold
             constraint.
 
@@ -235,8 +241,7 @@ class Langevin(MethodRATTLE):
 
         sphere = hoomd.md.manifold.Sphere(r=10)
         langevin_rattle = hoomd.md.methods.rattle.Langevin(
-            filter=hoomd.filter.All(), kT=0.2, manifold_constraint=sphere,
-            seed=1)
+            filter=hoomd.filter.All(), kT=0.2, manifold_constraint=sphere)
 
     Attributes:
         filter (hoomd.filter.filter_like): Subset of particles to apply this
@@ -266,6 +271,8 @@ class Langevin(MethodRATTLE):
     def __init__(self,
                  filter,
                  kT,
+                 default_gamma=1.0,
+                 default_gamma_r=(1.0, 1.0, 1.0),
                  manifold_constraint,
                  tally_reservoir_energy=False,
                  tolerance=0.000001):
@@ -283,11 +290,13 @@ class Langevin(MethodRATTLE):
         gamma = TypeParameter('gamma',
                               type_kind='particle_types',
                               param_dict=TypeParameterDict(1., len_keys=1))
+        gamma.default = default_gamma
 
         gamma_r = TypeParameter('gamma_r',
                                 type_kind='particle_types',
                                 param_dict=TypeParameterDict((1., 1., 1.),
                                                              len_keys=1))
+        gamma_r.default = default_gamma_r
 
         self._extend_typeparam([gamma, gamma_r])
 
@@ -324,6 +333,12 @@ class Brownian(MethodRATTLE):
         kT (hoomd.variant.variant_like): Temperature of the simulation
             :math:`[\mathrm{energy}]`.
 
+        default_gamma (float): Default drag coefficient for all particle types
+            :math:`[\mathrm{mass} \cdot \mathrm{time}^{-1}]`.
+
+        default_gamma_r ([`float`, `float`, `float`]): Default rotational drag
+            coefficient tensor for all particles :math:`[\mathrm{time}^{-1}]`.
+
         manifold_constraint (hoomd.md.manifold.Manifold): Manifold
             constraint.
 
@@ -344,8 +359,7 @@ class Brownian(MethodRATTLE):
 
         sphere = hoomd.md.manifold.Sphere(r=10)
         brownian_rattle = hoomd.md.methods.rattle.Brownian(
-        filter=hoomd.filter.All(), kT=0.2, manifold_constraint=sphere,
-        seed=1)
+        filter=hoomd.filter.All(), kT=0.2, manifold_constraint=sphere)
         integrator = hoomd.md.Integrator(dt=0.001, methods=[brownian_rattle],
         forces=[lj])
 
@@ -374,7 +388,15 @@ class Brownian(MethodRATTLE):
             :math:`[\mathrm{time}^{-1}]`.
     """
 
-    def __init__(self, filter, kT, manifold_constraint, tolerance=1e-6):
+    def __init__(
+            self,
+            filter,
+            kT,
+            default_gamma=1.0,
+            default_gamma_r=(1.0, 1.0, 1.0),
+            manifold_constraint,
+            tolerance=1e-6
+    ):
 
         # store metadata
         param_dict = ParameterDict(
@@ -389,11 +411,14 @@ class Brownian(MethodRATTLE):
         gamma = TypeParameter('gamma',
                               type_kind='particle_types',
                               param_dict=TypeParameterDict(1., len_keys=1))
+        gamma.default = default_gamma
 
         gamma_r = TypeParameter('gamma_r',
                                 type_kind='particle_types',
                                 param_dict=TypeParameterDict((1., 1., 1.),
                                                              len_keys=1))
+        gamma_r.default = default_gamma_r
+
         self._extend_typeparam([gamma, gamma_r])
 
         super().__init__(manifold_constraint, tolerance)
@@ -426,6 +451,12 @@ class OverdampedViscous(MethodRATTLE):
         filter (hoomd.filter.filter_like): Subset of particles to apply this
             method to.
 
+        default_gamma (float): Default drag coefficient for all particle types
+            :math:`[\mathrm{mass} \cdot \mathrm{time}^{-1}]`.
+
+        default_gamma_r ([`float`, `float`, `float`]): Default rotational drag
+            coefficient tensor for all particles :math:`[\mathrm{time}^{-1}]`.
+
         manifold_constraint (hoomd.md.manifold.Manifold): Manifold constraint.
 
         tolerance (float): Defines the tolerated error particles are allowed to
@@ -445,7 +476,7 @@ class OverdampedViscous(MethodRATTLE):
 
         sphere = hoomd.md.manifold.Sphere(r=10)
         odv_rattle = hoomd.md.methods.rattle.OverdampedViscous(
-            filter=hoomd.filter.All(), manifold_constraint=sphere, seed=1)
+            filter=hoomd.filter.All(), manifold_constraint=sphere)
         integrator = hoomd.md.Integrator(
             dt=0.001, methods=[odv_rattle], forces=[lj])
 
@@ -472,7 +503,14 @@ class OverdampedViscous(MethodRATTLE):
             :math:`[\mathrm{time}^{-1}]`.
     """
 
-    def __init__(self, filter, manifold_constraint, tolerance=1e-6):
+    def __init__(
+            self,
+            filter,
+            default_gamma=1.0,
+            default_gamma_r=(1.0, 1.0, 1.0),
+            manifold_constraint,
+            tolerance=1e-6
+    ):
         # store metadata
         param_dict = ParameterDict(filter=ParticleFilter,)
         param_dict.update(dict(filter=filter))
@@ -483,11 +521,14 @@ class OverdampedViscous(MethodRATTLE):
         gamma = TypeParameter('gamma',
                               type_kind='particle_types',
                               param_dict=TypeParameterDict(1., len_keys=1))
+        gamma.default = default_gamma
 
         gamma_r = TypeParameter('gamma_r',
                                 type_kind='particle_types',
                                 param_dict=TypeParameterDict((1., 1., 1.),
                                                              len_keys=1))
+        gamma_r.default = default_gamma_r
+
         self._extend_typeparam([gamma, gamma_r])
 
         super().__init__(manifold_constraint, tolerance)

--- a/hoomd/md/methods/rattle.py
+++ b/hoomd/md/methods/rattle.py
@@ -273,9 +273,9 @@ class Langevin(MethodRATTLE):
                  kT,
                  default_gamma=1.0,
                  default_gamma_r=(1.0, 1.0, 1.0),
-                 manifold_constraint,
                  tally_reservoir_energy=False,
-                 tolerance=0.000001):
+                 tolerance=0.000001,
+                 manifold_constraint):
 
         # store metadata
         param_dict = ParameterDict(

--- a/hoomd/md/pytest/test_methods.py
+++ b/hoomd/md/pytest/test_methods.py
@@ -329,12 +329,16 @@ class TestMethods:
         }),
         (hoomd.md.methods.OverdampedViscous, {}),
         (hoomd.md.methods.rattle.Brownian, {
-            'kT': 1.5, 'manifold_constraint': sphere
+            'kT': 1.5,
+            'manifold_constraint': hoomd.md.manifold.Sphere(r=10)
         }),
         (hoomd.md.methods.rattle.Langevin, {
-            'kT': 1.5, 'manifold_constraint': sphere
+            'kT': 1.5,
+            'manifold_constraint': hoomd.md.manifold.Sphere(r=10)
         }),
-        (hoomd.md.methods.rattle.OverdampedViscous, {})
+        (hoomd.md.methods.rattle.OverdampedViscous, {
+            'manifold_constraint': hoomd.md.manifold.Sphere(r=10)
+        }),
     ])
     def test_default_gamma(self, cls, init_args):
         c = cls(filter=hoomd.filter.All(), **init_args)

--- a/hoomd/md/pytest/test_methods.py
+++ b/hoomd/md/pytest/test_methods.py
@@ -328,6 +328,13 @@ class TestMethods:
             'kT': 1.5
         }),
         (hoomd.md.methods.OverdampedViscous, {}),
+        (hoomd.md.methods.rattle.Brownian, {
+            'kT': 1.5, 'manifold_constraint'=sphere
+        }),
+        (hoomd.md.methods.rattle.Langevin, {
+            'kT': 1.5, 'manifold_constraint'=sphere
+        }),
+        (hoomd.md.methods.rattle.OverdampedViscous, {})
     ])
     def test_default_gamma(self, cls, init_args):
         c = cls(filter=hoomd.filter.All(), **init_args)

--- a/hoomd/md/pytest/test_methods.py
+++ b/hoomd/md/pytest/test_methods.py
@@ -329,10 +329,10 @@ class TestMethods:
         }),
         (hoomd.md.methods.OverdampedViscous, {}),
         (hoomd.md.methods.rattle.Brownian, {
-            'kT': 1.5, 'manifold_constraint'=sphere
+            'kT': 1.5, 'manifold_constraint': sphere
         }),
         (hoomd.md.methods.rattle.Langevin, {
-            'kT': 1.5, 'manifold_constraint'=sphere
+            'kT': 1.5, 'manifold_constraint': sphere
         }),
         (hoomd.md.methods.rattle.OverdampedViscous, {})
     ])


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should be based on *trunk-patch*. -->
<!-- Backwards compatible new features should be based on *trunk-minor*. -->
<!-- Incompatible API changes should be based on *trunk-major*. -->

## Description
`default_gamma` and `default_gamma_r` arguments do not exist in the following constructors:

`hoomd.md.methods.rattle.Brownian`
`hoomd.md.methods.rattle.Langevin`
`hoomd.md.methods.rattle.OverdampedViscous`

This PR added these arguments to the corresponding classes and doc strings. 
<!-- Describe your changes in detail. -->

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves #1589 

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->
Appended the test case before `test_default_gamma` function in `test_methods.py` 
## Change log

<!-- Propose a change log entry. -->
```

```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
