### PR TITLE
Provide an error message when using md.external.field.Periodic in 2D.

### DIFF
--- a/hoomd/md/PotentialExternal.h
+++ b/hoomd/md/PotentialExternal.h
@@ -5,6 +5,7 @@
 #include "hoomd/GPUArray.h"
 #include "hoomd/GlobalArray.h"
 #include "hoomd/managed_allocator.h"
+#include "hoomd/md/EvaluatorExternalPeriodic.h"
 #include <memory>
 #include <stdexcept>
 
@@ -90,6 +91,11 @@ template<class evaluator> PotentialExternal<evaluator>::~PotentialExternal() { }
 */
 template<class evaluator> void PotentialExternal<evaluator>::computeForces(uint64_t timestep)
     {
+    if (std::is_same<evaluator, EvaluatorExternalPeriodic>() && m_sysdef->getNDimensions() == 2)
+        {
+        throw std::runtime_error("The external periodic potential is not valid in 2D boxes.");
+        }
+
     assert(m_pdata);
     // access the particle data arrays
     ArrayHandle<Scalar4> h_pos(m_pdata->getPositions(), access_location::host, access_mode::read);


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should be based on *trunk-patch*. -->
<!-- Backwards compatible new features should be based on *trunk-minor*. -->
<!-- Incompatible API changes should be based on *trunk-major*. -->

## Description

<!-- Describe your changes in detail. -->
Provide an error message when using external periodic in 2D.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
An error message is preferable to a NaN particle position.

<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves #1475

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
I executed the minimal reproducer in #1475 and got the expected output.
```
Starting Simulation
Traceback (most recent call last):
  File "/Users/joaander/build/hoomd/test.py", line 112, in <module>
    sim.run(TTOT_input)
  File "/Users/joaander/build/hoomd/hoomd/simulation.py", line 562, in run
    self._cpp_sys.run(steps_int, write_at_start)
RuntimeError: The external periodic potential is not valid in 2D boxes.
```

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
Fixes:

* Provide an error message when using ``md.external.field.Periodic`` in 2D.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
