### PR TITLE
Move HDF5Log example before attributes.

### DIFF
--- a/hoomd/write/hdf5.py
+++ b/hoomd/write/hdf5.py
@@ -277,18 +277,6 @@ class HDF5Log(_InternalCustomWriter):
     .. _h5py:
         https://docs.h5py.org/en/stable/high/file.html#opening-creating-files
 
-    Attributes:
-        cls.accepted_categories (hoomd.logging.LoggerCategories): The enum value
-            for all accepted categories for `HDF5Log` instances which is all
-            categories other than "string", "strings", and "object" (see
-            `hoomd.logging.LoggerCategories`).
-        trigger (hoomd.trigger.trigger_like): The trigger to determine when to
-            run the HDF5 backend.
-        filename (str): The filename of the HDF5 file written to.
-        logger (hoomd.logging.Logger): The logger instance used for querying
-            log data.
-        mode (str): The mode the file was opened in.
-
     .. rubric:: Example
 
     .. code-block:: python
@@ -300,6 +288,18 @@ class HDF5Log(_InternalCustomWriter):
             filename=hdf5_filename,
             logger=logger)
         simulation.operations += hdf5_writer
+
+    Attributes:
+        cls.accepted_categories (hoomd.logging.LoggerCategories): The enum value
+            for all accepted categories for `HDF5Log` instances which is all
+            categories other than "string", "strings", and "object" (see
+            `hoomd.logging.LoggerCategories`).
+        trigger (hoomd.trigger.trigger_like): The trigger to determine when to
+            run the HDF5 backend.
+        filename (str): The filename of the HDF5 file written to.
+        logger (hoomd.logging.Logger): The logger instance used for querying
+            log data.
+        mode (str): The mode the file was opened in.
     """
     _internal_class = _HDF5LogInternal
     _wrap_methods = ("flush",)


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should be based on *trunk-patch*. -->
<!-- Backwards compatible new features should be based on *trunk-minor*. -->
<!-- Incompatible API changes should be based on *trunk-major*. -->

## Description

<!-- Describe your changes in detail. -->
Move HDF5Log example before attributes.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
The example appears mixed in between the attribute and method documentation. It should appear before attributes.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
I have not yet checked that the output appears correct.

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
Fixed:

* Make ``HDF5Log`` example more visible.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
