### PR TITLE
Deprecate depletant fugacity.

### DIFF
--- a/hoomd/hpmc/integrate.py
+++ b/hoomd/hpmc/integrate.py
@@ -408,10 +408,9 @@ class HPMCIntegrator(Integrator):
         HPMC uses RNGs. Warn the user if they did not set the seed.
         """
         if any([f != 0 for f in self.depletant_fugacity.values()]):
-            warnings.warn(
-                    "depletant_fugacity > 0 is deprecated since 4.4.0.",
-                    FutureWarning,
-                    stacklevel=1)
+            warnings.warn("depletant_fugacity > 0 is deprecated since 4.4.0.",
+                          FutureWarning,
+                          stacklevel=1)
 
             if (isinstance(self._simulation.device, hoomd.device.CPU)
                     and self._simulation.device.num_cpu_threads > 1):

--- a/hoomd/hpmc/integrate.py
+++ b/hoomd/hpmc/integrate.py
@@ -252,6 +252,10 @@ Set `HPMCIntegrator.depletant_fugacity` to activate the implicit depletant code
 path. This inerts depletant particles during every trial move and modifies the
 acceptance criterion accordingly. See `Glaser 2015
 <https://dx.doi.org/10.1063/1.4935175>`_ for details.
+
+.. deprecated:: 4.4.0
+
+    ``depletant_fugacity > 0`` is deprecated.
 """
 
 from hoomd import _hoomd
@@ -301,6 +305,10 @@ class HPMCIntegrator(Integrator):
 
     HPMC integrators use threaded execution on multiple CPU cores only when
     placing implicit depletants (``depletant_fugacity != 0``).
+
+    .. deprecated:: 4.4.0
+
+        ``num_cpu_threads >= 1`` is deprecated. Set ``num_cpu_threads = 1``.
 
     .. rubric:: Mixed precision
 
@@ -399,14 +407,19 @@ class HPMCIntegrator(Integrator):
 
         HPMC uses RNGs. Warn the user if they did not set the seed.
         """
-        if (isinstance(self._simulation.device, hoomd.device.CPU)
-                and self._simulation.device.num_cpu_threads > 1
-                and any([f != 0 for f in self.depletant_fugacity.values()])):
+        if any([f != 0 for f in self.depletant_fugacity.values()]):
             warnings.warn(
-                "num_cpu_threads > 1 is deprecated since 4.4.0. "
-                "Use num_cpu_threads=1.",
-                FutureWarning,
-                stacklevel=2)
+                    "depletant_fugacity > 0 is deprecated since 4.4.0.",
+                    FutureWarning,
+                    stacklevel=1)
+
+            if (isinstance(self._simulation.device, hoomd.device.CPU)
+                    and self._simulation.device.num_cpu_threads > 1):
+                warnings.warn(
+                    "num_cpu_threads > 1 is deprecated since 4.4.0. "
+                    "Use num_cpu_threads=1.",
+                    FutureWarning,
+                    stacklevel=1)
 
         self._simulation._warn_if_seed_unset()
         sys_def = self._simulation.state._cpp_sys_def

--- a/hoomd/hpmc/pair/user.py
+++ b/hoomd/hpmc/pair/user.py
@@ -339,8 +339,7 @@ class CPPPotentialUnion(CPPPotentialBase):
 
     .. deprecated:: 4.4.0
 
-        Use of ``num_cpu_threads >= 1`` is deprecated. Use
-        ``num_cpu_threads = 1``.
+        ``num_cpu_threads >= 1`` is deprecated. Set ``num_cpu_threads = 1``.
 
     See Also:
         :doc:`howto/cpppotential`.
@@ -535,7 +534,7 @@ class CPPPotentialUnion(CPPPotentialBase):
                 "num_cpu_threads > 1 is deprecated since 4.4.0. "
                 "Use num_cpu_threads=1.",
                 FutureWarning,
-                stacklevel=2)
+                stacklevel=1)
 
         integrator = self._simulation.operations.integrator
         if not isinstance(integrator, integrate.HPMCIntegrator):

--- a/sphinx-doc/deprecated.rst
+++ b/sphinx-doc/deprecated.rst
@@ -18,7 +18,9 @@ documentation for more information on warning filters.
 
   * Use `hoomd.Snapshot.from_gsd_frame`.
 
-* ``num_cpu_threads > 1`` (since 4.4.0).
+* ``Device.num_cpu_threads > 1`` (since 4.4.0).
 
-  * Use ``num_cpu_threads = 1``.
+  * Set ``num_cpu_threads = 1``.
   * All TBB code will be removed in the 5.0 release.
+
+* ``HPMCIntegrator.depletant_fugacity > 0`` (since 4.4.0).


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should be based on *trunk-patch*. -->
<!-- Backwards compatible new features should be based on *trunk-minor*. -->
<!-- Incompatible API changes should be based on *trunk-major*. -->

## Description

<!-- Describe your changes in detail. -->
Document that `depletant_fugacity > 0` is deprecated.

Also adjust the deprecation notice grammar and stacklevels implemented in #1656. The stacklevel argument did not behave as I expected. See the commit message for further details.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
See #1651.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
`pytest hoomd/hpmc -W all -v -x -ra` issues the expected warnings.

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
Deprecated:

* ``HPMCIntegrator.depletant_fugacity > 0``.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
