### PR TITLE
Improve performance of accessing per-particle energy, forces, torques, and virials properties

### DIFF
--- a/hoomd/ForceCompute.cc
+++ b/hoomd/ForceCompute.cc
@@ -368,7 +368,7 @@ pybind11::object ForceCompute::getEnergiesPython()
         }
     else
         {
-        global_energy = local_energy;
+        global_energy = std::move(local_energy);
         }
 
     if (root)
@@ -423,7 +423,7 @@ pybind11::object ForceCompute::getForcesPython()
         }
     else
         {
-        global_force = local_force;
+        global_force = std::move(local_force);
         }
 
     if (root)
@@ -481,7 +481,7 @@ pybind11::object ForceCompute::getTorquesPython()
         }
     else
         {
-        global_torque = local_torque;
+        global_torque = std::move(local_torque);
         }
 
     if (root)
@@ -547,7 +547,7 @@ pybind11::object ForceCompute::getVirialsPython()
         }
     else
         {
-        global_virial = local_virial;
+        global_virial = std::move(local_virial);
         }
 
     if (root)

--- a/hoomd/ForceCompute.cc
+++ b/hoomd/ForceCompute.cc
@@ -520,7 +520,7 @@ pybind11::object ForceCompute::getVirialsPython()
         }
     std::vector<hoomd::detail::vec6<double>> global_virial(dims[0]);
 
-    // sort forces by particle tag
+    // sort virials by particle tag
     std::vector<hoomd::detail::vec6<double>> local_virial(m_pdata->getN());
     std::vector<uint32_t> local_tag(m_pdata->getN());
     ArrayHandle<unsigned int> h_tag(m_pdata->getTags(), access_location::host, access_mode::read);

--- a/hoomd/ForceCompute.cc
+++ b/hoomd/ForceCompute.cc
@@ -397,23 +397,38 @@ pybind11::object ForceCompute::getForcesPython()
         dims[0] = 0;
         dims[1] = 0;
         }
-    std::vector<vec3<double>> force(dims[0]);
+    std::vector<vec3<double>> global_force(dims[0]);
 
-    // This is slow: TODO implement a proper gather operation
-    for (unsigned int i = 0; i < m_pdata->getNGlobal(); i++)
+    // sort forces by particle tag
+    std::vector<vec3<double>> local_force(m_pdata->getN());
+    std::vector<uint32_t> local_tag(m_pdata->getN());
+    ArrayHandle<unsigned int> h_tag(m_pdata->getTags(), access_location::host, access_mode::read);
+    ArrayHandle<unsigned int> h_rtag(m_pdata->getRTags(), access_location::host, access_mode::read);
+    ArrayHandle<Scalar4> h_force(m_force, access_location::host, access_mode::read);
+    std::copy(h_tag.data, h_tag.data + m_pdata->getN(), local_tag.begin());
+    std::sort(local_tag.begin(), local_tag.end());
+    for (unsigned int i = 0; i < m_pdata->getN(); i++)
         {
-        Scalar3 f = getForce(i);
-        if (root)
-            {
-            force[i].x = f.x;
-            force[i].y = f.y;
-            force[i].z = f.z;
-            }
+        local_force[i].x = h_force.data[h_rtag.data[local_tag[i]]].x;
+        local_force[i].y = h_force.data[h_rtag.data[local_tag[i]]].y;
+        local_force[i].z = h_force.data[h_rtag.data[local_tag[i]]].z;
+        }
+
+    if (m_sysdef->isDomainDecomposed())
+        {
+#ifdef ENABLE_MPI
+        m_gather_tag_order.setLocalTagsSorted(local_tag);
+        m_gather_tag_order.gatherArray(global_force, local_force);
+#endif
+        }
+    else
+        {
+        global_force = local_force;
         }
 
     if (root)
         {
-        return pybind11::array(dims, (double*)force.data());
+        return pybind11::array(dims, (double*)global_force.data());
         }
     else
         {
@@ -440,23 +455,38 @@ pybind11::object ForceCompute::getTorquesPython()
         dims[0] = 0;
         dims[1] = 0;
         }
-    std::vector<vec3<double>> torque(dims[0]);
+    std::vector<vec3<double>> global_torque(dims[0]);
 
-    // This is slow: TODO implement a proper gather operation
-    for (unsigned int i = 0; i < m_pdata->getNGlobal(); i++)
+    // sort torques by particle tag
+    std::vector<vec3<double>> local_torque(m_pdata->getN());
+    std::vector<uint32_t> local_tag(m_pdata->getN());
+    ArrayHandle<unsigned int> h_tag(m_pdata->getTags(), access_location::host, access_mode::read);
+    ArrayHandle<unsigned int> h_rtag(m_pdata->getRTags(), access_location::host, access_mode::read);
+    ArrayHandle<Scalar4> h_torque(m_torque, access_location::host, access_mode::read);
+    std::copy(h_tag.data, h_tag.data + m_pdata->getN(), local_tag.begin());
+    std::sort(local_tag.begin(), local_tag.end());
+    for (unsigned int i = 0; i < m_pdata->getN(); i++)
         {
-        Scalar4 f = getTorque(i);
-        if (root)
-            {
-            torque[i].x = f.x;
-            torque[i].y = f.y;
-            torque[i].z = f.z;
-            }
+        local_torque[i].x = h_torque.data[h_rtag.data[local_tag[i]]].x;
+        local_torque[i].y = h_torque.data[h_rtag.data[local_tag[i]]].y;
+        local_torque[i].z = h_torque.data[h_rtag.data[local_tag[i]]].z;
+        }
+
+    if (m_sysdef->isDomainDecomposed())
+        {
+#ifdef ENABLE_MPI
+        m_gather_tag_order.setLocalTagsSorted(local_tag);
+        m_gather_tag_order.gatherArray(global_torque, local_torque);
+#endif
+        }
+    else
+        {
+        global_torque = local_torque;
         }
 
     if (root)
         {
-        return pybind11::array(dims, (double*)torque.data());
+        return pybind11::array(dims, (double*)global_torque.data());
         }
     else
         {
@@ -488,32 +518,41 @@ pybind11::object ForceCompute::getVirialsPython()
         dims[0] = 0;
         dims[1] = 0;
         }
-    std::vector<double> virial(dims[0] * dims[1]);
+    std::vector<hoomd::detail::vec6<double>> global_virial(dims[0]);
 
-    // This is slow: TODO implement a proper gather operation
-    for (unsigned int i = 0; i < m_pdata->getNGlobal(); i++)
+    // sort forces by particle tag
+    std::vector<hoomd::detail::vec6<double>> local_virial(m_pdata->getN());
+    std::vector<uint32_t> local_tag(m_pdata->getN());
+    ArrayHandle<unsigned int> h_tag(m_pdata->getTags(), access_location::host, access_mode::read);
+    ArrayHandle<unsigned int> h_rtag(m_pdata->getRTags(), access_location::host, access_mode::read);
+    ArrayHandle<Scalar> h_virial(m_virial, access_location::host, access_mode::read);
+    std::copy(h_tag.data, h_tag.data + m_pdata->getN(), local_tag.begin());
+    std::sort(local_tag.begin(), local_tag.end());
+    for (unsigned int i = 0; i < m_pdata->getN(); i++)
         {
-        double v0 = getVirial(i, 0);
-        double v1 = getVirial(i, 1);
-        double v2 = getVirial(i, 2);
-        double v3 = getVirial(i, 3);
-        double v4 = getVirial(i, 4);
-        double v5 = getVirial(i, 5);
+        local_virial[i].xx = h_virial.data[m_virial_pitch * 0 + h_rtag.data[local_tag[i]]];
+        local_virial[i].xy = h_virial.data[m_virial_pitch * 1 + h_rtag.data[local_tag[i]]];
+        local_virial[i].xz = h_virial.data[m_virial_pitch * 2 + h_rtag.data[local_tag[i]]];
+        local_virial[i].yy = h_virial.data[m_virial_pitch * 3 + h_rtag.data[local_tag[i]]];
+        local_virial[i].yz = h_virial.data[m_virial_pitch * 4 + h_rtag.data[local_tag[i]]];
+        local_virial[i].zz = h_virial.data[m_virial_pitch * 5 + h_rtag.data[local_tag[i]]];
+        }
 
-        if (root)
-            {
-            virial[i * 6 + 0] = v0;
-            virial[i * 6 + 1] = v1;
-            virial[i * 6 + 2] = v2;
-            virial[i * 6 + 3] = v3;
-            virial[i * 6 + 4] = v4;
-            virial[i * 6 + 5] = v5;
-            }
+    if (m_sysdef->isDomainDecomposed())
+        {
+#ifdef ENABLE_MPI
+        m_gather_tag_order.setLocalTagsSorted(local_tag);
+        m_gather_tag_order.gatherArray(global_virial, local_virial);
+#endif
+        }
+    else
+        {
+        global_virial = local_virial;
         }
 
     if (root)
         {
-        return pybind11::array(dims, (double*)virial.data());
+        return pybind11::array(dims, (double*)global_virial.data());
         }
     else
         {

--- a/hoomd/ForceCompute.cc
+++ b/hoomd/ForceCompute.cc
@@ -397,23 +397,38 @@ pybind11::object ForceCompute::getForcesPython()
         dims[0] = 0;
         dims[1] = 0;
         }
-    std::vector<vec3<double>> force(dims[0]);
+    std::vector<vec3<double>> global_force(dims[0]);
 
-    // This is slow: TODO implement a proper gather operation
-    for (unsigned int i = 0; i < m_pdata->getNGlobal(); i++)
+    // sort forces by particle tag
+    std::vector<vec3<double>> local_force(m_pdata->getN());
+    std::vector<uint32_t> local_tag(m_pdata->getN());
+    ArrayHandle<unsigned int> h_tag(m_pdata->getTags(), access_location::host, access_mode::read);
+    ArrayHandle<unsigned int> h_rtag(m_pdata->getRTags(), access_location::host, access_mode::read);
+    ArrayHandle<Scalar4> h_force(m_force, access_location::host, access_mode::read);
+    std::copy(h_tag.data, h_tag.data + m_pdata->getN(), local_tag.begin());
+    std::sort(local_tag.begin(), local_tag.end());
+    for (unsigned int i = 0; i < m_pdata->getN(); i++)
         {
-        Scalar3 f = getForce(i);
-        if (root)
-            {
-            force[i].x = f.x;
-            force[i].y = f.y;
-            force[i].z = f.z;
-            }
+        local_force[i].x = h_force.data[h_rtag.data[local_tag[i]]].x;
+        local_force[i].y = h_force.data[h_rtag.data[local_tag[i]]].y;
+        local_force[i].z = h_force.data[h_rtag.data[local_tag[i]]].z;
+        }
+
+    if (m_sysdef->isDomainDecomposed())
+        {
+#ifdef ENABLE_MPI
+        m_gather_tag_order.setLocalTagsSorted(local_tag);
+        m_gather_tag_order.gatherArray(global_force, local_force);
+#endif
+        }
+    else
+        {
+        global_force = local_force;
         }
 
     if (root)
         {
-        return pybind11::array(dims, (double*)force.data());
+        return pybind11::array(dims, (double*)global_force.data());
         }
     else
         {
@@ -440,23 +455,38 @@ pybind11::object ForceCompute::getTorquesPython()
         dims[0] = 0;
         dims[1] = 0;
         }
-    std::vector<vec3<double>> torque(dims[0]);
+    std::vector<vec3<double>> global_torque(dims[0]);
 
-    // This is slow: TODO implement a proper gather operation
-    for (unsigned int i = 0; i < m_pdata->getNGlobal(); i++)
+    // sort torques by particle tag
+    std::vector<vec3<double>> local_torque(m_pdata->getN());
+    std::vector<uint32_t> local_tag(m_pdata->getN());
+    ArrayHandle<unsigned int> h_tag(m_pdata->getTags(), access_location::host, access_mode::read);
+    ArrayHandle<unsigned int> h_rtag(m_pdata->getRTags(), access_location::host, access_mode::read);
+    ArrayHandle<Scalar4> h_torque(m_torque, access_location::host, access_mode::read);
+    std::copy(h_tag.data, h_tag.data + m_pdata->getN(), local_tag.begin());
+    std::sort(local_tag.begin(), local_tag.end());
+    for (unsigned int i = 0; i < m_pdata->getN(); i++)
         {
-        Scalar4 f = getTorque(i);
-        if (root)
-            {
-            torque[i].x = f.x;
-            torque[i].y = f.y;
-            torque[i].z = f.z;
-            }
+        local_torque[i].x = h_torque.data[h_rtag.data[local_tag[i]]].x;
+        local_torque[i].y = h_torque.data[h_rtag.data[local_tag[i]]].y;
+        local_torque[i].z = h_torque.data[h_rtag.data[local_tag[i]]].z;
+        }
+
+    if (m_sysdef->isDomainDecomposed())
+        {
+#ifdef ENABLE_MPI
+        m_gather_tag_order.setLocalTagsSorted(local_tag);
+        m_gather_tag_order.gatherArray(global_torque, local_torque);
+#endif
+        }
+    else
+        {
+        global_torque = local_torque;
         }
 
     if (root)
         {
-        return pybind11::array(dims, (double*)torque.data());
+        return pybind11::array(dims, (double*)global_torque.data());
         }
     else
         {
@@ -488,32 +518,41 @@ pybind11::object ForceCompute::getVirialsPython()
         dims[0] = 0;
         dims[1] = 0;
         }
-    std::vector<double> virial(dims[0] * dims[1]);
+    std::vector<vec6<double>> global_virial(dims[0]);
 
-    // This is slow: TODO implement a proper gather operation
-    for (unsigned int i = 0; i < m_pdata->getNGlobal(); i++)
+    // sort forces by particle tag
+    std::vector<vec6<double>> local_virial(m_pdata->getN());
+    std::vector<uint32_t> local_tag(m_pdata->getN());
+    ArrayHandle<unsigned int> h_tag(m_pdata->getTags(), access_location::host, access_mode::read);
+    ArrayHandle<unsigned int> h_rtag(m_pdata->getRTags(), access_location::host, access_mode::read);
+    ArrayHandle<Scalar> h_virial(m_virial, access_location::host, access_mode::read);
+    std::copy(h_tag.data, h_tag.data + m_pdata->getN(), local_tag.begin());
+    std::sort(local_tag.begin(), local_tag.end());
+    for (unsigned int i = 0; i < m_pdata->getN(); i++)
         {
-        double v0 = getVirial(i, 0);
-        double v1 = getVirial(i, 1);
-        double v2 = getVirial(i, 2);
-        double v3 = getVirial(i, 3);
-        double v4 = getVirial(i, 4);
-        double v5 = getVirial(i, 5);
+        local_virial[i].xx = h_virial.data[m_virial_pitch * 0 + h_rtag.data[local_tag[i]]];
+        local_virial[i].xy = h_virial.data[m_virial_pitch * 1 + h_rtag.data[local_tag[i]]];
+        local_virial[i].xz = h_virial.data[m_virial_pitch * 2 + h_rtag.data[local_tag[i]]];
+        local_virial[i].yy = h_virial.data[m_virial_pitch * 3 + h_rtag.data[local_tag[i]]];
+        local_virial[i].yz = h_virial.data[m_virial_pitch * 4 + h_rtag.data[local_tag[i]]];
+        local_virial[i].zz = h_virial.data[m_virial_pitch * 5 + h_rtag.data[local_tag[i]]];
+        }
 
-        if (root)
-            {
-            virial[i * 6 + 0] = v0;
-            virial[i * 6 + 1] = v1;
-            virial[i * 6 + 2] = v2;
-            virial[i * 6 + 3] = v3;
-            virial[i * 6 + 4] = v4;
-            virial[i * 6 + 5] = v5;
-            }
+    if (m_sysdef->isDomainDecomposed())
+        {
+#ifdef ENABLE_MPI
+        m_gather_tag_order.setLocalTagsSorted(local_tag);
+        m_gather_tag_order.gatherArray(global_virial, local_virial);
+#endif
+        }
+    else
+        {
+        global_virial = local_virial;
         }
 
     if (root)
         {
-        return pybind11::array(dims, (double*)virial.data());
+        return pybind11::array(dims, (double*)global_virial.data());
         }
     else
         {

--- a/hoomd/ForceCompute.cc
+++ b/hoomd/ForceCompute.cc
@@ -348,21 +348,19 @@ pybind11::object ForceCompute::getEnergiesPython()
     // sort energies by particle tag
     std::vector<double> local_energy;
     local_energy.reserve(m_pdata->getN());
-    std::vector<uint32_t> local_tag(m_pdata->getN());
     ArrayHandle<unsigned int> h_tag(m_pdata->getTags(), access_location::host, access_mode::read);
     ArrayHandle<unsigned int> h_rtag(m_pdata->getRTags(), access_location::host, access_mode::read);
     ArrayHandle<Scalar4> h_force(m_force, access_location::host, access_mode::read);
-    std::copy(h_tag.data, h_tag.data + m_pdata->getN(), local_tag.begin());
-    std::sort(local_tag.begin(), local_tag.end());
+    getSortedLocalTags();
     for (unsigned int i = 0; i < m_pdata->getN(); i++)
         {
-        local_energy.push_back(h_force.data[h_rtag.data[local_tag[i]]].w);
+        local_energy.push_back(h_force.data[h_rtag.data[m_local_tag[i]]].w);
         }
 
     if (m_sysdef->isDomainDecomposed())
         {
 #ifdef ENABLE_MPI
-        m_gather_tag_order.setLocalTagsSorted(local_tag);
+        m_gather_tag_order.setLocalTagsSorted(m_local_tag);
         m_gather_tag_order.gatherArray(global_energy, local_energy);
 #endif
         }

--- a/hoomd/ForceCompute.h
+++ b/hoomd/ForceCompute.h
@@ -199,6 +199,20 @@ class PYBIND11_EXPORT ForceCompute : public Compute
     //! Update GPU memory hints
     void updateGPUAdvice();
 
+    //! Sort local tags
+    void getSortedLocalTags()
+        {
+        m_local_tag.resize(m_pdata->getN());
+        ArrayHandle<unsigned int> h_tag(m_pdata->getTags(),
+                                        access_location::host,
+                                        access_mode::read);
+        ArrayHandle<unsigned int> h_rtag(m_pdata->getRTags(),
+                                         access_location::host,
+                                         access_mode::read);
+        std::copy(h_tag.data, h_tag.data + m_pdata->getN(), m_local_tag.begin());
+        std::sort(m_local_tag.begin(), m_local_tag.end());
+        }
+
     Scalar m_deltaT; //!< timestep size (required for some types of non-conservative forces)
 
     GlobalArray<Scalar4> m_force; //!< m_force.x,m_force.y,m_force.z are the x,y,z components of the
@@ -227,6 +241,9 @@ class PYBIND11_EXPORT ForceCompute : public Compute
     /// Helper class to gather particle forces, energies, and virials
     GatherTagOrder m_gather_tag_order;
 #endif
+
+    // Store local tags for gathering particle forces, energies, torques, and virials
+    std::vector<uint32_t> m_local_tag;
 
     //! Actually perform the computation of the forces
     /*! This is pure virtual here. Sub-classes must implement this function. It will be called by

--- a/hoomd/ForceCompute.h
+++ b/hoomd/ForceCompute.h
@@ -222,6 +222,11 @@ class PYBIND11_EXPORT ForceCompute : public Compute
     // whether the local force buffers exposed by this class should be read-only
     bool m_buffers_writeable;
 
+#ifdef ENABLE_MPI
+    /// Helper class to gather particle forces, energies, and virials
+    GatherTagOrder m_gather_tag_order;
+#endif
+
     //! Actually perform the computation of the forces
     /*! This is pure virtual here. Sub-classes must implement this function. It will be called by
         the base class compute() when the forces need to be computed.

--- a/hoomd/ForceCompute.h
+++ b/hoomd/ForceCompute.h
@@ -3,7 +3,6 @@
 
 #include "Compute.h"
 #include "GlobalArray.h"
-#include "HOOMDMath.h"
 #include "Index1D.h"
 #include "ParticleGroup.h"
 #include "PythonLocalDataAccess.h"
@@ -65,6 +64,8 @@ class PYBIND11_EXPORT ForceCompute : public Compute
         m_deltaT = dt;
         }
 
+    namespace detail
+        {
     template<class Real> struct vec6
         {
         //! Construct a vec6
@@ -78,70 +79,6 @@ class PYBIND11_EXPORT ForceCompute : public Compute
             {
             }
 
-        Real& operator[](unsigned int i)
-            {
-            switch (i)
-                {
-            case 0:
-                return xx;
-            case 1:
-                return xy;
-            case 2:
-                return xz;
-            case 3:
-                return yy;
-            case 4:
-                return yz;
-            case 5:
-                return zz;
-            default:
-// Just return x on GPU or when using JIT as exceptions are disabled on GPU and JIT code.
-#if defined(__HIPCC__) || defined(HOOMD_LLVMJIT_BUILD)
-                // This branch should not be reached, but must include something to avoid
-                // compiler warnings on the GPU and it must be something that can be returned by
-                // reference, so x is as good a choice as any.
-                return xx;
-#else
-                // On the CPU we throw an error to help with debugging any errors in use of the
-                // code.
-                throw std::invalid_argument(
-                    "Attempting to access non-existent vec6 entry (i.e. i > 2)");
-#endif
-                }
-            }
-
-        const Real operator[](unsigned int i) const
-            {
-            switch (i)
-                {
-            case 0:
-                return xx;
-            case 1:
-                return xy;
-            case 2:
-                return xz;
-            case 3:
-                return yy;
-            case 4:
-                return yz;
-            case 5:
-                return zz;
-            default:
-// Just return x on GPU or when using JIT as exceptions are disabled on GPU and JIT code.
-#if defined(__HIPCC__) || defined(HOOMD_LLVMJIT_BUILD)
-                // This branch should not be reached, but must include something to avoid
-                // compiler warnings on the GPU and returning x matches the non-const version of the
-                // operator.
-                return xx;
-#else
-                // On the CPU we throw an error to help with debugging any errors in use of the
-                // code.
-                throw std::invalid_argument(
-                    "Attempting to access non-existent vec6 entry (i.e. i > 2)");
-#endif
-                }
-            }
-
         //! Default construct a 0 vector
         vec6() : xx(0), xy(0), xz(0), yy(0), yz(0), zz(0) { }
 
@@ -152,6 +89,7 @@ class PYBIND11_EXPORT ForceCompute : public Compute
         Real yz;
         Real zz;
         };
+        } // namespace detail
 
 #ifdef ENABLE_MPI
     //! Pre-compute the forces

--- a/hoomd/ForceCompute.h
+++ b/hoomd/ForceCompute.h
@@ -200,7 +200,7 @@ class PYBIND11_EXPORT ForceCompute : public Compute
     void updateGPUAdvice();
 
     //! Sort local tags
-    void getSortedLocalTags()
+    void sortLocalTags()
         {
         m_local_tag.resize(m_pdata->getN());
         ArrayHandle<unsigned int> h_tag(m_pdata->getTags(),

--- a/hoomd/ForceCompute.h
+++ b/hoomd/ForceCompute.h
@@ -3,6 +3,7 @@
 
 #include "Compute.h"
 #include "GlobalArray.h"
+#include "HOOMDMath.h"
 #include "Index1D.h"
 #include "ParticleGroup.h"
 #include "PythonLocalDataAccess.h"
@@ -63,33 +64,6 @@ class PYBIND11_EXPORT ForceCompute : public Compute
         {
         m_deltaT = dt;
         }
-
-    namespace detail
-        {
-    template<class Real> struct vec6
-        {
-        //! Construct a vec6
-        vec6(const Real& _xx,
-             const Real& _xy,
-             const Real& _xz,
-             const Real& _yy,
-             const Real& _yz,
-             const Real& _zz)
-            : xx(_xx), xy(_xy), xz(_xz), yy(_yy), yz(_yz), zz(_zz)
-            {
-            }
-
-        //! Default construct a 0 vector
-        vec6() : xx(0), xy(0), xz(0), yy(0), yz(0), zz(0) { }
-
-        Real xx;
-        Real xy;
-        Real xz;
-        Real yy;
-        Real yz;
-        Real zz;
-        };
-        } // namespace detail
 
 #ifdef ENABLE_MPI
     //! Pre-compute the forces
@@ -346,6 +320,31 @@ class PYBIND11_EXPORT LocalForceComputeData : public GhostLocalDataAccess<Output
 
 namespace detail
     {
+
+template<class Real> struct vec6
+    {
+    //! Construct a vec6
+    vec6(const Real& _xx,
+         const Real& _xy,
+         const Real& _xz,
+         const Real& _yy,
+         const Real& _yz,
+         const Real& _zz)
+        : xx(_xx), xy(_xy), xz(_xz), yy(_yy), yz(_yz), zz(_zz)
+        {
+        }
+
+    //! Default construct a 0 vector
+    vec6() : xx(0), xy(0), xz(0), yy(0), yz(0), zz(0) { }
+
+    Real xx;
+    Real xy;
+    Real xz;
+    Real yy;
+    Real yz;
+    Real zz;
+    };
+
 //! Exports the ForceCompute class to python
 #ifndef __HIPCC__
 void export_ForceCompute(pybind11::module& m);

--- a/hoomd/md/pytest/test_custom_force.py
+++ b/hoomd/md/pytest/test_custom_force.py
@@ -126,13 +126,9 @@ class ForceEqualsTag(md.force.Custom):
                 force_arrays.force[:] = -5
                 energy = local_snapshot.particles.tag * -10
                 force_arrays.potential_energy[:] = energy
-                force_arrays.torque[:] = np.ones(
-                    (len(local_snapshot.particles.tag),
-                     3)) * (local_snapshot.particles.tag).reshape((-1, 1))
+                force_arrays.torque[:] = 23
                 if force_arrays.virial.shape[0] != 0:
-                    force_arrays.virial[:] = np.ones(
-                        (len(local_snapshot.particles.tag),
-                         6)) * (local_snapshot.particles.tag).reshape((-1, 1))
+                    force_arrays.virial[:] = np.arange(6)[None, :]
 
 
 @pytest.mark.cpu
@@ -150,14 +146,9 @@ def test_force_equals_tag(force_simulation_factory, lattice_snapshot_factory):
     if sim.device.communicator.rank == 0:
         npt.assert_allclose(forces, -5)
         npt.assert_array_equal(energies, np.arange(sim.state.N_particles) * -10)
-        npt.assert_array_equal(
-            torques,
-            np.ones_like(torques) * np.arange(sim.state.N_particles).reshape(
-                (-1, 1)))
-        npt.assert_array_equal(
-            virials,
-            np.ones_like(virials) * np.arange(sim.state.N_particles).reshape(
-                (-1, 1)))
+        npt.assert_allclose(torques, 23)
+        for i in range(6):
+            npt.assert_allclose(virials[:, i], i)
 
 
 class MyPeriodicField(md.force.Custom):

--- a/hoomd/md/pytest/test_custom_force.py
+++ b/hoomd/md/pytest/test_custom_force.py
@@ -126,9 +126,13 @@ class ForceEqualsTag(md.force.Custom):
                 force_arrays.force[:] = -5
                 energy = local_snapshot.particles.tag * -10
                 force_arrays.potential_energy[:] = energy
-                force_arrays.torque[:] = 23
+                force_arrays.torque[:] = np.ones(
+                    (len(local_snapshot.particles.tag),
+                     3)) * (local_snapshot.particles.tag).reshape((-1, 1))
                 if force_arrays.virial.shape[0] != 0:
-                    force_arrays.virial[:] = np.arange(6)[None, :]
+                    force_arrays.virial[:] = np.ones(
+                        (len(local_snapshot.particles.tag),
+                         6)) * (local_snapshot.particles.tag).reshape((-1, 1))
 
 
 @pytest.mark.cpu
@@ -146,9 +150,14 @@ def test_force_equals_tag(force_simulation_factory, lattice_snapshot_factory):
     if sim.device.communicator.rank == 0:
         npt.assert_allclose(forces, -5)
         npt.assert_array_equal(energies, np.arange(sim.state.N_particles) * -10)
-        npt.assert_allclose(torques, 23)
-        for i in range(6):
-            npt.assert_allclose(virials[:, i], i)
+        npt.assert_array_equal(
+            torques,
+            np.ones_like(torques) * np.arange(sim.state.N_particles).reshape(
+                (-1, 1)))
+        npt.assert_array_equal(
+            virials,
+            np.ones_like(virials) * np.arange(sim.state.N_particles).reshape(
+                (-1, 1)))
 
 
 class MyPeriodicField(md.force.Custom):


### PR DESCRIPTION
## Description

Use the GatherTagOrder class to properly gather the per-particle properties from all ranks instead of the slow, previous implementation. This change should drastically improve the performance of (benchmarks to come):
* ForceCompute::getEnergiesPython()
* ForceCompute::getForcesPython()
* ForceCompute::getTorquesPython()
* ForceCompute::getVirialsPython()

I added a `vec6` struct for the `getVirialsPython()` function since you cannot create vectors of arrays like `std::vector<double[6]>`. 

## Motivation and context

Resolves #1539.

## How has this been tested?

Updated tests in `md/pytest/test_custom_force.py` that sets the properties of a `Custom` force to be functions of the particle tag, so that you can check that the returned values are returned in the correct order.

## Change log

<!-- Propose a change log entry. -->
```
Improve performance of accessing per-particle properties of `Force` objects.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
