### PR TITLE
Call hipInit before MPI_Init.

### DIFF
--- a/hoomd/module.cc
+++ b/hoomd/module.cc
@@ -102,6 +102,10 @@ char env_enable_mpi_cuda[] = "MV2_USE_CUDA=1";
 //! Initialize the MPI environment
 int initialize_mpi()
     {
+    #if defined(ENABLE_HIP) && defined(__HIP_PLATFORM_HCC__)
+    hipInit(0);
+    #endif
+
     // initialize MPI if it has not been initialized by another program
     int external_init = 0;
     MPI_Initialized(&external_init);

--- a/hoomd/module.cc
+++ b/hoomd/module.cc
@@ -102,9 +102,9 @@ char env_enable_mpi_cuda[] = "MV2_USE_CUDA=1";
 //! Initialize the MPI environment
 int initialize_mpi()
     {
-    #if defined(ENABLE_HIP) && defined(__HIP_PLATFORM_HCC__)
+#if defined(ENABLE_HIP) && defined(__HIP_PLATFORM_HCC__)
     hipInit(0);
-    #endif
+#endif
 
     // initialize MPI if it has not been initialized by another program
     int external_init = 0;


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should be based on *trunk-patch*. -->
<!-- Backwards compatible new features should be based on *trunk-minor*. -->
<!-- Incompatible API changes should be based on *trunk-major*. -->

## Description

<!-- Describe your changes in detail. -->
Call `hipInit(0)` before `MPI_Init`.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
OLCF suggests this as a workaround for segmentation faults in `MPI_Init`: https://docs.olcf.ornl.gov/systems/frontier_user_guide.html#olcfdev-1655-occasional-seg-fault-during-mpi-init.

## How has this been tested?

I attempted to reproduce the failure. Prior to this change, i did observe:
```
Fri Sep 22 11:49:53 2023: [PE_388]:_pmi_mmap_tmp: Warning bootstrap barrier failed: num_syncd=3, pes_this_node=8, timeout=180 secs
Fri Sep 22 11:49:53 2023: [PE_385]:_pmi_mmap_tmp: Warning bootstrap barrier failed: num_syncd=3, pes_this_node=8, timeout=180 secs
Fri Sep 22 11:49:53 2023: [PE_385]:_pmi_mmap_init:Failed to setup PMI mmap.Fri Sep 22 11:49:53 2023: [PE_385]:globals_init:_pmi_mmap_init returned -1
MPICH ERROR [Rank 0] [job id unknown] [Fri Sep 22 11:49:53 2023] [frontier04084] - Abort(1091855) (rank 0 in comm 0): Fatal error in PMPI_Init: Other MPI error, error stack:
MPIR_Init_thread(170): 
MPID_Init(441).......: 
MPIR_pmi_init(110)...: PMI_Init returned 1
```
*very* occasionally - approximately 3 times out of hundreds of launches ranging from 10 nodes to 500 nodes. This error occurred during both CPU-only and GPU jobs.

With ~20 submissions after this change, I did not observe the error. With such a low rate of occurrence, we will only be certain of the fix after long term testing with production runs. There is no harm in initializing the hip runtime early: https://rocm.docs.amd.com/projects/HIP/en/latest/.doxygen/docBin/html/group___driver.html#ga01baa652dda5815c594d047060496caa - it is normally initialized automatically on the first HIP call.

<!--- Please describe in detail how you tested your changes. -->

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
Fixed:

* Attempt to workaround `PMI_Init returned 1` error on OLCF Frontier.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
