### PR TITLE
Changes to Bussi thermostat

### DIFF
--- a/hoomd/RandomNumbers.h
+++ b/hoomd/RandomNumbers.h
@@ -480,16 +480,16 @@ template<typename Real> class GammaDistribution
         {
         if (m_alpha <= 0)
             {
-            #ifndef __HIPCC__
+#ifndef __HIPCC__
             throw std::domain_error("alpha must be positive.");
-            #else
+#else
             return 0;
-            #endif
+#endif
             }
         else if (m_alpha < Real(1.0))
             {
             Real x = GammaDistribution(m_alpha + Real(1.0), m_b)(rng);
-            return x * fast::pow(detail::generate_canonical<Real>(rng), Real(1.0)/m_alpha);
+            return x * fast::pow(detail::generate_canonical<Real>(rng), Real(1.0) / m_alpha);
             }
 
         Real v;
@@ -522,8 +522,8 @@ template<typename Real> class GammaDistribution
 
     private:
     Real m_alpha; //!< Gamma distribution alpha parameter
-    Real m_b; //!< Gamma-distribution b-parameter
-    Real m_c; //!< c-parameter for Marsaglia and Tsang method
+    Real m_b;     //!< Gamma-distribution b-parameter
+    Real m_c;     //!< c-parameter for Marsaglia and Tsang method
 
     NormalDistribution<Real> m_normal; //!< Normal variate generator
     };

--- a/hoomd/RandomNumbers.h
+++ b/hoomd/RandomNumbers.h
@@ -449,8 +449,6 @@ template<typename Real> class SpherePointGenerator
  *      Mathematical Software (TOMS), vol. 26, issue 3, Sept. 2000, 363--372.
  *      https://doi.org/10.1145/358407.358414
  *
- * WARNING: This implementation assumes alpha > 1.
- *
  * \tparam Real Precision of the random number
  */
 template<typename Real> class GammaDistribution
@@ -461,10 +459,9 @@ template<typename Real> class GammaDistribution
      * \param alpha
      * \param b
      */
-    DEVICE explicit GammaDistribution(const Real alpha, const Real b) : m_b(b)
+    DEVICE explicit GammaDistribution(const Real alpha, const Real b) : m_alpha(alpha), m_b(b)
         {
-        m_d = alpha - Real(1. / 3.);
-        m_c = fast::rsqrt(m_d) / Real(3.);
+        m_c = fast::rsqrt(m_alpha - Real(1. / 3.)) / Real(3.);
         }
 
     //! Draw a random number from the gamma distribution
@@ -481,7 +478,22 @@ template<typename Real> class GammaDistribution
      */
     template<typename RNG> DEVICE inline Real operator()(RNG& rng)
         {
+        if (m_alpha <= 0)
+            {
+            #ifndef __HIPCC__
+            throw std::domain_error("alpha must be positive.");
+            #else
+            return 0;
+            #endif
+            }
+        else if (m_alpha < Real(1.0))
+            {
+            Real x = GammaDistribution(m_alpha + Real(1.0), m_b)(rng);
+            return x * fast::pow(detail::generate_canonical<Real>(rng), Real(1.0)/m_alpha);
+            }
+
         Real v;
+        Real d = m_alpha - Real(1. / 3.);
         while (1)
             {
             // first draw a valid Marsaglia v value using the normal distribution
@@ -500,18 +512,18 @@ template<typename Real> class GammaDistribution
                 break;
 
             // otherwise, do expensive log comparison
-            if (fast::log(u) < Real(0.5) * x2 + m_d * (Real(1.0) - v + fast::log(v)))
+            if (fast::log(u) < Real(0.5) * x2 + d * (Real(1.0) - v + fast::log(v)))
                 break;
             }
 
         // convert the Gamma(alpha,1) to Gamma(alpha,beta)
-        return m_d * v * m_b;
+        return d * v * m_b;
         }
 
     private:
+    Real m_alpha; //!< Gamma distribution alpha parameter
     Real m_b; //!< Gamma-distribution b-parameter
     Real m_c; //!< c-parameter for Marsaglia and Tsang method
-    Real m_d; //!< d-parameter for Marasglia and Tsang method
 
     NormalDistribution<Real> m_normal; //!< Normal variate generator
     };

--- a/hoomd/md/Thermostat.cc
+++ b/hoomd/md/Thermostat.cc
@@ -43,7 +43,8 @@ void export_BussiThermostat(pybind11::module& m)
                             std::shared_ptr<ParticleGroup>,
                             std::shared_ptr<ComputeThermo>,
                             std::shared_ptr<SystemDefinition>,
-                            Scalar>());
+                            Scalar>())
+        .def_property("tau", &BussiThermostat::getTau, &BussiThermostat::setTau);
     }
 
 void export_BerendsenThermostat(pybind11::module& m)

--- a/hoomd/md/Thermostat.cc
+++ b/hoomd/md/Thermostat.cc
@@ -42,7 +42,8 @@ void export_BussiThermostat(pybind11::module& m)
         .def(pybind11::init<std::shared_ptr<Variant>,
                             std::shared_ptr<ParticleGroup>,
                             std::shared_ptr<ComputeThermo>,
-                            std::shared_ptr<SystemDefinition>>());
+                            std::shared_ptr<SystemDefinition>,
+                            Scalar>());
     }
 
 void export_BerendsenThermostat(pybind11::module& m)

--- a/hoomd/md/Thermostat.h
+++ b/hoomd/md/Thermostat.h
@@ -425,7 +425,7 @@ class BussiThermostat : public Thermostat
         else if (nrdof_left == 1)
             {
             Scalar r_random_temp = normal_rotation(rng);
-            r_random_left = rr_temp * rr_temp;
+            r_random_left = r_random_temp * r_random_temp;
             }
         else if (nrdof_left_even)
             {

--- a/hoomd/md/Thermostat.h
+++ b/hoomd/md/Thermostat.h
@@ -432,16 +432,15 @@ class BussiThermostat : public Thermostat
         Scalar r_normal_one = normal(rng);
 
         GammaDistribution<double> gamma((degrees_of_freedom - 1.0) / Scalar(2.0), Scalar(1.0));
-        double r_gamma_n_minus_one = 0.0;
+        double r_gamma = 0.0;
         if (degrees_of_freedom > 1.0)
             {
-            r_gamma_n_minus_one = 2.0 * gamma(rng);
+            r_gamma = 2.0 * gamma(rng);
             }
 
-        double term1 = set_T / 2.0 / K * (1.0 - time_decay_factor)
-                       * (r_gamma_n_minus_one + r_normal_one * r_normal_one);
-        double term2 = 2.0 * r_normal_one
-                       * sqrt(set_T / 2.0 / K * (1.0 - time_decay_factor) * time_decay_factor);
+        double v = set_T / 2.0 / K;
+        double term1 = v * (1.0 - time_decay_factor) * (r_gamma + r_normal_one * r_normal_one);
+        double term2 = 2.0 * r_normal_one * sqrt(v * (1.0 - time_decay_factor) * time_decay_factor);
 
         return Scalar(sqrt(time_decay_factor + term1 + term2));
         }

--- a/hoomd/md/Thermostat.h
+++ b/hoomd/md/Thermostat.h
@@ -365,8 +365,7 @@ class BussiThermostat : public Thermostat
         const int nrdof = static_cast<int>(m_thermo->getRotationalDOF());
         const auto ket_int = m_thermo->getTranslationalKineticEnergy();
         const auto ker_int = m_thermo->getRotationalKineticEnergy();
-        if ((ntdof != 0 && m_thermo->getTranslationalKineticEnergy() == 0)
-            || (nrdof != 0 && m_thermo->getRotationalKineticEnergy() == 0))
+        if ((ntdof != 0 && ket_int == 0) || (nrdof != 0 && ker_int == 0))
             {
             throw std::runtime_error("Bussi thermostat requires non-zero initial temperatures");
             }

--- a/hoomd/md/Thermostat.h
+++ b/hoomd/md/Thermostat.h
@@ -398,8 +398,8 @@ class BussiThermostat : public Thermostat
         Scalar t_random_first = normal_translation(rng);
         Scalar r_random_first = normal_rotation(rng);
 
-        Scalar t_random_left = sample_sumnormalsq(ntdof - 1, rng);
-        Scalar r_random_left = sample_sumnormalsq(nrdof - 1, rng);
+        Scalar t_random_left = sample_sumnormal_squared(ntdof - 1, rng);
+        Scalar r_random_left = sample_sumnormal_squared(nrdof - 1, rng);
 
         Scalar t_rescale
             = sqrt(time_decay_factor
@@ -434,27 +434,17 @@ class BussiThermostat : public Thermostat
     protected:
     Scalar m_tau;
 
-    Scalar sample_sumnormalsq(int dof_left, RandomGenerator& rng)
+    static Scalar sample_sumnormal_squared(int dof_left, RandomGenerator& rng)
         {
-        Scalar sum_normal_square;
-
         if (dof_left == 0)
             {
-            sum_normal_square = 0.;
-            }
-        else if (dof_left == 1)
-            {
-            NormalDistribution<double> normal(1.0);
-            Scalar normal_random = normal(rng);
-            sum_normal_square = normal_random * normal_random;
+            return 0;
             }
         else
             {
-            GammaDistribution<double> gamma(dof_left / 2.0, 1.0);
-            sum_normal_square = 2.0 * gamma(rng);
+            GammaDistribution<Scalar> gamma(dof_left / Scalar(2.0), Scalar(1.0));
+            return Scalar(2.0) * gamma(rng);
             }
-
-        return sum_normal_square;
         }
     };
 

--- a/hoomd/md/Thermostat.h
+++ b/hoomd/md/Thermostat.h
@@ -379,9 +379,9 @@ class BussiThermostat : public Thermostat
 
         const auto set_T = m_T->operator()(timestep);
 
-        if (m_tau > 0.1)
+        if (m_tau / deltaT > 0.1)
             {
-            e_factor = exp(-1.0 / m_tau);
+            e_factor = exp(-1.0 / (m_tau / deltaT));
             }
         else  // the limit case when tau is near 0
             {

--- a/hoomd/md/Thermostat.h
+++ b/hoomd/md/Thermostat.h
@@ -361,6 +361,9 @@ class BussiThermostat : public Thermostat
         Scalar time_decay_factor;
         Scalar t_random_left;
         Scalar r_random_left;
+        // Integration methods will always operate on subsets with integer degrees of freedom.
+        // Partial degrees of freedom are removed by getTranslationalDOF() when the subset of
+        // particles is not the same subet selected for integration.
         const int ntdof = static_cast<int>(m_thermo->getTranslationalDOF());
         const int nrdof = static_cast<int>(m_thermo->getRotationalDOF());
         const auto ket_int = m_thermo->getTranslationalKineticEnergy();

--- a/hoomd/md/Thermostat.h
+++ b/hoomd/md/Thermostat.h
@@ -379,15 +379,11 @@ class BussiThermostat : public Thermostat
 
         const auto set_T = m_T->operator()(timestep);
 
-        if (deltaT < 1e-12)
-            {
-            e_factor = 1.0;
-            }
-        else if (m_tau / deltaT > 0.1)
+        if (m_tau != 0.0)
             {
             e_factor = exp(-deltaT / m_tau);
             }
-        else // the limit case when tau is near 0
+        else
             {
             e_factor = 0.0;
             }

--- a/hoomd/md/Thermostat.h
+++ b/hoomd/md/Thermostat.h
@@ -361,8 +361,8 @@ class BussiThermostat : public Thermostat
         Scalar e_factor;
         Scalar rt_left;
         Scalar rr_left;
-        const auto ntdof = m_thermo->getTranslationalDOF();
-        const auto nrdof = m_thermo->getRotationalDOF();
+        const int ntdof = static_cast<int>(m_thermo->getTranslationalDOF());
+        const int nrdof = static_cast<int>(m_thermo->getRotationalDOF());
         const auto ket_int = m_thermo->getTranslationalKineticEnergy();
         const auto ker_int = m_thermo->getRotationalKineticEnergy();
         if ((ntdof != 0 && m_thermo->getTranslationalKineticEnergy() == 0)

--- a/hoomd/md/Thermostat.h
+++ b/hoomd/md/Thermostat.h
@@ -399,8 +399,8 @@ class BussiThermostat : public Thermostat
         Scalar t_random_first = normal_translation(rng);
         Scalar r_random_first = normal_rotation(rng);
 
-        Scalar t_random_left = sample_sumnormal(ntdof - 1, rng);
-        Scalar r_random_left = sample_sumnormal(nrdof - 1, rng);
+        Scalar t_random_left = sample_sumnormalsq(ntdof - 1, rng);
+        Scalar r_random_left = sample_sumnormalsq(nrdof - 1, rng);
 
         Scalar t_rescale
             = sqrt(time_decay_factor
@@ -423,10 +423,9 @@ class BussiThermostat : public Thermostat
     protected:
     Scalar m_tau;
 
-    Scalar sample_sumnormal(int dof_left, RandomGenerator rng)
+    Scalar sample_sumnormalsq(int dof_left, RandomGenerator rng)
         {
         Scalar sum_normal_square;
-        const bool dof_left_even = ((dof_left & 1) == 0);
 
         if (dof_left == 0)
             {
@@ -438,17 +437,10 @@ class BussiThermostat : public Thermostat
             Scalar normal_random = normal(rng);
             sum_normal_square = normal_random * normal_random;
             }
-        else if (dof_left_even)
+        else
             {
             GammaDistribution<double> gamma(dof_left / 2.0, 1.0);
             sum_normal_square = 2.0 * gamma(rng);
-            }
-        else
-            {
-            NormalDistribution<double> normal(1.0);
-            GammaDistribution<double> gamma((dof_left - 1) / 2.0, 1.0);
-            Scalar normal_random = normal(rng);
-            sum_normal_square = 2.0 * gamma(rng) + normal_random * normal_random;
             }
 
         return sum_normal_square;

--- a/hoomd/md/Thermostat.h
+++ b/hoomd/md/Thermostat.h
@@ -379,9 +379,13 @@ class BussiThermostat : public Thermostat
 
         const auto set_T = m_T->operator()(timestep);
 
-        if (m_tau / deltaT > 0.1)
+        if (deltaT < 1e-12)
             {
-            e_factor = exp(-1.0 / (m_tau / deltaT));
+            e_factor = 1.0;
+            }
+        else if (m_tau / deltaT > 0.1)
+            {
+            e_factor = exp(-deltaT / m_tau);
             }
         else  // the limit case when tau is near 0
             {

--- a/hoomd/md/Thermostat.h
+++ b/hoomd/md/Thermostat.h
@@ -387,7 +387,7 @@ class BussiThermostat : public Thermostat
             {
             e_factor = exp(-deltaT / m_tau);
             }
-        else  // the limit case when tau is near 0
+        else // the limit case when tau is near 0
             {
             e_factor = 0.0;
             }
@@ -408,7 +408,7 @@ class BussiThermostat : public Thermostat
         else if (ntdof_left == 1)
             {
             Scalar rt_temp = normal_translation(rng);
-            rt_left = rt_temp*rt_temp;
+            rt_left = rt_temp * rt_temp;
             }
         else if (ntdof_left_even)
             {
@@ -419,7 +419,7 @@ class BussiThermostat : public Thermostat
             {
             GammaDistribution<double> gamma_translation((ntdof_left - 1) / 2.0, 1.0);
             Scalar rt_temp = normal_translation(rng);
-            rt_left = 2.0 * gamma_translation(rng) + rt_temp*rt_temp;
+            rt_left = 2.0 * gamma_translation(rng) + rt_temp * rt_temp;
             }
 
         if (nrdof_left == 0)
@@ -429,7 +429,7 @@ class BussiThermostat : public Thermostat
         else if (nrdof_left == 1)
             {
             Scalar rr_temp = normal_rotation(rng);
-            rr_left = rr_temp*rr_temp;
+            rr_left = rr_temp * rr_temp;
             }
         else if (nrdof_left_even)
             {
@@ -440,17 +440,19 @@ class BussiThermostat : public Thermostat
             {
             GammaDistribution<double> gamma_rotation((nrdof_left - 1) / 2.0, 1.0);
             Scalar rr_temp = normal_rotation(rng);
-            rr_left = 2.0 * gamma_rotation(rng) + rr_temp*rr_temp;
+            rr_left = 2.0 * gamma_rotation(rng) + rr_temp * rr_temp;
             }
 
         Scalar t_rescale = sqrt(
             e_factor
             + set_T / Scalar(2.0) / ket_int * (Scalar(1.0) - e_factor) * (rt_left + rt * rt)
-            + Scalar(2.0) * rt * sqrt(set_T / Scalar(2.0) / ket_int * (Scalar(1.0) - e_factor) * e_factor));
+            + Scalar(2.0) * rt
+                  * sqrt(set_T / Scalar(2.0) / ket_int * (Scalar(1.0) - e_factor) * e_factor));
         Scalar r_rescale = sqrt(
             e_factor
             + set_T / Scalar(2.0) / ker_int * (Scalar(1.0) - e_factor) * (rr_left + rr * rr)
-            + Scalar(2.0) * rr * sqrt(set_T / Scalar(2.0) / ker_int * (Scalar(1.0) - e_factor) * e_factor));
+            + Scalar(2.0) * rr
+                  * sqrt(set_T / Scalar(2.0) / ker_int * (Scalar(1.0) - e_factor) * e_factor));
 
         return {t_rescale, r_rescale};
         }

--- a/hoomd/md/Thermostat.h
+++ b/hoomd/md/Thermostat.h
@@ -396,8 +396,8 @@ class BussiThermostat : public Thermostat
 
         NormalDistribution<double> normal_translation(1.0);
         NormalDistribution<double> normal_rotation(1.0);
-        Scalar t_random_one = normal_translation(rng);
-        Scalar r_random_one = normal_rotation(rng);
+        Scalar t_random_first = normal_translation(rng);
+        Scalar r_random_first = normal_rotation(rng);
 
         Scalar t_random_left = sample_sumnormal(ntdof - 1, rng);
         Scalar r_random_left = sample_sumnormal(nrdof - 1, rng);
@@ -405,15 +405,15 @@ class BussiThermostat : public Thermostat
         Scalar t_rescale
             = sqrt(time_decay_factor
                    + set_T / Scalar(2.0) / ket_int * (Scalar(1.0) - time_decay_factor)
-                         * (t_random_left + t_random_one * t_random_one)
-                   + Scalar(2.0) * t_random_one
+                         * (t_random_left + t_random_first * t_random_first)
+                   + Scalar(2.0) * t_random_first
                          * sqrt(set_T / Scalar(2.0) / ket_int * (Scalar(1.0) - time_decay_factor)
                                 * time_decay_factor));
         Scalar r_rescale
             = sqrt(time_decay_factor
                    + set_T / Scalar(2.0) / ker_int * (Scalar(1.0) - time_decay_factor)
-                         * (r_random_left + r_random_one * r_random_one)
-                   + Scalar(2.0) * r_random_one
+                         * (r_random_left + r_random_first * r_random_first)
+                   + Scalar(2.0) * r_random_first
                          * sqrt(set_T / Scalar(2.0) / ker_int * (Scalar(1.0) - time_decay_factor)
                                 * time_decay_factor));
 

--- a/hoomd/md/Thermostat.h
+++ b/hoomd/md/Thermostat.h
@@ -420,10 +420,22 @@ class BussiThermostat : public Thermostat
         return {t_rescale, r_rescale};
         }
 
+    /// Get the thermostat time constant.
+    Scalar getTau()
+        {
+        return m_tau;
+        }
+
+    /// Set the thermostat time constant.
+    void setTau(Scalar tau)
+        {
+        m_tau = tau;
+        }
+
     protected:
     Scalar m_tau;
 
-    Scalar sample_sumnormalsq(int dof_left, RandomGenerator rng)
+    Scalar sample_sumnormalsq(int dof_left, RandomGenerator& rng)
         {
         Scalar sum_normal_square;
 

--- a/hoomd/md/Thermostat.h
+++ b/hoomd/md/Thermostat.h
@@ -367,7 +367,8 @@ class BussiThermostat : public Thermostat
         const auto rotational_dof = m_thermo->getRotationalDOF();
         const auto translational_kinetic_energy = m_thermo->getTranslationalKineticEnergy();
         const auto rotational_kinetic_energy = m_thermo->getRotationalKineticEnergy();
-        if ((translational_dof != 0 && translational_kinetic_energy == 0) || (rotational_dof != 0 && rotational_kinetic_energy == 0))
+        if ((translational_dof != 0 && translational_kinetic_energy == 0)
+            || (rotational_dof != 0 && rotational_kinetic_energy == 0))
             {
             throw std::runtime_error("Bussi thermostat requires non-zero initial momenta.");
             }
@@ -380,8 +381,13 @@ class BussiThermostat : public Thermostat
 
         const auto set_T = m_T->operator()(timestep);
 
-        return {compute_rescale_factor(translational_kinetic_energy, translational_dof, deltaT, set_T, rng)
-        , compute_rescale_factor(rotational_kinetic_energy, rotational_dof, deltaT, set_T, rng)};
+        return {
+            compute_rescale_factor(translational_kinetic_energy,
+                                   translational_dof,
+                                   deltaT,
+                                   set_T,
+                                   rng),
+            compute_rescale_factor(rotational_kinetic_energy, rotational_dof, deltaT, set_T, rng)};
         }
 
     /// Get the thermostat time constant.
@@ -407,7 +413,11 @@ class BussiThermostat : public Thermostat
         @param set_T Temperature set point.
         @param rng Random number generator.
     **/
-    Scalar compute_rescale_factor(Scalar K, double degrees_of_freedom, Scalar deltaT, Scalar set_T, RandomGenerator& rng)
+    Scalar compute_rescale_factor(Scalar K,
+                                  double degrees_of_freedom,
+                                  Scalar deltaT,
+                                  Scalar set_T,
+                                  RandomGenerator& rng)
         {
         if (degrees_of_freedom == 0)
             return Scalar(1.0);
@@ -428,13 +438,12 @@ class BussiThermostat : public Thermostat
             r_gamma_n_minus_one = 2.0 * gamma(rng);
             }
 
-        double alpha = sqrt(time_decay_factor
-                   + set_T / 2.0 / K * (1.0 - time_decay_factor)
-                         * (r_gamma_n_minus_one + r_normal_one * r_normal_one)
-                   + 2.0 * r_normal_one
-                         * sqrt(set_T / 2.0 / K * (1.0 - time_decay_factor)
-                                * time_decay_factor));
-        return Scalar(alpha);
+        double term1 = set_T / 2.0 / K * (1.0 - time_decay_factor)
+                       * (r_gamma_n_minus_one + r_normal_one * r_normal_one);
+        double term2 = 2.0 * r_normal_one
+                       * sqrt(set_T / 2.0 / K * (1.0 - time_decay_factor) * time_decay_factor);
+
+        return Scalar(sqrt(time_decay_factor + term1 + term2));
         }
     };
 

--- a/hoomd/md/Thermostat.h
+++ b/hoomd/md/Thermostat.h
@@ -379,6 +379,11 @@ class BussiThermostat : public Thermostat
 
         const auto set_T = m_T->operator()(timestep);
 
+        if (deltaT == 0.0)
+            {
+            return {1.0, 1.0};
+            }
+
         Scalar time_decay_factor;
         if (m_tau != 0.0)
             {

--- a/hoomd/md/methods/thermostats.py
+++ b/hoomd/md/methods/thermostats.py
@@ -248,6 +248,9 @@ class Bussi(Thermostat):
         kT (hoomd.variant.variant_like): Temperature set point for the
             thermostat :math:`[\mathrm{energy}]`.
 
+        tau (float): Thermostat time constant. Defaults to 0
+        :math:`[\mathrm{time}].`
+
     Provides temperature control by rescaling the velocity by a factor taken
     from the canonical velocity distribution. On each timestep, velocities are
     rescaled by a factor :math:`\alpha=\sqrt{K_t / K}`, where :math:`K` is the
@@ -259,6 +262,28 @@ class Bussi(Thermostat):
 
     where :math:`N_f` is the number of degrees of freedom thermalized.
 
+    By default, when `tau` is approaching 0, the stochastic evolution of
+    system is instantly thermalized and this algorithm reduces to the
+    fully stochastic velocity-rescaling scheme
+    , where :math:`\alpha` is given by:
+
+    .. math::
+        \alpha = \sqrt{\frac{K_{\mathrm{set}}}{KN_f}(2G + R^2)}
+
+    In general case, when `tau` is non-zero, :math:`\alpha` is given by:
+
+    .. math::
+        \alpha = \sqrt{f + (1-f)\frac{K_{\mathrm{set}}}{KN_f}(2G + R^2) +
+        2R\sqrt{f(1-f)\frac{K_{\mathrm{set}}}{KN_f}}
+        }
+
+    where :math:`K_{\mathrm{set}}` is the set mean kinetic energy of
+    :math:`N_f/2 kT`, :math:`f` is the time decay factor of
+    :math:`\exp(-\delta t / \tau)`, :math:`G` is the random number
+    sampled from the gamma distribution of :math:`Gamma[(N_f-1)/2, 1]`,
+    and :math:`R` is the random number sampled from the standard
+    normal distribution.
+
     See Also:
         `Bussi et. al. 2007 <https://doi.org/10.1063/1.2408420>`_.
 
@@ -266,7 +291,8 @@ class Bussi(Thermostat):
 
     .. code-block:: python
 
-        bussi = hoomd.md.methods.thermostats.Bussi(kT=1.5)
+        bussi = hoomd.md.methods.thermostats.Bussi(kT=1.5,
+            tau=simulation.operations.integrator.dt*20)
         simulation.operations.integrator.methods[0].thermostat = bussi
 
     Attributes:
@@ -285,6 +311,9 @@ class Bussi(Thermostat):
                                               B=2.0,
                                               t_start=0,
                                               t_ramp=1_000_000)
+
+        tau (float): Thermostat time constant. Defaults to 0
+        :math:`[\mathrm{time}].`
     """
 
     def __init__(self, kT, tau=0.):

--- a/hoomd/md/methods/thermostats.py
+++ b/hoomd/md/methods/thermostats.py
@@ -287,13 +287,17 @@ class Bussi(Thermostat):
                                               t_ramp=1_000_000)
     """
 
-    def __init__(self, kT):
+    def __init__(self, kT, tau=0.):
         super().__init__(kT)
+        param_dict = ParameterDict(tau=float)
+        param_dict["tau"] = tau
+        self._param_dict.update(param_dict)
 
     def _attach_hook(self):
         group = self._simulation.state._get_group(self._filter)
-        self._cpp_obj = _md.BussiThermostat(self.kT, group, self._thermo,
-                                            self._simulation.state._cpp_sys_def)
+        self._cpp_obj = _md.BussiThermostat(
+            self.kT, group, self._thermo, self._simulation.state._cpp_sys_def,
+            self.tau)
         self._simulation._warn_if_seed_unset()
 
 

--- a/hoomd/md/methods/thermostats.py
+++ b/hoomd/md/methods/thermostats.py
@@ -316,7 +316,7 @@ class Bussi(Thermostat):
         :math:`[\mathrm{time}].`
     """
 
-    def __init__(self, kT, tau=0.):
+    def __init__(self, kT, tau=0.0):
         super().__init__(kT)
         param_dict = ParameterDict(tau=float)
         param_dict["tau"] = tau

--- a/hoomd/md/methods/thermostats.py
+++ b/hoomd/md/methods/thermostats.py
@@ -275,7 +275,7 @@ class Bussi(Thermostat):
     .. math::
         \alpha = \sqrt{e^{\delta t / \tau}
                  + (1 - e^{\delta t / \tau}) \frac{(2 g_{N-1} + n^2) kT}{2 K}
-                 + 2 n \sqrt{e^{\delta t / \tau} (1-e{\delta t / \tau})
+                 + 2 n \sqrt{e^{\delta t / \tau} (1-e^{\delta t / \tau})
                     \frac{kT}{2 K}}}
 
     where :math:`\delta t` is the step size and :math:`n` is a random value

--- a/hoomd/md/methods/thermostats.py
+++ b/hoomd/md/methods/thermostats.py
@@ -295,9 +295,9 @@ class Bussi(Thermostat):
 
     def _attach_hook(self):
         group = self._simulation.state._get_group(self._filter)
-        self._cpp_obj = _md.BussiThermostat(
-            self.kT, group, self._thermo, self._simulation.state._cpp_sys_def,
-            self.tau)
+        self._cpp_obj = _md.BussiThermostat(self.kT, group, self._thermo,
+                                            self._simulation.state._cpp_sys_def,
+                                            self.tau)
         self._simulation._warn_if_seed_unset()
 
 

--- a/hoomd/md/methods/thermostats.py
+++ b/hoomd/md/methods/thermostats.py
@@ -264,7 +264,7 @@ class Bussi(Thermostat):
     where :math:`K` is the instantaneous kinetic energy of the corresponding
     translational or rotational degrees of freedom, :math:`N` is the number of
     degrees of freedom, and :math:`g_N` is a random value sampled from the
-    gamma distribution :math:`\mathrm{Gamma}(N, 1)`:
+    distribution :math:`\mathrm{Gamma}(N, 1)`:
 
     .. math::
         f_N(g) = \frac{1}{\Gamma(N)} g^{N-1} e^{-g}.

--- a/hoomd/md/pytest/test_methods.py
+++ b/hoomd/md/pytest/test_methods.py
@@ -92,8 +92,10 @@ _thermostat_definition = (
         "tau": float
     },
                     generator=generator),
-    ClassDefinition(hoomd.md.methods.thermostats.Bussi,
-                    {"kT": hoomd.variant.Variant},
+    ClassDefinition(hoomd.md.methods.thermostats.Bussi, {
+        "kT": hoomd.variant.Variant,
+        "tau": float
+    },
                     generator=generator),
     ClassDefinition(hoomd.md.methods.thermostats.Berendsen, {
         "kT": hoomd.variant.Variant,
@@ -163,7 +165,9 @@ class TestThermostats:
         check_instance_attrs(thermostat, constructor_args)
 
         change_attrs = thermostat_definition.generate_all_attr_change()
-        if isinstance(thermostat, hoomd.md.methods.thermostats.Berendsen):
+        if isinstance(thermostat,
+                      hoomd.md.methods.thermostats.Berendsen) or isinstance(
+                          thermostat, hoomd.md.methods.thermostats.Bussi):
             with pytest.raises(hoomd.error.MutabilityError):
                 thermostat.tau = change_attrs.pop("tau")
         check_instance_attrs(thermostat, change_attrs, True)

--- a/hoomd/md/pytest/test_methods.py
+++ b/hoomd/md/pytest/test_methods.py
@@ -165,9 +165,7 @@ class TestThermostats:
         check_instance_attrs(thermostat, constructor_args)
 
         change_attrs = thermostat_definition.generate_all_attr_change()
-        if isinstance(thermostat,
-                      hoomd.md.methods.thermostats.Berendsen) or isinstance(
-                          thermostat, hoomd.md.methods.thermostats.Bussi):
+        if isinstance(thermostat, hoomd.md.methods.thermostats.Berendsen):
             with pytest.raises(hoomd.error.MutabilityError):
                 thermostat.tau = change_attrs.pop("tau")
         check_instance_attrs(thermostat, change_attrs, True)

--- a/hoomd/test/random_numbers_test.cc
+++ b/hoomd/test/random_numbers_test.cc
@@ -245,6 +245,16 @@ UP_TEST(normal_float_test)
     check_moments(gen, 500000, mean, var, exkurtosis, skew, 0.01);
     }
 
+//! Test case for GammaDistribution -- double (alpha=1/2)
+UP_TEST(gamma_double_half_alpha)
+    {
+    double alpha = 0.5, b = 2.0;
+    double mean = alpha * b, var = alpha * b * b, skew = 2.0 / sqrt(alpha),
+           exkurtosis = 6.0 / alpha;
+    hoomd::GammaDistribution<double> gen(alpha, b);
+    check_moments(gen, 5000000, mean, var, skew, exkurtosis, 0.01);
+    }
+
 //! Test case for GammaDistribution -- double (small alpha)
 UP_TEST(gamma_double_small_alpha_test)
     {


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should be based on *trunk-patch*. -->
<!-- Backwards compatible new features should be based on *trunk-minor*. -->
<!-- Incompatible API changes should be based on *trunk-major*. -->

## Description

Correct the behavior of Bussi thermostat, which currently has two problems.
This PR resolves #1618


## Motivation and context

1. The time constant tau only default to 0. Add an option for users to set finite tau larger than 0.
2. Potential problem that the current implementation is problematic, which relates to an uncorrected typo in the original velocity rescaling thermostat paper.
3. Need to update current documentation based on the changes.

<!-- Replace ??? with the issue number that this pull request resolves. -->

## How has this been tested?

1. Need to check the kinetic energy distribution and the kinetic energy autocorrelation sampled from the corrected Bussi thermostat are correct and reasonable.


## Change log

<!-- Propose a change log entry. -->
```
Pass `tau` into BussiThermostat class. Defaults to 0.
Calculate the rescaling factor for both zero and positive non-zero tau.
Calculate the rescaling factor so it is always 1 when the timestep is 0.
Modify the hoomd/md/pytest/test_methods.py according to the changes above.
Update the documentation of the Python code according to the changes.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
