### PR TITLE
Fix/hdf5 scalar detection

### DIFF
--- a/hoomd/md/pytest/test_hdf5.py
+++ b/hoomd/md/pytest/test_hdf5.py
@@ -158,7 +158,7 @@ def test_mode(tmp_path, create_md_sim):
 def test_type_handling(tmp_path, create_md_sim):
     logger = hoomd.logging.Logger(categories=['scalar'])
     sim = create_md_sim
-    fn = tmp_path / "eg.py"
+    fn = tmp_path / "types.h5"
     loggables = {
         int: lambda: 42,
         float: lambda: 0.0,
@@ -173,9 +173,11 @@ def test_type_handling(tmp_path, create_md_sim):
     sim.operations.writers.append(hdf5_writer)
     sim.run(1)
 
+    rank = sim.device.communicator.rank
     del sim
 
-    with h5py.File(fn, "r") as fh:
-        for key in loggables:
-            type_ = key if key not in (float, int, bool) else np.dtype(key)
-            assert fh[f"hoomd-data/{str(key)}"].dtype == type_
+    if rank == 0:
+        with h5py.File(fn, "r") as fh:
+            for key in loggables:
+                type_ = key if key not in (float, int, bool) else np.dtype(key)
+                assert fh[f"hoomd-data/{str(key)}"].dtype == type_

--- a/hoomd/write/hdf5.py
+++ b/hoomd/write/hdf5.py
@@ -209,7 +209,7 @@ class _HDF5LogInternal(custom._InternalAction):
             chunk_size = None
             if category == "scalar":
                 data_shape = (1,)
-                if isinstance(value, (np.integer, np.floating, np.bool_)):
+                if isinstance(value, (np.number, np.bool_)):
                     dtype = value.dtype
                 elif isinstance(value, int):
                     dtype = np.dtype(bool) if isinstance(value, bool) else "i8"

--- a/hoomd/write/hdf5.py
+++ b/hoomd/write/hdf5.py
@@ -209,7 +209,12 @@ class _HDF5LogInternal(custom._InternalAction):
             chunk_size = None
             if category == "scalar":
                 data_shape = (1,)
-                dtype = "f8" if isinstance(value, float) else "i8"
+                if isinstance(value, (np.integer, np.floating, np.bool_)):
+                    dtype = value.dtype
+                elif isinstance(value, int):
+                    dtype = np.dtype(bool) if isinstance(value, bool) else "i8"
+                else:
+                    dtype = "f8"
                 chunk_size = (self._SCALAR_CHUNK,)
             else:
                 if not isinstance(value, np.ndarray):


### PR DESCRIPTION
## Description
Improves and corrects `hoomd.write.HDF5Log`'s detection of scalar value types and converts to the appropriate NumPy dtype.

## Motivation and context

Resolves #1620

## How has this been tested?
An appropriate test was added to validate the typing behavior.

## Change log

<!-- Propose a change log entry. -->
```
Fixed: ``hoomd.write.HDF5Log's scalar loggable typing.``
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
