### PR TITLE
Allow 0 values in Table writer.

### DIFF
--- a/hoomd/pytest/test_table.py
+++ b/hoomd/pytest/test_table.py
@@ -39,6 +39,8 @@ def logger():
     logger[('dummy', 'loggable', 'float')] = (Identity(3.1415), 'scalar')
     logger[('dummy', 'loggable', 'small_float')] = (Identity(0.0000001),
                                                     'scalar')
+    logger[('dummy', 'loggable', 'zero_float')] = (Identity(0.0), 'scalar')
+    logger[('dummy', 'loggable', 'zero_int')] = (Identity(0), 'scalar')
     logger[('dummy', 'loggable', 'string')] = (Identity("foobarbaz"), 'string')
     return logger
 
@@ -49,7 +51,9 @@ def expected_values():
         'dummy.loggable.int': 42000000,
         'dummy.loggable.float': 3.1415,
         'dummy.loggable.string': "foobarbaz",
-        'dummy.loggable.small_float': 0.0000001
+        'dummy.loggable.small_float': 0.0000001,
+        'dummy.loggable.zero_float': 0.0,
+        'dummy.loggable.zero_int': 0,
     }
 
 

--- a/hoomd/write/table.py
+++ b/hoomd/write/table.py
@@ -99,6 +99,9 @@ class _Formatter:
     @staticmethod
     def _digits_from_decimal(num):
         """Return digits to represent to the first significant digit."""
+        if num == 0.0:
+            return 1
+
         digits = int(log10(abs(num)))
         # Positive exponents require an extra space (10^0 == 1)
         digits = 1 + digits if digits >= 0 else -digits


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should be based on *trunk-patch*. -->
<!-- Backwards compatible new features should be based on *trunk-minor*. -->
<!-- Incompatible API changes should be based on *trunk-major*. -->

## Description

<!-- Describe your changes in detail. -->
Write 0 values correctly with write.Table.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
#1617 fixed small number formatting in `write.Table` but now raises exceptions when the value is exactly 0.0.

<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves #1625 

## How has this been tested?

Added parameters to existing unit tests.
<!--- Please describe in detail how you tested your changes. -->

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
Fixed:

* ``hoomd.write.Table`` correctly displays floating point values that are exactly 0.0.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
