### PR TITLE
import GPUNotAvailableError to error.py

### DIFF
--- a/hoomd/data/array.py
+++ b/hoomd/data/array.py
@@ -708,7 +708,7 @@ if hoomd.version.gpu_enabled:
                     return "<emph>" + name + "</emph>" \
                         + "(<strong>INVALID</strong>)"
 else:
-    from hoomd.util import _NoGPU
+    from hoomd.error import _NoGPU
 
     class HOOMDGPUArray(_NoGPU):
         """GPU arrays are not available on the CPU."""

--- a/hoomd/data/local_access_gpu.py
+++ b/hoomd/data/local_access_gpu.py
@@ -63,7 +63,7 @@ if hoomd.version.gpu_enabled:
             self._constraints = ConstraintLocalAccessGPU(state)
 
 else:
-    from hoomd.util import _NoGPU
+    from hoomd.error import _NoGPU
 
     class BondLocalAccessGPU(_NoGPU):
         """GPU data access is not available in CPU builds."""

--- a/hoomd/error.py
+++ b/hoomd/error.py
@@ -37,6 +37,19 @@ class TypeConversionError(ValueError):
     pass
 
 
+class GPUNotAvailableError(NotImplementedError):
+    """Error for when a GPU specific feature was requested without a GPU."""
+    pass
+
+
+class _NoGPU:
+    """Used in nonGPU builds of hoomd to raise errors for attempted use."""
+
+    def __init__(self, *args, **kwargs):
+        raise GPUNotAvailableError(
+            "This build of HOOMD-blue does not support GPUs.")
+
+
 class IncompleteSpecificationError(ValueError):
     """Error when a value is missing."""
     pass
@@ -55,8 +68,3 @@ class IsolationWarning(UserWarning):
         return ("The data structure is removed from its original data source, "
                 "and updates will no longer modify the previously composing "
                 "object. Call obj.to_base() to remove this warning.")
-
-
-class GPUNotAvailableError(NotImplementedError):
-    """Error for when a GPU specific feature was requested without a GPU."""
-    pass

--- a/hoomd/error.py
+++ b/hoomd/error.py
@@ -55,3 +55,8 @@ class IsolationWarning(UserWarning):
         return ("The data structure is removed from its original data source, "
                 "and updates will no longer modify the previously composing "
                 "object. Call obj.to_base() to remove this warning.")
+
+
+class GPUNotAvailableError(NotImplementedError):
+    """Error for when a GPU specific feature was requested without a GPU."""
+    pass

--- a/hoomd/md/data/local_access_gpu.py
+++ b/hoomd/md/data/local_access_gpu.py
@@ -23,7 +23,7 @@ if hoomd.version.gpu_enabled:
         _array_cls = HOOMDGPUArray
 
 else:
-    from hoomd.util import _NoGPU
+    from hoomd.error import _NoGPU
 
     class ForceLocalAccessGPU(_NoGPU):
         """GPU data access is not available in CPU builds."""

--- a/hoomd/util.py
+++ b/hoomd/util.py
@@ -257,14 +257,6 @@ class GPUNotAvailableError(NotImplementedError):
     from hoomd.error import GPUNotAvailableError
 
 
-class _NoGPU:
-    """Used in nonGPU builds of hoomd to raise errors for attempted use."""
-
-    def __init__(self, *args, **kwargs):
-        raise GPUNotAvailableError(
-            "This build of HOOMD-blue does not support GPUs.")
-
-
 def make_example_simulation(device=None, dimensions=3, particle_types=['A']):
     """Make an example Simulation object.
 

--- a/hoomd/util.py
+++ b/hoomd/util.py
@@ -6,6 +6,7 @@
 import hoomd
 import io
 from collections.abc import Iterable, Mapping, MutableMapping
+from hoomd.error import GPUNotAvailableError  # noqa: F401
 
 
 def _to_camel_case(string):
@@ -250,11 +251,6 @@ class _SafeNamespaceDict(_NamespaceDict):
                            "replacing.".format(namespace))
         else:
             super().__setitem__(namespace, value)
-
-
-class GPUNotAvailableError(NotImplementedError):
-    """Error for when a GPU specific feature was requested without a GPU."""
-    from hoomd.error import GPUNotAvailableError
 
 
 def make_example_simulation(device=None, dimensions=3, particle_types=['A']):

--- a/hoomd/util.py
+++ b/hoomd/util.py
@@ -254,7 +254,7 @@ class _SafeNamespaceDict(_NamespaceDict):
 
 class GPUNotAvailableError(NotImplementedError):
     """Error for when a GPU specific feature was requested without a GPU."""
-    pass
+    from hoomd.error import GPUNotAvailableError
 
 
 class _NoGPU:

--- a/sphinx-doc/deprecated.rst
+++ b/sphinx-doc/deprecated.rst
@@ -24,3 +24,7 @@ documentation for more information on warning filters.
   * All TBB code will be removed in the 5.0 release.
 
 * ``HPMCIntegrator.depletant_fugacity > 0`` (since 4.4.0).
+
+* ``hoomd.util.GPUNotAvailableError`` (since 4.4.1).
+
+  * use ``hoomd.error.GPUNotAvailableError``.

--- a/sphinx-doc/module-hoomd-error.rst
+++ b/sphinx-doc/module-hoomd-error.rst
@@ -14,6 +14,7 @@ hoomd.error
     DataAccessError
     TypeConversionError
     MutabilityError
+    GPUNotAvailableError
 
 .. rubric:: Details
 
@@ -21,6 +22,7 @@ hoomd.error
     :synopsis: HOOMD errors
     :members: DataAccessError,
               TypeConversionError,
-              MutabilityError
+              MutabilityError,
+              GPUNotAvailableError
     :no-inherited-members:
     :show-inheritance:

--- a/sphinx-doc/module-hoomd-util.rst
+++ b/sphinx-doc/module-hoomd-util.rst
@@ -11,12 +11,10 @@ hoomd.util
 .. autosummary::
     :nosignatures:
 
-    GPUNotAvailableError
     make_example_simulation
 
 .. rubric:: Details
 
 .. automodule:: hoomd.util
     :synopsis: Utilities
-    :members: GPUNotAvailableError,
-              make_example_simulation
+    :members: make_example_simulation


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should be based on *trunk-patch*. -->
<!-- Backwards compatible new features should be based on *trunk-minor*. -->
<!-- Incompatible API changes should be based on *trunk-major*. -->

## Description
Imported `GPUNotAvailableError` in `error.py`.

Will remove `util.GPNotavailableError` in a branch off `trunk-major` after this branch is merged

## Motivation and context

`util` should hold utility methods and `error` should hold error classes.

Resolves #1649 

## How has this been tested?

## Change log
```
Added

* ``hoomd.error.GPUNotAvailableError``
  (`#1694 <https://github.com/glotzerlab/hoomd-blue/pull/1694>`__).

Deprecated:

* ``hoomd.util.GPUNotAvailableError``
  (`#1694 <https://github.com/glotzerlab/hoomd-blue/pull/1694>`__).
```

## Checklist:
- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
