### PR TITLE
add warning message for the deprecated methods

### DIFF
--- a/hoomd/tune/custom_tuner.py
+++ b/hoomd/tune/custom_tuner.py
@@ -76,10 +76,10 @@ class _InternalCustomTuner(_InternalCustomOperation, Tuner):
     def tune(self, timestep):
         return self._action.act(timestep)
         """
-        .. deprecated:: 5.0.0
+        .. deprecated:: 4.5.0
 
-           use `Simulation` to call the operation
+           Use `Simulation` to call the operation.
         """
         warnings.warn(
             "`_InternalCustomTuner.tune` is deprecated,"
-            "use `Simulation` to call the operation", FutureWarning)
+            "use `Simulation` to call the operation.", FutureWarning)

--- a/hoomd/tune/custom_tuner.py
+++ b/hoomd/tune/custom_tuner.py
@@ -15,6 +15,7 @@
 
 from hoomd.custom import (CustomOperation, _InternalCustomOperation, Action)
 from hoomd.operation import Tuner
+import warnings
 
 
 class _TunerProperty:
@@ -74,3 +75,11 @@ class _InternalCustomTuner(_InternalCustomOperation, Tuner):
 
     def tune(self, timestep):
         return self._action.act(timestep)
+        """
+        .. deprecated:: 5.0.0
+
+           use `Simulation` to call the operation
+        """
+        warnings.warn(
+            "`_InternalCustomTuner.tune` is deprecated,"
+            "use `Simulation` to call the operation", FutureWarning)

--- a/hoomd/update/custom_updater.py
+++ b/hoomd/update/custom_updater.py
@@ -75,10 +75,10 @@ class _InternalCustomUpdater(_InternalCustomOperation, Updater):
     def update(self, timestep):
         return self._action.act(timestep)
         """
-        .. deprecated:: 5.0.0
+        .. deprecated:: 4.5.0
 
-            use `Simulation` to call the operation.
+            Use `Simulation` to call the operation.
         """
         warnings.warn(
             "`_InternalCustomUpdater.update` is deprecated,"
-            "use `Simulation` to call the operation", FutureWarning)
+            "use `Simulation` to call the operation.", FutureWarning)

--- a/hoomd/update/custom_updater.py
+++ b/hoomd/update/custom_updater.py
@@ -15,6 +15,7 @@
 
 from hoomd.custom import (CustomOperation, _InternalCustomOperation, Action)
 from hoomd.operation import Updater
+import warnings
 
 
 class _UpdaterProperty:
@@ -73,3 +74,11 @@ class _InternalCustomUpdater(_InternalCustomOperation, Updater):
 
     def update(self, timestep):
         return self._action.act(timestep)
+        """
+        .. deprecated:: 5.0.0
+
+            use `Simulation` to call the operation.
+        """
+        warnings.warn(
+            "`_InternalCustomUpdater.update` is deprecated,"
+            "use `Simulation` to call the operation", FutureWarning)

--- a/hoomd/write/custom_writer.py
+++ b/hoomd/write/custom_writer.py
@@ -76,10 +76,10 @@ class _InternalCustomWriter(_InternalCustomOperation, Writer):
     def write(self, timestep):
         return self._action.act(timestep)
         """
-        .. deprecated:: 5.0.0
+        .. deprecated:: 4.5.0
 
-            use `Simulation` to call the operation
+            Use `Simulation` to call the operation.
         """
         warnings.warn(
             "`_InternalCustomWriter.write` is deprecated,"
-            "use `Simulation` to call the operation", FutureWarning)
+            "use `Simulation` to call the operation.", FutureWarning)

--- a/hoomd/write/custom_writer.py
+++ b/hoomd/write/custom_writer.py
@@ -15,6 +15,7 @@
 
 from hoomd.custom import (CustomOperation, _InternalCustomOperation, Action)
 from hoomd.operation import Writer
+import warnings
 
 
 class _WriterProperty:
@@ -74,3 +75,11 @@ class _InternalCustomWriter(_InternalCustomOperation, Writer):
 
     def write(self, timestep):
         return self._action.act(timestep)
+        """
+        .. deprecated:: 5.0.0
+
+            use `Simulation` to call the operation
+        """
+        warnings.warn(
+            "`_InternalCustomWriter.write` is deprecated,"
+            "use `Simulation` to call the operation", FutureWarning)

--- a/hoomd/write/hdf5.py
+++ b/hoomd/write/hdf5.py
@@ -348,13 +348,13 @@ class HDF5Log(_InternalCustomWriter):
 
             hdf5_writer.write()
 
-        .. deprecated:: 5.0.0
+        .. deprecated:: 4.5.0
 
-            use `Simulation` to call the operation
+            Use `Simulation` to call the operation.
         """
         warnings.warn(
             "`HDF5Log.writer` is deprecated,"
-            "use `Simulation` to call the operation", FutureWarning)
+            "use `Simulation` to call the operation.", FutureWarning)
         self._action.act(timestep)
 
 

--- a/hoomd/write/hdf5.py
+++ b/hoomd/write/hdf5.py
@@ -37,6 +37,7 @@ import hoomd.util as util
 
 from hoomd.write.custom_writer import _InternalCustomWriter
 from hoomd.data.parameterdicts import ParameterDict
+import warnings
 
 try:
     import h5py
@@ -346,7 +347,14 @@ class HDF5Log(_InternalCustomWriter):
         .. code-block:: python
 
             hdf5_writer.write()
+
+        .. deprecated:: 5.0.0
+
+            use `Simulation` to call the operation
         """
+        warnings.warn(
+            "`HDF5Log.writer` is deprecated,"
+            "use `Simulation` to call the operation", FutureWarning)
         self._action.act(timestep)
 
 

--- a/sphinx-doc/deprecated.rst
+++ b/sphinx-doc/deprecated.rst
@@ -25,7 +25,7 @@ documentation for more information on warning filters.
 
 * ``HPMCIntegrator.depletant_fugacity > 0`` (since 4.4.0).
 
-* ``_InternalCustomUpdater.update`` (since 4.4.1)
-* ``_InternalCustomTuner.tune`` (since 4.4.1)
-* ``_InternalCustomWriter.write`` (since 4.4.1)
-* ``HDF5Log.write`` (since 4.4.1)
+* ``_InternalCustomUpdater.update`` (since 4.5.0)
+* ``_InternalCustomTuner.tune`` (since 4.5.0)
+* ``_InternalCustomWriter.write`` (since 4.5.0)
+* ``HDF5Log.write`` (since 4.5.0)

--- a/sphinx-doc/deprecated.rst
+++ b/sphinx-doc/deprecated.rst
@@ -24,3 +24,8 @@ documentation for more information on warning filters.
   * All TBB code will be removed in the 5.0 release.
 
 * ``HPMCIntegrator.depletant_fugacity > 0`` (since 4.4.0).
+
+* ``_InternalCustomUpdater.update`` (since 4.4.1)
+* ``_InternalCustomTuner.tune`` (since 4.4.1)
+* ``_InternalCustomWriter.write`` (since 4.4.1)
+* ``HDF5Log.write`` (since 4.4.1)


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should be based on *trunk-patch*. -->
<!-- Backwards compatible new features should be based on *trunk-minor*. -->
<!-- Incompatible API changes should be based on *trunk-major*. -->

## Description
Added deprecation warnings for the following methods:
* `_InternalCustomUpdater.update`.
* `_InternalCustomTuner.tune`.
* `_InternalCustomWriter.write`.
* `HDF5Log.write`.

## Motivation and context
Resolves #1648 

## How has this been tested?
Used the existing python tests

## Change log
```
Deprecated:

* ``_InternalCustomUpdater.update``.
  (`#1692 <https://github.com/glotzerlab/hoomd-blue/pull/1692>`__).
* ``_InternalCustomTuner.tune``.
  (`#1692 <https://github.com/glotzerlab/hoomd-blue/pull/1692>`__).  
* ``_InternalCustomWriter.write``.
  (`#1692 <https://github.com/glotzerlab/hoomd-blue/pull/1692>`__).
* ``HDF5Log.write``.
  (`#1692 <https://github.com/glotzerlab/hoomd-blue/pull/1692>`__).

``` 

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
