### PR TITLE
Check for SLURM_LOCALID last.

### DIFF
--- a/hoomd/ExecutionConfiguration.cc
+++ b/hoomd/ExecutionConfiguration.cc
@@ -122,7 +122,8 @@ ExecutionConfiguration::ExecutionConfiguration(executionMode mode,
             gpu_id.push_back((local_rank % dev_count));
 
             ostringstream s;
-            s << "Selected GPU " << gpu_id[0] << " by MPI rank (" << dev_count << " available)." << endl;
+            s << "Selected GPU " << gpu_id[0] << " by MPI rank (" << dev_count << " available)."
+              << endl;
             msg->collectiveNoticeStr(4, s.str());
             }
 
@@ -635,7 +636,7 @@ int ExecutionConfiguration::guessLocalRank()
     env_vars.push_back("MV2_COMM_WORLD_LOCAL_RANK");
     env_vars.push_back("OMPI_COMM_WORLD_LOCAL_RANK");
     env_vars.push_back("JSM_NAMESPACE_LOCAL_RANK");
-    
+
     // Always check SLURM_LOCALID last to allow other mpi launchers to override.
     env_vars.push_back("SLURM_LOCALID");
 


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should be based on *trunk-patch*. -->
<!-- Backwards compatible new features should be based on *trunk-minor*. -->
<!-- Incompatible API changes should be based on *trunk-major*. -->

## Description

<!-- Describe your changes in detail. -->
Check for SLURM_LOCALID last.

## Motivation and context

Some systems set SLURM_LOCALID=0 in the controlling job. HOOMD will see this first and use it instead of the intended MPI specific env var set by mpirun.

<!--- Why is this change required? What problem does it solve? -->

<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves #???

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
Tested on Great Lakes.

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
Fixed:

* Use ``mpirun`` specific local ranks to select GPUs before checking ``SLURM_LOCALID``.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
