### PR TITLE
Fix compile errors with Apple clang 15.

### DIFF
--- a/hoomd/CommunicatorGPU.cc
+++ b/hoomd/CommunicatorGPU.cc
@@ -288,7 +288,7 @@ void CommunicatorGPU::initializeCommunicationStages()
     }
 
 //! Select a particle for migration
-struct get_migrate_key : public std::unary_function<const unsigned int, unsigned int>
+struct get_migrate_key
     {
     const uint3 my_pos;               //!< My domain decomposition position
     const Index3D di;                 //!< Domain indexer

--- a/hoomd/ParticleData.cc
+++ b/hoomd/ParticleData.cc
@@ -2890,7 +2890,7 @@ template<class Real> void SnapshotParticleData<Real>::validate() const
 
 #ifdef ENABLE_MPI
 //! Select non-zero communication lags
-struct comm_flag_select : std::unary_function<const unsigned int, bool>
+struct comm_flag_select
     {
     bool operator()(const unsigned int comm_flag) const
         {
@@ -3070,7 +3070,7 @@ void ParticleData::removeParticles(std::vector<detail::pdata_element>& out,
         std::remove_copy_if(h_comm_flags.data,
                             h_comm_flags.data + old_nparticles,
                             comm_flags.begin(),
-                            std::not1(comm_flag_select()));
+                            std::not_fn(comm_flag_select()));
 
         // reset communication flags to zero
         std::fill(h_comm_flags.data, h_comm_flags.data + new_nparticles, 0);


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should be based on *trunk-patch*. -->
<!-- Backwards compatible new features should be based on *trunk-minor*. -->
<!-- Incompatible API changes should be based on *trunk-major*. -->

## Description

<!-- Describe your changes in detail. -->
Fix compile errors with Apple clang 15.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Allow users to build HOOMD on Mac.

<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves #1590

## How has this been tested?

The compile error:
```
/Users/joaander/devel/hoomd/hoomd/ParticleData.cc:2893:32: error: no template named 'unary_function' in namespace 'std'; did you mean '__unary_function'? 
```
no longer appears after this fix.

<!--- Please describe in detail how you tested your changes. -->

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
Fixed:

* HOOMD-blue compiles without errors with Apple clang 15.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
