### PR TITLE
Remove MD integrator warning when no methods are set

### DIFF
--- a/hoomd/md/IntegratorTwoStep.cc
+++ b/hoomd/md/IntegratorTwoStep.cc
@@ -17,7 +17,7 @@ namespace hoomd
 namespace md
     {
 IntegratorTwoStep::IntegratorTwoStep(std::shared_ptr<SystemDefinition> sysdef, Scalar deltaT)
-    : Integrator(sysdef, deltaT), m_prepared(false), m_gave_warning(false)
+    : Integrator(sysdef, deltaT), m_prepared(false)
     {
     m_exec_conf->msg->notice(5) << "Constructing IntegratorTwoStep" << endl;
 
@@ -51,13 +51,6 @@ IntegratorTwoStep::~IntegratorTwoStep()
 void IntegratorTwoStep::update(uint64_t timestep)
     {
     Integrator::update(timestep);
-
-    // issue a warning if no integration methods are set
-    if (!m_gave_warning && m_methods.size() == 0)
-        {
-        m_exec_conf->msg->warning() << "MD Integrator has no integration methods." << endl;
-        m_gave_warning = true;
-        }
 
     // ensure that prepRun() has been called
     assert(m_prepared);

--- a/hoomd/md/IntegratorTwoStep.h
+++ b/hoomd/md/IntegratorTwoStep.h
@@ -119,8 +119,7 @@ class PYBIND11_EXPORT IntegratorTwoStep : public Integrator
 
     std::shared_ptr<ForceComposite> m_rigid_bodies; /// definition and updater for rigid bodies
 
-    bool m_prepared;     //!< True if preprun has been called
-    bool m_gave_warning; //!< True if a warning has been given about no methods added
+    bool m_prepared; //!< True if preprun has been called
 
     /// True when orientation degrees of freedom should be integrated
     bool m_integrate_rotational_dof = false;

--- a/hoomd/mpcd/Integrator.cc
+++ b/hoomd/mpcd/Integrator.cc
@@ -43,13 +43,6 @@ mpcd::Integrator::~Integrator()
 void mpcd::Integrator::update(uint64_t timestep)
     {
     IntegratorTwoStep::update(timestep);
-    // issue a warning if no integration methods are set
-    if (!m_gave_warning && m_methods.size() == 0 && !m_stream)
-        {
-        m_exec_conf->msg->warning()
-            << "mpcd.integrate: No integration methods are set." << std::endl;
-        m_gave_warning = true;
-        }
 
     // remove any leftover virtual particles
     if (checkCollide(timestep))


### PR DESCRIPTION
## Description

Remove the warning issued by `IntegratorTwoStep` when no integration methods are set.

## Motivation and context

This warning doesn't need to be there, and it can create inconveniences if a class derives from the MD integrator.

Resolves #1658 

## How has this been tested?

The unit tests used to raise lots of warnings about this. I verified they are not there after the change.

## Change log

```
* Remove warning when ``hoomd.md.Integrator`` is used without an integration method.
```

## Checklist:

- [X] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.rst).
- [X] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [X] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
