### PR TITLE
Remove GPUNotAvailableError from util

### DIFF
--- a/hoomd/util.py
+++ b/hoomd/util.py
@@ -6,7 +6,6 @@
 import hoomd
 import io
 from collections.abc import Iterable, Mapping, MutableMapping
-from hoomd.error import GPUNotAvailableError  # noqa: F401
 
 
 def _to_camel_case(string):


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should be based on *trunk-patch*. -->
<!-- Backwards compatible new features should be based on *trunk-minor*. -->
<!-- Incompatible API changes should be based on *trunk-major*. -->

## Description

Removed `util.GPUNotAvailableError` after #1694 was merged

## Motivation and context

Resolves #1649 

## How has this been tested?

Existing python tests

## Change log

<!-- Propose a change log entry. -->
```
Deprecated:

* ``hoomd.util.GPUNotAvailableError``
  (`#1694 <https://github.com/glotzerlab/hoomd-blue/pull/1694>`__).
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
