### PR TITLE
Reimplement MPCD bounce-back integration method

### DIFF
--- a/hoomd/mpcd/BounceBackNVE.h
+++ b/hoomd/mpcd/BounceBackNVE.h
@@ -106,14 +106,6 @@ template<class Geometry> BounceBackNVE<Geometry>::~BounceBackNVE()
 
 template<class Geometry> void BounceBackNVE<Geometry>::integrateStepOne(uint64_t timestep)
     {
-    if (m_aniso)
-        {
-        m_exec_conf->msg->error() << "mpcd.integrate: anisotropic particles are not supported with "
-                                     "bounce-back integrators."
-                                  << std::endl;
-        throw std::runtime_error("Anisotropic integration not supported with bounce-back");
-        }
-
     if (m_validate_geom)
         validate();
 
@@ -174,13 +166,6 @@ template<class Geometry> void BounceBackNVE<Geometry>::integrateStepOne(uint64_t
 
 template<class Geometry> void BounceBackNVE<Geometry>::integrateStepTwo(uint64_t timestep)
     {
-    if (m_aniso)
-        {
-        m_exec_conf->msg->error() << "mpcd.integrate: anisotropic particles are not supported with "
-                                     "bounce-back integrators."
-                                  << std::endl;
-        throw std::runtime_error("Anisotropic integration not supported with bounce-back");
-        }
     ArrayHandle<Scalar4> h_vel(m_pdata->getVelocities(),
                                access_location::host,
                                access_mode::readwrite);

--- a/hoomd/mpcd/CMakeLists.txt
+++ b/hoomd/mpcd/CMakeLists.txt
@@ -146,6 +146,7 @@ set(files
     force.py
     geometry.py
     integrate.py
+    methods.py
     stream.py
     tune.py
     )

--- a/hoomd/mpcd/__init__.py
+++ b/hoomd/mpcd/__init__.py
@@ -73,5 +73,6 @@ from hoomd.mpcd import fill
 from hoomd.mpcd import geometry
 from hoomd.mpcd import integrate
 from hoomd.mpcd.integrate import Integrator
+from hoomd.mpcd import methods
 from hoomd.mpcd import stream
 from hoomd.mpcd import tune

--- a/hoomd/mpcd/fill.py
+++ b/hoomd/mpcd/fill.py
@@ -69,6 +69,8 @@ class GeometryFiller(VirtualParticleFiller):
 
     """
 
+    _cpp_class_map = {}
+
     def __init__(self, type, density, kT, geometry):
         super().__init__(type, density, kT)
 
@@ -84,7 +86,7 @@ class GeometryFiller(VirtualParticleFiller):
         # try to find class in map, otherwise default to internal MPCD module
         geom_type = type(self.geometry)
         try:
-            class_info = self._class_map[geom_type]
+            class_info = self._cpp_class_map[geom_type]
         except KeyError:
             class_info = (_mpcd, geom_type.__name__ + "GeometryFiller")
         class_info = list(class_info)
@@ -107,12 +109,10 @@ class GeometryFiller(VirtualParticleFiller):
         self.geometry._detach()
         super()._detach_hook()
 
-    _class_map = {}
-
     @classmethod
-    def _register_geometry(cls, geometry, module, class_name):
-        cls._class_map[geometry] = (module, class_name)
+    def _register_cpp_class(cls, geometry, module, cpp_class_name):
+        cls._cpp_class_map[geometry] = (module, cpp_class_name)
 
 
-GeometryFiller._register_geometry(ParallelPlates, _mpcd,
-                                  "ParallelPlateGeometryFiller")
+GeometryFiller._register_cpp_class(ParallelPlates, _mpcd,
+                                   "ParallelPlateGeometryFiller")

--- a/hoomd/mpcd/methods.py
+++ b/hoomd/mpcd/methods.py
@@ -1,0 +1,107 @@
+# Copyright (c) 2009-2023 The Regents of the University of Michigan.
+# Part of HOOMD-blue, released under the BSD 3-Clause License.
+
+r""" MPCD integration methods
+
+Defines extra integration methods useful for solutes (MD particles) embedded in
+an MPCD solvent. However, these methods are not restricted to MPCD
+simulations: they can be used as methods of `hoomd.md.Integrator`. For example,
+`BounceBack` might be used to run DPD simulations with surfaces.
+
+"""
+
+import hoomd
+from hoomd.data.parameterdicts import ParameterDict
+from hoomd.filter import ParticleFilter
+from hoomd.md.methods import Method
+from hoomd.mpcd import _mpcd
+from hoomd.mpcd.geometry import Geometry
+
+
+class BounceBack(Method):
+    r"""Velocity Verlet integration method with bounce-back rule for surfaces.
+
+    Args:
+        filter (hoomd.filter.filter_like): Subset of particles on which to
+            apply this method.
+        geometry (hoomd.mpcd.geometry.Geometry): Surface to bounce back from.
+
+    A bounce-back method for integrating solutes (MD particles) embedded in
+    an MPCD solvent. The integration scheme is velocity Verlet with bounce-back
+    performed at the solid boundaries defined by a geometry, as in
+    `hoomd.mpcd.stream.BounceBack`. This gives a simple approximation of the
+    interactions required to keep a solute bounded in a geometry, and more complex
+    interactions can be specified, for example, by writing custom external fields.
+
+    Similar caveats apply to these methods as for `hoomd.mpcd.stream.BounceBack`.
+    In particular:
+
+    1. The simulation box is periodic, but the `geometry` may impose non-periodic
+       boundary conditions. You must ensure that the box is sufficiently large to
+       enclose the `geometry` and that all particles lie inside it, or an error will
+       be raised at runtime.
+    2. You must also ensure that particles do not self-interact through the periodic
+       boundaries. This is usually achieved for simple pair potentials by padding
+       the box size by the largest cutoff radius. Failure to do so may result in
+       unphysical interactions.
+    3. Bounce-back rules do not always enforce no-slip conditions at surfaces
+       properly. It may still be necessary to add additional "ghost" MD particles in
+       the surface to achieve the right boundary conditions and reduce density
+       fluctuations.
+
+    Warning:
+
+        This method does not support anisotropic integration because
+        torques are not computed for collisions with the boundary.
+        Rigid bodies will also not be treated correctly because the
+        integrator is not aware of the extent of the particles. The surface
+        reflections are treated as point particles. These conditions are too
+        complicated to validate easily, so it is the user's responsibility to
+        choose the `filter` correctly.
+
+    Attributes:
+        filter (hoomd.filter.filter_like): Subset of particles on which to apply
+            this method.
+
+        geometry (hoomd.mpcd.geometry.Geometry): Surface to bounce back from.
+
+    """
+
+    def __init__(self, filter, geometry):
+        super().__init__()
+
+        param_dict = ParameterDict(filter=ParticleFilter, geometry=Geometry)
+        param_dict.update(dict(filter=filter, geometry=geometry))
+        self._param_dict.update(param_dict)
+
+    def _attach_hook(self):
+        sim = self._simulation
+
+        self.geometry._attach(sim)
+
+        # try to find class in map, otherwise default to internal MPCD module
+        geom_type = type(self.geometry)
+        try:
+            class_info = self._class_map[geom_type]
+        except KeyError:
+            class_info = (_mpcd, "BounceBackNVE" + geom_type.__name__)
+        class_info = list(class_info)
+        if isinstance(sim.device, hoomd.device.GPU):
+            class_info[1] += "GPU"
+        class_ = getattr(*class_info, None)
+        assert class_ is not None, "Bounce back method for geometry not found"
+
+        group = sim.state._get_group(self.filter)
+        self._cpp_obj = class_(sim.state._cpp_sys_def, group,
+                               self.geometry._cpp_obj)
+        super()._attach_hook()
+
+    def _detach_hook(self):
+        self.geometry._detach()
+        super()._detach_hook()
+
+    _class_map = {}
+
+    @classmethod
+    def _register_geometry(cls, geometry, module, class_name):
+        cls._class_map[geometry] = (module, class_name)

--- a/hoomd/mpcd/methods.py
+++ b/hoomd/mpcd/methods.py
@@ -67,6 +67,8 @@ class BounceBack(Method):
 
     """
 
+    _cpp_class_map = {}
+
     def __init__(self, filter, geometry):
         super().__init__()
 
@@ -82,7 +84,7 @@ class BounceBack(Method):
         # try to find class in map, otherwise default to internal MPCD module
         geom_type = type(self.geometry)
         try:
-            class_info = self._class_map[geom_type]
+            class_info = self._cpp_class_map[geom_type]
         except KeyError:
             class_info = (_mpcd, "BounceBackNVE" + geom_type.__name__)
         class_info = list(class_info)
@@ -100,8 +102,6 @@ class BounceBack(Method):
         self.geometry._detach()
         super()._detach_hook()
 
-    _class_map = {}
-
     @classmethod
-    def _register_geometry(cls, geometry, module, class_name):
-        cls._class_map[geometry] = (module, class_name)
+    def _register_cpp_class(cls, geometry, module, cpp_class_name):
+        cls._cpp_class_map[geometry] = (module, cpp_class_name)

--- a/hoomd/mpcd/pytest/CMakeLists.txt
+++ b/hoomd/mpcd/pytest/CMakeLists.txt
@@ -4,6 +4,7 @@ set(files __init__.py
     test_fill.py
     test_geometry.py
     test_integrator.py
+    test_methods.py
     test_snapshot.py
     test_stream.py
     test_tune.py

--- a/hoomd/mpcd/pytest/test_methods.py
+++ b/hoomd/mpcd/pytest/test_methods.py
@@ -1,0 +1,164 @@
+# Copyright (c) 2009-2023 The Regents of the University of Michigan.
+# Part of HOOMD-blue, released under the BSD 3-Clause License.
+
+import hoomd
+from hoomd.conftest import pickling_check
+import numpy as np
+import pytest
+
+
+@pytest.fixture
+def snap():
+    snap_ = hoomd.Snapshot()
+    if snap_.communicator.rank == 0:
+        snap_.configuration.box = [10, 10, 10, 0, 0, 0]
+        snap_.particles.N = 2
+        snap_.particles.types = ["A"]
+        snap_.particles.position[:] = [[4.95, -4.95, 3.85], [0.0, 0.0, -3.8]]
+        snap_.particles.velocity[:] = [[1.0, -1.0, 1.0], [-1.0, -1.0, -1.0]]
+        snap_.particles.mass[:] = [1.0, 2.0]
+    return snap_
+
+
+@pytest.fixture
+def integrator():
+    bb = hoomd.mpcd.methods.BounceBack(
+        filter=hoomd.filter.All(),
+        geometry=hoomd.mpcd.geometry.ParallelPlates(H=4))
+    ig = hoomd.mpcd.Integrator(dt=0.1, methods=[bb])
+    return ig
+
+
+class TestBounceBack:
+
+    def test_step_noslip(self, simulation_factory, snap, integrator):
+        """Test step with no-slip boundary conditions."""
+        sim = simulation_factory(snap)
+        sim.operations.integrator = integrator
+
+        # take one step
+        sim.run(1)
+        snap = sim.state.get_snapshot()
+        if snap.communicator.rank == 0:
+            np.testing.assert_array_almost_equal(
+                snap.particles.position,
+                [[-4.95, 4.95, 3.95], [-0.1, -0.1, -3.9]])
+            np.testing.assert_array_almost_equal(
+                snap.particles.velocity, [[1.0, -1.0, 1.0], [-1.0, -1.0, -1.0]])
+
+        # take another step where one particle will now hit the wall
+        sim.run(1)
+        snap = sim.state.get_snapshot()
+        if snap.communicator.rank == 0:
+            np.testing.assert_array_almost_equal(
+                snap.particles.position,
+                [[-4.95, 4.95, 3.95], [-0.2, -0.2, -4.0]])
+            np.testing.assert_array_almost_equal(
+                snap.particles.velocity,
+                [[-1.0, 1.0, -1.0], [-1.0, -1.0, -1.0]])
+
+        # take another step, reflecting the second particle
+        sim.run(1)
+        snap = sim.state.get_snapshot()
+        if snap.communicator.rank == 0:
+            np.testing.assert_array_almost_equal(
+                snap.particles.position,
+                [[4.95, -4.95, 3.85], [-0.1, -0.1, -3.9]])
+            np.testing.assert_array_almost_equal(
+                snap.particles.velocity, [[-1.0, 1.0, -1.0], [1.0, 1.0, 1.0]])
+
+    def test_step_slip(self, simulation_factory, snap, integrator):
+        """Test step with slip boundary conditions."""
+        integrator.methods[0].geometry.no_slip = False
+
+        sim = simulation_factory(snap)
+        sim.operations.integrator = integrator
+
+        # take one step
+        sim.run(1)
+        snap = sim.state.get_snapshot()
+        if snap.communicator.rank == 0:
+            np.testing.assert_array_almost_equal(
+                snap.particles.position,
+                [[-4.95, 4.95, 3.95], [-0.1, -0.1, -3.9]])
+            np.testing.assert_array_almost_equal(
+                snap.particles.velocity, [[1.0, -1.0, 1.0], [-1.0, -1.0, -1.0]])
+
+        # take another step where one particle will now hit the wall
+        sim.run(1)
+        snap = sim.state.get_snapshot()
+        if snap.communicator.rank == 0:
+            np.testing.assert_array_almost_equal(
+                snap.particles.position,
+                [[-4.85, 4.85, 3.95], [-0.2, -0.2, -4.0]])
+            np.testing.assert_array_almost_equal(
+                snap.particles.velocity,
+                [[1.0, -1.0, -1.0], [-1.0, -1.0, -1.0]])
+
+        # take another step, reflecting the perpendicular motion of second particle
+        sim.run(1)
+        snap = sim.state.get_snapshot()
+        if snap.communicator.rank == 0:
+            np.testing.assert_array_almost_equal(
+                snap.particles.position,
+                [[-4.75, 4.75, 3.85], [-0.3, -0.3, -3.9]])
+            np.testing.assert_array_almost_equal(
+                snap.particles.velocity, [[1.0, -1.0, -1.0], [-1.0, -1.0, 1.0]])
+
+    def test_step_moving_wall(self, simulation_factory, snap, integrator):
+        integrator.dt = 0.3
+        integrator.methods[0].geometry.V = 1.0
+
+        if snap.communicator.rank == 0:
+            snap.particles.velocity[1] = [-2.0, -1.0, -1.0]
+        sim = simulation_factory(snap)
+        sim.operations.integrator = integrator
+
+        # run one step and check bounce back of particles
+        sim.run(1)
+        snap = sim.state.get_snapshot()
+        if snap.communicator.rank == 0:
+            np.testing.assert_array_almost_equal(
+                snap.particles.position,
+                [[-4.75, -4.95, 3.85], [-0.4, -0.1, -3.9]])
+            np.testing.assert_array_almost_equal(
+                snap.particles.velocity, [[1.0, 1.0, -1.0], [0.0, 1.0, 1.0]])
+
+    def test_accel(self, simulation_factory, snap, integrator):
+        force = hoomd.md.force.Constant(filter=hoomd.filter.All())
+        force.constant_force["A"] = (2, -2, 4)
+        integrator.forces.append(force)
+
+        if snap.communicator.rank == 0:
+            snap.particles.position[:] = [[0, 0, 0], [0, 0, 0]]
+        sim = simulation_factory(snap)
+        sim.operations.integrator = integrator
+
+        sim.run(1)
+        snap = sim.state.get_snapshot()
+        if snap.communicator.rank == 0:
+            np.testing.assert_array_almost_equal(
+                snap.particles.position,
+                [[0.11, -0.11, 0.12], [-0.095, -0.105, -0.09]])
+            np.testing.assert_array_almost_equal(
+                snap.particles.velocity, [[1.2, -1.2, 1.4], [-0.9, -1.1, -0.8]])
+
+    def test_validate_box(self, simulation_factory, snap, integrator):
+        """Test box validation raises an error on run."""
+        integrator.methods[0].geometry.H = 10
+
+        sim = simulation_factory(snap)
+        sim.operations.integrator = integrator
+
+        with pytest.raises(RuntimeError):
+            sim.run(1)
+
+    def test_test_of_bounds(self, simulation_factory, snap, integrator):
+        """Test box validation raises an error on run."""
+        integrator.methods[0].geometry.H = 3.8
+
+        sim = simulation_factory(snap)
+        sim.operations.integrator = integrator
+
+        with pytest.raises(RuntimeError):
+            sim.run(1)

--- a/hoomd/mpcd/pytest/test_stream.py
+++ b/hoomd/mpcd/pytest/test_stream.py
@@ -166,7 +166,7 @@ class TestParallelPlates:
             np.testing.assert_array_almost_equal(
                 snap.mpcd.velocity, [[-1.0, 1.0, -1.0], [1.0, 1.0, 1.0]])
 
-    def test_slip(self, simulation_factory, snap):
+    def test_step_slip(self, simulation_factory, snap):
         """Test step with slip boundary conditions."""
         if snap.communicator.rank == 0:
             snap.mpcd.N = 2

--- a/hoomd/mpcd/stream.py
+++ b/hoomd/mpcd/stream.py
@@ -122,6 +122,8 @@ class BounceBack(StreamingMethod):
 
     """
 
+    _cpp_class_map = {}
+
     def __init__(self, period, geometry):
         super().__init__(period)
 
@@ -137,7 +139,7 @@ class BounceBack(StreamingMethod):
         # try to find class in map, otherwise default to internal MPCD module
         geom_type = type(self.geometry)
         try:
-            class_info = self._class_map[geom_type]
+            class_info = self._cpp_class_map[geom_type]
         except KeyError:
             class_info = (_mpcd,
                           "BounceBackStreamingMethod" + geom_type.__name__)
@@ -161,8 +163,6 @@ class BounceBack(StreamingMethod):
         self.geometry._detach()
         super()._detach_hook()
 
-    _class_map = {}
-
     @classmethod
-    def _register_geometry(cls, geometry, module, class_name):
-        cls._class_map[geometry] = (module, class_name)
+    def _register_cpp_class(cls, geometry, module, cpp_class_name):
+        cls._cpp_class_map[geometry] = (module, cpp_class_name)

--- a/hoomd/mpcd/stream.py
+++ b/hoomd/mpcd/stream.py
@@ -22,28 +22,6 @@ where **r** and **v** are the particle position and velocity, respectively, and
 **f** is the external force acting on the particles of mass *m*. For a list of
 forces that can be applied, see :mod:`.mpcd.force`.
 
-Since one of the main strengths of the MPCD algorithm is that it can be coupled
-to complex boundaries, the streaming geometry can be configured. MPCD solvent
-particles will be reflected from boundary surfaces using specular reflections
-(bounce-back) rules consistent with either "slip" or "no-slip" hydrodynamic
-boundary conditions. (The external force is only applied to the particles at the
-beginning and the end of this process.)
-
-Although a streaming geometry is enforced on the MPCD solvent particles, there
-are a few important caveats:
-
-1. Embedded particles are not coupled to the boundary walls. They must be
-   confined by an appropriate method, e.g., an external potential, an
-   explicit particle wall, or a bounce-back method.
-2. The confined geometry exists inside a fully periodic simulation box.
-   Hence, the box must be padded large enough that the MPCD cells do not
-   interact through the periodic boundary. Usually, this means adding at
-   least one extra layer of cells in the confined dimensions. Your periodic
-   simulation box will be validated by the confined geometry.
-3. It is an error for MPCD particles to lie "outside" the confined geometry.
-   You must initialize your system carefully to ensure all particles are
-   "inside" the geometry. An error will be raised otherwise.
-
 """
 
 import hoomd
@@ -116,6 +94,28 @@ class BounceBack(StreamingMethod):
     Args:
         period (int): Number of integration steps covered by streaming step.
         geometry (hoomd.mpcd.geometry.Geometry): Surface to bounce back from.
+
+    One of the main strengths of the MPCD algorithm is that it can be coupled
+    to complex boundaries, defined by a `geometry`. This `StreamingMethod` reflects
+    the MPCD solvent particles from boundary surfaces using specular reflections
+    (bounce-back) rules consistent with either "slip" or "no-slip" hydrodynamic
+    boundary conditions. (The external force is only applied to the particles at the
+    beginning and the end of this process.)
+
+    Although a streaming geometry is enforced on the MPCD solvent particles, there
+    are a few important caveats:
+
+    1. Embedded particles are not coupled to the boundary walls. They must be
+       confined by an appropriate method, e.g., an external potential, an
+       explicit particle wall, or a bounce-back method (`hoomd.mpcd.methods.BounceBack`).
+    2. The `geometry` exists inside a fully periodic simulation box.
+       Hence, the box must be padded large enough that the MPCD cells do not
+       interact through the periodic boundary. Usually, this means adding at
+       least one extra layer of cells in the confined dimensions. Your periodic
+       simulation box will be validated by the `geometry`.
+    3. It is an error for MPCD particles to lie "outside" the `geometry`.
+       You must initialize your system carefully to ensure all particles are
+       "inside" the geometry. An error will be raised otherwise.
 
     Attributes:
         geometry (hoomd.mpcd.geometry.Geometry): Surface to bounce back from.

--- a/sphinx-doc/module-mpcd-methods.rst
+++ b/sphinx-doc/module-mpcd-methods.rst
@@ -1,0 +1,21 @@
+.. Copyright (c) 2009-2023 The Regents of the University of Michigan.
+.. Part of HOOMD-blue, released under the BSD 3-Clause License.
+
+mpcd.methods
+------------
+
+.. rubric:: Overview
+
+.. py:currentmodule:: hoomd.mpcd.methods
+
+.. autosummary::
+    :nosignatures:
+
+    BounceBack
+
+.. rubric:: Details
+
+.. automodule:: hoomd.mpcd.methods
+    :synopsis: Integration methods.
+    :members: BounceBack
+    :show-inheritance:

--- a/sphinx-doc/package-mpcd.rst
+++ b/sphinx-doc/package-mpcd.rst
@@ -19,5 +19,6 @@ hoomd.mpcd
     module-mpcd-collide
     module-mpcd-fill
     module-mpcd-geometry
+    module-mpcd-methods
     module-mpcd-stream
     module-mpcd-tune


### PR DESCRIPTION
## Description

This PR reimplements the bounce-back integrator for MD particles that is a companion to the bounce-back streaming method for the MPCD particles. It is added in `mpcd.methods` and uses `mpcd.geometry.Geometry` to define the bounce back geometry.

There are some documentation improvements to `mpcd.stream` included in this PR for stuff that I noticed when I was also writing the `mpcd.methods` documentation. Since everything is going into a staging branch, I just included them on this PR.

~This PR should be reviewed after #1690.~

## Motivation and context

This feature is helpful for coupling solute particles to the same geometry as the MPCD solvent, especially if it isn't easy to define an external potential to keep the solute particles out of some regions.

## How has this been tested?

Python unit tests from 2.9.7 have been reimplemented.

## Change log

N/A

## Checklist:

- [X] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.rst).
- [X] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [X] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
