### PR TITLE
Tweak GPU detection in MPI.

### DIFF
--- a/hoomd/ExecutionConfiguration.cc
+++ b/hoomd/ExecutionConfiguration.cc
@@ -105,7 +105,7 @@ ExecutionConfiguration::ExecutionConfiguration(executionMode mode,
     if (exec_mode == GPU)
         {
         bool using_mpi = false;
-        #ifdef ENABLE_MPI
+#ifdef ENABLE_MPI
         // single rank simulations emulate the ENABLE_MPI=off behavior
         int size;
         MPI_Comm_size(MPI_COMM_WORLD, &size);
@@ -113,7 +113,7 @@ ExecutionConfiguration::ExecutionConfiguration(executionMode mode,
             {
             using_mpi = true;
             }
-        #endif
+#endif
 
         if (!gpu_id.size() && using_mpi)
             {

--- a/hoomd/ExecutionConfiguration.h
+++ b/hoomd/ExecutionConfiguration.h
@@ -339,9 +339,8 @@ class PYBIND11_EXPORT ExecutionConfiguration
     //! Guess local rank of this processor, used for GPU initialization
     /*! \returns Local rank guessed from common environment variables
                  or falls back to the global rank if no information is available
-        \param found [output] True if a local rank was found, false otherwise
      */
-    int guessLocalRank(bool& found);
+    int guessLocalRank();
 
 #if defined(ENABLE_HIP)
     //! Initialize the GPU with the given id (where gpu_id is an index into s_capable_gpu_ids)


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should be based on *trunk-patch*. -->
<!-- Backwards compatible new features should be based on *trunk-minor*. -->
<!-- Incompatible API changes should be based on *trunk-major*. -->

## Description

<!-- Describe your changes in detail. -->
* Call `guessLocalRank` only in MPI simulations with more than one rank.
* Use `SLURM_LOCALID` even when it is 0 on all ranks.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
In cases where users manually partition and pass in a mpi4py communicator, `guessLocalRank` was not operating as intended. In communicators with only 1 rank, `guessLocalRank` would report that `SLURM_LOCALID` was 0 on all ranks. In this use-case, this change does not impact the GPU selection (0 % 8 = 0), but it does provide notice messages from `guessLocalRank` that make more sense.

This check was for an old broken Intel MPI build on a specific cluster that always reported 0. As far as I know, all modern slurm versions provide `SLURM_LOCALID` correctly. 

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
I rank these scripts locally and got the expected behavior running on various ranks with various partition sizes:
```
import hoomd
hoomd.device.GPU(notice_level=4)
```
```
import hoomd
from mpi4py import MPI

comm = MPI.COMM_WORLD
rank = comm.Get_rank()
partition = rank // 2

partition_comm = comm.Split(partition, rank)

device = hoomd.device.GPU(notice_level=4, communicator=hoomd.communicator.Communicator(partition_comm))
```

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
Fixed:

* More consistent notice messages regarding MPI ranks used in GPU selection.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
