### PR TITLE
Reimplement MPCD virtual particle fillers

### DIFF
--- a/hoomd/mpcd/CMakeLists.txt
+++ b/hoomd/mpcd/CMakeLists.txt
@@ -142,6 +142,7 @@ install(TARGETS _mpcd EXPORT HOOMDTargets
 set(files
     __init__.py
     collide.py
+    fill.py
     force.py
     geometry.py
     integrate.py

--- a/hoomd/mpcd/Integrator.cc
+++ b/hoomd/mpcd/Integrator.cc
@@ -15,6 +15,9 @@
 #endif
 #endif
 
+#include <pybind11/stl_bind.h>
+PYBIND11_MAKE_OPAQUE(std::vector<std::shared_ptr<hoomd::mpcd::VirtualParticleFiller>>);
+
 namespace hoomd
     {
 /*!
@@ -165,6 +168,10 @@ void mpcd::Integrator::syncCellList()
  */
 void mpcd::detail::export_Integrator(pybind11::module& m)
     {
+    pybind11::bind_vector<std::vector<std::shared_ptr<mpcd::VirtualParticleFiller>>>(
+        m,
+        "VirtualParticleFillerList");
+
     pybind11::class_<mpcd::Integrator,
                      hoomd::md::IntegratorTwoStep,
                      std::shared_ptr<mpcd::Integrator>>(m, "Integrator")

--- a/hoomd/mpcd/Integrator.cc
+++ b/hoomd/mpcd/Integrator.cc
@@ -76,9 +76,12 @@ void mpcd::Integrator::update(uint64_t timestep)
 #endif // ENABLE_MPI
 
     // fill in any virtual particles
-    if (checkCollide(timestep) && m_filler)
+    if (checkCollide(timestep))
         {
-        m_filler->fill(timestep);
+        for (auto& filler : m_fillers)
+            {
+            filler->fill(timestep);
+            }
         }
 
     // optionally sort for performance
@@ -151,9 +154,9 @@ void mpcd::Integrator::syncCellList()
         m_mpcd_comm->setCellList(m_cl);
         }
 #endif
-    if (m_filler)
+    for (auto& filler : m_fillers)
         {
-        m_filler->setCellList(m_cl);
+        filler->setCellList(m_cl);
         }
     }
 
@@ -174,6 +177,6 @@ void mpcd::detail::export_Integrator(pybind11::module& m)
                       &mpcd::Integrator::getStreamingMethod,
                       &mpcd::Integrator::setStreamingMethod)
         .def_property("solvent_sorter", &mpcd::Integrator::getSorter, &mpcd::Integrator::setSorter)
-        .def_property("filler", &mpcd::Integrator::getFiller, &mpcd::Integrator::setFiller);
+        .def_property_readonly("fillers", &mpcd::Integrator::getFillers);
     }
     } // end namespace hoomd

--- a/hoomd/mpcd/Integrator.h
+++ b/hoomd/mpcd/Integrator.h
@@ -126,15 +126,10 @@ class PYBIND11_EXPORT Integrator : public hoomd::md::IntegratorTwoStep
         m_sorter = sorter;
         }
 
-    std::shared_ptr<mpcd::VirtualParticleFiller> getFiller() const
+    //! Get the virtual particle fillers
+    std::vector<std::shared_ptr<mpcd::VirtualParticleFiller>>& getFillers()
         {
-        return m_filler;
-        }
-
-    //! Set the virtual particle filling method
-    void setFiller(std::shared_ptr<mpcd::VirtualParticleFiller> filler)
-        {
-        m_filler = filler;
+        return m_fillers;
         }
 
     protected:
@@ -145,7 +140,8 @@ class PYBIND11_EXPORT Integrator : public hoomd::md::IntegratorTwoStep
 #ifdef ENABLE_MPI
     std::shared_ptr<mpcd::Communicator> m_mpcd_comm; //!< MPCD communicator
 #endif
-    std::shared_ptr<mpcd::VirtualParticleFiller> m_filler; //!< MPCD virtual particle fillers
+    std::vector<std::shared_ptr<mpcd::VirtualParticleFiller>>
+        m_fillers; //!< MPCD virtual particle fillers
 
     private:
     //! Check if a collision will occur at the current timestep

--- a/hoomd/mpcd/ParallelPlateGeometryFiller.cc
+++ b/hoomd/mpcd/ParallelPlateGeometryFiller.cc
@@ -14,11 +14,11 @@ namespace hoomd
     {
 mpcd::ParallelPlateGeometryFiller::ParallelPlateGeometryFiller(
     std::shared_ptr<SystemDefinition> sysdef,
+    const std::string& type,
     Scalar density,
-    unsigned int type,
     std::shared_ptr<Variant> T,
     std::shared_ptr<const mpcd::ParallelPlateGeometry> geom)
-    : mpcd::VirtualParticleFiller(sysdef, density, type, T), m_geom(geom)
+    : mpcd::VirtualParticleFiller(sysdef, type, density, T), m_geom(geom)
     {
     m_exec_conf->msg->notice(5) << "Constructing MPCD ParallelPlateGeometryFiller" << std::endl;
     }
@@ -148,11 +148,11 @@ void mpcd::detail::export_ParallelPlateGeometryFiller(pybind11::module& m)
         m,
         "ParallelPlateGeometryFiller")
         .def(pybind11::init<std::shared_ptr<SystemDefinition>,
+                            const std::string&,
                             Scalar,
-                            unsigned int,
                             std::shared_ptr<Variant>,
                             std::shared_ptr<const mpcd::ParallelPlateGeometry>>())
-        .def("setGeometry", &mpcd::ParallelPlateGeometryFiller::setGeometry);
+        .def_property_readonly("geometry", &mpcd::ParallelPlateGeometryFiller::getGeometry);
     }
 
     } // end namespace hoomd

--- a/hoomd/mpcd/ParallelPlateGeometryFiller.h
+++ b/hoomd/mpcd/ParallelPlateGeometryFiller.h
@@ -31,12 +31,17 @@ class PYBIND11_EXPORT ParallelPlateGeometryFiller : public mpcd::VirtualParticle
     {
     public:
     ParallelPlateGeometryFiller(std::shared_ptr<SystemDefinition> sysdef,
+                                const std::string& type,
                                 Scalar density,
-                                unsigned int type,
                                 std::shared_ptr<Variant> T,
                                 std::shared_ptr<const mpcd::ParallelPlateGeometry> geom);
 
     virtual ~ParallelPlateGeometryFiller();
+
+    std::shared_ptr<const mpcd::ParallelPlateGeometry> getGeometry() const
+        {
+        return m_geom;
+        }
 
     void setGeometry(std::shared_ptr<const mpcd::ParallelPlateGeometry> geom)
         {

--- a/hoomd/mpcd/ParallelPlateGeometryFillerGPU.cc
+++ b/hoomd/mpcd/ParallelPlateGeometryFillerGPU.cc
@@ -13,11 +13,11 @@ namespace hoomd
     {
 mpcd::ParallelPlateGeometryFillerGPU::ParallelPlateGeometryFillerGPU(
     std::shared_ptr<SystemDefinition> sysdef,
+    const std::string& type,
     Scalar density,
-    unsigned int type,
     std::shared_ptr<Variant> T,
     std::shared_ptr<const mpcd::ParallelPlateGeometry> geom)
-    : mpcd::ParallelPlateGeometryFiller(sysdef, density, type, T, geom)
+    : mpcd::ParallelPlateGeometryFiller(sysdef, type, density, T, geom)
     {
     m_tuner.reset(new Autotuner<1>({AutotunerBase::makeBlockSizeRange(m_exec_conf)},
                                    m_exec_conf,
@@ -78,8 +78,8 @@ void mpcd::detail::export_ParallelPlateGeometryFillerGPU(pybind11::module& m)
         m,
         "ParallelPlateGeometryFillerGPU")
         .def(pybind11::init<std::shared_ptr<SystemDefinition>,
+                            const std::string&,
                             Scalar,
-                            unsigned int,
                             std::shared_ptr<Variant>,
                             std::shared_ptr<const mpcd::ParallelPlateGeometry>>());
     }

--- a/hoomd/mpcd/ParallelPlateGeometryFillerGPU.h
+++ b/hoomd/mpcd/ParallelPlateGeometryFillerGPU.h
@@ -27,8 +27,8 @@ class PYBIND11_EXPORT ParallelPlateGeometryFillerGPU : public mpcd::ParallelPlat
     public:
     //! Constructor
     ParallelPlateGeometryFillerGPU(std::shared_ptr<SystemDefinition> sysdef,
+                                   const std::string& type,
                                    Scalar density,
-                                   unsigned int type,
                                    std::shared_ptr<Variant> T,
                                    std::shared_ptr<const mpcd::ParallelPlateGeometry> geom);
 

--- a/hoomd/mpcd/PlanarPoreGeometryFiller.cc
+++ b/hoomd/mpcd/PlanarPoreGeometryFiller.cc
@@ -16,12 +16,11 @@ namespace hoomd
     {
 mpcd::PlanarPoreGeometryFiller::PlanarPoreGeometryFiller(
     std::shared_ptr<SystemDefinition> sysdef,
+    const std::string& type,
     Scalar density,
-    unsigned int type,
     std::shared_ptr<Variant> T,
-    uint16_t seed,
     std::shared_ptr<const mpcd::PlanarPoreGeometry> geom)
-    : mpcd::VirtualParticleFiller(sysdef, density, type, T), m_num_boxes(0),
+    : mpcd::VirtualParticleFiller(sysdef, type, density, T), m_num_boxes(0),
       m_boxes(MAX_BOXES, m_exec_conf), m_ranges(MAX_BOXES, m_exec_conf)
     {
     m_exec_conf->msg->notice(5) << "Constructing MPCD PlanarPoreGeometryFiller" << std::endl;
@@ -222,12 +221,11 @@ void mpcd::detail::export_PlanarPoreGeometryFiller(pybind11::module& m)
                      mpcd::VirtualParticleFiller,
                      std::shared_ptr<mpcd::PlanarPoreGeometryFiller>>(m, "PlanarPoreGeometryFiller")
         .def(pybind11::init<std::shared_ptr<SystemDefinition>,
+                            const std::string&,
                             Scalar,
-                            unsigned int,
                             std::shared_ptr<Variant>,
-                            unsigned int,
                             std::shared_ptr<const mpcd::PlanarPoreGeometry>>())
-        .def("setGeometry", &mpcd::PlanarPoreGeometryFiller::setGeometry);
+        .def_property_readonly("geometry", &mpcd::PlanarPoreGeometryFiller::getGeometry);
     }
 
     } // end namespace hoomd

--- a/hoomd/mpcd/PlanarPoreGeometryFiller.h
+++ b/hoomd/mpcd/PlanarPoreGeometryFiller.h
@@ -31,13 +31,17 @@ class PYBIND11_EXPORT PlanarPoreGeometryFiller : public mpcd::VirtualParticleFil
     {
     public:
     PlanarPoreGeometryFiller(std::shared_ptr<SystemDefinition> sysdef,
+                             const std::string& type,
                              Scalar density,
-                             unsigned int type,
                              std::shared_ptr<Variant> T,
-                             uint16_t seed,
                              std::shared_ptr<const mpcd::PlanarPoreGeometry> geom);
 
     virtual ~PlanarPoreGeometryFiller();
+
+    std::shared_ptr<const mpcd::PlanarPoreGeometry> getGeometry() const
+        {
+        return m_geom;
+        }
 
     void setGeometry(std::shared_ptr<const mpcd::PlanarPoreGeometry> geom)
         {

--- a/hoomd/mpcd/PlanarPoreGeometryFillerGPU.cc
+++ b/hoomd/mpcd/PlanarPoreGeometryFillerGPU.cc
@@ -13,12 +13,11 @@ namespace hoomd
     {
 mpcd::PlanarPoreGeometryFillerGPU::PlanarPoreGeometryFillerGPU(
     std::shared_ptr<SystemDefinition> sysdef,
+    const std::string& type,
     Scalar density,
-    unsigned int type,
     std::shared_ptr<Variant> T,
-    uint16_t seed,
     std::shared_ptr<const mpcd::PlanarPoreGeometry> geom)
-    : mpcd::PlanarPoreGeometryFiller(sysdef, density, type, T, seed, geom)
+    : mpcd::PlanarPoreGeometryFiller(sysdef, type, density, T, geom)
     {
     m_tuner.reset(new Autotuner<1>({AutotunerBase::makeBlockSizeRange(m_exec_conf)},
                                    m_exec_conf,
@@ -82,10 +81,9 @@ void mpcd::detail::export_PlanarPoreGeometryFillerGPU(pybind11::module& m)
         m,
         "PlanarPoreGeometryFillerGPU")
         .def(pybind11::init<std::shared_ptr<SystemDefinition>,
+                            const std::string&,
                             Scalar,
-                            unsigned int,
                             std::shared_ptr<Variant>,
-                            unsigned int,
                             std::shared_ptr<const mpcd::PlanarPoreGeometry>>());
     }
 

--- a/hoomd/mpcd/PlanarPoreGeometryFillerGPU.h
+++ b/hoomd/mpcd/PlanarPoreGeometryFillerGPU.h
@@ -27,10 +27,9 @@ class PYBIND11_EXPORT PlanarPoreGeometryFillerGPU : public mpcd::PlanarPoreGeome
     public:
     //! Constructor
     PlanarPoreGeometryFillerGPU(std::shared_ptr<SystemDefinition> sysdef,
+                                const std::string& type,
                                 Scalar density,
-                                unsigned int type,
                                 std::shared_ptr<Variant> T,
-                                uint16_t seed,
                                 std::shared_ptr<const mpcd::PlanarPoreGeometry> geom);
 
     protected:

--- a/hoomd/mpcd/VirtualParticleFiller.h
+++ b/hoomd/mpcd/VirtualParticleFiller.h
@@ -20,6 +20,8 @@
 #include "hoomd/Variant.h"
 #include <pybind11/pybind11.h>
 
+#include <string>
+
 namespace hoomd
     {
 namespace mpcd
@@ -38,8 +40,8 @@ class PYBIND11_EXPORT VirtualParticleFiller : public Autotuned
     {
     public:
     VirtualParticleFiller(std::shared_ptr<SystemDefinition> sysdef,
+                          const std::string& type,
                           Scalar density,
-                          unsigned int type,
                           std::shared_ptr<Variant> T);
 
     virtual ~VirtualParticleFiller() { }
@@ -47,11 +49,23 @@ class PYBIND11_EXPORT VirtualParticleFiller : public Autotuned
     //! Fill up virtual particles
     void fill(uint64_t timestep);
 
+    Scalar getDensity() const
+        {
+        return m_density;
+        }
+
     //! Set the fill particle density
     void setDensity(Scalar density);
 
+    std::string getType() const;
+
     //! Set the fill particle type
-    void setType(unsigned int type);
+    void setType(const std::string& type);
+
+    std::shared_ptr<Variant> getTemperature() const
+        {
+        return m_T;
+        }
 
     //! Set the fill particle temperature
     void setTemperature(std::shared_ptr<Variant> T)

--- a/hoomd/mpcd/__init__.py
+++ b/hoomd/mpcd/__init__.py
@@ -69,6 +69,7 @@ from hoomd import _hoomd
 from hoomd.md import _md
 
 from hoomd.mpcd import collide
+from hoomd.mpcd import fill
 from hoomd.mpcd import geometry
 from hoomd.mpcd import integrate
 from hoomd.mpcd.integrate import Integrator

--- a/hoomd/mpcd/collide.py
+++ b/hoomd/mpcd/collide.py
@@ -17,10 +17,10 @@ import hoomd
 from hoomd.data.parameterdicts import ParameterDict
 from hoomd.data.typeconverter import OnlyTypes, variant_preprocessing
 from hoomd.mpcd import _mpcd
-from hoomd.operation import AutotunedObject
+from hoomd.operation import Compute, Operation
 
 
-class CellList(AutotunedObject):
+class CellList(Compute):
     """Collision cell list.
 
     Args:
@@ -67,7 +67,7 @@ class CellList(AutotunedObject):
         super()._attach_hook()
 
 
-class CollisionMethod(AutotunedObject):
+class CollisionMethod(Operation):
     """Base collision method.
 
     Args:

--- a/hoomd/mpcd/fill.py
+++ b/hoomd/mpcd/fill.py
@@ -62,7 +62,7 @@ class GeometryFiller(VirtualParticleFiller):
 
     Virtual particles are inserted in cells whose volume is sliced by the
     specified `geometry`. The algorithm for doing the filling depends on the
-    specific `geometry.
+    specific `geometry`.
 
     Attributes:
         geometry (hoomd.mpcd.geometry.Geometry): Surface to fill around.

--- a/hoomd/mpcd/fill.py
+++ b/hoomd/mpcd/fill.py
@@ -1,0 +1,118 @@
+# Copyright (c) 2009-2023 The Regents of the University of Michigan.
+# Part of HOOMD-blue, released under the BSD 3-Clause License.
+
+r""" MPCD virtual-particle fillers.
+
+Virtual particles are MPCD solvent particles that are added to ensure MPCD
+collision cells that are sliced by solid boundaries do not become "underfilled".
+From the perspective of the MPCD algorithm, the number density of particles in
+these sliced cells is lower than the average density, and so the solvent
+properties may differ. In practice, this means that the boundary conditions do
+not appear to be properly enforced.
+"""
+
+import hoomd
+from hoomd.data.parameterdicts import ParameterDict
+from hoomd.mpcd import _mpcd
+from hoomd.mpcd.geometry import Geometry, ParallelPlates
+from hoomd.operation import Operation
+
+
+class VirtualParticleFiller(Operation):
+    """Base virtual-particle filler.
+
+    Args:
+        type (str): Type of particles to fill.
+        density (float): Particle number density.
+        kT (hoomd.variant.variant_like): Temperature of particles.
+
+    Virtual particles will be added with the specified `type` and `density`.
+    Their velocities will be drawn from a Maxwell--Boltzmann distribution
+    consistent with `kT`.
+
+    Attributes:
+        type (str): Type of particles to fill.
+
+        density (float): Particle number density.
+
+        kT (hoomd.variant.variant_like): Temperature of particles.
+
+    """
+
+    def __init__(self, type, density, kT):
+        super().__init__()
+
+        param_dict = ParameterDict(
+            type=str(type),
+            density=float(density),
+            kT=hoomd.variant.Variant,
+        )
+        param_dict["kT"] = kT
+        self._param_dict.update(param_dict)
+
+
+class GeometryFiller(VirtualParticleFiller):
+    """Virtual-particle filler for known geometry.
+
+    Args:
+        type (str): Type of particles to fill.
+        density (float): Particle number density.
+        kT (hoomd.variant.variant_like): Temperature of particles.
+        geometry (hoomd.mpcd.geometry.Geometry): Surface to fill around.
+
+    Virtual particles are inserted in cells whose volume is sliced by the
+    specified `geometry`. The algorithm for doing the filling depends on the
+    specific `geometry.
+
+    Attributes:
+        geometry (hoomd.mpcd.geometry.Geometry): Surface to fill around.
+
+    """
+
+    def __init__(self, type, density, kT, geometry):
+        super().__init__(type, density, kT)
+
+        param_dict = ParameterDict(geometry=Geometry,)
+        param_dict["geometry"] = geometry
+        self._param_dict.update(param_dict)
+
+    def _attach_hook(self):
+        sim = self._simulation
+
+        self.geometry._attach(sim)
+
+        # try to find class in map, otherwise default to internal MPCD module
+        geom_type = type(self.geometry)
+        try:
+            class_info = self._class_map[geom_type]
+        except KeyError:
+            class_info = (_mpcd, geom_type.__name__ + "GeometryFiller")
+        class_info = list(class_info)
+        if isinstance(sim.device, hoomd.device.GPU):
+            class_info[1] += "GPU"
+        class_ = getattr(*class_info, None)
+        assert class_ is not None, "Virtual particle filler for geometry not found"
+
+        self._cpp_obj = class_(
+            sim.state._cpp_sys_def,
+            self.type,
+            self.density,
+            self.kT,
+            self.geometry._cpp_obj,
+        )
+
+        super()._attach_hook()
+
+    def _detach_hook(self):
+        self.geometry._detach()
+        super()._detach_hook()
+
+    _class_map = {}
+
+    @classmethod
+    def _register_geometry(cls, geometry, module, class_name):
+        cls._class_map[geometry] = (module, class_name)
+
+
+GeometryFiller._register_geometry(ParallelPlates, _mpcd,
+                                  "ParallelPlateGeometryFiller")

--- a/hoomd/mpcd/integrate.py
+++ b/hoomd/mpcd/integrate.py
@@ -1,8 +1,6 @@
 # Copyright (c) 2009-2023 The Regents of the University of Michigan.
 # Part of HOOMD-blue, released under the BSD 3-Clause License.
 
-import itertools
-
 import hoomd
 from hoomd.data.parameterdicts import ParameterDict
 from hoomd.data import syncedlist
@@ -156,13 +154,6 @@ class Integrator(_MDIntegrator):
     @virtual_particle_fillers.setter
     def virtual_particle_fillers(self, value):
         _set_synced_list(self._virtual_particle_fillers, value)
-
-    @property
-    def _children(self):
-        children = super()._children
-        for child in itertools.chain(self.virtual_particle_fillers):
-            children.extend(child._children)
-        return children
 
     def _attach_hook(self):
         self._cell_list._attach(self._simulation)

--- a/hoomd/mpcd/pytest/CMakeLists.txt
+++ b/hoomd/mpcd/pytest/CMakeLists.txt
@@ -1,6 +1,7 @@
 # copy python modules to the build directory to make it a working python package
 set(files __init__.py
     test_collide.py
+    test_fill.py
     test_geometry.py
     test_integrator.py
     test_snapshot.py

--- a/hoomd/mpcd/pytest/test_fill.py
+++ b/hoomd/mpcd/pytest/test_fill.py
@@ -1,0 +1,87 @@
+# Copyright (c) 2009-2023 The Regents of the University of Michigan.
+# Part of HOOMD-blue, released under the BSD 3-Clause License.
+
+import hoomd
+from hoomd.conftest import pickling_check
+import numpy as np
+import pytest
+
+
+@pytest.fixture
+def snap():
+    snap_ = hoomd.Snapshot()
+    if snap_.communicator.rank == 0:
+        snap_.configuration.box = [10, 10, 10, 0, 0, 0]
+        snap_.particles.N = 0
+        snap_.particles.types = ["A"]
+        snap_.mpcd.N = 1
+        snap_.mpcd.types = ["A"]
+    return snap_
+
+
+@pytest.mark.parametrize(
+    "cls, init_args",
+    [
+        (hoomd.mpcd.geometry.ParallelPlates, {
+            "H": 4.0
+        }),
+        (hoomd.mpcd.geometry.PlanarPore, {
+            "H": 4.0,
+            "L": 5.0
+        }),
+    ],
+    ids=["ParallelPlates", "PlanarPore"],
+)
+class TestGeometryFiller:
+
+    def test_create_and_attributes(self, simulation_factory, snap, cls,
+                                   init_args):
+        geom = cls(**init_args)
+        filler = hoomd.mpcd.fill.GeometryFiller(type="A",
+                                                density=5.0,
+                                                kT=1.0,
+                                                geometry=geom)
+
+        assert filler.geometry is geom
+        assert filler.type == "A"
+        assert filler.density == 5.0
+        assert isinstance(filler.kT, hoomd.variant.Constant)
+        assert filler.kT(0) == 1.0
+
+        sim = simulation_factory(snap)
+        filler._attach(sim)
+        assert filler.geometry is geom
+        assert filler.type == "A"
+        assert filler.density == 5.0
+        assert isinstance(filler.kT, hoomd.variant.Constant)
+        assert filler.kT(0) == 1.0
+
+        filler.density = 3.0
+        filler.kT = hoomd.variant.Ramp(2.0, 1.0, 0, 10)
+        assert filler.geometry is geom
+        assert filler.type == "A"
+        assert filler.density == 3.0
+        assert isinstance(filler.kT, hoomd.variant.Ramp)
+        assert filler.kT(0) == 2.0
+
+    def test_run(self, simulation_factory, snap, cls, init_args):
+        filler = hoomd.mpcd.fill.GeometryFiller(type="A",
+                                                density=5.0,
+                                                kT=1.0,
+                                                geometry=cls(**init_args))
+        sim = simulation_factory(snap)
+        ig = hoomd.mpcd.Integrator(dt=0.1, solvent_fillers=[filler])
+        sim.operations.integrator = ig
+        sim.run(1)
+
+    def test_pickling(self, simulation_factory, snap, cls, init_args):
+        geom = cls(**init_args)
+        filler = hoomd.mpcd.fill.GeometryFiller(type="A",
+                                                density=5.0,
+                                                kT=1.0,
+                                                geometry=geom)
+        pickling_check(filler)
+
+        sim = simulation_factory(snap)
+        filler._attach(sim)
+        pickling_check(filler)

--- a/hoomd/mpcd/pytest/test_fill.py
+++ b/hoomd/mpcd/pytest/test_fill.py
@@ -70,7 +70,7 @@ class TestGeometryFiller:
                                                 kT=1.0,
                                                 geometry=cls(**init_args))
         sim = simulation_factory(snap)
-        ig = hoomd.mpcd.Integrator(dt=0.1, solvent_fillers=[filler])
+        ig = hoomd.mpcd.Integrator(dt=0.1, virtual_particle_fillers=[filler])
         sim.operations.integrator = ig
         sim.run(1)
 

--- a/hoomd/mpcd/pytest/test_integrator.py
+++ b/hoomd/mpcd/pytest/test_integrator.py
@@ -84,7 +84,7 @@ def test_streaming_method(make_simulation):
     assert ig.streaming_method is stream
 
 
-def test_solvent_fillers(make_simulation):
+def test_virtual_particle_fillers(make_simulation):
     sim = make_simulation()
     geom = hoomd.mpcd.geometry.ParallelPlates(H=4.0)
     filler = hoomd.mpcd.fill.GeometryFiller(
@@ -95,13 +95,13 @@ def test_solvent_fillers(make_simulation):
     )
 
     # check that constructor assigns right
-    ig = hoomd.mpcd.Integrator(dt=0.1, solvent_fillers=[filler])
+    ig = hoomd.mpcd.Integrator(dt=0.1, virtual_particle_fillers=[filler])
     sim.operations.integrator = ig
-    assert len(ig.solvent_fillers) == 1
-    assert filler in ig.solvent_fillers
+    assert len(ig.virtual_particle_fillers) == 1
+    assert filler in ig.virtual_particle_fillers
     sim.run(0)
-    assert len(ig.solvent_fillers) == 1
-    assert filler in ig.solvent_fillers
+    assert len(ig.virtual_particle_fillers) == 1
+    assert filler in ig.virtual_particle_fillers
 
     # attach a second filler
     filler2 = hoomd.mpcd.fill.GeometryFiller(
@@ -110,19 +110,19 @@ def test_solvent_fillers(make_simulation):
         kT=1.0,
         geometry=geom,
     )
-    ig.solvent_fillers.append(filler2)
-    assert len(ig.solvent_fillers) == 2
-    assert filler in ig.solvent_fillers
-    assert filler2 in ig.solvent_fillers
+    ig.virtual_particle_fillers.append(filler2)
+    assert len(ig.virtual_particle_fillers) == 2
+    assert filler in ig.virtual_particle_fillers
+    assert filler2 in ig.virtual_particle_fillers
     sim.run(0)
-    assert len(ig.solvent_fillers) == 2
-    assert filler in ig.solvent_fillers
-    assert filler2 in ig.solvent_fillers
+    assert len(ig.virtual_particle_fillers) == 2
+    assert filler in ig.virtual_particle_fillers
+    assert filler2 in ig.virtual_particle_fillers
 
-    ig.solvent_fillers = []
-    assert len(ig.solvent_fillers) == 0
+    ig.virtual_particle_fillers = []
+    assert len(ig.virtual_particle_fillers) == 0
     sim.run(0)
-    assert len(ig.solvent_fillers) == 0
+    assert len(ig.virtual_particle_fillers) == 0
 
 
 def test_solvent_sorter(make_simulation):
@@ -160,7 +160,7 @@ def test_attach_and_detach(make_simulation):
     assert ig.cell_list._attached
     assert ig.streaming_method is None
     assert ig.collision_method is None
-    assert len(ig.solvent_fillers) == 0
+    assert len(ig.virtual_particle_fillers) == 0
     assert ig.solvent_sorter is None
 
     # attach with both methods

--- a/hoomd/mpcd/pytest/test_integrator.py
+++ b/hoomd/mpcd/pytest/test_integrator.py
@@ -119,6 +119,11 @@ def test_virtual_particle_fillers(make_simulation):
     assert filler in ig.virtual_particle_fillers
     assert filler2 in ig.virtual_particle_fillers
 
+    # make sure synced list is working right with non-empty list assignment
+    ig.virtual_particle_fillers = [filler]
+    assert len(ig.virtual_particle_fillers) == 1
+    assert len(ig._cpp_obj.fillers) == 1
+
     ig.virtual_particle_fillers = []
     assert len(ig.virtual_particle_fillers) == 0
     sim.run(0)

--- a/hoomd/mpcd/stream.py
+++ b/hoomd/mpcd/stream.py
@@ -27,8 +27,7 @@ to complex boundaries, the streaming geometry can be configured. MPCD solvent
 particles will be reflected from boundary surfaces using specular reflections
 (bounce-back) rules consistent with either "slip" or "no-slip" hydrodynamic
 boundary conditions. (The external force is only applied to the particles at the
-beginning and the end of this process.) To help fully enforce the boundary
-conditions, "virtual" MPCD particles can be inserted near the boundary walls.
+beginning and the end of this process.)
 
 Although a streaming geometry is enforced on the MPCD solvent particles, there
 are a few important caveats:
@@ -49,14 +48,13 @@ are a few important caveats:
 
 import hoomd
 from hoomd.data.parameterdicts import ParameterDict
-from hoomd.data.typeconverter import OnlyTypes
 from hoomd.mpcd import _mpcd
 from hoomd.mpcd.geometry import Geometry
-from hoomd.operation import AutotunedObject
+from hoomd.operation import Operation
 
 
-# TODO: add force and filler
-class StreamingMethod(AutotunedObject):
+# TODO: add force
+class StreamingMethod(Operation):
     """Base streaming method.
 
     Args:
@@ -127,7 +125,7 @@ class BounceBack(StreamingMethod):
     def __init__(self, period, geometry):
         super().__init__(period)
 
-        param_dict = ParameterDict(geometry=OnlyTypes(Geometry))
+        param_dict = ParameterDict(geometry=Geometry)
         param_dict["geometry"] = geometry
         self._param_dict.update(param_dict)
 

--- a/hoomd/mpcd/test/parallel_plate_geometry_filler_mpi_test.cc
+++ b/hoomd/mpcd/test/parallel_plate_geometry_filler_mpi_test.cc
@@ -24,6 +24,7 @@ void parallel_plate_fill_mpi_test(std::shared_ptr<ExecutionConfiguration> exec_c
     snap->particle_data.type_mapping.push_back("A");
     snap->mpcd_data.resize(1);
     snap->mpcd_data.type_mapping.push_back("A");
+    snap->mpcd_data.type_mapping.push_back("B");
     snap->mpcd_data.position[0] = vec3<Scalar>(1, 1, 1);
     snap->mpcd_data.velocity[0] = vec3<Scalar>(123, 456, 789);
 
@@ -42,7 +43,7 @@ void parallel_plate_fill_mpi_test(std::shared_ptr<ExecutionConfiguration> exec_c
     auto slit = std::make_shared<const mpcd::ParallelPlateGeometry>(5.0, 0.0, true);
     std::shared_ptr<Variant> kT = std::make_shared<VariantConstant>(1.0);
     std::shared_ptr<mpcd::ParallelPlateGeometryFiller> filler
-        = std::make_shared<F>(sysdef, 2.0, 0, kT, slit);
+        = std::make_shared<F>(sysdef, "B", 2.0, kT, slit);
     filler->setCellList(cl);
 
     /*

--- a/hoomd/mpcd/test/parallel_plate_geometry_filler_test.cc
+++ b/hoomd/mpcd/test/parallel_plate_geometry_filler_test.cc
@@ -21,6 +21,7 @@ void parallel_plate_fill_basic_test(std::shared_ptr<ExecutionConfiguration> exec
     snap->particle_data.type_mapping.push_back("A");
     snap->mpcd_data.resize(1);
     snap->mpcd_data.type_mapping.push_back("A");
+    snap->mpcd_data.type_mapping.push_back("B");
     snap->mpcd_data.position[0] = vec3<Scalar>(1, -2, 3);
     snap->mpcd_data.velocity[0] = vec3<Scalar>(123, 456, 789);
     std::shared_ptr<SystemDefinition> sysdef(new SystemDefinition(snap, exec_conf));
@@ -33,7 +34,7 @@ void parallel_plate_fill_basic_test(std::shared_ptr<ExecutionConfiguration> exec
     auto slit = std::make_shared<const mpcd::ParallelPlateGeometry>(5.0, 1.0, true);
     std::shared_ptr<Variant> kT = std::make_shared<VariantConstant>(1.5);
     std::shared_ptr<mpcd::ParallelPlateGeometryFiller> filler
-        = std::make_shared<F>(sysdef, 2.0, 1, kT, slit);
+        = std::make_shared<F>(sysdef, "B", 2.0, kT, slit);
     filler->setCellList(cl);
 
     /*

--- a/hoomd/mpcd/test/planar_pore_geometry_filler_mpi_test.cc
+++ b/hoomd/mpcd/test/planar_pore_geometry_filler_mpi_test.cc
@@ -23,6 +23,7 @@ template<class F> void planar_pore_fill_mpi_test(std::shared_ptr<ExecutionConfig
     snap->particle_data.type_mapping.push_back("A");
     snap->mpcd_data.resize(1);
     snap->mpcd_data.type_mapping.push_back("A");
+    snap->mpcd_data.type_mapping.push_back("B");
     snap->mpcd_data.position[0] = vec3<Scalar>(1, 1, 1);
     snap->mpcd_data.velocity[0] = vec3<Scalar>(123, 456, 789);
 
@@ -41,7 +42,7 @@ template<class F> void planar_pore_fill_mpi_test(std::shared_ptr<ExecutionConfig
     auto slit = std::make_shared<const mpcd::PlanarPoreGeometry>(5.0, 8.0, true);
     std::shared_ptr<Variant> kT = std::make_shared<VariantConstant>(1.0);
     std::shared_ptr<mpcd::PlanarPoreGeometryFiller> filler
-        = std::make_shared<F>(sysdef, 2.0, 0, kT, 42, slit);
+        = std::make_shared<F>(sysdef, "A", 2.0, kT, slit);
     filler->setCellList(cl);
 
     /*

--- a/hoomd/mpcd/test/planar_pore_geometry_filler_test.cc
+++ b/hoomd/mpcd/test/planar_pore_geometry_filler_test.cc
@@ -21,6 +21,7 @@ void planar_pore_fill_basic_test(std::shared_ptr<ExecutionConfiguration> exec_co
     snap->particle_data.type_mapping.push_back("A");
     snap->mpcd_data.resize(1);
     snap->mpcd_data.type_mapping.push_back("A");
+    snap->mpcd_data.type_mapping.push_back("B");
     snap->mpcd_data.position[0] = vec3<Scalar>(1, -2, 3);
     snap->mpcd_data.velocity[0] = vec3<Scalar>(123, 456, 789);
     std::shared_ptr<SystemDefinition> sysdef(new SystemDefinition(snap, exec_conf));
@@ -34,7 +35,7 @@ void planar_pore_fill_basic_test(std::shared_ptr<ExecutionConfiguration> exec_co
     // fill density 2, temperature 1.5
     std::shared_ptr<Variant> kT = std::make_shared<VariantConstant>(1.5);
     std::shared_ptr<mpcd::PlanarPoreGeometryFiller> filler
-        = std::make_shared<F>(sysdef, 2.0, 1, kT, 42, slit);
+        = std::make_shared<F>(sysdef, "B", 2.0, kT, slit);
     filler->setCellList(cl);
 
     /*

--- a/hoomd/mpcd/tune.py
+++ b/hoomd/mpcd/tune.py
@@ -10,10 +10,10 @@ their correctness.
 
 import hoomd
 from hoomd.mpcd import _mpcd
-from hoomd.operation import Tuner
+from hoomd.operation import TriggeredOperation
 
 
-class ParticleSorter(Tuner):
+class ParticleSorter(TriggeredOperation):
     r"""MPCD particle sorter.
 
     Args:

--- a/sphinx-doc/module-mpcd-fill.rst
+++ b/sphinx-doc/module-mpcd-fill.rst
@@ -1,0 +1,23 @@
+.. Copyright (c) 2009-2023 The Regents of the University of Michigan.
+.. Part of HOOMD-blue, released under the BSD 3-Clause License.
+
+mpcd.fill
+---------
+
+.. rubric:: Overview
+
+.. py:currentmodule:: hoomd.mpcd.fill
+
+.. autosummary::
+    :nosignatures:
+
+    GeometryFiller
+    VirtualParticleFiller
+
+.. rubric:: Details
+
+.. automodule:: hoomd.mpcd.fill
+    :synopsis: Virtual-particle fillers.
+    :members: VirtualParticleFiller,
+              GeometryFiller
+    :show-inheritance:

--- a/sphinx-doc/package-mpcd.rst
+++ b/sphinx-doc/package-mpcd.rst
@@ -17,6 +17,7 @@ hoomd.mpcd
     :maxdepth: 1
 
     module-mpcd-collide
+    module-mpcd-fill
     module-mpcd-geometry
     module-mpcd-stream
     module-mpcd-tune


### PR DESCRIPTION
## Description

This PR reimplements the Python API for adding "virtual" solvent particles during the collision step.

~This code is branched off `mpcd-v4-geometries` and so should be reviewed after PR #1689 is merged.~ This one is ready to merge now!

## Motivation and context

This feature is needed to get the correct solvent properties near boundaries defined in `mpcd.geometry`.

## How has this been tested?

C++ tests already existed for the virtual particle fillers, and Python tests were rewritten.

## Change log

N/A

## Checklist:

- [X] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.rst).
- [X] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [X] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
