### PR TITLE
Deprecate the single-process multi-gpu code path.

### DIFF
--- a/hoomd/device.py
+++ b/hoomd/device.py
@@ -40,6 +40,7 @@ See Also:
 import contextlib
 import hoomd
 from hoomd import _hoomd
+import warnings
 
 
 class NoticeFile:
@@ -214,8 +215,23 @@ class Device:
 
     @property
     def devices(self):
-        """list[str]: Descriptions of the active hardware devices."""
+        """list[str]: Descriptions of the active hardware devices.
+
+        .. deprecated:: 4.5.0
+
+            Use `device`.
+        """
+        warnings.warn(
+            "devices is deprecated, use device.", FutureWarning,
+            stacklevel=2)
+
         return self._cpp_exec_conf.getActiveDevices()
+
+    @property
+    def device(self):
+        """str: Descriptions of the active hardware device.
+        """
+        return self._cpp_exec_conf.getActiveDevices()[0]
 
     @property
     def num_cpu_threads(self):
@@ -285,6 +301,10 @@ class GPU(Device):
         gpu_ids (list[int]): List of GPU ids to use. Set to `None` to let the
             driver auto-select a GPU.
 
+            .. deprecated:: 4.5.0
+
+                Use ``gpu_id``.
+
         num_cpu_threads (int): Number of TBB threads. Set to `None` to
             auto-select.
 
@@ -297,23 +317,26 @@ class GPU(Device):
 
         notice_level (int): Minimum level of messages to print.
 
+        gpu_id (int): GPU id to use. Set to `None` to let the driver auto-select
+            a GPU.
+
     Tip:
         Call `GPU.get_available_devices` to get a human readable list of
-        devices. ``gpu_ids = [0]`` will select the first device in this list,
-        ``[1]`` will select the second, and so on.
+        devices. ``gpu_id = 0`` will select the first device in this list,
+        ``1`` will select the second, and so on.
 
         The ordering of the devices is determined by the GPU driver and runtime.
 
     .. rubric:: Device auto-selection
 
-    When ``gpu_ids`` is `None`, HOOMD will ask the GPU driver to auto-select a
+    When ``gpu_id`` is `None`, HOOMD will ask the GPU driver to auto-select a
     GPU. In most cases, this will select device 0. When all devices are set to a
     compute exclusive mode, the driver will choose a free GPU.
 
     .. rubric:: MPI
 
     In MPI execution environments, create a `GPU` device on every rank. When
-    ``gpu_ids`` is left `None`, HOOMD will attempt to detect the MPI local rank
+    ``gpu_id`` is left `None`, HOOMD will attempt to detect the MPI local rank
     environment and choose an appropriate GPU with ``id = local_rank %
     num_capable_gpus``. Set `notice_level` to 3 to see status messages from this
     process. Override this auto-selection by providing appropriate device ids on
@@ -323,6 +346,10 @@ class GPU(Device):
 
     Specify a list of GPUs to ``gpu_ids`` to activate a single-process multi-GPU
     code path.
+
+    .. deprecated:: 4.5.0
+
+        Use MPI.
 
     Note:
         Not all features are optimized to use this code path, and it requires
@@ -346,12 +373,23 @@ class GPU(Device):
         communicator=None,
         message_filename=None,
         notice_level=2,
+        gpu_id=None,
     ):
 
         super().__init__(communicator, notice_level, message_filename)
 
-        if gpu_ids is None:
+        if gpu_ids is not None:
+            warnings.warn(
+                "gpu_ids is deprecated, use gpu_id.", FutureWarning,
+                stacklevel=2)
+
+        if gpu_ids is not None and gpu_id is not None:
+            raise ValueError("Set either gpu_id or gpu_ids, not both.")
+
+        if gpu_id is None:
             gpu_ids = []
+        else:
+            gpu_ids = [gpu_id]
 
         # convert None options to defaults
         self._cpp_exec_conf = _hoomd.ExecutionConfiguration(

--- a/hoomd/device.py
+++ b/hoomd/device.py
@@ -221,16 +221,15 @@ class Device:
 
             Use `device`.
         """
-        warnings.warn(
-            "devices is deprecated, use device.", FutureWarning,
-            stacklevel=2)
+        warnings.warn("devices is deprecated, use device.",
+                      FutureWarning,
+                      stacklevel=2)
 
         return self._cpp_exec_conf.getActiveDevices()
 
     @property
     def device(self):
-        """str: Descriptions of the active hardware device.
-        """
+        """str: Descriptions of the active hardware device."""
         return self._cpp_exec_conf.getActiveDevices()[0]
 
     @property
@@ -379,9 +378,9 @@ class GPU(Device):
         super().__init__(communicator, notice_level, message_filename)
 
         if gpu_ids is not None:
-            warnings.warn(
-                "gpu_ids is deprecated, use gpu_id.", FutureWarning,
-                stacklevel=2)
+            warnings.warn("gpu_ids is deprecated, use gpu_id.",
+                          FutureWarning,
+                          stacklevel=2)
 
         if gpu_ids is not None and gpu_id is not None:
             raise ValueError("Set either gpu_id or gpu_ids, not both.")

--- a/hoomd/pytest/test_device.py
+++ b/hoomd/pytest/test_device.py
@@ -62,6 +62,7 @@ def test_gpu_specific_properties(device):
 
     # make sure we can give a list of GPU ids to the constructor
     hoomd.device.GPU(gpu_ids=[0])
+    hoomd.device.GPU(gpu_id=0)
 
     c = device.compute_capability
     assert type(c) is tuple

--- a/sphinx-doc/deprecated.rst
+++ b/sphinx-doc/deprecated.rst
@@ -42,8 +42,8 @@ documentation for more information on warning filters.
 * Single-process multi-GPU code path (since 4.5.0)
 * ``gpu_ids`` argument to ``GPU`` (since 4.5.0)
 
-    * Use ``gpu_id``.
+  * Use ``gpu_id``.
 
 * ``GPU.devices`` (since 4.5.0)
 
-    * Use ``device``.
+  * Use ``device``.

--- a/sphinx-doc/deprecated.rst
+++ b/sphinx-doc/deprecated.rst
@@ -39,3 +39,11 @@ documentation for more information on warning filters.
 * ``_InternalCustomTuner.tune`` (since 4.5.0)
 * ``_InternalCustomWriter.write`` (since 4.5.0)
 * ``HDF5Log.write`` (since 4.5.0)
+* Single-process multi-GPU code path (since 4.5.0)
+* ``gpu_ids`` argument to ``GPU`` (since 4.5.0)
+
+    * Use ``gpu_id``.
+
+* ``GPU.devices`` (since 4.5.0)
+
+    * Use ``device``.


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should be based on *trunk-patch*. -->
<!-- Backwards compatible new features should be based on *trunk-minor*. -->
<!-- Incompatible API changes should be based on *trunk-major*. -->

## Description

<!-- Describe your changes in detail. -->
In `GPU`:
* Deprecate `gpu_ids` and replace with `gpu_id`.
* Deprecate `devices` and replace with `device`.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Multi-GPU was specifically designed for Summit, which will be retired soon. No other current HPC systems provide the high bandwidth interconnects needed. MPI parallelization is effective in more cases.

See also #1644.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
I added a unit test for `gpu_id`. I manually checked the deprecation warning and the error condition when users provide both arguments.

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
Deprecated:

* Single-process multi-gpu code path
  (`#1706 <https://github.com/glotzerlab/hoomd-blue/pull/1706>`__)..
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
