### PR TITLE
Fix Local Snapshot Net Virial

### DIFF
--- a/hoomd/ParticleData.h
+++ b/hoomd/ParticleData.h
@@ -1545,6 +1545,9 @@ class PYBIND11_EXPORT LocalParticleData : public GhostLocalDataAccess<Output, Pa
 
     Output getNetVirial(GhostDataFlag flag)
         {
+        // Need pitch not particle numbers since GPUArrays can be padded for
+        // faster data access.
+        size_t size = this->m_data.getNetVirial().getPitch();
         return this->template getLocalBuffer<Scalar, Scalar>(
             m_net_virial_handle,
             &ParticleData::getNetVirial,
@@ -1552,7 +1555,7 @@ class PYBIND11_EXPORT LocalParticleData : public GhostLocalDataAccess<Output, Pa
             true,
             6,
             0,
-            std::vector<size_t>({6 * sizeof(Scalar), sizeof(Scalar)}));
+            std::vector<size_t>({sizeof(Scalar), size * sizeof(Scalar)}));
         }
 
     Output getNetEnergy(GhostDataFlag flag)


### PR DESCRIPTION
## Description
Switch strides from N, 6 to 6, GPUArray::getPitch.
<!-- Describe your changes in detail. -->

## Motivation and context
#1663

## How has this been tested?
Existing tests pass plus test proposed in #1663 ran successfully.

## Change log

<!-- Propose a change log entry. -->
```
Fixed: Access to net_virial in local snapshots.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
