### PR TITLE
Fix HPMC performance bugs.

### DIFF
--- a/hoomd/hpmc/IntegratorHPMCMono.h
+++ b/hoomd/hpmc/IntegratorHPMCMono.h
@@ -943,8 +943,18 @@ void IntegratorHPMCMono<Shape>::update(uint64_t timestep)
                     }
 
                 // update the position of the particle in the tree for future updates
-                hoomd::detail::AABB aabb = aabb_i_local;
-                aabb.translate(pos_i);
+                hoomd::detail::AABB aabb;
+                if (!m_patch)
+                    {
+                    aabb = shape_i.getAABB(pos_i);
+                    }
+                else
+                    {
+                    Scalar radius = std::max(0.5*shape_i.getCircumsphereDiameter(),
+                        0.5*m_patch->getAdditiveCutoff(typ_i));
+                    aabb = hoomd::detail::AABB(pos_i, radius);
+                    }
+
                 m_aabb_tree.update(i, aabb);
 
                 // update position of particle

--- a/hoomd/hpmc/ShapeSphere.h
+++ b/hoomd/hpmc/ShapeSphere.h
@@ -257,13 +257,11 @@ struct ShapeSphere
 */
 template<class ShapeA, class ShapeB>
 DEVICE inline bool
-check_circumsphere_overlap(const vec3<Scalar>& r_ab, const ShapeA& a, const ShapeB& b)
+check_circumsphere_overlap(const vec3<LongReal>& r_ab, const ShapeA& a, const ShapeB& b)
     {
-    vec2<ShortReal> dr(ShortReal(r_ab.x), ShortReal(r_ab.y));
-
-    ShortReal rsq = dot(dr, dr);
-    ShortReal DaDb = a.getCircumsphereDiameter() + b.getCircumsphereDiameter();
-    return (rsq * ShortReal(4.0) <= DaDb * DaDb);
+    LongReal r_squared = dot(r_ab, r_ab);
+    LongReal diameter_sum = a.getCircumsphereDiameter() + b.getCircumsphereDiameter();
+    return (r_squared * LongReal(4.0) <= diameter_sum * diameter_sum);
     }
 
 //! Define the general overlap function


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should be based on *trunk-patch*. -->
<!-- Backwards compatible new features should be based on *trunk-minor*. -->
<!-- Incompatible API changes should be based on *trunk-major*. -->

## Description

<!-- Describe your changes in detail. -->
Expand the AABB node of a given particle by the maximum of the size of the particle and the additive cutoff radius. 

Prior to this change, a test system with 1000 particles (number density 1, LJ potential, r_cut=2.5) would evaluate potential overlaps between 1500 potential neighbors per particle! The cause of the slowdown was using the `R_query` search radius to update the size of the AABB tree nodes.

After this change, the same test system checks 350 potential interactions. This is still far larger than the minimum of ~125 - but there are cost tradeoffs. Decrease the leaf node capacity to check fewer potential interacting neighbors, but at the cost of iterating over more AABB tree nodes. I tested, and a leaf node capacity of 16 seems to remain the optimal.

Also, fix the *circumsphere* overlap test to check all 3 dimensions. This boost performance of all hard shape HPMC simulations.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Improve performance. 

* The LJ test system went from 31 sweeps per second to 80 sweeps per second after this change.
* A hard octahedra system (moderate density rho=1.0) went from 434 sweeps per second to 550.

## How has this been tested?

Performance tested with new HPMC benchmarks: https://github.com/glotzerlab/hoomd-benchmarks/pull/68
<!--- Please describe in detail how you tested your changes. -->

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
Fixed:

* Drastically improve HPMC performance on the CPU when using a pair potential
  (`#1679 <https://github.com/glotzerlab/hoomd-blue/pull/1679>`__).
* Improve HPMC performance with hard shapes
  (`#1679 <https://github.com/glotzerlab/hoomd-blue/pull/1679>`__).
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
