### PR TITLE
Fixed QuickCompress logic when changing box tilts

### DIFF
--- a/hoomd/hpmc/UpdaterQuickCompress.cc
+++ b/hoomd/hpmc/UpdaterQuickCompress.cc
@@ -3,6 +3,7 @@
 
 #include "UpdaterQuickCompress.h"
 #include "hoomd/RNGIdentifiers.h"
+#include <cmath>
 
 namespace hoomd
     {
@@ -111,7 +112,7 @@ void UpdaterQuickCompress::performBoxScale(uint64_t timestep)
 
     @returns The scaled value.
 */
-static inline double scaleValue(double current, double target, double s)
+static inline double scaleLength(double current, double target, double s)
     {
     assert(s <= 1.0);
     if (target < current)
@@ -121,6 +122,20 @@ static inline double scaleValue(double current, double target, double s)
     else
         {
         return std::min(target, current * 1.0 / s);
+        }
+    }
+
+static inline double scaleTilt(double current, double target, double s)
+    {
+    assert(s <= 1.0);
+    double scaled_value = current + (1.0 - s) * target;
+    if (target < current)
+        {
+        return std::min(scaled_value, target);
+        }
+    else
+        {
+        return std::max(scaled_value, target);
         }
     }
 
@@ -157,7 +172,6 @@ BoxDim UpdaterQuickCompress::getNewBox(uint64_t timestep)
     hoomd::UniformDistribution<double> uniform(min_scale, 1.0);
     double scale = uniform(rng);
 
-    // TODO: This slow. We will implement a general reusable fix later in #705
     const auto& target_box = *m_target_box;
 
     // construct the scaled box
@@ -166,18 +180,18 @@ BoxDim UpdaterQuickCompress::getNewBox(uint64_t timestep)
     Scalar new_xy, new_xz, new_yz;
     if (m_sysdef->getNDimensions() == 3)
         {
-        new_L.x = scaleValue(current_box.getL().x, target_box.getL().x, scale);
-        new_L.y = scaleValue(current_box.getL().y, target_box.getL().y, scale);
-        new_L.z = scaleValue(current_box.getL().z, target_box.getL().z, scale);
-        new_xy = scaleValue(current_box.getTiltFactorXY(), target_box.getTiltFactorXY(), scale);
-        new_xz = scaleValue(current_box.getTiltFactorXZ(), target_box.getTiltFactorXZ(), scale);
-        new_yz = scaleValue(current_box.getTiltFactorYZ(), target_box.getTiltFactorYZ(), scale);
+        new_L.x = scaleLength(current_box.getL().x, target_box.getL().x, scale);
+        new_L.y = scaleLength(current_box.getL().y, target_box.getL().y, scale);
+        new_L.z = scaleLength(current_box.getL().z, target_box.getL().z, scale);
+        new_xy = scaleTilt(current_box.getTiltFactorXY(), target_box.getTiltFactorXY(), scale);
+        new_xz = scaleTilt(current_box.getTiltFactorXZ(), target_box.getTiltFactorXZ(), scale);
+        new_yz = scaleTilt(current_box.getTiltFactorYZ(), target_box.getTiltFactorYZ(), scale);
         }
     else
         {
-        new_L.x = scaleValue(current_box.getL().x, target_box.getL().x, scale);
-        new_L.y = scaleValue(current_box.getL().y, target_box.getL().y, scale);
-        new_xy = scaleValue(current_box.getTiltFactorXY(), target_box.getTiltFactorXY(), scale);
+        new_L.x = scaleLength(current_box.getL().x, target_box.getL().x, scale);
+        new_L.y = scaleLength(current_box.getL().y, target_box.getL().y, scale);
+        new_xy = scaleTilt(current_box.getTiltFactorXY(), target_box.getTiltFactorXY(), scale);
 
         // assume that the unused fields in the 2D target box are valid
         new_L.z = target_box.getL().z;

--- a/hoomd/hpmc/pytest/test_quick_compress.py
+++ b/hoomd/hpmc/pytest/test_quick_compress.py
@@ -118,7 +118,7 @@ def test_valid_setattr_attached(attr, value, simulation_factory,
 def test_sphere_compression_triclinic(xy, xz, yz, phi, simulation_factory,
                                       lattice_snapshot_factory):
     """Test that QuickCompress can resize and reshape triclinic boxes."""
-    n = 3
+    n = (3, 3, 4)
     snap = lattice_snapshot_factory(n=n, a=1.1)
     snap.configuration.box = hoomd.Box.from_box([10, 9, 8, xy, xz, yz])
 
@@ -127,7 +127,7 @@ def test_sphere_compression_triclinic(xy, xz, yz, phi, simulation_factory,
     target_box = hoomd.Box.from_box([0.95, 1.05, 1, *tilts])
 
     v_particle = 4 / 3 * math.pi * (0.5)**3
-    target_box.volume = n**3 * v_particle / phi
+    target_box.volume = np.prod(n) * v_particle / phi
 
     qc = hoomd.hpmc.update.QuickCompress(trigger=hoomd.trigger.Periodic(25),
                                          target_box=target_box)

--- a/hoomd/hpmc/pytest/test_quick_compress.py
+++ b/hoomd/hpmc/pytest/test_quick_compress.py
@@ -116,9 +116,10 @@ def test_valid_setattr_attached(attr, value, simulation_factory,
 @pytest.mark.parametrize("phi", [0.01, 0.4, 0.6])
 @pytest.mark.validate
 def test_sphere_compression_triclinic(xy, xz, yz, phi, simulation_factory,
-                                      lattice_snapshot_factory):
+                                      lattice_snapshot_factory, device):
     """Test that QuickCompress can resize and reshape triclinic boxes."""
-    n = (5, 5, 5)
+    n = 6 if device.communicator.num_ranks > 1 else 3
+
     snap = lattice_snapshot_factory(n=n, a=1.1)
     snap.configuration.box = hoomd.Box.from_box([10, 9, 8, xy, xz, yz])
 
@@ -127,7 +128,7 @@ def test_sphere_compression_triclinic(xy, xz, yz, phi, simulation_factory,
     target_box = hoomd.Box.from_box([0.95, 1.05, 1, *tilts])
 
     v_particle = 4 / 3 * math.pi * (0.5)**3
-    target_box.volume = np.prod(n) * v_particle / phi
+    target_box.volume = n**3 * v_particle / phi
 
     qc = hoomd.hpmc.update.QuickCompress(trigger=hoomd.trigger.Periodic(25),
                                          target_box=target_box)

--- a/hoomd/hpmc/pytest/test_quick_compress.py
+++ b/hoomd/hpmc/pytest/test_quick_compress.py
@@ -118,7 +118,7 @@ def test_valid_setattr_attached(attr, value, simulation_factory,
 def test_sphere_compression_triclinic(xy, xz, yz, phi, simulation_factory,
                                       lattice_snapshot_factory):
     """Test that QuickCompress can resize and reshape triclinic boxes."""
-    n = (3, 3, 4)
+    n = (4, 4, 4)
     snap = lattice_snapshot_factory(n=n, a=1.1)
     snap.configuration.box = hoomd.Box.from_box([10, 9, 8, xy, xz, yz])
 

--- a/hoomd/hpmc/pytest/test_quick_compress.py
+++ b/hoomd/hpmc/pytest/test_quick_compress.py
@@ -121,7 +121,7 @@ def test_sphere_compression_triclinic(xy, xz, yz, phi, simulation_factory,
     n = 7 if device.communicator.num_ranks > 1 else 3
 
     snap = lattice_snapshot_factory(n=n, a=1.1)
-    snap.configuration.box = hoomd.Box.from_box([11, 10, 9, xy, xz, yz])
+    snap.configuration.box = hoomd.Box.from_box([14, 13, 12, xy, xz, yz])
 
     # Generate random tilts in [-1,1] and apply to the target box
     tilts = np.random.rand(3) * 2 - 1

--- a/hoomd/hpmc/pytest/test_quick_compress.py
+++ b/hoomd/hpmc/pytest/test_quick_compress.py
@@ -118,7 +118,7 @@ def test_valid_setattr_attached(attr, value, simulation_factory,
 def test_sphere_compression_triclinic(xy, xz, yz, phi, simulation_factory,
                                       lattice_snapshot_factory):
     """Test that QuickCompress can resize and reshape triclinic boxes."""
-    n = (4, 4, 4)
+    n = (5, 5, 5)
     snap = lattice_snapshot_factory(n=n, a=1.1)
     snap.configuration.box = hoomd.Box.from_box([10, 9, 8, xy, xz, yz])
 

--- a/hoomd/hpmc/pytest/test_quick_compress.py
+++ b/hoomd/hpmc/pytest/test_quick_compress.py
@@ -119,9 +119,11 @@ def test_sphere_compression_triclinic(xy, xz, yz, phi, simulation_factory,
                                       lattice_snapshot_factory, device):
     """Test that QuickCompress can resize and reshape triclinic boxes."""
     n = 7 if device.communicator.num_ranks > 1 else 3
+    if isinstance(device, hoomd.device.GPU):
+        n = 8  # Increase simulation size even further to accomodate GPU
 
     snap = lattice_snapshot_factory(n=n, a=1.1)
-    snap.configuration.box = hoomd.Box.from_box([14, 13, 12, xy, xz, yz])
+    snap.configuration.box = hoomd.Box.from_box([15, 14, 13, xy, xz, yz])
 
     # Generate random tilts in [-1,1] and apply to the target box
     tilts = np.random.rand(3) * 2 - 1

--- a/hoomd/hpmc/pytest/test_quick_compress.py
+++ b/hoomd/hpmc/pytest/test_quick_compress.py
@@ -114,6 +114,7 @@ def test_valid_setattr_attached(attr, value, simulation_factory,
 @pytest.mark.parametrize("xz", [-0.3, 0, 0.3])
 @pytest.mark.parametrize("yz", [-0.2, 0, 0.4])
 @pytest.mark.parametrize("phi", [0.01, 0.4, 0.6])
+pytest.mark.cpu
 @pytest.mark.validate
 def test_sphere_compression_triclinic(xy, xz, yz, phi, simulation_factory,
                                       lattice_snapshot_factory, device):

--- a/hoomd/hpmc/pytest/test_quick_compress.py
+++ b/hoomd/hpmc/pytest/test_quick_compress.py
@@ -114,7 +114,7 @@ def test_valid_setattr_attached(attr, value, simulation_factory,
 @pytest.mark.parametrize("xz", [-0.3, 0, 0.3])
 @pytest.mark.parametrize("yz", [-0.2, 0, 0.4])
 @pytest.mark.parametrize("phi", [0.01, 0.4, 0.6])
-pytest.mark.cpu
+@pytest.mark.cpu
 @pytest.mark.validate
 def test_sphere_compression_triclinic(xy, xz, yz, phi, simulation_factory,
                                       lattice_snapshot_factory, device):

--- a/hoomd/hpmc/pytest/test_quick_compress.py
+++ b/hoomd/hpmc/pytest/test_quick_compress.py
@@ -123,7 +123,7 @@ def test_sphere_compression_triclinic(xy, xz, yz, phi, simulation_factory,
         n = 8  # Increase simulation size even further to accomodate GPU
 
     snap = lattice_snapshot_factory(n=n, a=1.1)
-    snap.configuration.box = hoomd.Box.from_box([15, 14, 13, xy, xz, yz])
+    snap.configuration.box = hoomd.Box.from_box([20, 18, 16, xy, xz, yz])
 
     # Generate random tilts in [-1,1] and apply to the target box
     tilts = np.random.rand(3) * 2 - 1

--- a/hoomd/hpmc/pytest/test_quick_compress.py
+++ b/hoomd/hpmc/pytest/test_quick_compress.py
@@ -121,7 +121,7 @@ def test_sphere_compression_triclinic(xy, xz, yz, phi, simulation_factory,
     n = 6 if device.communicator.num_ranks > 1 else 3
 
     snap = lattice_snapshot_factory(n=n, a=1.1)
-    snap.configuration.box = hoomd.Box.from_box([10, 9, 8, xy, xz, yz])
+    snap.configuration.box = hoomd.Box.from_box([11, 10, 9, xy, xz, yz])
 
     # Generate random tilts in [-1,1] and apply to the target box
     tilts = np.random.rand(3) * 2 - 1

--- a/hoomd/hpmc/pytest/test_quick_compress.py
+++ b/hoomd/hpmc/pytest/test_quick_compress.py
@@ -118,7 +118,7 @@ def test_valid_setattr_attached(attr, value, simulation_factory,
 def test_sphere_compression_triclinic(xy, xz, yz, phi, simulation_factory,
                                       lattice_snapshot_factory, device):
     """Test that QuickCompress can resize and reshape triclinic boxes."""
-    n = 6 if device.communicator.num_ranks > 1 else 3
+    n = 7 if device.communicator.num_ranks > 1 else 3
 
     snap = lattice_snapshot_factory(n=n, a=1.1)
     snap.configuration.box = hoomd.Box.from_box([11, 10, 9, xy, xz, yz])

--- a/hoomd/hpmc/pytest/test_quick_compress.py
+++ b/hoomd/hpmc/pytest/test_quick_compress.py
@@ -150,8 +150,8 @@ def test_sphere_compression_triclinic(xy, xz, yz, phi, simulation_factory,
         sim.run(100)
 
     # Check that compression is complete and debug which statement is incorrect
+    assert sim.state.box == target_box, f"{sim.state.box}!={target_box}"
     assert mc.overlaps == 0
-    assert sim.state.box == target_box
     assert qc.complete
 
 


### PR DESCRIPTION
## Description

`QuickCompress` sometimes fails when reshaping a box, especially when tilt factors are less than or equal to zero. The additional logic provided in this PR addresses this issue.


## Motivation and context

Prior to this change, attempting to use `QuickCompress` in a few uncommon scenarios would result in incorrect behavior. The following box tilt factor changes now function properly:

`[0,0,0]` → `[xy,xz,yz]!=0`
`[xy,xz,yz]!=0` → `[0,0,0]`

`[xy,xz,yz] < 0` → `[xy,xz,yz]`
`[xy,xz,yz]`  → `[xy,xz,yz] < 0`


Resolves #1700 

## How has this been tested?

Additional testing has been added through in `test_quick_compress::test_quick_compression_triclinic`. This is a validate flagged test, as it tests many cases.

## Change log

```
`QuickCompress` can now reshape boxes with tilt factors <= 0.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
