### PR TITLE
Fix GSD file exists error message.

### DIFF
--- a/hoomd/extern/gsd.c
+++ b/hoomd/extern/gsd.c
@@ -1623,7 +1623,10 @@ int gsd_create(const char* fname,
                            O_RDWR | O_CREAT | O_TRUNC | extra_flags,
                            S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP);
     int retval = gsd_initialize_file(fd, application, schema, schema_version);
-    close(fd);
+    if (fd != -1)
+        {
+        close(fd);
+        }
     return retval;
     }
 
@@ -1670,14 +1673,20 @@ int gsd_create_and_open(struct gsd_handle* handle,
     int retval = gsd_initialize_file(handle->fd, application, schema, schema_version);
     if (retval != 0)
         {
-        close(handle->fd);
+        if (handle->fd != -1)
+            {
+            close(handle->fd);
+            }
         return retval;
         }
 
     retval = gsd_initialize_handle(handle);
     if (retval != 0)
         {
-        close(handle->fd);
+        if (handle->fd != -1)
+            {
+            close(handle->fd);
+            }
         }
     return retval;
     }
@@ -1712,7 +1721,10 @@ int gsd_open(struct gsd_handle* handle, const char* fname, const enum gsd_open_f
     int retval = gsd_initialize_handle(handle);
     if (retval != 0)
         {
-        close(handle->fd);
+        if (handle->fd != -1)
+            {
+            close(handle->fd);
+            }
         }
     return retval;
     }

--- a/hoomd/md/pytest/test_gsd.py
+++ b/hoomd/md/pytest/test_gsd.py
@@ -161,7 +161,7 @@ def test_write_gsd_mode(create_md_sim, hoomd_snapshot, tmp_path,
                                      trigger=hoomd.trigger.Periodic(1),
                                      mode='xb',
                                      dynamic=['property', 'momentum'])
-        with pytest.raises(Exception):
+        with pytest.raises(Exception, match='.*File exists.*'):
             sim.operations.writers.append(gsd_writer)
             sim.run(1)
 


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should be based on *trunk-patch*. -->
<!-- Backwards compatible new features should be based on *trunk-minor*. -->
<!-- Incompatible API changes should be based on *trunk-major*. -->

## Description

<!-- Describe your changes in detail. -->
Provide "RuntimeError: GSD: File exists" error message instead of "Bad file descriptor." when using the 'xb' file mode and the file exists.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Users expect to see a "File exists" error when the file exists. See https://github.com/glotzerlab/gsd/issues/270.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
Added a unit tests that verifies the correct message. The test fails before the fix and passes after.

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
Fixed:

* ``hoomd.write.GSD`` reports "File exists" in the exception description when using the ``'xb'`` mode and the file exists.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
