### PR TITLE
Use standards compliant `thrust::get`.

### DIFF
--- a/hoomd/md/ForceCompositeGPU.cu
+++ b/hoomd/md/ForceCompositeGPU.cu
@@ -822,7 +822,7 @@ struct is_center
     {
     __host__ __device__ bool operator()(const thrust::tuple<unsigned int, unsigned int>& t)
         {
-        return t.get<0>() == t.get<1>();
+        return thrust::get<0>(t) == thrust::get<1>(t);
         }
     };
 


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should be based on *trunk-patch*. -->
<!-- Backwards compatible new features should be based on *trunk-minor*. -->
<!-- Incompatible API changes should be based on *trunk-major*. -->

## Description

Use standards compliant `thrust::get`.
<!-- Describe your changes in detail. -->

## Motivation and context

A future version of thrust requires this change.
<!--- Why is this change required? What problem does it solve? -->

## How has this been tested?

CI checks.
<!--- Please describe in detail how you tested your changes. -->

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
Fixed:

* Use standards compliant ``thrust::get``.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
