### PR TITLE
Modify example format for the rattle methods in md

### DIFF
--- a/hoomd/md/methods/rattle.py
+++ b/hoomd/md/methods/rattle.py
@@ -83,13 +83,15 @@ class NVE(MethodRATTLE):
     in `hoomd.md.methods.ConstantVolume` without any thermostat. In addition
     the particles are constrained to a manifold by using the RATTLE algorithm.
 
-    Examples::
+    .. rubric:: Example
 
-        sphere = hoomd.md.manifold.Sphere(r=10)
+    .. code-block:: python
+
+        sphere = hoomd.md.manifold.Sphere(r=5)
         nve_rattle = hoomd.md.methods.rattle.NVE(
-            filter=hoomd.filter.All(),maifold=sphere)
-        integrator = hoomd.md.Integrator(
-            dt=0.005, methods=[nve_rattle], forces=[lj])
+            filter=hoomd.filter.All(),
+            manifold_constraint=sphere)
+        simulation.operations.integrator.methods = [nve_rattle]
 
 
     Attributes:
@@ -166,15 +168,16 @@ class DisplacementCapped(NVE):
     `hoomd.md.methods.DisplacementCapped`. In addition the particles are
     constrained to a manifold by using the RATTLE algorithm.
 
-    Examples::
+    .. rubric:: Example
 
-        sphere = hoomd.md.manifold.Sphere(r=10)
+    .. code-block:: python
+
+        sphere = hoomd.md.manifold.Sphere(r=5)
         relax_rattle = hoomd.md.methods.rattle.DisplacementCapped(
-            filter=hoomd.filter.All(), maximum_displacement=0.01,
-            manifold=sphere)
-        integrator = hoomd.md.Integrator(
-            dt=0.005, methods=[relax_rattle], forces=[lj])
-
+            filter=hoomd.filter.All(),
+            maximum_displacement=0.01,
+            manifold_constraint=sphere)
+        simulation.operations.integrator.methods = [relax_rattle]
 
     Attributes:
         filter (hoomd.filter.filter_like): Subset of particles on which to apply


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should be based on *trunk-patch*. -->
<!-- Backwards compatible new features should be based on *trunk-minor*. -->
<!-- Incompatible API changes should be based on *trunk-major*. -->

## Description
This PR continues from #1596
Formatted the code examples in the doc strings for 2 additional classes in `rattle.py` 
<!-- Describe your changes in detail. -->

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

<!-- Replace ??? with the issue number that this pull request resolves. -->
Continues from #1596 

## How has this been tested?
Tested `rattle.py` and `test_methods.py` using pytest
<!--- Please describe in detail how you tested your changes. -->

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
Updated the formatting of code examples in `NVE` class and `DisplacementCapped` class for making the example code visible to the user. 
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
