### PR TITLE
Remove custom action methods

### DIFF
--- a/hoomd/custom/custom_operation.py
+++ b/hoomd/custom/custom_operation.py
@@ -216,9 +216,6 @@ class _InternalCustomOperation(CustomOperation,
             key: value.update_cls(self.__class__)
             for key, value in self._export_dict.items()
         }
-        # Wrap action act method with operation appropriate one.
-        wrapping_method = getattr(self, self._operation_func).__func__
-        setattr(wrapping_method, "__doc__", self._action.act.__doc__)
 
     def __dir__(self):
         """Expose all attributes for dynamic querying in notebooks and IDEs."""

--- a/hoomd/md/pytest/test_hdf5.py
+++ b/hoomd/md/pytest/test_hdf5.py
@@ -88,37 +88,6 @@ def test_write(create_md_sim, tmp_path):
             assert np.allclose(fh[key], kinetic_energy_list)
 
 
-def test_write_method(create_md_sim, tmp_path):
-    filename = tmp_path / "temporary_test_file.h5"
-
-    sim = create_md_sim
-    thermo = hoomd.md.compute.ThermodynamicQuantities(filter=hoomd.filter.All())
-    sim.operations.computes.append(thermo)
-
-    logger = hoomd.logging.Logger(["scalar", "particle", "sequence"])
-    logger.add(thermo)
-
-    # Writer should never run on its own.
-    hdf5_writer = hoomd.write.HDF5Log(filename=filename,
-                                      trigger=hoomd.trigger.Periodic(100),
-                                      mode='w',
-                                      logger=logger)
-    sim.operations.writers.append(hdf5_writer)
-
-    kinetic_energy_list = []
-    for _ in range(5):
-        sim.run(1)
-        kinetic_energy_list.append(thermo.kinetic_energy)
-        hdf5_writer.write()
-
-    hdf5_writer.flush()
-
-    if sim.device.communicator.rank == 0:
-        key = 'hoomd-data/md/compute/ThermodynamicQuantities/kinetic_energy'
-        with h5py.File(filename, mode='r') as fh:
-            assert np.allclose(fh[key], kinetic_energy_list)
-
-
 def test_mode(tmp_path, create_md_sim):
     logger = hoomd.logging.Logger(categories=['scalar'])
     sim = create_md_sim

--- a/hoomd/tune/custom_tuner.py
+++ b/hoomd/tune/custom_tuner.py
@@ -15,7 +15,6 @@
 
 from hoomd.custom import (CustomOperation, _InternalCustomOperation, Action)
 from hoomd.operation import Tuner
-import warnings
 
 
 class _TunerProperty:
@@ -72,14 +71,3 @@ class _InternalCustomTuner(_InternalCustomOperation, Tuner):
     _cpp_list_name = 'tuners'
     _cpp_class_name = 'PythonTuner'
     _operation_func = "tune"
-
-    def tune(self, timestep):
-        return self._action.act(timestep)
-        """
-        .. deprecated:: 4.5.0
-
-           Use `Simulation` to call the operation.
-        """
-        warnings.warn(
-            "`_InternalCustomTuner.tune` is deprecated,"
-            "use `Simulation` to call the operation.", FutureWarning)

--- a/hoomd/update/custom_updater.py
+++ b/hoomd/update/custom_updater.py
@@ -15,7 +15,6 @@
 
 from hoomd.custom import (CustomOperation, _InternalCustomOperation, Action)
 from hoomd.operation import Updater
-import warnings
 
 
 class _UpdaterProperty:
@@ -71,14 +70,3 @@ class _InternalCustomUpdater(_InternalCustomOperation, Updater):
     _cpp_list_name = 'updaters'
     _cpp_class_name = 'PythonUpdater'
     _operation_func = "update"
-
-    def update(self, timestep):
-        return self._action.act(timestep)
-        """
-        .. deprecated:: 4.5.0
-
-            Use `Simulation` to call the operation.
-        """
-        warnings.warn(
-            "`_InternalCustomUpdater.update` is deprecated,"
-            "use `Simulation` to call the operation.", FutureWarning)

--- a/hoomd/write/custom_writer.py
+++ b/hoomd/write/custom_writer.py
@@ -15,7 +15,6 @@
 
 from hoomd.custom import (CustomOperation, _InternalCustomOperation, Action)
 from hoomd.operation import Writer
-import warnings
 
 
 class _WriterProperty:
@@ -72,14 +71,3 @@ class _InternalCustomWriter(_InternalCustomOperation, Writer):
     _cpp_list_name = 'analyzers'
     _cpp_class_name = 'PythonAnalyzer'
     _operation_func = "write"
-
-    def write(self, timestep):
-        return self._action.act(timestep)
-        """
-        .. deprecated:: 4.5.0
-
-            Use `Simulation` to call the operation.
-        """
-        warnings.warn(
-            "`_InternalCustomWriter.write` is deprecated,"
-            "use `Simulation` to call the operation.", FutureWarning)

--- a/hoomd/write/hdf5.py
+++ b/hoomd/write/hdf5.py
@@ -37,7 +37,6 @@ import hoomd.util as util
 
 from hoomd.write.custom_writer import _InternalCustomWriter
 from hoomd.data.parameterdicts import ParameterDict
-import warnings
 
 try:
     import h5py
@@ -331,31 +330,6 @@ class HDF5Log(_InternalCustomWriter):
     """
     _internal_class = _HDF5LogInternal
     _wrap_methods = ("flush",)
-
-    def write(self, timestep=None):
-        """Write out data to the HDF5 file.
-
-        Writes out a frame at the current timestep from the composed logger.
-
-        Warning:
-            This may not be able to write out quantities which require the
-            pressure tensor, rotational kinetic energy, or external field
-            virial.
-
-        .. rubric:: Example:
-
-        .. code-block:: python
-
-            hdf5_writer.write()
-
-        .. deprecated:: 4.5.0
-
-            Use `Simulation` to call the operation.
-        """
-        warnings.warn(
-            "`HDF5Log.writer` is deprecated,"
-            "use `Simulation` to call the operation.", FutureWarning)
-        self._action.act(timestep)
 
 
 __all__ = ["HDF5Log"]

--- a/sphinx-doc/migrating.rst
+++ b/sphinx-doc/migrating.rst
@@ -4,6 +4,20 @@
 Migrating to the latest version
 ===============================
 
+Migrating to HOOMD v5
+---------------------
+
+Removed functionalities
+^^^^^^^^^^^^^^^^^^^^^^^
+
+HOOMD-blue v5 removes functionalities deprecated in v4.x releases:
+
+* ``_InternalCustomUpdater.update`` 
+* ``_InternalCustomTuner.tune``
+* ``_InternalCustomWriter.write``
+* ``HDF5Log.write``
+
+
 Migrating to HOOMD v4
 ---------------------
 

--- a/sphinx-doc/migrating.rst
+++ b/sphinx-doc/migrating.rst
@@ -12,7 +12,7 @@ Removed functionalities
 
 HOOMD-blue v5 removes functionalities deprecated in v4.x releases:
 
-* ``_InternalCustomUpdater.update`` 
+* ``_InternalCustomUpdater.update``
 * ``_InternalCustomTuner.tune``
 * ``_InternalCustomWriter.write``
 * ``HDF5Log.write``


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should be based on *trunk-patch*. -->
<!-- Backwards compatible new features should be based on *trunk-minor*. -->
<!-- Incompatible API changes should be based on *trunk-major*. -->

## Description

Removed the following methods in a branch off `trunk-major` after adding deprecation warnings in #1692 
* `_InternalCustomUpdater.update`.
* `_InternalCustomTuner.tune`.
* `_InternalCustomWriter.write`.
* `HDF5Log.write`.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves #1648 

## How has this been tested?

Ran python tests on all the hoomd files, removed the wrap action act method in `custom_operation.py` to avoid the test calling the operation function and introduce error. 

## Change log 
```
Removed:

* ``_InternalCustomUpdater.update``.
  (`#1699 <https://github.com/glotzerlab/hoomd-blue/pull/1699>`__).
* ``_InternalCustomTuner.tune``.
  (`#1699 <https://github.com/glotzerlab/hoomd-blue/pull/1699>`__).  
* ``_InternalCustomWriter.write``.
  (`#1699 <https://github.com/glotzerlab/hoomd-blue/pull/1699>`__).
* ``HDF5Log.write``.
  (`#1699 <https://github.com/glotzerlab/hoomd-blue/pull/1699>`__).

```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
