### PR TITLE
Add QuickCompress.allow_unsafe_resize

### DIFF
--- a/hoomd/hpmc/UpdaterQuickCompress.cc
+++ b/hoomd/hpmc/UpdaterQuickCompress.cc
@@ -16,7 +16,7 @@ UpdaterQuickCompress::UpdaterQuickCompress(std::shared_ptr<SystemDefinition> sys
                                            bool allow_unsafe_resize,
                                            std::shared_ptr<BoxDim> target_box)
     : Updater(sysdef, trigger), m_mc(mc), m_max_overlaps_per_particle(max_overlaps_per_particle),
-      m_target_box(target_box)
+      m_allow_unsafe_resize(allow_unsafe_resize), m_target_box(target_box)
     {
     m_exec_conf->msg->notice(5) << "Constructing UpdaterQuickCompress" << std::endl;
     setMinScale(min_scale);

--- a/hoomd/hpmc/UpdaterQuickCompress.cc
+++ b/hoomd/hpmc/UpdaterQuickCompress.cc
@@ -159,49 +159,49 @@ BoxDim UpdaterQuickCompress::getNewBox(uint64_t timestep)
         double min_move_size = m_mc->getMinTransMoveSize() * std::min(accept_ratio, 0.5);
         min_scale = std::max(m_min_scale, 1.0 - min_move_size / max_diameter);
         };
-        };
+    };
 
-    // Create a prng instance for this timestep
-    hoomd::RandomGenerator rng(
-        hoomd::Seed(hoomd::RNGIdentifier::UpdaterQuickCompress, timestep, m_sysdef->getSeed()),
+// Create a prng instance for this timestep
+hoomd::RandomGenerator
+    rng(hoomd::Seed(hoomd::RNGIdentifier::UpdaterQuickCompress, timestep, m_sysdef->getSeed()),
         hoomd::Counter(m_instance));
 
-    // choose a scale randomly between min_scale and 1.0
-    hoomd::UniformDistribution<double> uniform(min_scale, 1.0);
-    double scale = uniform(rng);
+// choose a scale randomly between min_scale and 1.0
+hoomd::UniformDistribution<double> uniform(min_scale, 1.0);
+double scale = uniform(rng);
 
-    // TODO: This slow. We will implement a general reusable fix later in #705
-    const auto& target_box = *m_target_box;
+// TODO: This slow. We will implement a general reusable fix later in #705
+const auto& target_box = *m_target_box;
 
-    // construct the scaled box
-    BoxDim current_box = m_pdata->getGlobalBox();
-    Scalar3 new_L;
-    Scalar new_xy, new_xz, new_yz;
-    if (m_sysdef->getNDimensions() == 3)
-        {
-        new_L.x = scaleValue(current_box.getL().x, target_box.getL().x, scale);
-        new_L.y = scaleValue(current_box.getL().y, target_box.getL().y, scale);
-        new_L.z = scaleValue(current_box.getL().z, target_box.getL().z, scale);
-        new_xy = scaleValue(current_box.getTiltFactorXY(), target_box.getTiltFactorXY(), scale);
-        new_xz = scaleValue(current_box.getTiltFactorXZ(), target_box.getTiltFactorXZ(), scale);
-        new_yz = scaleValue(current_box.getTiltFactorYZ(), target_box.getTiltFactorYZ(), scale);
-        }
-    else
-        {
-        new_L.x = scaleValue(current_box.getL().x, target_box.getL().x, scale);
-        new_L.y = scaleValue(current_box.getL().y, target_box.getL().y, scale);
-        new_xy = scaleValue(current_box.getTiltFactorXY(), target_box.getTiltFactorXY(), scale);
+// construct the scaled box
+BoxDim current_box = m_pdata->getGlobalBox();
+Scalar3 new_L;
+Scalar new_xy, new_xz, new_yz;
+if (m_sysdef->getNDimensions() == 3)
+    {
+    new_L.x = scaleValue(current_box.getL().x, target_box.getL().x, scale);
+    new_L.y = scaleValue(current_box.getL().y, target_box.getL().y, scale);
+    new_L.z = scaleValue(current_box.getL().z, target_box.getL().z, scale);
+    new_xy = scaleValue(current_box.getTiltFactorXY(), target_box.getTiltFactorXY(), scale);
+    new_xz = scaleValue(current_box.getTiltFactorXZ(), target_box.getTiltFactorXZ(), scale);
+    new_yz = scaleValue(current_box.getTiltFactorYZ(), target_box.getTiltFactorYZ(), scale);
+    }
+else
+    {
+    new_L.x = scaleValue(current_box.getL().x, target_box.getL().x, scale);
+    new_L.y = scaleValue(current_box.getL().y, target_box.getL().y, scale);
+    new_xy = scaleValue(current_box.getTiltFactorXY(), target_box.getTiltFactorXY(), scale);
 
-        // assume that the unused fields in the 2D target box are valid
-        new_L.z = target_box.getL().z;
-        new_xz = target_box.getTiltFactorXZ();
-        new_yz = target_box.getTiltFactorYZ();
-        }
+    // assume that the unused fields in the 2D target box are valid
+    new_L.z = target_box.getL().z;
+    new_xz = target_box.getTiltFactorXZ();
+    new_yz = target_box.getTiltFactorYZ();
+    }
 
-    BoxDim new_box = current_box;
-    new_box.setL(new_L);
-    new_box.setTiltFactors(new_xy, new_xz, new_yz);
-    return new_box;
+BoxDim new_box = current_box;
+new_box.setL(new_L);
+new_box.setTiltFactors(new_xy, new_xz, new_yz);
+return new_box;
     }
 
 namespace detail
@@ -236,4 +236,4 @@ void export_UpdaterQuickCompress(pybind11::module& m)
     }
     } // end namespace detail
     } // end namespace hpmc
-    } // end namespace hoomd
+} // end namespace hoomd

--- a/hoomd/hpmc/UpdaterQuickCompress.cc
+++ b/hoomd/hpmc/UpdaterQuickCompress.cc
@@ -2,6 +2,7 @@
 // Part of HOOMD-blue, released under the BSD 3-Clause License.
 
 #include "UpdaterQuickCompress.h"
+
 #include "hoomd/RNGIdentifiers.h"
 
 namespace hoomd
@@ -16,7 +17,7 @@ UpdaterQuickCompress::UpdaterQuickCompress(std::shared_ptr<SystemDefinition> sys
                                            bool allow_unsafe_resize,
                                            std::shared_ptr<BoxDim> target_box)
     : Updater(sysdef, trigger), m_mc(mc), m_max_overlaps_per_particle(max_overlaps_per_particle),
-      m_allow_unsafe_resize(allow_unsafe_resize), m_target_box(target_box)
+      m_target_box(target_box), m_allow_unsafe_resize(allow_unsafe_resize)
     {
     m_exec_conf->msg->notice(5) << "Constructing UpdaterQuickCompress" << std::endl;
     setMinScale(min_scale);
@@ -53,7 +54,8 @@ void UpdaterQuickCompress::update(uint64_t timestep)
         performBoxScale(timestep);
         }
 
-    // The compression is complete when we have reached the target box and there are no overlaps.
+    // The compression is complete when we have reached the target box and there are no
+    // overlaps.
     if (n_overlaps == 0 && current_box == *m_target_box)
         m_is_complete = true;
     else
@@ -140,13 +142,13 @@ BoxDim UpdaterQuickCompress::getNewBox(uint64_t timestep)
         }
 
     // If unsafe box moves are allowed, set min_scale without considering min_move_size.
-    // Otherwise, determine the worst case minimum allowable scale factor. The minimum allowable
-    // scale factor assumes that the typical accepted trial move shifts particles by the current
-    // acceptance ratio times the maximum displacement. Assuming that the particles are all spheres
-    // with their circumsphere diameter, set the minimum allowable scale factor so that overlaps of
-    // this size can be removed by trial move. The worst case estimate uses the minimum move size
-    // and the maximum core diameter. Cap the acceptance ratio at 0.5 to prevent excessive box
-    // moves.
+    // Otherwise, determine the worst case minimum allowable scale factor. The minimum
+    // allowable scale factor assumes that the typical accepted trial move shifts
+    // particles by the current acceptance ratio times the maximum displacement. Assuming
+    // that the particles are all spheres with their circumsphere diameter, set the
+    // minimum allowable scale factor so that overlaps of this size can be removed by
+    // trial move. The worst case estimate uses the minimum move size and the maximum core
+    // diameter. Cap the acceptance ratio at 0.5 to prevent excessive box moves.
     double min_scale;
 
     if (allow_unsafe_resize)

--- a/hoomd/hpmc/UpdaterQuickCompress.cc
+++ b/hoomd/hpmc/UpdaterQuickCompress.cc
@@ -147,11 +147,14 @@ BoxDim UpdaterQuickCompress::getNewBox(uint64_t timestep)
     double max_diameter = m_mc->getMaxCoreDiameter();
     double min_move_size = m_mc->getMinTransMoveSize() * std::min(accept_ratio, 0.5);
     double min_scale;
-    if (min_move_size==0){
+    if (min_move_size == 0)
+        {
         min_scale = m_min_scale;
-    } else {
+        }
+    else
+        {
         min_scale = std::max(m_min_scale, 1.0 - min_move_size / max_diameter);
-    };
+        };
 
     // Create a prng instance for this timestep
     hoomd::RandomGenerator rng(

--- a/hoomd/hpmc/UpdaterQuickCompress.cc
+++ b/hoomd/hpmc/UpdaterQuickCompress.cc
@@ -146,7 +146,12 @@ BoxDim UpdaterQuickCompress::getNewBox(uint64_t timestep)
     // maximum core diameter. Cap the acceptance ratio at 0.5 to prevent excessive box moves.
     double max_diameter = m_mc->getMaxCoreDiameter();
     double min_move_size = m_mc->getMinTransMoveSize() * std::min(accept_ratio, 0.5);
-    double min_scale = std::max(m_min_scale, 1.0 - min_move_size / max_diameter);
+    double min_scale;
+    if (min_move_size==0){
+        min_scale = m_min_scale;
+    } else {
+        min_scale = std::max(m_min_scale, 1.0 - min_move_size / max_diameter);
+    };
 
     // Create a prng instance for this timestep
     hoomd::RandomGenerator rng(

--- a/hoomd/hpmc/UpdaterQuickCompress.cc
+++ b/hoomd/hpmc/UpdaterQuickCompress.cc
@@ -2,7 +2,6 @@
 // Part of HOOMD-blue, released under the BSD 3-Clause License.
 
 #include "UpdaterQuickCompress.h"
-
 #include "hoomd/RNGIdentifiers.h"
 
 namespace hoomd
@@ -54,8 +53,7 @@ void UpdaterQuickCompress::update(uint64_t timestep)
         performBoxScale(timestep);
         }
 
-    // The compression is complete when we have reached the target box and there are no
-    // overlaps.
+    // The compression is complete when we have reached the target box and there are no overlaps.
     if (n_overlaps == 0 && current_box == *m_target_box)
         m_is_complete = true;
     else

--- a/hoomd/hpmc/UpdaterQuickCompress.cc
+++ b/hoomd/hpmc/UpdaterQuickCompress.cc
@@ -5,96 +5,104 @@
 
 #include "hoomd/RNGIdentifiers.h"
 
-namespace hoomd {
-namespace hpmc {
+namespace hoomd
+    {
+namespace hpmc
+    {
 UpdaterQuickCompress::UpdaterQuickCompress(std::shared_ptr<SystemDefinition> sysdef,
                                            std::shared_ptr<Trigger> trigger,
                                            std::shared_ptr<IntegratorHPMC> mc,
                                            double max_overlaps_per_particle,
-                                           double min_scale, bool allow_unsafe_resize,
+                                           double min_scale,
+                                           bool allow_unsafe_resize,
                                            std::shared_ptr<BoxDim> target_box)
-    : Updater(sysdef, trigger),
-      m_mc(mc),
-      m_max_overlaps_per_particle(max_overlaps_per_particle),
-      m_target_box(target_box),
-      m_allow_unsafe_resize(allow_unsafe_resize) {
-  m_exec_conf->msg->notice(5) << "Constructing UpdaterQuickCompress" << std::endl;
-  setMinScale(min_scale);
+    : Updater(sysdef, trigger), m_mc(mc), m_max_overlaps_per_particle(max_overlaps_per_particle),
+      m_target_box(target_box), m_allow_unsafe_resize(allow_unsafe_resize)
+    {
+    m_exec_conf->msg->notice(5) << "Constructing UpdaterQuickCompress" << std::endl;
+    setMinScale(min_scale);
 
-  // allocate memory for m_pos_backup
-  unsigned int MaxN = m_pdata->getMaxN();
-  GPUArray<Scalar4>(MaxN, m_exec_conf).swap(m_pos_backup);
+    // allocate memory for m_pos_backup
+    unsigned int MaxN = m_pdata->getMaxN();
+    GPUArray<Scalar4>(MaxN, m_exec_conf).swap(m_pos_backup);
 
-  // Connect to the MaxParticleNumberChange signal
-  m_pdata->getMaxParticleNumberChangeSignal()
-      .connect<UpdaterQuickCompress, &UpdaterQuickCompress::slotMaxNChange>(this);
+    // Connect to the MaxParticleNumberChange signal
+    m_pdata->getMaxParticleNumberChangeSignal()
+        .connect<UpdaterQuickCompress, &UpdaterQuickCompress::slotMaxNChange>(this);
 
-  m_last_move_counters = m_mc->getCounters();
-}
+    m_last_move_counters = m_mc->getCounters();
+    }
 
-UpdaterQuickCompress::~UpdaterQuickCompress() {
-  m_exec_conf->msg->notice(5) << "Destroying UpdaterQuickCompress" << std::endl;
-  m_pdata->getMaxParticleNumberChangeSignal()
-      .disconnect<UpdaterQuickCompress, &UpdaterQuickCompress::slotMaxNChange>(this);
-}
+UpdaterQuickCompress::~UpdaterQuickCompress()
+    {
+    m_exec_conf->msg->notice(5) << "Destroying UpdaterQuickCompress" << std::endl;
+    m_pdata->getMaxParticleNumberChangeSignal()
+        .disconnect<UpdaterQuickCompress, &UpdaterQuickCompress::slotMaxNChange>(this);
+    }
 
-void UpdaterQuickCompress::update(uint64_t timestep) {
-  Updater::update(timestep);
-  m_exec_conf->msg->notice(10) << "UpdaterQuickCompress: " << timestep << std::endl;
+void UpdaterQuickCompress::update(uint64_t timestep)
+    {
+    Updater::update(timestep);
+    m_exec_conf->msg->notice(10) << "UpdaterQuickCompress: " << timestep << std::endl;
 
-  // count the number of overlaps in the current configuration
-  auto n_overlaps = m_mc->countOverlaps(false);
-  BoxDim current_box = m_pdata->getGlobalBox();
+    // count the number of overlaps in the current configuration
+    auto n_overlaps = m_mc->countOverlaps(false);
+    BoxDim current_box = m_pdata->getGlobalBox();
 
-  if (n_overlaps == 0 && current_box != *m_target_box) {
-    performBoxScale(timestep);
-  }
+    if (n_overlaps == 0 && current_box != *m_target_box)
+        {
+        performBoxScale(timestep);
+        }
 
-  // The compression is complete when we have reached the target box and there are no
-  // overlaps.
-  if (n_overlaps == 0 && current_box == *m_target_box)
-    m_is_complete = true;
-  else
-    m_is_complete = false;
-}
+    // The compression is complete when we have reached the target box and there are no
+    // overlaps.
+    if (n_overlaps == 0 && current_box == *m_target_box)
+        m_is_complete = true;
+    else
+        m_is_complete = false;
+    }
 
-void UpdaterQuickCompress::performBoxScale(uint64_t timestep) {
-  auto new_box = getNewBox(timestep);
-  auto old_box = m_pdata->getGlobalBox();
+void UpdaterQuickCompress::performBoxScale(uint64_t timestep)
+    {
+    auto new_box = getNewBox(timestep);
+    auto old_box = m_pdata->getGlobalBox();
 
-  Scalar3 old_origin = m_pdata->getOrigin();
+    Scalar3 old_origin = m_pdata->getOrigin();
 
-  // Make a backup copy of position data
-  unsigned int N_backup = m_pdata->getN();
-  {
-    ArrayHandle<Scalar4> h_pos(m_pdata->getPositions(), access_location::host,
-                               access_mode::read);
-    ArrayHandle<Scalar4> h_pos_backup(m_pos_backup, access_location::host,
-                                      access_mode::overwrite);
-    memcpy(h_pos_backup.data, h_pos.data, sizeof(Scalar4) * N_backup);
-  }
+    // Make a backup copy of position data
+    unsigned int N_backup = m_pdata->getN();
+        {
+        ArrayHandle<Scalar4> h_pos(m_pdata->getPositions(),
+                                   access_location::host,
+                                   access_mode::read);
+        ArrayHandle<Scalar4> h_pos_backup(m_pos_backup,
+                                          access_location::host,
+                                          access_mode::overwrite);
+        memcpy(h_pos_backup.data, h_pos.data, sizeof(Scalar4) * N_backup);
+        }
 
-  m_mc->attemptBoxResize(timestep, new_box);
-  Scalar3 new_origin = m_pdata->getOrigin();
-  Scalar3 origin_shift = new_origin - old_origin;
+    m_mc->attemptBoxResize(timestep, new_box);
+    Scalar3 new_origin = m_pdata->getOrigin();
+    Scalar3 origin_shift = new_origin - old_origin;
 
-  auto n_overlaps = m_mc->countOverlaps(false);
-  if (n_overlaps > m_max_overlaps_per_particle * m_pdata->getNGlobal()) {
-    // the box move generated too many overlaps, undo the move
-    ArrayHandle<Scalar4> h_pos(m_pdata->getPositions(), access_location::host,
-                               access_mode::readwrite);
-    ArrayHandle<Scalar4> h_pos_backup(m_pos_backup, access_location::host,
-                                      access_mode::read);
-    unsigned int N = m_pdata->getN();
-    assert(N == N_backup);
-    memcpy(h_pos.data, h_pos_backup.data, sizeof(Scalar4) * N);
-    m_pdata->setGlobalBox(old_box);
-    m_pdata->translateOrigin(-origin_shift);
+    auto n_overlaps = m_mc->countOverlaps(false);
+    if (n_overlaps > m_max_overlaps_per_particle * m_pdata->getNGlobal())
+        {
+        // the box move generated too many overlaps, undo the move
+        ArrayHandle<Scalar4> h_pos(m_pdata->getPositions(),
+                                   access_location::host,
+                                   access_mode::readwrite);
+        ArrayHandle<Scalar4> h_pos_backup(m_pos_backup, access_location::host, access_mode::read);
+        unsigned int N = m_pdata->getN();
+        assert(N == N_backup);
+        memcpy(h_pos.data, h_pos_backup.data, sizeof(Scalar4) * N);
+        m_pdata->setGlobalBox(old_box);
+        m_pdata->translateOrigin(-origin_shift);
 
-    // we have moved particles, communicate those changes
-    m_mc->communicate(false);
-  }
-}
+        // we have moved particles, communicate those changes
+        m_mc->communicate(false);
+        }
+    }
 
 /** Adjust a value by the scale.
 
@@ -106,110 +114,127 @@ void UpdaterQuickCompress::performBoxScale(uint64_t timestep) {
 
     @returns The scaled value.
 */
-static inline double scaleValue(double current, double target, double s) {
-  assert(s <= 1.0);
-  if (target < current) {
-    return std::max(target, current * s);
-  } else {
-    return std::min(target, current * 1.0 / s);
-  }
-}
+static inline double scaleValue(double current, double target, double s)
+    {
+    assert(s <= 1.0);
+    if (target < current)
+        {
+        return std::max(target, current * s);
+        }
+    else
+        {
+        return std::min(target, current * 1.0 / s);
+        }
+    }
 
-BoxDim UpdaterQuickCompress::getNewBox(uint64_t timestep) {
-  // compute the current MC translate acceptance ratio
-  auto current_counters = m_mc->getCounters();
-  auto counter_delta = current_counters - m_last_move_counters;
-  m_last_move_counters = current_counters;
-  double accept_ratio = 1.0;
-  if (counter_delta.translate_accept_count > 0) {
-    accept_ratio = double(counter_delta.translate_accept_count) /
-                   double(counter_delta.translate_accept_count +
-                          counter_delta.translate_reject_count);
-  }
+BoxDim UpdaterQuickCompress::getNewBox(uint64_t timestep)
+    {
+    // compute the current MC translate acceptance ratio
+    auto current_counters = m_mc->getCounters();
+    auto counter_delta = current_counters - m_last_move_counters;
+    m_last_move_counters = current_counters;
+    double accept_ratio = 1.0;
+    if (counter_delta.translate_accept_count > 0)
+        {
+        accept_ratio
+            = double(counter_delta.translate_accept_count)
+              / double(counter_delta.translate_accept_count + counter_delta.translate_reject_count);
+        }
 
-  // If unsafe box moves are allowed, set min_scale without considering min_move_size.
-  // Otherwise, determine the worst case minimum allowable scale factor. The minimum
-  // allowable scale factor assumes that the typical accepted trial move shifts
-  // particles by the current acceptance ratio times the maximum displacement. Assuming
-  // that the particles are all spheres with their circumsphere diameter, set the
-  // minimum allowable scale factor so that overlaps of this size can be removed by
-  // trial move. The worst case estimate uses the minimum move size and the maximum core
-  // diameter. Cap the acceptance ratio at 0.5 to prevent excessive box moves.
-  double min_scale;
+    // If unsafe box moves are allowed, set min_scale without considering min_move_size.
+    // Otherwise, determine the worst case minimum allowable scale factor. The minimum
+    // allowable scale factor assumes that the typical accepted trial move shifts
+    // particles by the current acceptance ratio times the maximum displacement. Assuming
+    // that the particles are all spheres with their circumsphere diameter, set the
+    // minimum allowable scale factor so that overlaps of this size can be removed by
+    // trial move. The worst case estimate uses the minimum move size and the maximum core
+    // diameter. Cap the acceptance ratio at 0.5 to prevent excessive box moves.
+    double min_scale;
 
-  if (m_allow_unsafe_resize) {
-    min_scale = m_min_scale;
-  } else {
-    double max_diameter = m_mc->getMaxCoreDiameter();
-    double min_move_size = m_mc->getMinTransMoveSize() * std::min(accept_ratio, 0.5);
-    min_scale = std::max(m_min_scale, 1.0 - min_move_size / max_diameter);
-  };
-};
+    if (m_allow_unsafe_resize)
+        {
+        min_scale = m_min_scale;
+        }
+    else
+        {
+        double max_diameter = m_mc->getMaxCoreDiameter();
+        double min_move_size = m_mc->getMinTransMoveSize() * std::min(accept_ratio, 0.5);
+        min_scale = std::max(m_min_scale, 1.0 - min_move_size / max_diameter);
+        };
 
-// Create a prng instance for this timestep
-hoomd::RandomGenerator rng(hoomd::Seed(hoomd::RNGIdentifier::UpdaterQuickCompress,
-                                       timestep, m_sysdef->getSeed()),
-                           hoomd::Counter(m_instance));
+    // Create a prng instance for this timestep
+    hoomd::RandomGenerator rng(
+        hoomd::Seed(hoomd::RNGIdentifier::UpdaterQuickCompress, timestep, m_sysdef->getSeed()),
+        hoomd::Counter(m_instance));
 
-// choose a scale randomly between min_scale and 1.0
-hoomd::UniformDistribution<double> uniform(min_scale, 1.0);
-double scale = uniform(rng);
+    // choose a scale randomly between min_scale and 1.0
+    hoomd::UniformDistribution<double> uniform(min_scale, 1.0);
+    double scale = uniform(rng);
 
-// TODO: This slow. We will implement a general reusable fix later in #705
-const auto& target_box = *m_target_box;
+    // TODO: This slow. We will implement a general reusable fix later in #705
+    const auto& target_box = *m_target_box;
 
-// construct the scaled box
-BoxDim current_box = m_pdata->getGlobalBox();
-Scalar3 new_L;
-Scalar new_xy, new_xz, new_yz;
-if (m_sysdef->getNDimensions() == 3) {
-  new_L.x = scaleValue(current_box.getL().x, target_box.getL().x, scale);
-  new_L.y = scaleValue(current_box.getL().y, target_box.getL().y, scale);
-  new_L.z = scaleValue(current_box.getL().z, target_box.getL().z, scale);
-  new_xy =
-      scaleValue(current_box.getTiltFactorXY(), target_box.getTiltFactorXY(), scale);
-  new_xz =
-      scaleValue(current_box.getTiltFactorXZ(), target_box.getTiltFactorXZ(), scale);
-  new_yz =
-      scaleValue(current_box.getTiltFactorYZ(), target_box.getTiltFactorYZ(), scale);
-} else {
-  new_L.x = scaleValue(current_box.getL().x, target_box.getL().x, scale);
-  new_L.y = scaleValue(current_box.getL().y, target_box.getL().y, scale);
-  new_xy =
-      scaleValue(current_box.getTiltFactorXY(), target_box.getTiltFactorXY(), scale);
+    // construct the scaled box
+    BoxDim current_box = m_pdata->getGlobalBox();
+    Scalar3 new_L;
+    Scalar new_xy, new_xz, new_yz;
+    if (m_sysdef->getNDimensions() == 3)
+        {
+        new_L.x = scaleValue(current_box.getL().x, target_box.getL().x, scale);
+        new_L.y = scaleValue(current_box.getL().y, target_box.getL().y, scale);
+        new_L.z = scaleValue(current_box.getL().z, target_box.getL().z, scale);
+        new_xy = scaleValue(current_box.getTiltFactorXY(), target_box.getTiltFactorXY(), scale);
+        new_xz = scaleValue(current_box.getTiltFactorXZ(), target_box.getTiltFactorXZ(), scale);
+        new_yz = scaleValue(current_box.getTiltFactorYZ(), target_box.getTiltFactorYZ(), scale);
+        }
+    else
+        {
+        new_L.x = scaleValue(current_box.getL().x, target_box.getL().x, scale);
+        new_L.y = scaleValue(current_box.getL().y, target_box.getL().y, scale);
+        new_xy = scaleValue(current_box.getTiltFactorXY(), target_box.getTiltFactorXY(), scale);
 
-  // assume that the unused fields in the 2D target box are valid
-  new_L.z = target_box.getL().z;
-  new_xz = target_box.getTiltFactorXZ();
-  new_yz = target_box.getTiltFactorYZ();
-}
+        // assume that the unused fields in the 2D target box are valid
+        new_L.z = target_box.getL().z;
+        new_xz = target_box.getTiltFactorXZ();
+        new_yz = target_box.getTiltFactorYZ();
+        }
 
-BoxDim new_box = current_box;
-new_box.setL(new_L);
-new_box.setTiltFactors(new_xy, new_xz, new_yz);
-return new_box;
-}
+    BoxDim new_box = current_box;
+    new_box.setL(new_L);
+    new_box.setTiltFactors(new_xy, new_xz, new_yz);
+    return new_box;
+    }
 
-namespace detail {
-void export_UpdaterQuickCompress(pybind11::module& m) {
-  pybind11::class_<UpdaterQuickCompress, Updater,
-                   std::shared_ptr<UpdaterQuickCompress>>(m, "UpdaterQuickCompress")
-      .def(pybind11::init<std::shared_ptr<SystemDefinition>, std::shared_ptr<Trigger>,
-                          std::shared_ptr<IntegratorHPMC>, double, double,
-                          std::shared_ptr<BoxDim>>())
-      .def("isComplete", &UpdaterQuickCompress::isComplete)
-      .def_property("max_overlaps_per_particle",
-                    &UpdaterQuickCompress::getMaxOverlapsPerParticle,
-                    &UpdaterQuickCompress::setMaxOverlapsPerParticle)
-      .def_property("min_scale", &UpdaterQuickCompress::getMinScale,
-                    &UpdaterQuickCompress::setMinScale)
-      .def_property("target_box", &UpdaterQuickCompress::getTargetBox,
-                    &UpdaterQuickCompress::setTargetBox)
-      .def_property("instance", &UpdaterQuickCompress::getInstance,
-                    &UpdaterQuickCompress::setInstance);
-  .def_property("allow_unsafe_resize", &UpdaterQuickCompress::getInstance,
-                &UpdaterQuickCompress::setInstance);
-}
-}  // end namespace detail
-}  // end namespace hpmc
-}  // end namespace hoomd
+namespace detail
+    {
+void export_UpdaterQuickCompress(pybind11::module& m)
+    {
+    pybind11::class_<UpdaterQuickCompress, Updater, std::shared_ptr<UpdaterQuickCompress>>(
+        m,
+        "UpdaterQuickCompress")
+        .def(pybind11::init<std::shared_ptr<SystemDefinition>,
+                            std::shared_ptr<Trigger>,
+                            std::shared_ptr<IntegratorHPMC>,
+                            double,
+                            double,
+                            std::shared_ptr<BoxDim>>())
+        .def("isComplete", &UpdaterQuickCompress::isComplete)
+        .def_property("max_overlaps_per_particle",
+                      &UpdaterQuickCompress::getMaxOverlapsPerParticle,
+                      &UpdaterQuickCompress::setMaxOverlapsPerParticle)
+        .def_property("min_scale",
+                      &UpdaterQuickCompress::getMinScale,
+                      &UpdaterQuickCompress::setMinScale)
+        .def_property("target_box",
+                      &UpdaterQuickCompress::getTargetBox,
+                      &UpdaterQuickCompress::setTargetBox)
+        .def_property("instance",
+                      &UpdaterQuickCompress::getInstance,
+                      &UpdaterQuickCompress::setInstance);
+    .def_property("allow_unsafe_resize",
+                  &UpdaterQuickCompress::getInstance,
+                  &UpdaterQuickCompress::setInstance);
+    }
+    } // end namespace detail
+    } // end namespace hpmc
+    } // end namespace hoomd

--- a/hoomd/hpmc/UpdaterQuickCompress.cc
+++ b/hoomd/hpmc/UpdaterQuickCompress.cc
@@ -230,10 +230,10 @@ void export_UpdaterQuickCompress(pybind11::module& m)
                       &UpdaterQuickCompress::setTargetBox)
         .def_property("instance",
                       &UpdaterQuickCompress::getInstance,
+                      &UpdaterQuickCompress::setInstance)
+        .def_property("allow_unsafe_resize",
+                      &UpdaterQuickCompress::getInstance,
                       &UpdaterQuickCompress::setInstance);
-    .def_property("allow_unsafe_resize",
-                  &UpdaterQuickCompress::getInstance,
-                  &UpdaterQuickCompress::setInstance);
     }
     } // end namespace detail
     } // end namespace hpmc

--- a/hoomd/hpmc/UpdaterQuickCompress.cc
+++ b/hoomd/hpmc/UpdaterQuickCompress.cc
@@ -13,10 +13,9 @@ UpdaterQuickCompress::UpdaterQuickCompress(std::shared_ptr<SystemDefinition> sys
                                            std::shared_ptr<IntegratorHPMC> mc,
                                            double max_overlaps_per_particle,
                                            double min_scale,
-                                           bool allow_unsafe_resize,
                                            std::shared_ptr<BoxDim> target_box)
     : Updater(sysdef, trigger), m_mc(mc), m_max_overlaps_per_particle(max_overlaps_per_particle),
-      m_target_box(target_box), m_allow_unsafe_resize(allow_unsafe_resize)
+      m_target_box(target_box)
     {
     m_exec_conf->msg->notice(5) << "Constructing UpdaterQuickCompress" << std::endl;
     setMinScale(min_scale);
@@ -158,7 +157,7 @@ BoxDim UpdaterQuickCompress::getNewBox(uint64_t timestep)
         double max_diameter = m_mc->getMaxCoreDiameter();
         double min_move_size = m_mc->getMinTransMoveSize() * std::min(accept_ratio, 0.5);
         min_scale = std::max(m_min_scale, 1.0 - min_move_size / max_diameter);
-        };
+        }
 
     // Create a prng instance for this timestep
     hoomd::RandomGenerator rng(
@@ -230,8 +229,8 @@ void export_UpdaterQuickCompress(pybind11::module& m)
                       &UpdaterQuickCompress::getInstance,
                       &UpdaterQuickCompress::setInstance)
         .def_property("allow_unsafe_resize",
-                      &UpdaterQuickCompress::getInstance,
-                      &UpdaterQuickCompress::setInstance);
+                      &UpdaterQuickCompress::getAllowUnsafeResize,
+                      &UpdaterQuickCompress::setAllowUnsafeResize);
     }
     } // end namespace detail
     } // end namespace hpmc

--- a/hoomd/hpmc/UpdaterQuickCompress.cc
+++ b/hoomd/hpmc/UpdaterQuickCompress.cc
@@ -5,104 +5,96 @@
 
 #include "hoomd/RNGIdentifiers.h"
 
-namespace hoomd
-    {
-namespace hpmc
-    {
+namespace hoomd {
+namespace hpmc {
 UpdaterQuickCompress::UpdaterQuickCompress(std::shared_ptr<SystemDefinition> sysdef,
                                            std::shared_ptr<Trigger> trigger,
                                            std::shared_ptr<IntegratorHPMC> mc,
                                            double max_overlaps_per_particle,
-                                           double min_scale,
-                                           bool allow_unsafe_resize,
+                                           double min_scale, bool allow_unsafe_resize,
                                            std::shared_ptr<BoxDim> target_box)
-    : Updater(sysdef, trigger), m_mc(mc), m_max_overlaps_per_particle(max_overlaps_per_particle),
-      m_target_box(target_box), m_allow_unsafe_resize(allow_unsafe_resize)
-    {
-    m_exec_conf->msg->notice(5) << "Constructing UpdaterQuickCompress" << std::endl;
-    setMinScale(min_scale);
+    : Updater(sysdef, trigger),
+      m_mc(mc),
+      m_max_overlaps_per_particle(max_overlaps_per_particle),
+      m_target_box(target_box),
+      m_allow_unsafe_resize(allow_unsafe_resize) {
+  m_exec_conf->msg->notice(5) << "Constructing UpdaterQuickCompress" << std::endl;
+  setMinScale(min_scale);
 
-    // allocate memory for m_pos_backup
-    unsigned int MaxN = m_pdata->getMaxN();
-    GPUArray<Scalar4>(MaxN, m_exec_conf).swap(m_pos_backup);
+  // allocate memory for m_pos_backup
+  unsigned int MaxN = m_pdata->getMaxN();
+  GPUArray<Scalar4>(MaxN, m_exec_conf).swap(m_pos_backup);
 
-    // Connect to the MaxParticleNumberChange signal
-    m_pdata->getMaxParticleNumberChangeSignal()
-        .connect<UpdaterQuickCompress, &UpdaterQuickCompress::slotMaxNChange>(this);
+  // Connect to the MaxParticleNumberChange signal
+  m_pdata->getMaxParticleNumberChangeSignal()
+      .connect<UpdaterQuickCompress, &UpdaterQuickCompress::slotMaxNChange>(this);
 
-    m_last_move_counters = m_mc->getCounters();
-    }
+  m_last_move_counters = m_mc->getCounters();
+}
 
-UpdaterQuickCompress::~UpdaterQuickCompress()
-    {
-    m_exec_conf->msg->notice(5) << "Destroying UpdaterQuickCompress" << std::endl;
-    m_pdata->getMaxParticleNumberChangeSignal()
-        .disconnect<UpdaterQuickCompress, &UpdaterQuickCompress::slotMaxNChange>(this);
-    }
+UpdaterQuickCompress::~UpdaterQuickCompress() {
+  m_exec_conf->msg->notice(5) << "Destroying UpdaterQuickCompress" << std::endl;
+  m_pdata->getMaxParticleNumberChangeSignal()
+      .disconnect<UpdaterQuickCompress, &UpdaterQuickCompress::slotMaxNChange>(this);
+}
 
-void UpdaterQuickCompress::update(uint64_t timestep)
-    {
-    Updater::update(timestep);
-    m_exec_conf->msg->notice(10) << "UpdaterQuickCompress: " << timestep << std::endl;
+void UpdaterQuickCompress::update(uint64_t timestep) {
+  Updater::update(timestep);
+  m_exec_conf->msg->notice(10) << "UpdaterQuickCompress: " << timestep << std::endl;
 
-    // count the number of overlaps in the current configuration
-    auto n_overlaps = m_mc->countOverlaps(false);
-    BoxDim current_box = m_pdata->getGlobalBox();
+  // count the number of overlaps in the current configuration
+  auto n_overlaps = m_mc->countOverlaps(false);
+  BoxDim current_box = m_pdata->getGlobalBox();
 
-    if (n_overlaps == 0 && current_box != *m_target_box)
-        {
-        performBoxScale(timestep);
-        }
+  if (n_overlaps == 0 && current_box != *m_target_box) {
+    performBoxScale(timestep);
+  }
 
-    // The compression is complete when we have reached the target box and there are no
-    // overlaps.
-    if (n_overlaps == 0 && current_box == *m_target_box)
-        m_is_complete = true;
-    else
-        m_is_complete = false;
-    }
+  // The compression is complete when we have reached the target box and there are no
+  // overlaps.
+  if (n_overlaps == 0 && current_box == *m_target_box)
+    m_is_complete = true;
+  else
+    m_is_complete = false;
+}
 
-void UpdaterQuickCompress::performBoxScale(uint64_t timestep)
-    {
-    auto new_box = getNewBox(timestep);
-    auto old_box = m_pdata->getGlobalBox();
+void UpdaterQuickCompress::performBoxScale(uint64_t timestep) {
+  auto new_box = getNewBox(timestep);
+  auto old_box = m_pdata->getGlobalBox();
 
-    Scalar3 old_origin = m_pdata->getOrigin();
+  Scalar3 old_origin = m_pdata->getOrigin();
 
-    // Make a backup copy of position data
-    unsigned int N_backup = m_pdata->getN();
-        {
-        ArrayHandle<Scalar4> h_pos(m_pdata->getPositions(),
-                                   access_location::host,
-                                   access_mode::read);
-        ArrayHandle<Scalar4> h_pos_backup(m_pos_backup,
-                                          access_location::host,
-                                          access_mode::overwrite);
-        memcpy(h_pos_backup.data, h_pos.data, sizeof(Scalar4) * N_backup);
-        }
+  // Make a backup copy of position data
+  unsigned int N_backup = m_pdata->getN();
+  {
+    ArrayHandle<Scalar4> h_pos(m_pdata->getPositions(), access_location::host,
+                               access_mode::read);
+    ArrayHandle<Scalar4> h_pos_backup(m_pos_backup, access_location::host,
+                                      access_mode::overwrite);
+    memcpy(h_pos_backup.data, h_pos.data, sizeof(Scalar4) * N_backup);
+  }
 
-    m_mc->attemptBoxResize(timestep, new_box);
-    Scalar3 new_origin = m_pdata->getOrigin();
-    Scalar3 origin_shift = new_origin - old_origin;
+  m_mc->attemptBoxResize(timestep, new_box);
+  Scalar3 new_origin = m_pdata->getOrigin();
+  Scalar3 origin_shift = new_origin - old_origin;
 
-    auto n_overlaps = m_mc->countOverlaps(false);
-    if (n_overlaps > m_max_overlaps_per_particle * m_pdata->getNGlobal())
-        {
-        // the box move generated too many overlaps, undo the move
-        ArrayHandle<Scalar4> h_pos(m_pdata->getPositions(),
-                                   access_location::host,
-                                   access_mode::readwrite);
-        ArrayHandle<Scalar4> h_pos_backup(m_pos_backup, access_location::host, access_mode::read);
-        unsigned int N = m_pdata->getN();
-        assert(N == N_backup);
-        memcpy(h_pos.data, h_pos_backup.data, sizeof(Scalar4) * N);
-        m_pdata->setGlobalBox(old_box);
-        m_pdata->translateOrigin(-origin_shift);
+  auto n_overlaps = m_mc->countOverlaps(false);
+  if (n_overlaps > m_max_overlaps_per_particle * m_pdata->getNGlobal()) {
+    // the box move generated too many overlaps, undo the move
+    ArrayHandle<Scalar4> h_pos(m_pdata->getPositions(), access_location::host,
+                               access_mode::readwrite);
+    ArrayHandle<Scalar4> h_pos_backup(m_pos_backup, access_location::host,
+                                      access_mode::read);
+    unsigned int N = m_pdata->getN();
+    assert(N == N_backup);
+    memcpy(h_pos.data, h_pos_backup.data, sizeof(Scalar4) * N);
+    m_pdata->setGlobalBox(old_box);
+    m_pdata->translateOrigin(-origin_shift);
 
-        // we have moved particles, communicate those changes
-        m_mc->communicate(false);
-        }
-    }
+    // we have moved particles, communicate those changes
+    m_mc->communicate(false);
+  }
+}
 
 /** Adjust a value by the scale.
 
@@ -114,59 +106,50 @@ void UpdaterQuickCompress::performBoxScale(uint64_t timestep)
 
     @returns The scaled value.
 */
-static inline double scaleValue(double current, double target, double s)
-    {
-    assert(s <= 1.0);
-    if (target < current)
-        {
-        return std::max(target, current * s);
-        }
-    else
-        {
-        return std::min(target, current * 1.0 / s);
-        }
-    }
+static inline double scaleValue(double current, double target, double s) {
+  assert(s <= 1.0);
+  if (target < current) {
+    return std::max(target, current * s);
+  } else {
+    return std::min(target, current * 1.0 / s);
+  }
+}
 
-BoxDim UpdaterQuickCompress::getNewBox(uint64_t timestep)
-    {
-    // compute the current MC translate acceptance ratio
-    auto current_counters = m_mc->getCounters();
-    auto counter_delta = current_counters - m_last_move_counters;
-    m_last_move_counters = current_counters;
-    double accept_ratio = 1.0;
-    if (counter_delta.translate_accept_count > 0)
-        {
-        accept_ratio
-            = double(counter_delta.translate_accept_count)
-              / double(counter_delta.translate_accept_count + counter_delta.translate_reject_count);
-        }
+BoxDim UpdaterQuickCompress::getNewBox(uint64_t timestep) {
+  // compute the current MC translate acceptance ratio
+  auto current_counters = m_mc->getCounters();
+  auto counter_delta = current_counters - m_last_move_counters;
+  m_last_move_counters = current_counters;
+  double accept_ratio = 1.0;
+  if (counter_delta.translate_accept_count > 0) {
+    accept_ratio = double(counter_delta.translate_accept_count) /
+                   double(counter_delta.translate_accept_count +
+                          counter_delta.translate_reject_count);
+  }
 
-    // If unsafe box moves are allowed, set min_scale without considering min_move_size.
-    // Otherwise, determine the worst case minimum allowable scale factor. The minimum
-    // allowable scale factor assumes that the typical accepted trial move shifts
-    // particles by the current acceptance ratio times the maximum displacement. Assuming
-    // that the particles are all spheres with their circumsphere diameter, set the
-    // minimum allowable scale factor so that overlaps of this size can be removed by
-    // trial move. The worst case estimate uses the minimum move size and the maximum core
-    // diameter. Cap the acceptance ratio at 0.5 to prevent excessive box moves.
-    double min_scale;
+  // If unsafe box moves are allowed, set min_scale without considering min_move_size.
+  // Otherwise, determine the worst case minimum allowable scale factor. The minimum
+  // allowable scale factor assumes that the typical accepted trial move shifts
+  // particles by the current acceptance ratio times the maximum displacement. Assuming
+  // that the particles are all spheres with their circumsphere diameter, set the
+  // minimum allowable scale factor so that overlaps of this size can be removed by
+  // trial move. The worst case estimate uses the minimum move size and the maximum core
+  // diameter. Cap the acceptance ratio at 0.5 to prevent excessive box moves.
+  double min_scale;
 
-    if (allow_unsafe_resize)
-        {
-        min_scale = m_min_scale;
-        }
-    else
-        {
-        double max_diameter = m_mc->getMaxCoreDiameter();
-        double min_move_size = m_mc->getMinTransMoveSize() * std::min(accept_ratio, 0.5);
-        min_scale = std::max(m_min_scale, 1.0 - min_move_size / max_diameter);
-        };
-    };
+  if (m_allow_unsafe_resize) {
+    min_scale = m_min_scale;
+  } else {
+    double max_diameter = m_mc->getMaxCoreDiameter();
+    double min_move_size = m_mc->getMinTransMoveSize() * std::min(accept_ratio, 0.5);
+    min_scale = std::max(m_min_scale, 1.0 - min_move_size / max_diameter);
+  };
+};
 
 // Create a prng instance for this timestep
-hoomd::RandomGenerator
-    rng(hoomd::Seed(hoomd::RNGIdentifier::UpdaterQuickCompress, timestep, m_sysdef->getSeed()),
-        hoomd::Counter(m_instance));
+hoomd::RandomGenerator rng(hoomd::Seed(hoomd::RNGIdentifier::UpdaterQuickCompress,
+                                       timestep, m_sysdef->getSeed()),
+                           hoomd::Counter(m_instance));
 
 // choose a scale randomly between min_scale and 1.0
 hoomd::UniformDistribution<double> uniform(min_scale, 1.0);
@@ -179,63 +162,54 @@ const auto& target_box = *m_target_box;
 BoxDim current_box = m_pdata->getGlobalBox();
 Scalar3 new_L;
 Scalar new_xy, new_xz, new_yz;
-if (m_sysdef->getNDimensions() == 3)
-    {
-    new_L.x = scaleValue(current_box.getL().x, target_box.getL().x, scale);
-    new_L.y = scaleValue(current_box.getL().y, target_box.getL().y, scale);
-    new_L.z = scaleValue(current_box.getL().z, target_box.getL().z, scale);
-    new_xy = scaleValue(current_box.getTiltFactorXY(), target_box.getTiltFactorXY(), scale);
-    new_xz = scaleValue(current_box.getTiltFactorXZ(), target_box.getTiltFactorXZ(), scale);
-    new_yz = scaleValue(current_box.getTiltFactorYZ(), target_box.getTiltFactorYZ(), scale);
-    }
-else
-    {
-    new_L.x = scaleValue(current_box.getL().x, target_box.getL().x, scale);
-    new_L.y = scaleValue(current_box.getL().y, target_box.getL().y, scale);
-    new_xy = scaleValue(current_box.getTiltFactorXY(), target_box.getTiltFactorXY(), scale);
+if (m_sysdef->getNDimensions() == 3) {
+  new_L.x = scaleValue(current_box.getL().x, target_box.getL().x, scale);
+  new_L.y = scaleValue(current_box.getL().y, target_box.getL().y, scale);
+  new_L.z = scaleValue(current_box.getL().z, target_box.getL().z, scale);
+  new_xy =
+      scaleValue(current_box.getTiltFactorXY(), target_box.getTiltFactorXY(), scale);
+  new_xz =
+      scaleValue(current_box.getTiltFactorXZ(), target_box.getTiltFactorXZ(), scale);
+  new_yz =
+      scaleValue(current_box.getTiltFactorYZ(), target_box.getTiltFactorYZ(), scale);
+} else {
+  new_L.x = scaleValue(current_box.getL().x, target_box.getL().x, scale);
+  new_L.y = scaleValue(current_box.getL().y, target_box.getL().y, scale);
+  new_xy =
+      scaleValue(current_box.getTiltFactorXY(), target_box.getTiltFactorXY(), scale);
 
-    // assume that the unused fields in the 2D target box are valid
-    new_L.z = target_box.getL().z;
-    new_xz = target_box.getTiltFactorXZ();
-    new_yz = target_box.getTiltFactorYZ();
-    }
+  // assume that the unused fields in the 2D target box are valid
+  new_L.z = target_box.getL().z;
+  new_xz = target_box.getTiltFactorXZ();
+  new_yz = target_box.getTiltFactorYZ();
+}
 
 BoxDim new_box = current_box;
 new_box.setL(new_L);
 new_box.setTiltFactors(new_xy, new_xz, new_yz);
 return new_box;
-    }
+}
 
-namespace detail
-    {
-void export_UpdaterQuickCompress(pybind11::module& m)
-    {
-    pybind11::class_<UpdaterQuickCompress, Updater, std::shared_ptr<UpdaterQuickCompress>>(
-        m,
-        "UpdaterQuickCompress")
-        .def(pybind11::init<std::shared_ptr<SystemDefinition>,
-                            std::shared_ptr<Trigger>,
-                            std::shared_ptr<IntegratorHPMC>,
-                            double,
-                            double,
-                            std::shared_ptr<BoxDim>>())
-        .def("isComplete", &UpdaterQuickCompress::isComplete)
-        .def_property("max_overlaps_per_particle",
-                      &UpdaterQuickCompress::getMaxOverlapsPerParticle,
-                      &UpdaterQuickCompress::setMaxOverlapsPerParticle)
-        .def_property("min_scale",
-                      &UpdaterQuickCompress::getMinScale,
-                      &UpdaterQuickCompress::setMinScale)
-        .def_property("target_box",
-                      &UpdaterQuickCompress::getTargetBox,
-                      &UpdaterQuickCompress::setTargetBox)
-        .def_property("instance",
-                      &UpdaterQuickCompress::getInstance,
-                      &UpdaterQuickCompress::setInstance);
-    .def_property("allow_unsafe_resize",
-                  &UpdaterQuickCompress::getInstance,
-                  &UpdaterQuickCompress::setInstance);
-    }
-    } // end namespace detail
-    } // end namespace hpmc
-} // end namespace hoomd
+namespace detail {
+void export_UpdaterQuickCompress(pybind11::module& m) {
+  pybind11::class_<UpdaterQuickCompress, Updater,
+                   std::shared_ptr<UpdaterQuickCompress>>(m, "UpdaterQuickCompress")
+      .def(pybind11::init<std::shared_ptr<SystemDefinition>, std::shared_ptr<Trigger>,
+                          std::shared_ptr<IntegratorHPMC>, double, double,
+                          std::shared_ptr<BoxDim>>())
+      .def("isComplete", &UpdaterQuickCompress::isComplete)
+      .def_property("max_overlaps_per_particle",
+                    &UpdaterQuickCompress::getMaxOverlapsPerParticle,
+                    &UpdaterQuickCompress::setMaxOverlapsPerParticle)
+      .def_property("min_scale", &UpdaterQuickCompress::getMinScale,
+                    &UpdaterQuickCompress::setMinScale)
+      .def_property("target_box", &UpdaterQuickCompress::getTargetBox,
+                    &UpdaterQuickCompress::setTargetBox)
+      .def_property("instance", &UpdaterQuickCompress::getInstance,
+                    &UpdaterQuickCompress::setInstance);
+  .def_property("allow_unsafe_resize", &UpdaterQuickCompress::getInstance,
+                &UpdaterQuickCompress::setInstance);
+}
+}  // end namespace detail
+}  // end namespace hpmc
+}  // end namespace hoomd

--- a/hoomd/hpmc/UpdaterQuickCompress.h
+++ b/hoomd/hpmc/UpdaterQuickCompress.h
@@ -150,6 +150,9 @@ class UpdaterQuickCompress : public Updater
     /// hold backup copy of particle positions
     GPUArray<Scalar4> m_pos_backup;
 
+    /// Flag whether unsafe box resizes are allowed
+    bool m_allow_unsafe_resize = false;
+
     /// Perform the box scale move
     void performBoxScale(uint64_t timestep);
 

--- a/hoomd/hpmc/UpdaterQuickCompress.h
+++ b/hoomd/hpmc/UpdaterQuickCompress.h
@@ -39,6 +39,7 @@ class UpdaterQuickCompress : public Updater
                          std::shared_ptr<IntegratorHPMC> mc,
                          double max_overlaps_per_particle,
                          double min_scale,
+                         bool allow_unsafe_resize,
                          std::shared_ptr<BoxDim> target_box);
 
     /// Destructor

--- a/hoomd/hpmc/UpdaterQuickCompress.h
+++ b/hoomd/hpmc/UpdaterQuickCompress.h
@@ -60,6 +60,18 @@ class UpdaterQuickCompress : public Updater
     */
     virtual void update(uint64_t timestep);
 
+    /// Get whether unsafe (overlap-allowed) resizes are enabled
+    double getAllowUnsafeResize()
+        {
+        return m_allow_unsafe_resize;
+        }
+
+    /// Set whether unsafe (overlap-allowed) resizes are enabled
+    void setAllowUnsafeResize(bool allow_unsafe_resize)
+        {
+        m_allow_unsafe_resize = allow_unsafe_resize;
+        }
+
     /// Get the maximum number of overlaps allowed per particle
     double getMaxOverlapsPerParticle()
         {

--- a/hoomd/hpmc/UpdaterQuickCompress.h
+++ b/hoomd/hpmc/UpdaterQuickCompress.h
@@ -39,7 +39,6 @@ class UpdaterQuickCompress : public Updater
                          std::shared_ptr<IntegratorHPMC> mc,
                          double max_overlaps_per_particle,
                          double min_scale,
-                         bool allow_unsafe_resize,
                          std::shared_ptr<BoxDim> target_box);
 
     /// Destructor

--- a/hoomd/hpmc/pytest/test_quick_compress.py
+++ b/hoomd/hpmc/pytest/test_quick_compress.py
@@ -13,30 +13,37 @@ import math
 valid_constructor_args = [
     dict(trigger=hoomd.trigger.Periodic(10),
          target_box=hoomd.Box.from_box([10, 10, 10])),
-    dict(trigger=hoomd.trigger.After(100),
-         target_box=hoomd.Box.from_box([10, 20, 40]),
-         max_overlaps_per_particle=0.2),
-    dict(trigger=hoomd.trigger.Before(100),
-         target_box=hoomd.Box.from_box([50, 50]),
-         min_scale=0.75),
-    dict(trigger=hoomd.trigger.Periodic(1000),
-         target_box=hoomd.Box.from_box([80, 50, 40, 0.2, 0.4, 0.5]),
-         max_overlaps_per_particle=0.2,
-         min_scale=0.999),
+    dict(
+        trigger=hoomd.trigger.After(100),
+        target_box=hoomd.Box.from_box([10, 20, 40]),
+        max_overlaps_per_particle=0.2,
+    ),
+    dict(
+        trigger=hoomd.trigger.Before(100),
+        target_box=hoomd.Box.from_box([50, 50]),
+        min_scale=0.75,
+    ),
+    dict(
+        trigger=hoomd.trigger.Periodic(1000),
+        target_box=hoomd.Box.from_box([80, 50, 40, 0.2, 0.4, 0.5]),
+        max_overlaps_per_particle=0.2,
+        min_scale=0.999,
+    ),
 ]
 
 valid_attrs = [
-    ('trigger', hoomd.trigger.Periodic(10000)),
-    ('trigger', hoomd.trigger.After(100)),
-    ('trigger', hoomd.trigger.Before(12345)),
-    ('target_box', hoomd.Box.from_box([10, 20, 30])),
-    ('target_box', hoomd.Box.from_box([50, 50])),
-    ('max_overlaps_per_particle', 0.2),
-    ('max_overlaps_per_particle', 0.5),
-    ('max_overlaps_per_particle', 2.5),
-    ('min_scale', 0.1),
-    ('min_scale', 0.5),
-    ('min_scale', 0.9999),
+    ("trigger", hoomd.trigger.Periodic(10000)),
+    ("trigger", hoomd.trigger.After(100)),
+    ("trigger", hoomd.trigger.Before(12345)),
+    ("target_box", hoomd.Box.from_box([10, 20, 30])),
+    ("target_box", hoomd.Box.from_box([50, 50])),
+    ("max_overlaps_per_particle", 0.2),
+    ("max_overlaps_per_particle", 0.5),
+    ("max_overlaps_per_particle", 2.5),
+    ("min_scale", 0.1),
+    ("min_scale", 0.5),
+    ("min_scale", 0.9999),
+    # TODO: add tests for new allow_unsafe_resize
 ]
 
 
@@ -62,7 +69,7 @@ def test_valid_construction_and_attach(simulation_factory,
 
     # QuickCompress requires an HPMC integrator
     mc = hoomd.hpmc.integrate.Sphere()
-    mc.shape['A'] = dict(diameter=1)
+    mc.shape["A"] = dict(diameter=1)
     sim.operations.integrator = mc
 
     sim.operations._schedule()
@@ -96,7 +103,7 @@ def test_valid_setattr_attached(attr, value, simulation_factory,
 
     # QuickCompress requires an HPMC integrator
     mc = hoomd.hpmc.integrate.Sphere()
-    mc.shape['A'] = dict(diameter=1)
+    mc.shape["A"] = dict(diameter=1)
     sim.operations.integrator = mc
 
     sim.operations._schedule()
@@ -121,7 +128,7 @@ def test_sphere_compression(phi, simulation_factory, lattice_snapshot_factory):
     sim.operations.updaters.append(qc)
 
     mc = hoomd.hpmc.integrate.Sphere(default_d=0.05)
-    mc.shape['A'] = dict(diameter=1)
+    mc.shape["A"] = dict(diameter=1)
     sim.operations.integrator = mc
 
     sim.run(1)
@@ -155,7 +162,7 @@ def test_disk_compression(phi, simulation_factory, lattice_snapshot_factory):
     sim.operations.updaters.append(qc)
 
     mc = hoomd.hpmc.integrate.Sphere(default_d=0.05)
-    mc.shape['A'] = dict(diameter=1)
+    mc.shape["A"] = dict(diameter=1)
     sim.operations.integrator = mc
 
     sim.run(1)
@@ -175,10 +182,10 @@ def test_disk_compression(phi, simulation_factory, lattice_snapshot_factory):
 def test_pickling(simulation_factory, two_particle_snapshot_factory):
     """Test that QuickCompress objects are picklable."""
     qc = hoomd.hpmc.update.QuickCompress(trigger=hoomd.trigger.Periodic(10),
-                                         target_box=hoomd.Box.square(10.))
+                                         target_box=hoomd.Box.square(10.0))
 
     sim = simulation_factory(two_particle_snapshot_factory())
     mc = hoomd.hpmc.integrate.Sphere(default_d=0.05)
-    mc.shape['A'] = dict(diameter=1)
+    mc.shape["A"] = dict(diameter=1)
     sim.operations.integrator = mc
     operation_pickling_check(qc, sim)

--- a/hoomd/hpmc/pytest/test_quick_compress.py
+++ b/hoomd/hpmc/pytest/test_quick_compress.py
@@ -11,8 +11,9 @@ import math
 # note: The parameterized tests validate parameters so we can't pass in values
 # here that require preprocessing
 valid_constructor_args = [
-    dict(trigger=hoomd.trigger.Periodic(10),
-         target_box=hoomd.Box.from_box([10, 10, 10])),
+    dict(
+        trigger=hoomd.trigger.Periodic(10), target_box=hoomd.Box.from_box([10, 10, 10])
+    ),
     dict(
         trigger=hoomd.trigger.After(100),
         target_box=hoomd.Box.from_box([10, 20, 40]),
@@ -58,9 +59,9 @@ def test_valid_construction(constructor_args):
 
 
 @pytest.mark.parametrize("constructor_args", valid_constructor_args)
-def test_valid_construction_and_attach(simulation_factory,
-                                       two_particle_snapshot_factory,
-                                       constructor_args):
+def test_valid_construction_and_attach(
+    simulation_factory, two_particle_snapshot_factory, constructor_args
+):
     """Test that QuickCompress can be attached with valid arguments."""
     qc = hoomd.hpmc.update.QuickCompress(**constructor_args)
 
@@ -69,7 +70,7 @@ def test_valid_construction_and_attach(simulation_factory,
 
     # QuickCompress requires an HPMC integrator
     mc = hoomd.hpmc.integrate.Sphere()
-    mc.shape["A"] = dict(diameter=1)
+    mc.shape['A'] = dict(diameter=1)
     sim.operations.integrator = mc
 
     sim.operations._schedule()
@@ -82,28 +83,29 @@ def test_valid_construction_and_attach(simulation_factory,
 @pytest.mark.parametrize("attr,value", valid_attrs)
 def test_valid_setattr(attr, value):
     """Test that QuickCompress can get and set attributes."""
-    qc = hoomd.hpmc.update.QuickCompress(trigger=hoomd.trigger.Periodic(10),
-                                         target_box=hoomd.Box.from_box(
-                                             [10, 10, 10]))
+    qc = hoomd.hpmc.update.QuickCompress(
+        trigger=hoomd.trigger.Periodic(10), target_box=hoomd.Box.from_box([10, 10, 10])
+    )
 
     setattr(qc, attr, value)
     assert getattr(qc, attr) == value
 
 
 @pytest.mark.parametrize("attr,value", valid_attrs)
-def test_valid_setattr_attached(attr, value, simulation_factory,
-                                two_particle_snapshot_factory):
+def test_valid_setattr_attached(
+    attr, value, simulation_factory, two_particle_snapshot_factory
+):
     """Test that QuickCompress can get and set attributes while attached."""
-    qc = hoomd.hpmc.update.QuickCompress(trigger=hoomd.trigger.Periodic(10),
-                                         target_box=hoomd.Box.from_box(
-                                             [10, 10, 10]))
+    qc = hoomd.hpmc.update.QuickCompress(
+        trigger=hoomd.trigger.Periodic(10), target_box=hoomd.Box.from_box([10, 10, 10])
+    )
 
     sim = simulation_factory(two_particle_snapshot_factory())
     sim.operations.updaters.append(qc)
 
     # QuickCompress requires an HPMC integrator
     mc = hoomd.hpmc.integrate.Sphere()
-    mc.shape["A"] = dict(diameter=1)
+    mc.shape['A'] = dict(diameter=1)
     sim.operations.integrator = mc
 
     sim.operations._schedule()
@@ -118,17 +120,18 @@ def test_sphere_compression(phi, simulation_factory, lattice_snapshot_factory):
     """Test that QuickCompress can compress (and expand) simulation boxes."""
     n = 7
     snap = lattice_snapshot_factory(n=n, a=1.1)
-    v_particle = 4 / 3 * math.pi * (0.5)**3
-    target_box = hoomd.Box.cube((n * n * n * v_particle / phi)**(1 / 3))
+    v_particle = 4 / 3 * math.pi * (0.5) ** 3
+    target_box = hoomd.Box.cube((n * n * n * v_particle / phi) ** (1 / 3))
 
-    qc = hoomd.hpmc.update.QuickCompress(trigger=hoomd.trigger.Periodic(10),
-                                         target_box=target_box)
+    qc = hoomd.hpmc.update.QuickCompress(
+        trigger=hoomd.trigger.Periodic(10), target_box=target_box
+    )
 
     sim = simulation_factory(snap)
     sim.operations.updaters.append(qc)
 
     mc = hoomd.hpmc.integrate.Sphere(default_d=0.05)
-    mc.shape["A"] = dict(diameter=1)
+    mc.shape['A'] = dict(diameter=1)
     sim.operations.integrator = mc
 
     sim.run(1)
@@ -152,17 +155,18 @@ def test_disk_compression(phi, simulation_factory, lattice_snapshot_factory):
     """Test that QuickCompress can compress (and expand) simulation boxes."""
     n = 7
     snap = lattice_snapshot_factory(dimensions=2, n=n, a=1.1)
-    v_particle = math.pi * (0.5)**2
-    target_box = hoomd.Box.square((n * n * v_particle / phi)**(1 / 2))
+    v_particle = math.pi * (0.5) ** 2
+    target_box = hoomd.Box.square((n * n * v_particle / phi) ** (1 / 2))
 
-    qc = hoomd.hpmc.update.QuickCompress(trigger=hoomd.trigger.Periodic(10),
-                                         target_box=target_box)
+    qc = hoomd.hpmc.update.QuickCompress(
+        trigger=hoomd.trigger.Periodic(10), target_box=target_box
+    )
 
     sim = simulation_factory(snap)
     sim.operations.updaters.append(qc)
 
     mc = hoomd.hpmc.integrate.Sphere(default_d=0.05)
-    mc.shape["A"] = dict(diameter=1)
+    mc.shape['A'] = dict(diameter=1)
     sim.operations.integrator = mc
 
     sim.run(1)
@@ -181,11 +185,12 @@ def test_disk_compression(phi, simulation_factory, lattice_snapshot_factory):
 
 def test_pickling(simulation_factory, two_particle_snapshot_factory):
     """Test that QuickCompress objects are picklable."""
-    qc = hoomd.hpmc.update.QuickCompress(trigger=hoomd.trigger.Periodic(10),
-                                         target_box=hoomd.Box.square(10.0))
+    qc = hoomd.hpmc.update.QuickCompress(
+        trigger=hoomd.trigger.Periodic(10), target_box=hoomd.Box.square(10.0)
+    )
 
     sim = simulation_factory(two_particle_snapshot_factory())
     mc = hoomd.hpmc.integrate.Sphere(default_d=0.05)
-    mc.shape["A"] = dict(diameter=1)
+    mc.shape['A'] = dict(diameter=1)
     sim.operations.integrator = mc
     operation_pickling_check(qc, sim)

--- a/hoomd/hpmc/pytest/test_quick_compress.py
+++ b/hoomd/hpmc/pytest/test_quick_compress.py
@@ -11,40 +11,32 @@ import math
 # note: The parameterized tests validate parameters so we can't pass in values
 # here that require preprocessing
 valid_constructor_args = [
-    dict(
-        trigger=hoomd.trigger.Periodic(10), target_box=hoomd.Box.from_box([10, 10, 10])
-    ),
-    dict(
-        trigger=hoomd.trigger.After(100),
-        target_box=hoomd.Box.from_box([10, 20, 40]),
-        max_overlaps_per_particle=0.2,
-    ),
-    dict(
-        trigger=hoomd.trigger.Before(100),
-        target_box=hoomd.Box.from_box([50, 50]),
-        min_scale=0.75,
-    ),
-    dict(
-        trigger=hoomd.trigger.Periodic(1000),
-        target_box=hoomd.Box.from_box([80, 50, 40, 0.2, 0.4, 0.5]),
-        max_overlaps_per_particle=0.2,
-        min_scale=0.999,
-    ),
+    dict(trigger=hoomd.trigger.Periodic(10),
+         target_box=hoomd.Box.from_box([10, 10, 10])),
+    dict(trigger=hoomd.trigger.After(100),
+         target_box=hoomd.Box.from_box([10, 20, 40]),
+         max_overlaps_per_particle=0.2),
+    dict(trigger=hoomd.trigger.Before(100),
+         target_box=hoomd.Box.from_box([50, 50]),
+         min_scale=0.75),
+    dict(trigger=hoomd.trigger.Periodic(1000),
+         target_box=hoomd.Box.from_box([80, 50, 40, 0.2, 0.4, 0.5]),
+         max_overlaps_per_particle=0.2,
+         min_scale=0.999),
 ]
 
 valid_attrs = [
-    ("trigger", hoomd.trigger.Periodic(10000)),
-    ("trigger", hoomd.trigger.After(100)),
-    ("trigger", hoomd.trigger.Before(12345)),
-    ("target_box", hoomd.Box.from_box([10, 20, 30])),
-    ("target_box", hoomd.Box.from_box([50, 50])),
-    ("max_overlaps_per_particle", 0.2),
-    ("max_overlaps_per_particle", 0.5),
-    ("max_overlaps_per_particle", 2.5),
-    ("min_scale", 0.1),
-    ("min_scale", 0.5),
-    ("min_scale", 0.9999),
-    # TODO: add tests for new allow_unsafe_resize
+    ('trigger', hoomd.trigger.Periodic(10000)),
+    ('trigger', hoomd.trigger.After(100)),
+    ('trigger', hoomd.trigger.Before(12345)),
+    ('target_box', hoomd.Box.from_box([10, 20, 30])),
+    ('target_box', hoomd.Box.from_box([50, 50])),
+    ('max_overlaps_per_particle', 0.2),
+    ('max_overlaps_per_particle', 0.5),
+    ('max_overlaps_per_particle', 2.5),
+    ('min_scale', 0.1),
+    ('min_scale', 0.5),
+    ('min_scale', 0.9999),
 ]
 
 
@@ -59,9 +51,9 @@ def test_valid_construction(constructor_args):
 
 
 @pytest.mark.parametrize("constructor_args", valid_constructor_args)
-def test_valid_construction_and_attach(
-    simulation_factory, two_particle_snapshot_factory, constructor_args
-):
+def test_valid_construction_and_attach(simulation_factory,
+                                       two_particle_snapshot_factory,
+                                       constructor_args):
     """Test that QuickCompress can be attached with valid arguments."""
     qc = hoomd.hpmc.update.QuickCompress(**constructor_args)
 
@@ -83,22 +75,21 @@ def test_valid_construction_and_attach(
 @pytest.mark.parametrize("attr,value", valid_attrs)
 def test_valid_setattr(attr, value):
     """Test that QuickCompress can get and set attributes."""
-    qc = hoomd.hpmc.update.QuickCompress(
-        trigger=hoomd.trigger.Periodic(10), target_box=hoomd.Box.from_box([10, 10, 10])
-    )
+    qc = hoomd.hpmc.update.QuickCompress(trigger=hoomd.trigger.Periodic(10),
+                                         target_box=hoomd.Box.from_box(
+                                             [10, 10, 10]))
 
     setattr(qc, attr, value)
     assert getattr(qc, attr) == value
 
 
 @pytest.mark.parametrize("attr,value", valid_attrs)
-def test_valid_setattr_attached(
-    attr, value, simulation_factory, two_particle_snapshot_factory
-):
+def test_valid_setattr_attached(attr, value, simulation_factory,
+                                two_particle_snapshot_factory):
     """Test that QuickCompress can get and set attributes while attached."""
-    qc = hoomd.hpmc.update.QuickCompress(
-        trigger=hoomd.trigger.Periodic(10), target_box=hoomd.Box.from_box([10, 10, 10])
-    )
+    qc = hoomd.hpmc.update.QuickCompress(trigger=hoomd.trigger.Periodic(10),
+                                         target_box=hoomd.Box.from_box(
+                                             [10, 10, 10]))
 
     sim = simulation_factory(two_particle_snapshot_factory())
     sim.operations.updaters.append(qc)
@@ -120,12 +111,11 @@ def test_sphere_compression(phi, simulation_factory, lattice_snapshot_factory):
     """Test that QuickCompress can compress (and expand) simulation boxes."""
     n = 7
     snap = lattice_snapshot_factory(n=n, a=1.1)
-    v_particle = 4 / 3 * math.pi * (0.5) ** 3
-    target_box = hoomd.Box.cube((n * n * n * v_particle / phi) ** (1 / 3))
+    v_particle = 4 / 3 * math.pi * (0.5)**3
+    target_box = hoomd.Box.cube((n * n * n * v_particle / phi)**(1 / 3))
 
-    qc = hoomd.hpmc.update.QuickCompress(
-        trigger=hoomd.trigger.Periodic(10), target_box=target_box
-    )
+    qc = hoomd.hpmc.update.QuickCompress(trigger=hoomd.trigger.Periodic(10),
+                                         target_box=target_box)
 
     sim = simulation_factory(snap)
     sim.operations.updaters.append(qc)
@@ -155,12 +145,11 @@ def test_disk_compression(phi, simulation_factory, lattice_snapshot_factory):
     """Test that QuickCompress can compress (and expand) simulation boxes."""
     n = 7
     snap = lattice_snapshot_factory(dimensions=2, n=n, a=1.1)
-    v_particle = math.pi * (0.5) ** 2
-    target_box = hoomd.Box.square((n * n * v_particle / phi) ** (1 / 2))
+    v_particle = math.pi * (0.5)**2
+    target_box = hoomd.Box.square((n * n * v_particle / phi)**(1 / 2))
 
-    qc = hoomd.hpmc.update.QuickCompress(
-        trigger=hoomd.trigger.Periodic(10), target_box=target_box
-    )
+    qc = hoomd.hpmc.update.QuickCompress(trigger=hoomd.trigger.Periodic(10),
+                                         target_box=target_box)
 
     sim = simulation_factory(snap)
     sim.operations.updaters.append(qc)
@@ -185,9 +174,8 @@ def test_disk_compression(phi, simulation_factory, lattice_snapshot_factory):
 
 def test_pickling(simulation_factory, two_particle_snapshot_factory):
     """Test that QuickCompress objects are picklable."""
-    qc = hoomd.hpmc.update.QuickCompress(
-        trigger=hoomd.trigger.Periodic(10), target_box=hoomd.Box.square(10.0)
-    )
+    qc = hoomd.hpmc.update.QuickCompress(trigger=hoomd.trigger.Periodic(10),
+                                         target_box=hoomd.Box.square(10.))
 
     sim = simulation_factory(two_particle_snapshot_factory())
     mc = hoomd.hpmc.integrate.Sphere(default_d=0.05)

--- a/hoomd/hpmc/update.py
+++ b/hoomd/hpmc/update.py
@@ -852,10 +852,9 @@ class QuickCompress(Updater):
 
     Warning:
         When the smallest MC translational move size is 0, `allow_unsafe_resize`
-        must be set to `True` to progress toward the target box. A decrease in
-        `max_overlaps_per_particle` is recommended when using this setting. In
-        all other cases, using the default `allow_unsafe_resize` = `False` is
-        preferred, as it proposes better box moves.
+        must be set to `True` to progress toward the target box. Decrease
+        `max_overlaps_per_particle` when using this setting to prevent
+        unresolvable overlaps.
 
     Warning:
         Use `QuickCompress` *OR* `BoxMC`. Do not use both at the same time.

--- a/hoomd/hpmc/update.py
+++ b/hoomd/hpmc/update.py
@@ -879,16 +879,19 @@ class QuickCompress(Updater):
                  trigger,
                  target_box,
                  max_overlaps_per_particle=0.25,
-                 min_scale=0.99):
+                 min_scale=0.99,
+                 allow_unsafe_resize=False):
         super().__init__(trigger)
 
         param_dict = ParameterDict(max_overlaps_per_particle=float,
                                    min_scale=float,
                                    target_box=hoomd.Box,
-                                   instance=int)
+                                   instance=int,
+                                   allow_unsafe_resize=bool)
         param_dict['max_overlaps_per_particle'] = max_overlaps_per_particle
         param_dict['min_scale'] = min_scale
         param_dict['target_box'] = target_box
+        param_dict['allow_unsafe_resize'] = allow_unsafe_resize
 
         self._param_dict.update(param_dict)
 

--- a/hoomd/hpmc/update.py
+++ b/hoomd/hpmc/update.py
@@ -274,8 +274,8 @@ class BoxMC(Updater):
         _default_dict = dict(weight=0.0, delta=0.0)
         param_dict = ParameterDict(
             volume={
-                "mode": hoomd.data.typeconverter.OnlyFrom(["standard", "ln"]),
-                **_default_dict,
+                "mode": hoomd.data.typeconverter.OnlyFrom(['standard', 'ln']),
+                **_default_dict
             },
             aspect=_default_dict,
             length=dict(weight=0.0, delta=(0.0,) * 3),
@@ -298,12 +298,9 @@ class BoxMC(Updater):
         if not integrator._attached:
             raise RuntimeError("Integrator is not attached yet.")
 
-        self._cpp_obj = _hpmc.UpdaterBoxMC(
-            self._simulation.state._cpp_sys_def,
-            self.trigger,
-            integrator._cpp_obj,
-            self.betaP,
-        )
+        self._cpp_obj = _hpmc.UpdaterBoxMC(self._simulation.state._cpp_sys_def,
+                                           self.trigger, integrator._cpp_obj,
+                                           self.betaP)
 
     @property
     def counter(self):
@@ -417,14 +414,12 @@ class MuVT(Updater):
             :math:`[\mathrm{volume}^{-1}]` (**default:** 0).
     """
 
-    def __init__(
-        self,
-        transfer_types,
-        ngibbs=1,
-        max_volume_rescale=0.1,
-        volume_move_probability=0.5,
-        trigger=1,
-    ):
+    def __init__(self,
+                 transfer_types,
+                 ngibbs=1,
+                 max_volume_rescale=0.1,
+                 volume_move_probability=0.5,
+                 trigger=1):
         super().__init__(trigger)
 
         self.ngibbs = int(ngibbs)
@@ -438,12 +433,11 @@ class MuVT(Updater):
         self._param_dict.update(param_dict)
 
         typeparam_fugacity = TypeParameter(
-            "fugacity",
-            type_kind="particle_types",
+            'fugacity',
+            type_kind='particle_types',
             param_dict=TypeParameterDict(hoomd.variant.Variant,
                                          len_keys=1,
-                                         _defaults=hoomd.variant.Constant(0.0)),
-        )
+                                         _defaults=hoomd.variant.Constant(0.0)))
         self._append_typeparam(typeparam_fugacity)
 
     def _attach_hook(self):
@@ -455,14 +449,10 @@ class MuVT(Updater):
         cpp_cls_name += integrator.__class__.__name__
         cpp_cls = getattr(_hpmc, cpp_cls_name)
 
-        self._cpp_obj = cpp_cls(
-            self._simulation.state._cpp_sys_def,
-            self.trigger,
-            integrator._cpp_obj,
-            self.ngibbs,
-        )
+        self._cpp_obj = cpp_cls(self._simulation.state._cpp_sys_def,
+                                self.trigger, integrator._cpp_obj, self.ngibbs)
 
-    @log(category="sequence", requires_run=True)
+    @log(category='sequence', requires_run=True)
     def insert_moves(self):
         """tuple[int, int]: Count of the accepted and rejected paricle \
         insertion moves.
@@ -472,7 +462,7 @@ class MuVT(Updater):
         counter = self._cpp_obj.getCounters(1)
         return counter.insert
 
-    @log(category="sequence", requires_run=True)
+    @log(category='sequence', requires_run=True)
     def remove_moves(self):
         """tuple[int, int]: Count of the accepted and rejected paricle removal \
         moves.
@@ -482,7 +472,7 @@ class MuVT(Updater):
         counter = self._cpp_obj.getCounters(1)
         return counter.remove
 
-    @log(category="sequence", requires_run=True)
+    @log(category='sequence', requires_run=True)
     def exchange_moves(self):
         """tuple[int, int]: Count of the accepted and rejected paricle \
         exchange moves.
@@ -492,7 +482,7 @@ class MuVT(Updater):
         counter = self._cpp_obj.getCounters(1)
         return counter.exchange
 
-    @log(category="sequence", requires_run=True)
+    @log(category='sequence', requires_run=True)
     def volume_moves(self):
         """tuple[int, int]: Count of the accepted and rejected paricle volume \
         moves.
@@ -502,7 +492,7 @@ class MuVT(Updater):
         counter = self._cpp_obj.getCounters(1)
         return counter.volume
 
-    @log(category="object")
+    @log(category='object')
     def N(self):  # noqa: N802 - allow N as a function name
         """dict: Map of number of particles per type.
 
@@ -580,12 +570,10 @@ class Shape(Updater):
                  type_select=1,
                  nsweeps=1):
         super().__init__(trigger)
-        param_dict = ParameterDict(
-            shape_move=hoomd.hpmc.shape_move.ShapeMove,
-            pretend=bool(pretend),
-            type_select=int(type_select),
-            nsweeps=int(nsweeps),
-        )
+        param_dict = ParameterDict(shape_move=hoomd.hpmc.shape_move.ShapeMove,
+                                   pretend=bool(pretend),
+                                   type_select=int(type_select),
+                                   nsweeps=int(nsweeps))
         param_dict["shape_move"] = shape_move
         self._param_dict.update(param_dict)
 
@@ -623,22 +611,19 @@ class Shape(Updater):
 
         # check for supported shapes is done in the shape move classes
         integrator_name = integrator.__class__.__name__
-        updater_cls = getattr(_hpmc, "UpdaterShape" + integrator_name)
+        updater_cls = getattr(_hpmc, 'UpdaterShape' + integrator_name)
 
         self.shape_move._attach(self._simulation)
-        self._cpp_obj = updater_cls(
-            self._simulation.state._cpp_sys_def,
-            self.trigger,
-            integrator._cpp_obj,
-            self.shape_move._cpp_obj,
-        )
+        self._cpp_obj = updater_cls(self._simulation.state._cpp_sys_def,
+                                    self.trigger, integrator._cpp_obj,
+                                    self.shape_move._cpp_obj)
 
-    @log(category="sequence", requires_run=True)
+    @log(category='sequence', requires_run=True)
     def shape_moves(self):
         """tuple[int, int]: Count of the accepted and rejected shape moves."""
         return self._cpp_obj.getShapeMovesCount()
 
-    @log(category="scalar", requires_run=True)
+    @log(category='scalar', requires_run=True)
     def particle_volumes(self):
         """list[float]: Volume of a single particle for each type."""
         return self._cpp_obj.particle_volumes
@@ -689,9 +674,8 @@ class Clusters(Updater):
         trigger (Trigger): Select the timesteps on which to perform cluster
             moves.
     """
-
-    _remove_for_pickling = Updater._remove_for_pickling + ("_cpp_cell",)
-    _skip_for_equality = Updater._skip_for_equality | {"_cpp_cell"}
+    _remove_for_pickling = Updater._remove_for_pickling + ('_cpp_cell',)
+    _skip_for_equality = Updater._skip_for_equality | {'_cpp_cell'}
 
     def __init__(self,
                  pivot_move_probability=0.5,
@@ -701,8 +685,7 @@ class Clusters(Updater):
 
         param_dict = ParameterDict(
             pivot_move_probability=float(pivot_move_probability),
-            flip_probability=float(flip_probability),
-        )
+            flip_probability=float(flip_probability))
 
         self._param_dict.update(param_dict)
         self.instance = 0
@@ -718,7 +701,7 @@ class Clusters(Updater):
         cpp_cls_name += integrator.__class__.__name__
         cpp_cls = getattr(_hpmc, cpp_cls_name)
         use_gpu = (isinstance(self._simulation.device, hoomd.device.GPU)
-                   and (cpp_cls_name + "GPU") in _hpmc.__dict__)
+                   and (cpp_cls_name + 'GPU') in _hpmc.__dict__)
         if use_gpu:
             cpp_cls_name += "GPU"
         cpp_cls = getattr(_hpmc, cpp_cls_name)
@@ -729,12 +712,9 @@ class Clusters(Updater):
         if use_gpu:
             sys_def = self._simulation.state._cpp_sys_def
             self._cpp_cell = _hoomd.CellListGPU(sys_def)
-            self._cpp_obj = cpp_cls(
-                self._simulation.state._cpp_sys_def,
-                self.trigger,
-                integrator._cpp_obj,
-                self._cpp_cell,
-            )
+            self._cpp_obj = cpp_cls(self._simulation.state._cpp_sys_def,
+                                    self.trigger, integrator._cpp_obj,
+                                    self._cpp_cell)
         else:
             self._cpp_obj = cpp_cls(self._simulation.state._cpp_sys_def,
                                     self.trigger, integrator._cpp_obj)
@@ -764,11 +744,6 @@ class QuickCompress(Updater):
             particles when max_overlaps_per_particle=0.25).
 
         min_scale (float): The minimum scale factor to apply to box dimensions.
-
-        allow_unsafe_resize (bool): Whether to allow box moves that may or may
-            not be resolvable by the current particle translational move
-            sizes. If set to True, the box's move size will not be coupled to
-            translation move sizes.
 
     Use `QuickCompress` in conjunction with an HPMC integrator to scale the
     system to a target box size. `QuickCompress` can typically compress dilute
@@ -873,9 +848,6 @@ class QuickCompress(Updater):
     Warning:
         When the smallest MC translational move size is 0, `QuickCompress`
         will scale the box by 1.0 and not progress toward the target box.
-        Setting allow_unsafe_resize to True will allow the box to move
-        anyway, but is likely to cause unresolvable overlaps. Set
-        max_overlaps_per_particle to 0 to avoid this possibility.
 
     Warning:
         Use `QuickCompress` *OR* `BoxMC`. Do not use both at the same time.
@@ -897,38 +869,26 @@ class QuickCompress(Updater):
 
         min_scale (float): The minimum scale factor to apply to box dimensions.
 
-        allow_unsafe_resize (bool): Whether to allow box moves that may or may
-            not be resolvable by the current particle translational move
-            sizes. If set to True, the box's move size will not be coupled to
-            translation move sizes.
-
         instance (int):
             When using multiple `QuickCompress` updaters in a single simulation,
             give each a unique value for `instance` so that they generate
             different streams of random numbers.
     """
 
-    def __init__(
-        self,
-        trigger,
-        target_box,
-        max_overlaps_per_particle=0.25,
-        min_scale=0.99,
-        allow_unsafe_resize=False,
-    ):
+    def __init__(self,
+                 trigger,
+                 target_box,
+                 max_overlaps_per_particle=0.25,
+                 min_scale=0.99):
         super().__init__(trigger)
 
-        param_dict = ParameterDict(
-            max_overlaps_per_particle=float,
-            min_scale=float,
-            target_box=hoomd.Box,
-            allow_unsafe_resize=bool,
-            instance=int,
-        )
-        param_dict["max_overlaps_per_particle"] = max_overlaps_per_particle
-        param_dict["min_scale"] = min_scale
-        param_dict["target_box"] = target_box
-        param_dict["allow_unsafe_resize"] = allow_unsafe_resize
+        param_dict = ParameterDict(max_overlaps_per_particle=float,
+                                   min_scale=float,
+                                   target_box=hoomd.Box,
+                                   instance=int)
+        param_dict['max_overlaps_per_particle'] = max_overlaps_per_particle
+        param_dict['min_scale'] = min_scale
+        param_dict['target_box'] = target_box
 
         self._param_dict.update(param_dict)
 
@@ -945,13 +905,9 @@ class QuickCompress(Updater):
             raise RuntimeError("Integrator is not attached yet.")
 
         self._cpp_obj = _hpmc.UpdaterQuickCompress(
-            self._simulation.state._cpp_sys_def,
-            self.trigger,
-            integrator._cpp_obj,
-            self.max_overlaps_per_particle,
-            self.min_scale,
-            self.target_box._cpp_obj,
-        )
+            self._simulation.state._cpp_sys_def, self.trigger,
+            integrator._cpp_obj, self.max_overlaps_per_particle, self.min_scale,
+            self.target_box._cpp_obj)
 
     @property
     def complete(self):

--- a/hoomd/hpmc/update.py
+++ b/hoomd/hpmc/update.py
@@ -745,6 +745,9 @@ class QuickCompress(Updater):
 
         min_scale (float): The minimum scale factor to apply to box dimensions.
 
+        allow_unsafe_resize (bool): When `True`, box moves are proposed
+            independent of particle translational move sizes.
+
     Use `QuickCompress` in conjunction with an HPMC integrator to scale the
     system to a target box size. `QuickCompress` can typically compress dilute
     systems to near random close packing densities in tens of thousands of time
@@ -838,7 +841,9 @@ class QuickCompress(Updater):
     distributed between ``max(min_scale, 1.0 - min_move_size / max_diameter)``
     and 1.0 where ``min_move_size`` is the smallest MC translational move size
     adjusted by the acceptance ratio and ``max_diameter`` is the circumsphere
-    diameter of the largest particle type.
+    diameter of the largest particle type. If `allow_unsafe_resize` is `True`,
+    box move sizes will be uniformly distributed between ``min_scale`` and 1.0
+    (with no consideration of ``min_move_size``).
 
     Tip:
         Use the `hoomd.hpmc.tune.MoveSize` in conjunction with
@@ -846,8 +851,11 @@ class QuickCompress(Updater):
         acceptance ratio as the density of the system increases.
 
     Warning:
-        When the smallest MC translational move size is 0, `QuickCompress`
-        will scale the box by 1.0 and not progress toward the target box.
+        When the smallest MC translational move size is 0, `allow_unsafe_resize`
+        must be set to `True` to progress toward the target box. A decrease in
+        `max_overlaps_per_particle` is recommended when using this setting. In
+        all other cases, using the default `allow_unsafe_resize` = `False` is
+        preferred, as it proposes better box moves.
 
     Warning:
         Use `QuickCompress` *OR* `BoxMC`. Do not use both at the same time.
@@ -873,6 +881,8 @@ class QuickCompress(Updater):
             When using multiple `QuickCompress` updaters in a single simulation,
             give each a unique value for `instance` so that they generate
             different streams of random numbers.
+
+        allow_unsafe_resize (bool): Flag that determines whether
     """
 
     def __init__(self,

--- a/hoomd/hpmc/update.py
+++ b/hoomd/hpmc/update.py
@@ -274,8 +274,8 @@ class BoxMC(Updater):
         _default_dict = dict(weight=0.0, delta=0.0)
         param_dict = ParameterDict(
             volume={
-                "mode": hoomd.data.typeconverter.OnlyFrom(['standard', 'ln']),
-                **_default_dict
+                "mode": hoomd.data.typeconverter.OnlyFrom(["standard", "ln"]),
+                **_default_dict,
             },
             aspect=_default_dict,
             length=dict(weight=0.0, delta=(0.0,) * 3),
@@ -298,9 +298,12 @@ class BoxMC(Updater):
         if not integrator._attached:
             raise RuntimeError("Integrator is not attached yet.")
 
-        self._cpp_obj = _hpmc.UpdaterBoxMC(self._simulation.state._cpp_sys_def,
-                                           self.trigger, integrator._cpp_obj,
-                                           self.betaP)
+        self._cpp_obj = _hpmc.UpdaterBoxMC(
+            self._simulation.state._cpp_sys_def,
+            self.trigger,
+            integrator._cpp_obj,
+            self.betaP,
+        )
 
     @property
     def counter(self):
@@ -414,12 +417,14 @@ class MuVT(Updater):
             :math:`[\mathrm{volume}^{-1}]` (**default:** 0).
     """
 
-    def __init__(self,
-                 transfer_types,
-                 ngibbs=1,
-                 max_volume_rescale=0.1,
-                 volume_move_probability=0.5,
-                 trigger=1):
+    def __init__(
+        self,
+        transfer_types,
+        ngibbs=1,
+        max_volume_rescale=0.1,
+        volume_move_probability=0.5,
+        trigger=1,
+    ):
         super().__init__(trigger)
 
         self.ngibbs = int(ngibbs)
@@ -433,11 +438,12 @@ class MuVT(Updater):
         self._param_dict.update(param_dict)
 
         typeparam_fugacity = TypeParameter(
-            'fugacity',
-            type_kind='particle_types',
+            "fugacity",
+            type_kind="particle_types",
             param_dict=TypeParameterDict(hoomd.variant.Variant,
                                          len_keys=1,
-                                         _defaults=hoomd.variant.Constant(0.0)))
+                                         _defaults=hoomd.variant.Constant(0.0)),
+        )
         self._append_typeparam(typeparam_fugacity)
 
     def _attach_hook(self):
@@ -449,10 +455,14 @@ class MuVT(Updater):
         cpp_cls_name += integrator.__class__.__name__
         cpp_cls = getattr(_hpmc, cpp_cls_name)
 
-        self._cpp_obj = cpp_cls(self._simulation.state._cpp_sys_def,
-                                self.trigger, integrator._cpp_obj, self.ngibbs)
+        self._cpp_obj = cpp_cls(
+            self._simulation.state._cpp_sys_def,
+            self.trigger,
+            integrator._cpp_obj,
+            self.ngibbs,
+        )
 
-    @log(category='sequence', requires_run=True)
+    @log(category="sequence", requires_run=True)
     def insert_moves(self):
         """tuple[int, int]: Count of the accepted and rejected paricle \
         insertion moves.
@@ -462,7 +472,7 @@ class MuVT(Updater):
         counter = self._cpp_obj.getCounters(1)
         return counter.insert
 
-    @log(category='sequence', requires_run=True)
+    @log(category="sequence", requires_run=True)
     def remove_moves(self):
         """tuple[int, int]: Count of the accepted and rejected paricle removal \
         moves.
@@ -472,7 +482,7 @@ class MuVT(Updater):
         counter = self._cpp_obj.getCounters(1)
         return counter.remove
 
-    @log(category='sequence', requires_run=True)
+    @log(category="sequence", requires_run=True)
     def exchange_moves(self):
         """tuple[int, int]: Count of the accepted and rejected paricle \
         exchange moves.
@@ -482,7 +492,7 @@ class MuVT(Updater):
         counter = self._cpp_obj.getCounters(1)
         return counter.exchange
 
-    @log(category='sequence', requires_run=True)
+    @log(category="sequence", requires_run=True)
     def volume_moves(self):
         """tuple[int, int]: Count of the accepted and rejected paricle volume \
         moves.
@@ -492,7 +502,7 @@ class MuVT(Updater):
         counter = self._cpp_obj.getCounters(1)
         return counter.volume
 
-    @log(category='object')
+    @log(category="object")
     def N(self):  # noqa: N802 - allow N as a function name
         """dict: Map of number of particles per type.
 
@@ -570,10 +580,12 @@ class Shape(Updater):
                  type_select=1,
                  nsweeps=1):
         super().__init__(trigger)
-        param_dict = ParameterDict(shape_move=hoomd.hpmc.shape_move.ShapeMove,
-                                   pretend=bool(pretend),
-                                   type_select=int(type_select),
-                                   nsweeps=int(nsweeps))
+        param_dict = ParameterDict(
+            shape_move=hoomd.hpmc.shape_move.ShapeMove,
+            pretend=bool(pretend),
+            type_select=int(type_select),
+            nsweeps=int(nsweeps),
+        )
         param_dict["shape_move"] = shape_move
         self._param_dict.update(param_dict)
 
@@ -611,19 +623,22 @@ class Shape(Updater):
 
         # check for supported shapes is done in the shape move classes
         integrator_name = integrator.__class__.__name__
-        updater_cls = getattr(_hpmc, 'UpdaterShape' + integrator_name)
+        updater_cls = getattr(_hpmc, "UpdaterShape" + integrator_name)
 
         self.shape_move._attach(self._simulation)
-        self._cpp_obj = updater_cls(self._simulation.state._cpp_sys_def,
-                                    self.trigger, integrator._cpp_obj,
-                                    self.shape_move._cpp_obj)
+        self._cpp_obj = updater_cls(
+            self._simulation.state._cpp_sys_def,
+            self.trigger,
+            integrator._cpp_obj,
+            self.shape_move._cpp_obj,
+        )
 
-    @log(category='sequence', requires_run=True)
+    @log(category="sequence", requires_run=True)
     def shape_moves(self):
         """tuple[int, int]: Count of the accepted and rejected shape moves."""
         return self._cpp_obj.getShapeMovesCount()
 
-    @log(category='scalar', requires_run=True)
+    @log(category="scalar", requires_run=True)
     def particle_volumes(self):
         """list[float]: Volume of a single particle for each type."""
         return self._cpp_obj.particle_volumes
@@ -674,8 +689,9 @@ class Clusters(Updater):
         trigger (Trigger): Select the timesteps on which to perform cluster
             moves.
     """
-    _remove_for_pickling = Updater._remove_for_pickling + ('_cpp_cell',)
-    _skip_for_equality = Updater._skip_for_equality | {'_cpp_cell'}
+
+    _remove_for_pickling = Updater._remove_for_pickling + ("_cpp_cell",)
+    _skip_for_equality = Updater._skip_for_equality | {"_cpp_cell"}
 
     def __init__(self,
                  pivot_move_probability=0.5,
@@ -685,7 +701,8 @@ class Clusters(Updater):
 
         param_dict = ParameterDict(
             pivot_move_probability=float(pivot_move_probability),
-            flip_probability=float(flip_probability))
+            flip_probability=float(flip_probability),
+        )
 
         self._param_dict.update(param_dict)
         self.instance = 0
@@ -701,7 +718,7 @@ class Clusters(Updater):
         cpp_cls_name += integrator.__class__.__name__
         cpp_cls = getattr(_hpmc, cpp_cls_name)
         use_gpu = (isinstance(self._simulation.device, hoomd.device.GPU)
-                   and (cpp_cls_name + 'GPU') in _hpmc.__dict__)
+                   and (cpp_cls_name + "GPU") in _hpmc.__dict__)
         if use_gpu:
             cpp_cls_name += "GPU"
         cpp_cls = getattr(_hpmc, cpp_cls_name)
@@ -712,9 +729,12 @@ class Clusters(Updater):
         if use_gpu:
             sys_def = self._simulation.state._cpp_sys_def
             self._cpp_cell = _hoomd.CellListGPU(sys_def)
-            self._cpp_obj = cpp_cls(self._simulation.state._cpp_sys_def,
-                                    self.trigger, integrator._cpp_obj,
-                                    self._cpp_cell)
+            self._cpp_obj = cpp_cls(
+                self._simulation.state._cpp_sys_def,
+                self.trigger,
+                integrator._cpp_obj,
+                self._cpp_cell,
+            )
         else:
             self._cpp_obj = cpp_cls(self._simulation.state._cpp_sys_def,
                                     self.trigger, integrator._cpp_obj)
@@ -744,6 +764,11 @@ class QuickCompress(Updater):
             particles when max_overlaps_per_particle=0.25).
 
         min_scale (float): The minimum scale factor to apply to box dimensions.
+
+        allow_unsafe_resize (bool): Whether to allow box moves that may or may
+            not be resolvable by the current particle translational move
+            sizes. If set to True, the box's move size will not be coupled to
+            translation move sizes.
 
     Use `QuickCompress` in conjunction with an HPMC integrator to scale the
     system to a target box size. `QuickCompress` can typically compress dilute
@@ -848,6 +873,9 @@ class QuickCompress(Updater):
     Warning:
         When the smallest MC translational move size is 0, `QuickCompress`
         will scale the box by 1.0 and not progress toward the target box.
+        Setting allow_unsafe_resize to True will allow the box to move
+        anyway, but is likely to cause unresolvable overlaps. Set
+        max_overlaps_per_particle to 0 to avoid this possibility.
 
     Warning:
         Use `QuickCompress` *OR* `BoxMC`. Do not use both at the same time.
@@ -869,26 +897,38 @@ class QuickCompress(Updater):
 
         min_scale (float): The minimum scale factor to apply to box dimensions.
 
+        allow_unsafe_resize (bool): Whether to allow box moves that may or may
+            not be resolvable by the current particle translational move
+            sizes. If set to True, the box's move size will not be coupled to
+            translation move sizes.
+
         instance (int):
             When using multiple `QuickCompress` updaters in a single simulation,
             give each a unique value for `instance` so that they generate
             different streams of random numbers.
     """
 
-    def __init__(self,
-                 trigger,
-                 target_box,
-                 max_overlaps_per_particle=0.25,
-                 min_scale=0.99):
+    def __init__(
+        self,
+        trigger,
+        target_box,
+        max_overlaps_per_particle=0.25,
+        min_scale=0.99,
+        allow_unsafe_resize=False,
+    ):
         super().__init__(trigger)
 
-        param_dict = ParameterDict(max_overlaps_per_particle=float,
-                                   min_scale=float,
-                                   target_box=hoomd.Box,
-                                   instance=int)
-        param_dict['max_overlaps_per_particle'] = max_overlaps_per_particle
-        param_dict['min_scale'] = min_scale
-        param_dict['target_box'] = target_box
+        param_dict = ParameterDict(
+            max_overlaps_per_particle=float,
+            min_scale=float,
+            target_box=hoomd.Box,
+            allow_unsafe_resize=bool,
+            instance=int,
+        )
+        param_dict["max_overlaps_per_particle"] = max_overlaps_per_particle
+        param_dict["min_scale"] = min_scale
+        param_dict["target_box"] = target_box
+        param_dict["allow_unsafe_resize"] = allow_unsafe_resize
 
         self._param_dict.update(param_dict)
 
@@ -905,9 +945,13 @@ class QuickCompress(Updater):
             raise RuntimeError("Integrator is not attached yet.")
 
         self._cpp_obj = _hpmc.UpdaterQuickCompress(
-            self._simulation.state._cpp_sys_def, self.trigger,
-            integrator._cpp_obj, self.max_overlaps_per_particle, self.min_scale,
-            self.target_box._cpp_obj)
+            self._simulation.state._cpp_sys_def,
+            self.trigger,
+            integrator._cpp_obj,
+            self.max_overlaps_per_particle,
+            self.min_scale,
+            self.target_box._cpp_obj,
+        )
 
     @property
     def complete(self):


### PR DESCRIPTION
## Description

Added check for minimum move size in `QuickCompress` that sets the box scale if min_move_size is 0.

## Motivation and context

Several researchers have attempted to use `QuickCompress` with a translational move size of zero to compress a crystal with fixed particle positions. While the code could be trivially updated to allow this, the default settings are likely to result in unresolvable overlaps. The `allow_unsafe_resize`, which defaults to False, provides a solution to this: users who set it to True will allow compression regardless of translational move sizes. In most cases, however, users should also set `max_overlaps_per_particle` to zero to avoid these unresolvable cases.

Resolves #1677

## How has this been tested?

TODO: tests will be added

## Change log

```
Added `allow_unsafe_resize` flag to `QuickCompress`
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
