### PR TITLE
Fix SDF computation with patchy potentials.

### DIFF
--- a/hoomd/hpmc/ComputeSDF.h
+++ b/hoomd/hpmc/ComputeSDF.h
@@ -618,6 +618,9 @@ template<class Shape> void ComputeSDF<Shape>::countHistogramLinearSearch(uint64_
                                         min_bin_compression = bin_to_sample;
                                         hist_weight_ptl_i_compression
                                             = 1.0 - fast::exp(-(u_ij_new - u_ij_0));
+                                        // do not let weight go below zero
+                                        hist_weight_ptl_i_compression
+                                            = fmax(0, hist_weight_ptl_i_compression);
                                         }
                                     } // end if (!hard_overlap && m_mc->getPatchEnergy())
                                 }     // end loop over bins for compression
@@ -670,6 +673,9 @@ template<class Shape> void ComputeSDF<Shape>::countHistogramLinearSearch(uint64_
                                         min_bin_expansion = bin_to_sample;
                                         hist_weight_ptl_i_expansion
                                             = 1.0 - fast::exp(-(u_ij_new - u_ij_0));
+                                        // do not let weight go below zero
+                                        hist_weight_ptl_i_expansion
+                                            = fmax(0, hist_weight_ptl_i_expansion);
                                         }
                                     } // end if (!hard_overlap && m_mc->getPatchEnergy())
                                 }     // end loop over histogram bins for expansions

--- a/hoomd/hpmc/ComputeSDF.h
+++ b/hoomd/hpmc/ComputeSDF.h
@@ -616,11 +616,15 @@ template<class Shape> void ComputeSDF<Shape>::countHistogramLinearSearch(uint64_
                                     if (u_ij_new != u_ij_0)
                                         {
                                         min_bin_compression = bin_to_sample;
-                                        hist_weight_ptl_i_compression
-                                            = 1.0 - fast::exp(-(u_ij_new - u_ij_0));
-                                        // do not let weight go below zero
-                                        hist_weight_ptl_i_compression
-                                            = fmax(0, hist_weight_ptl_i_compression);
+                                        if (u_ij_new < u_ij_0)
+                                            {
+                                            hist_weight_ptl_i_compression = 0;
+                                            }
+                                        else
+                                            {
+                                            hist_weight_ptl_i_compression
+                                                = 1.0 - fast::exp(-(u_ij_new - u_ij_0));
+                                            }
                                         }
                                     } // end if (!hard_overlap && m_mc->getPatchEnergy())
                                 }     // end loop over bins for compression
@@ -671,11 +675,15 @@ template<class Shape> void ComputeSDF<Shape>::countHistogramLinearSearch(uint64_
                                     if (u_ij_new != u_ij_0)
                                         {
                                         min_bin_expansion = bin_to_sample;
-                                        hist_weight_ptl_i_expansion
-                                            = 1.0 - fast::exp(-(u_ij_new - u_ij_0));
-                                        // do not let weight go below zero
-                                        hist_weight_ptl_i_expansion
-                                            = fmax(0, hist_weight_ptl_i_expansion);
+                                        if (u_ij_new < u_ij_0)
+                                            {
+                                            hist_weight_ptl_i_expansion = 0;
+                                            }
+                                        else
+                                            {
+                                            hist_weight_ptl_i_expansion
+                                                = 1.0 - fast::exp(-(u_ij_new - u_ij_0));
+                                            }
                                         }
                                     } // end if (!hard_overlap && m_mc->getPatchEnergy())
                                 }     // end loop over histogram bins for expansions


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should be based on *trunk-patch*. -->
<!-- Backwards compatible new features should be based on *trunk-minor*. -->
<!-- Incompatible API changes should be based on *trunk-major*. -->

## Description

Changes the SDF pressure computation for patchy potentials. The correct formulation of the "soft overlap" approach should not add values less than zero to the histograms used for the SDF. This change adds the maximum of zero and the computed weight to add to the histograms.

## Motivation and context

Accurate pressure calculation is better than inaccurate pressure calculation.

## How has this been tested?

Added unit tests to make sure the SDF arrays contain the correct values.

The validation tests now pass, see https://github.com/glotzerlab/hoomd-validation/pull/66.


## Change log

```
- Fix implementation of SDF pressure compute for patchy potentials.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
