### PR TITLE
Improve component documentation.

### DIFF
--- a/.github/workflows/templates/test.yml
+++ b/.github/workflows/templates/test.yml
@@ -21,6 +21,8 @@ env:
   OMPI_MCA_btl: "vader,self"
   # skip running the CPU tests in GPU builds
   _HOOMD_SKIP_CPU_TESTS_WHEN_GPUS_PRESENT_: 1
+  # Require GPU tests in GPU builds.
+  _HOOMD_REQUIRE_GPU_TESTS_IN_GPU_BUILDS_: 1
   # import HOOMD out of the build directory
   PYTHONPATH: ${{ github.workspace }}/install
 <% endblock %>

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,6 +32,8 @@ env:
   OMPI_MCA_btl: "vader,self"
   # skip running the CPU tests in GPU builds
   _HOOMD_SKIP_CPU_TESTS_WHEN_GPUS_PRESENT_: 1
+  # Require GPU tests in GPU builds.
+  _HOOMD_REQUIRE_GPU_TESTS_IN_GPU_BUILDS_: 1
   # import HOOMD out of the build directory
   PYTHONPATH: ${{ github.workspace }}/install
 

--- a/CMake/hoomd/hoomd-macros.cmake
+++ b/CMake/hoomd/hoomd-macros.cmake
@@ -9,7 +9,7 @@
 # @param validate_pattern: Check ${CMAKE_CURRENT_BINARY_DIR}/${validate_pattern} for files
 #                          that are not in ${files} and issue a warning.
 # @param Additional parameters: List of files to ignore
-macro(copy_files_to_build files target validate_pattern)
+function(copy_files_to_build files target validate_pattern)
     set(ignore_files ${ARGN})
 
     file(RELATIVE_PATH relative_dir ${PROJECT_BINARY_DIR} ${CMAKE_CURRENT_BINARY_DIR})
@@ -29,14 +29,16 @@ macro(copy_files_to_build files target validate_pattern)
 
     file(GLOB _matching_files "${CMAKE_CURRENT_BINARY_DIR}/${validate_pattern}")
     foreach(file ${_matching_files})
+        # message("Matching files: ${_matching_files}")
         file(RELATIVE_PATH relative_file ${CMAKE_CURRENT_BINARY_DIR} ${file})
+        # message("Expected files: ${files}")
         list(FIND files ${relative_file} found)
         if (found EQUAL -1 AND NOT ${relative_file} IN_LIST ignore_files)
             message(WARNING "${file} exists but is not provided by the source. "
                             "Remove this file to prevent unexpected errors.")
         endif()
     endforeach()
-endmacro()
+endfunction()
 
 # find a package by config first
 macro(find_package_config_first package version)

--- a/hoomd/conftest.py
+++ b/hoomd/conftest.py
@@ -30,8 +30,9 @@ pytest_plugins = ("hoomd.pytest_plugin_validate",)
 
 devices = [hoomd.device.CPU]
 _n_available_gpu = len(hoomd.device.GPU.get_available_devices())
-_github_actions = os.environ.get('GITHUB_ACTIONS') is not None
-if hoomd.version.gpu_enabled and (_n_available_gpu > 0 or _github_actions):
+_require_gpu_tests = (os.environ.get('_HOOMD_REQUIRE_GPU_TESTS_IN_GPU_BUILDS_')
+                      is not None)
+if hoomd.version.gpu_enabled and (_n_available_gpu > 0 or _require_gpu_tests):
 
     if os.environ.get('_HOOMD_SKIP_CPU_TESTS_WHEN_GPUS_PRESENT_') is not None:
         devices.pop(0)

--- a/hoomd/pytest/CMakeLists.txt
+++ b/hoomd/pytest/CMakeLists.txt
@@ -45,4 +45,4 @@ install(PROGRAMS ${programs}
         DESTINATION ${PYTHON_SITE_INSTALL_DIR}/pytest
        )
 
-copy_files_to_build("${programs}" "hoomd_pytest_programs" "*.py")
+copy_files_to_build("${programs}" "hoomd_pytest_programs" "*.sh")

--- a/sphinx-doc/components.rst
+++ b/sphinx-doc/components.rst
@@ -12,7 +12,7 @@ Creating a component
 
 The `hoomd-component-template`_ repository provides a starting point for your
 component. It includes template C++ and Python modules, an example unit test, CMake
-scripts to build the component, and GitHub Actions configurations.
+scripts to build the component, and GitHub Actions workflows.
 
 .. _hoomd-component-template: https://github.com/glotzerlab/hoomd-component-template
 

--- a/sphinx-doc/components.rst
+++ b/sphinx-doc/components.rst
@@ -12,8 +12,7 @@ Creating a component
 
 The `hoomd-component-template`_ repository provides a starting point for your
 component. It includes template C++ and Python modules, an example unit test, CMake
-scripts to build the component, along with pre-commit and GitHub Actions 
-configurations.
+scripts to build the component, and GitHub Actions configurations.
 
 .. _hoomd-component-template: https://github.com/glotzerlab/hoomd-component-template
 

--- a/sphinx-doc/components.rst
+++ b/sphinx-doc/components.rst
@@ -11,13 +11,9 @@ Creating a component
 --------------------
 
 The `hoomd-component-template`_ repository provides a starting point for your
-component. It includes:
-
-* CMake scripts to build the component.
-* Template C++ and Python modules.
-* An example unit test.
-* Pre-commit configuration.
-* GitHub Actions configuration.
+component. It includes template C++ and Python modules, an example unit test, CMake
+scripts to build the component, along with pre-commit and GitHub Actions 
+configurations.
 
 .. _hoomd-component-template: https://github.com/glotzerlab/hoomd-component-template
 
@@ -48,7 +44,7 @@ To build an external component:
 
     $ cmake --install build/<component>
 
-Once installed, the template is available for import via::
+Once installed, the component is available for import via::
 
     import hoomd.<component>
 

--- a/sphinx-doc/components.rst
+++ b/sphinx-doc/components.rst
@@ -1,54 +1,58 @@
 .. Copyright (c) 2009-2023 The Regents of the University of Michigan.
 .. Part of HOOMD-blue, released under the BSD 3-Clause License.
 
-Components
-==========
+Extending HOOMD-blue
+====================
 
-Extend **HOOMD-blue** with a **component** implemented in C++ for performance-critical tasks, such
-as pair potential evaluation. A component provides a number of related functionalities. For example,
-the :py:mod:`hoomd.hpmc` component enables hard particle Monte Carlo methods with **HOOMD-blue**.
+Extend **HOOMD-blue** with a **component** implemented in C++ for performance-critical
+tasks, such as pair potential evaluation.
 
-Compile and install components **built-in** or as **external** components. The **HOOMD-blue** build
-process compiles all core and built-in components together, requiring one only one set of configure,
-make, and install commands. External components compile and link against a **HOOMD-blue**
-installation from a separate build directory with their own set of configure, make, and install
-commands. You may compile a component either way. When the end user is compiling **HOOMD-blue** and
-components from source, built-in components compile and install everything at once which minimizes
-chances for errors (e.g. building **HOOMD-blue** against python 3.6, but the component against
-python 3.7). External components provide more flexibility for packaging purposes.
+Creating a component
+--------------------
 
-The **HOOMD-Blue** source provides example component templates in the `example plugins`_
-subdirectory.
+The `hoomd-component-template`_ repository provides a starting point for your
+component. It includes:
 
-.. _example plugins: https://github.com/glotzerlab/hoomd-blue/tree/trunk-patch/example_plugins
+* CMake scripts to build the component.
+* Template C++ and Python modules.
+* An example unit test.
+* Pre-commit configuration.
+* GitHub Actions configuration.
 
-Built-in components
--------------------
+.. _hoomd-component-template: https://github.com/glotzerlab/hoomd-component-template
 
-You can fork **HOOMD-blue** and add your component directly, or you can create a separate source
-repository for your component. Create a symbolic link to the component in the ``hoomd`` source
-directory to compile it as a built-in component::
+The **HOOMD-Blue** source provides example component templates in the
+`example_plugins`_ subdirectory.
 
-  $ ln -s <path-to-component>/<component> hoomd-blue/hoomd/<component>
+.. _example_plugins: https://github.com/glotzerlab/hoomd-blue/tree/trunk-patch/example_plugins
+
+Building an external component
+------------------------------
+
+To build an external component:
+
+1. Build and install HOOMD-blue from source.
+2. Obtain the component's source::
+
+    $ git clone https://github.com/<organization>/<component>
+
+3. Configure::
+
+    $ cmake -B build/<component> -S <component>
+
+4. Build the component::
+
+    $ cmake --build build/<component>
+
+5. Install the component::
+
+    $ cmake --install build/<component>
+
+Once installed, the template is available for import via::
+
+    import hoomd.<component>
 
 .. note::
 
-    Built-in components may be used directly from the build directory or installed.
-
-External components
--------------------
-
-To compile an external component, you must first install **HOOMD-blue**. Then, configure your component
-with CMake and install it into the hoomd python library. Point ``CMAKE_PREFIX_PATH`` at your virtual
-environment (if needed) so that cmake can find **HOOMD-blue**::
-
-  $ cmake -B build/<component> -S <path-to-component>
-  $ cmake --build build/<component>
-  $ cmake --install build/<component>
-
-The component build environment, including the compiler, CUDA, MPI, python, and other libraries,
-must match exactly with those used to build **HOOMD-blue**.
-
-.. note::
-
-    External components must be installed before use.
+    Replace ``<organization>`` and ``<component>`` with the names of the organization
+    and repository of the component you would like to build.

--- a/sphinx-doc/components.rst
+++ b/sphinx-doc/components.rst
@@ -31,7 +31,7 @@ Building an external component
 
 To build an external component:
 
-1. Build and install HOOMD-blue from source.
+1. Build and install **HOOMD-blue** from source.
 2. Obtain the component's source::
 
     $ git clone https://github.com/<organization>/<component>

--- a/sphinx-doc/developers.rst
+++ b/sphinx-doc/developers.rst
@@ -10,4 +10,3 @@ For developers
     contributing
     style
     testing
-    components

--- a/sphinx-doc/getting-started.rst
+++ b/sphinx-doc/getting-started.rst
@@ -10,4 +10,5 @@ Getting started
     features
     installation
     building
+    components
     citing


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should be based on *trunk-patch*. -->
<!-- Backwards compatible new features should be based on *trunk-minor*. -->
<!-- Incompatible API changes should be based on *trunk-major*. -->

## Description

<!-- Describe your changes in detail. -->
Clean up the component building documentation and move it up to a more prominent location in the documentation. It is now under "Getting started" instead of hidden under "For developers".

Also make minor adjustments to allow CMake and GitHub Actions work better with the new component template repository. 

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Better document how users can develop their own extensions to HOOMD and foster community developed components.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
I have tested this branch and the instructions it provides with the hoomd-component-template.

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
Added:

* Improve component build documentation and link to the ``hoomd-component-template`` repository.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
