### PR TITLE
Consider Walls when inserting or removing particles for the MuVT updater

### DIFF
--- a/hoomd/hpmc/ExternalField.h
+++ b/hoomd/hpmc/ExternalField.h
@@ -39,6 +39,25 @@ class ExternalField : public Compute
         return 0;
         }
 
+    //! Evaluate the energy of the force.
+    /*! \param box The system box.
+        \param type Particle type.
+        \param r_i Particle position
+        \param q_i Particle orientation.
+        \param diameter Particle diameter.
+        \param charge Particle charge.
+        \returns Energy due to the force
+    */
+    virtual float energy(const BoxDim& box,
+                         unsigned int type,
+                         const vec3<Scalar>& r_i,
+                         const quat<Scalar>& q_i,
+                         Scalar diameter,
+                         Scalar charge)
+        {
+        return 0;
+        }
+
     virtual bool hasVolume()
         {
         return false;
@@ -88,6 +107,7 @@ template<class Shape> void export_ExternalFieldInterface(pybind11::module& m, st
         .def(pybind11::init<std::shared_ptr<SystemDefinition>>())
         .def("compute", &ExternalFieldMono<Shape>::compute)
         .def("energydiff", &ExternalFieldMono<Shape>::energydiff)
+        .def("energy", &ExternalFieldMono<Shape>::energy)
         .def("calculateDeltaE", &ExternalFieldMono<Shape>::calculateDeltaE);
     }
 

--- a/hoomd/hpmc/ExternalFieldJIT.h
+++ b/hoomd/hpmc/ExternalFieldJIT.h
@@ -283,7 +283,8 @@ template<class Shape> void export_ExternalFieldJIT(pybind11::module& m, std::str
                             const std::vector<std::string>&,
                             pybind11::array_t<float>>())
         .def("computeEnergy", &ExternalFieldJIT<Shape>::computeEnergy)
-        .def_property_readonly("param_array", &ExternalFieldJIT<Shape>::getParamArray);
+        .def_property_readonly("param_array", &ExternalFieldJIT<Shape>::getParamArray)
+        .def("energy", &ExternalFieldJIT::energy);
     }
 
     }  // end namespace hpmc

--- a/hoomd/hpmc/ExternalFieldJIT.h
+++ b/hoomd/hpmc/ExternalFieldJIT.h
@@ -283,8 +283,7 @@ template<class Shape> void export_ExternalFieldJIT(pybind11::module& m, std::str
                             const std::vector<std::string>&,
                             pybind11::array_t<float>>())
         .def("computeEnergy", &ExternalFieldJIT<Shape>::computeEnergy)
-        .def_property_readonly("param_array", &ExternalFieldJIT<Shape>::getParamArray)
-        .def("energy", &ExternalFieldJIT::energy);
+        .def_property_readonly("param_array", &ExternalFieldJIT<Shape>::getParamArray);
     }
 
     }  // end namespace hpmc

--- a/hoomd/hpmc/ExternalFieldJIT.h
+++ b/hoomd/hpmc/ExternalFieldJIT.h
@@ -66,6 +66,16 @@ template<class Shape> class ExternalFieldJIT : public hpmc::ExternalFieldMono<Sh
         m_factory = std::shared_ptr<ExternalFieldEvalFactory>(factory);
         }
 
+    float energy_no_wrap(const BoxDim& box,
+                         unsigned int type,
+                         const vec3<Scalar>& r_i,
+                         const quat<Scalar>& q_i,
+                         Scalar diameter,
+                         Scalar charge)
+        {
+        return m_eval(box, type, r_i, q_i, diameter, charge);
+        }
+
     //! Evaluate the energy of the force.
     /*! \param box The system box.
         \param type Particle type.
@@ -82,7 +92,10 @@ template<class Shape> class ExternalFieldJIT : public hpmc::ExternalFieldMono<Sh
                          Scalar diameter,
                          Scalar charge)
         {
-        return m_eval(box, type, r_i, q_i, diameter, charge);
+        vec3<Scalar> r_i_wrapped = r_i - vec3<Scalar>(this->m_pdata->getOrigin());
+        int3 image = make_int3(0, 0, 0);
+        box.wrap(r_i_wrapped, image);
+        return energy_no_wrap(box, type, r_i_wrapped, q_i, diameter, charge);
         }
 
     //! Computes the total field energy of the system at the current state
@@ -109,13 +122,10 @@ template<class Shape> class ExternalFieldJIT : public hpmc::ExternalFieldMono<Sh
             // read in the current position and orientation
             Scalar4 postype_i = h_postype.data[i];
             unsigned int typ_i = __scalar_as_int(postype_i.w);
-            vec3<Scalar> pos_i = vec3<Scalar>(postype_i) - vec3<Scalar>(this->m_pdata->getOrigin());
-            int3 image = make_int3(0, 0, 0);
-            box.wrap(pos_i, image);
 
             total_energy += energy(box,
                                    typ_i,
-                                   pos_i,
+                                   vec3<Scalar>(postype_i),
                                    quat<Scalar>(h_orientation.data[i]),
                                    h_diameter.data[i],
                                    h_charge.data[i]);
@@ -171,23 +181,20 @@ template<class Shape> class ExternalFieldJIT : public hpmc::ExternalFieldMono<Sh
             Scalar4 postype_i = h_postype.data[i];
             unsigned int typ_i = __scalar_as_int(postype_i.w);
             int3 image = make_int3(0, 0, 0);
-            vec3<Scalar> pos_i = vec3<Scalar>(postype_i) - vec3<Scalar>(this->m_pdata->getOrigin());
-            box_new.wrap(pos_i, image);
-            image = make_int3(0, 0, 0);
             vec3<Scalar> old_pos_i = vec3<Scalar>(*(position_old + i)) - vec3<Scalar>(origin_old);
             box_old.wrap(old_pos_i, image);
             dE += energy(box_new,
                          typ_i,
-                         pos_i,
+                         vec3<Scalar>(postype_i),
                          quat<Scalar>(h_orientation.data[i]),
                          h_diameter.data[i],
                          h_charge.data[i]);
-            dE -= energy(box_old,
-                         typ_i,
-                         old_pos_i,
-                         quat<Scalar>(*(orientation_old + i)),
-                         h_diameter.data[i],
-                         h_charge.data[i]);
+            dE -= energy_no_wrap(box_old,
+                                 typ_i,
+                                 old_pos_i,
+                                 quat<Scalar>(*(orientation_old + i)),
+                                 h_diameter.data[i],
+                                 h_charge.data[i]);
             }
 #ifdef ENABLE_MPI
         if (this->m_sysdef->isDomainDecomposed())
@@ -223,24 +230,17 @@ template<class Shape> class ExternalFieldJIT : public hpmc::ExternalFieldMono<Sh
         ArrayHandle<Scalar> h_charge(this->m_pdata->getCharges(),
                                      access_location::host,
                                      access_mode::read);
-        const BoxDim box = this->m_pdata->getGlobalBox();
-        int3 image = make_int3(0, 0, 0);
-        vec3<Scalar> pos_new_shifted = position_new - vec3<Scalar>(this->m_pdata->getOrigin());
-        vec3<Scalar> pos_old_shifted = position_old - vec3<Scalar>(this->m_pdata->getOrigin());
-        box.wrap(pos_new_shifted, image);
-        image = make_int3(0, 0, 0);
-        box.wrap(pos_old_shifted, image);
 
         double dE = 0.0;
         dE += energy(this->m_pdata->getGlobalBox(),
                      typ_i,
-                     pos_new_shifted,
+                     position_new,
                      shape_new.orientation,
                      h_diameter.data[index],
                      h_charge.data[index]);
         dE -= energy(this->m_pdata->getGlobalBox(),
                      typ_i,
-                     pos_old_shifted,
+                     position_old,
                      shape_old.orientation,
                      h_diameter.data[index],
                      h_charge.data[index]);

--- a/hoomd/hpmc/PatchEnergyJIT.cc
+++ b/hoomd/hpmc/PatchEnergyJIT.cc
@@ -69,7 +69,6 @@ void export_PatchEnergyJIT(pybind11::module& m)
                             Scalar,
                             pybind11::array_t<float>>())
         .def_property("r_cut", &PatchEnergyJIT::getRCut, &PatchEnergyJIT::setRCut)
-        .def("energy", &PatchEnergyJIT::energy)
         .def_property_readonly("param_array", &PatchEnergyJIT::getParamArray);
     }
 

--- a/hoomd/hpmc/PatchEnergyJIT.cc
+++ b/hoomd/hpmc/PatchEnergyJIT.cc
@@ -69,6 +69,7 @@ void export_PatchEnergyJIT(pybind11::module& m)
                             Scalar,
                             pybind11::array_t<float>>())
         .def_property("r_cut", &PatchEnergyJIT::getRCut, &PatchEnergyJIT::setRCut)
+        .def("energy", &PatchEnergyJIT::energy)
         .def_property_readonly("param_array", &PatchEnergyJIT::getParamArray);
     }
 

--- a/hoomd/hpmc/UpdaterMuVT.h
+++ b/hoomd/hpmc/UpdaterMuVT.h
@@ -1664,14 +1664,16 @@ bool UpdaterMuVT<Shape>::tryRemoveParticle(uint64_t timestep, unsigned int tag, 
             const BoxDim box = this->m_pdata->getGlobalBox();
             unsigned int type = this->m_pdata->getType(tag);
             quat<Scalar> orientation(m_pdata->getOrientation(tag));
+            Scalar diameter = m_pdata->getDiameter(tag);
+            Scalar charge = m_pdata->getCharge(tag);
             if (is_local)
                 {
                 lnboltzmann += field->energy(box,
                                              type,
                                              pos,
                                              quat<float>(orientation),
-                                             1.0, // diameter i
-                                             0.0  // charge i
+                                             float(diameter), // diameter i
+                                             float(charge)    // charge i
                 );
                 }
             }

--- a/hoomd/hpmc/UpdaterMuVT.h
+++ b/hoomd/hpmc/UpdaterMuVT.h
@@ -1911,6 +1911,9 @@ bool UpdaterMuVT<Shape>::tryInsertParticle(uint64_t timestep,
     // do we have to compute energetic contribution?
     auto patch = m_mc->getPatchEnergy();
 
+    // do we have to compute a wall contribution
+    auto field = m_mc->getExternalField();
+
     lnboltzmann = Scalar(0.0);
 
     unsigned int overlap = 0;
@@ -1944,6 +1947,18 @@ bool UpdaterMuVT<Shape>::tryInsertParticle(uint64_t timestep,
 
         ShortReal r_cut_patch(0.0);
         Scalar r_cut_self(0.0);
+
+        if (field)
+            {
+            const BoxDim box = this->m_pdata->getGlobalBox();
+            lnboltzmann -= field->energy(box,
+                                         type,
+                                         pos,
+                                         quat<float>(orientation),
+                                         1.0, // diameter i
+                                         0.0 // charge i
+            );
+            }
 
         if (patch)
             {

--- a/hoomd/hpmc/pytest/test_muvt.py
+++ b/hoomd/hpmc/pytest/test_muvt.py
@@ -11,19 +11,25 @@ import hoomd.hpmc.pytest.conftest
 # note: The parameterized tests validate parameters so we can't pass in values
 # here that require preprocessing
 valid_constructor_args = [
-    dict(trigger=hoomd.trigger.Periodic(10),
-         transfer_types=['A'],
-         max_volume_rescale=0.2,
-         volume_move_probability=0.5),
-    dict(trigger=hoomd.trigger.After(100), transfer_types=['A', 'B']),
+    dict(
+        trigger=hoomd.trigger.Periodic(10),
+        transfer_types=["A"],
+        max_volume_rescale=0.2,
+        volume_move_probability=0.5,
+    ),
+    dict(trigger=hoomd.trigger.After(100), transfer_types=["A", "B"]),
 ]
 
-valid_attrs = [('trigger', hoomd.trigger.Periodic(10000)),
-               ('trigger', hoomd.trigger.After(100)),
-               ('trigger', hoomd.trigger.Before(12345)),
-               ('volume_move_probability', 0.2), ('max_volume_rescale', 0.42),
-               ('transfer_types', ['A']), ('transfer_types', ['B']),
-               ('transfer_types', ['A', 'B'])]
+valid_attrs = [
+    ("trigger", hoomd.trigger.Periodic(10000)),
+    ("trigger", hoomd.trigger.After(100)),
+    ("trigger", hoomd.trigger.Before(12345)),
+    ("volume_move_probability", 0.2),
+    ("max_volume_rescale", 0.42),
+    ("transfer_types", ["A"]),
+    ("transfer_types", ["B"]),
+    ("transfer_types", ["A", "B"]),
+]
 
 
 @pytest.mark.serial
@@ -39,9 +45,13 @@ def test_valid_construction(device, constructor_args):
 
 @pytest.mark.serial
 @pytest.mark.parametrize("constructor_args", valid_constructor_args)
-def test_valid_construction_and_attach(device, simulation_factory,
-                                       two_particle_snapshot_factory,
-                                       constructor_args, valid_args):
+def test_valid_construction_and_attach(
+    device,
+    simulation_factory,
+    two_particle_snapshot_factory,
+    constructor_args,
+    valid_args,
+):
     """Test that MuVT can be attached with valid arguments."""
     integrator = valid_args[0]
     args = valid_args[1]
@@ -61,7 +71,7 @@ def test_valid_construction_and_attach(device, simulation_factory,
 
     muvt = hoomd.hpmc.update.MuVT(**constructor_args)
     sim = simulation_factory(
-        two_particle_snapshot_factory(particle_types=['A', 'B'],
+        two_particle_snapshot_factory(particle_types=["A", "B"],
                                       dimensions=n_dimensions,
                                       d=2,
                                       L=50))
@@ -80,7 +90,7 @@ def test_valid_construction_and_attach(device, simulation_factory,
 def test_valid_setattr(device, attr, value):
     """Test that MuVT can get and set attributes."""
     muvt = hoomd.hpmc.update.MuVT(trigger=hoomd.trigger.Periodic(10),
-                                  transfer_types=['A'])
+                                  transfer_types=["A"])
 
     setattr(muvt, attr, value)
     assert getattr(muvt, attr) == value
@@ -108,9 +118,9 @@ def test_valid_setattr_attached(device, attr, value, simulation_factory,
     mc.shape["B"] = args
 
     muvt = hoomd.hpmc.update.MuVT(trigger=hoomd.trigger.Periodic(10),
-                                  transfer_types=['A'])
+                                  transfer_types=["A"])
     sim = simulation_factory(
-        two_particle_snapshot_factory(particle_types=['A', 'B'],
+        two_particle_snapshot_factory(particle_types=["A", "B"],
                                       dimensions=n_dimensions,
                                       d=2,
                                       L=50))
@@ -122,68 +132,71 @@ def test_valid_setattr_attached(device, attr, value, simulation_factory,
     setattr(muvt, attr, value)
     assert getattr(muvt, attr) == value
 
+
 def test_insertion_removal(device, simulation_factory,
                            lattice_snapshot_factory):
     """Test that MuVT is able to insert and remove particles."""
     sim = simulation_factory(
-        lattice_snapshot_factory(particle_types=['A', 'B'],
+        lattice_snapshot_factory(particle_types=["A", "B"],
                                  dimensions=3,
                                  a=4,
                                  n=7,
                                  r=0.1))
 
     mc = hoomd.hpmc.integrate.Sphere(default_d=0.1, default_a=0.1)
-    mc.shape['A'] = dict(diameter=1.1)
-    mc.shape['B'] = dict(diameter=1.3)
+    mc.shape["A"] = dict(diameter=1.1)
+    mc.shape["B"] = dict(diameter=1.3)
     sim.operations.integrator = mc
 
     muvt = hoomd.hpmc.update.MuVT(trigger=hoomd.trigger.Periodic(5),
-                                  transfer_types=['B'])
+                                  transfer_types=["B"])
     sim.operations.updaters.append(muvt)
 
     sim.run(0)
 
     # we shouldn't have any particles of type B just yet
-    assert (muvt.N['B'] == 0)
+    assert muvt.N["B"] == 0
 
     # and no attempted moves
     assert sum(muvt.insert_moves) == 0
     assert sum(muvt.remove_moves) == 0
 
     # set a positive fugacity
-    muvt.fugacity['B'] = 1
+    muvt.fugacity["B"] = 1
 
     sim.run(20)
     assert sum(muvt.insert_moves) > 0
     assert sum(muvt.remove_moves) > 0
 
     # make a wild guess: there be B particles
-    assert (muvt.N['B'] > 0)
+    assert muvt.N["B"] > 0
 
-@pytest.mark.skipif(not hoomd.version.llvm_enabled, reason='LLVM not enabled')
+
+@pytest.mark.skipif(not hoomd.version.llvm_enabled, reason="LLVM not enabled")
 def test_jit_remove_insert(device, simulation_factory,
                            one_particle_snapshot_factory):
-    """Test that MuVT considers a cpp potential when removing particles by adding a high energy particles that should always be removed by the updater while inserting particles to the top of the box."""
+    """Test that MuVT considers cpp potential when removing/adding particles."""
     sim = simulation_factory(
-        one_particle_snapshot_factory(particle_types=['A'],
-                                 dimensions=3,
-                                 position=(0, 0, -5),
-                                 orientation=(1, 0, 0, 0),
-                                 L=20)
-                                    )
+        one_particle_snapshot_factory(
+            particle_types=["A"],
+            dimensions=3,
+            position=(-5, 0, 0),
+            orientation=(1, 0, 0, 0),
+            L=20,
+        ))
 
-    sphere_radius = 0.6 
+    sphere_radius = 0.6
     mc = hoomd.hpmc.integrate.Sphere(default_d=0.0, default_a=0.0)
-    mc.shape['A'] = dict(diameter=2*sphere_radius)
+    mc.shape["A"] = dict(diameter=2 * sphere_radius)
 
-    # code returns infinity if the particle center goes past the center of the box
+    # code returns infinity if the particle center goes past box center
 
-    center_wall = '''
-        if (r_i.z < 0. || r_i.z > box.getL().z/2)
+    center_wall = """
+        if (r_i.x < 0. || r_i.x > box.getL().x/2)
             return INFINITY;
         else
             return 0.0f;
-    '''
+    """
     cpp_external_potential = hoomd.hpmc.external.user.CPPExternalPotential(
         code=center_wall)
 
@@ -192,111 +205,143 @@ def test_jit_remove_insert(device, simulation_factory,
     sim.operations.integrator = mc
 
     muvt = hoomd.hpmc.update.MuVT(trigger=hoomd.trigger.Periodic(1),
-                                  transfer_types=['A'])
-    muvt.fugacity['A'] = 1e6 
+                                  transfer_types=["A"])
+    muvt.fugacity["A"] = 1e6
     sim.operations.updaters.append(muvt)
     sim.run(1000)
     snapshot = sim.state.get_snapshot()
-    pos = snapshot.particles.position
-    
+
+    if snapshot.communicator.rank == 0:
+
+        pos = snapshot.particles.position
+
+        # We should have added more than one particle to the box
+        assert len(pos) > 1
+
+        # insert to top of box and remove high energy bottom particle
+        assert numpy.min(pos[:, 0]) >= 0.0
+
     # We should have inserted particles successfully
     assert muvt.insert_moves[0] > 0
 
     # We should have successfully removed the high energy particle
     assert muvt.remove_moves[0] > 0
 
-    # We should have successfully inserted only to the top of the box and removed the high energy particle
-    assert  numpy.min(pos[:,2]) >= 0. 
-
-    # We should have added more than one particle to the box
-    assert  len(pos) > 1 
 
 def test_plane_wall_insertion(device, simulation_factory,
-                           one_particle_snapshot_factory):
+                              one_particle_snapshot_factory):
     """Test that MuVT considers a planar wall when inserting particles."""
     sim = simulation_factory(
-        one_particle_snapshot_factory(particle_types=['A'],
-                                 dimensions=3,
-                                 position=(0, 0, 5),
-                                 orientation=(1, 0, 0, 0),
-                                 L=20)
-                                    )
+        one_particle_snapshot_factory(
+            particle_types=["A"],
+            dimensions=3,
+            position=(0, 0, 5),
+            orientation=(1, 0, 0, 0),
+            L=20,
+        ))
 
-    sphere_radius = 0.6 
+    sphere_radius = 0.6
     mc = hoomd.hpmc.integrate.Sphere(default_d=0.0, default_a=0.0)
-    mc.shape['A'] = dict(diameter=2*sphere_radius)
-    walls = [hoomd.wall.Plane(origin=(0,0,0),normal=(0,0,1))]
+    mc.shape["A"] = dict(diameter=2 * sphere_radius)
+    walls = [hoomd.wall.Plane(origin=(0, 0, 0), normal=(0, 0, 1))]
     wall_potential = hoomd.hpmc.external.wall.WallPotential(walls)
     mc.external_potential = wall_potential
     sim.operations.integrator = mc
 
     muvt = hoomd.hpmc.update.MuVT(trigger=hoomd.trigger.Periodic(1),
-                                  transfer_types=['A'])
-    muvt.fugacity['A'] = 1000
+                                  transfer_types=["A"])
+    muvt.fugacity["A"] = 1000
     sim.operations.updaters.append(muvt)
     sim.run(300)
+
     snapshot = sim.state.get_snapshot()
-    pos = snapshot.particles.position
-    # Test if inserted spheres are above the plane 
-    assert  numpy.min(pos[:,2]) >= sphere_radius 
-    assert len(pos) > 1
+    if snapshot.communicator.rank == 0:
+        pos = snapshot.particles.position
+        # Test if inserted spheres are above the plane
+        assert numpy.min(pos[:, 2]) >= sphere_radius
+        assert len(pos) > 1
+
+    # We should have inserted particles successfully
+    assert muvt.insert_moves[0] > 0
+
+    # We should have successfully attempted some removes
+    assert sum(muvt.remove_moves) > 0
+
 
 def test_spherical_wall_insertion(device, simulation_factory,
-                           one_particle_snapshot_factory):
+                                  one_particle_snapshot_factory):
     """Test that MuVT considers a spherical wall when inserting particles."""
     sim = simulation_factory(
-        one_particle_snapshot_factory(particle_types=['A'],
-                                 dimensions=3,
-                                 position=(0, 0, 0),
-                                 orientation=(1, 0, 0, 0),
-                                 L=20)
-                                    )
+        one_particle_snapshot_factory(
+            particle_types=["A"],
+            dimensions=3,
+            position=(0, 0, 0),
+            orientation=(1, 0, 0, 0),
+            L=20,
+        ))
 
     mc = hoomd.hpmc.integrate.Sphere(default_d=0.1, default_a=0.1)
-    sphere_radius = 0.6 
-    mc.shape['A'] = dict(diameter=2*sphere_radius)
+    sphere_radius = 0.6
+    mc.shape["A"] = dict(diameter=2 * sphere_radius)
     walls = [hoomd.wall.Sphere(radius=5)]
     wall_potential = hoomd.hpmc.external.wall.WallPotential(walls)
     mc.external_potential = wall_potential
     sim.operations.integrator = mc
 
     muvt = hoomd.hpmc.update.MuVT(trigger=hoomd.trigger.Periodic(1),
-                                  transfer_types=['A'])
-    muvt.fugacity['A'] = 1000
+                                  transfer_types=["A"])
+    muvt.fugacity["A"] = 1000
     sim.operations.updaters.append(muvt)
     sim.run(300)
     snapshot = sim.state.get_snapshot()
-    pos = snapshot.particles.position
-    # Test if inserted spheres are inside the spherical wall
-    assert  numpy.max(numpy.linalg.norm(pos,axis=1))-sphere_radius <= 5 
-    assert len(pos) > 1
+    if snapshot.communicator.rank == 0:
+        pos = snapshot.particles.position
+        # Test if inserted spheres are inside the spherical wall
+        assert numpy.max(numpy.linalg.norm(pos, axis=1)) - sphere_radius <= 5
+        assert len(pos) > 1
+
+    # We should have inserted particles successfully
+    assert muvt.insert_moves[0] > 0
+
+    # We should have successfully attempted some removes
+    assert sum(muvt.remove_moves) > 0
+
 
 def test_cylindrical_wall_insertion(device, simulation_factory,
-                           one_particle_snapshot_factory):
+                                    one_particle_snapshot_factory):
     """Test that MuVT considers a cylindrical wall when inserting particles."""
     sim = simulation_factory(
-        one_particle_snapshot_factory(particle_types=['A'],
-                                 dimensions=3,
-                                 position=(0, 0, 0),
-                                 orientation=(1, 0, 0, 0),
-                                 L=20)
-                                    )
+        one_particle_snapshot_factory(
+            particle_types=["A"],
+            dimensions=3,
+            position=(0, 0, 0),
+            orientation=(1, 0, 0, 0),
+            L=20,
+        ))
 
-    sphere_radius = 0.6 
+    sphere_radius = 0.6
     mc = hoomd.hpmc.integrate.Sphere(default_d=0.0, default_a=0.0)
-    mc.shape['A'] = dict(diameter=2 * sphere_radius)
-    walls = [hoomd.wall.Cylinder(radius=5,axis=(0,0,1))]
+    mc.shape["A"] = dict(diameter=2 * sphere_radius)
+    walls = [hoomd.wall.Cylinder(radius=5, axis=(0, 0, 1))]
     wall_potential = hoomd.hpmc.external.wall.WallPotential(walls)
     mc.external_potential = wall_potential
     sim.operations.integrator = mc
 
     muvt = hoomd.hpmc.update.MuVT(trigger=hoomd.trigger.Periodic(1),
-                                  transfer_types=['A'])
-    muvt.fugacity['A'] = 1000
+                                  transfer_types=["A"])
+    muvt.fugacity["A"] = 1000
     sim.operations.updaters.append(muvt)
     sim.run(300)
     snapshot = sim.state.get_snapshot()
-    pos = snapshot.particles.position
-    # Test if inserted spheres are inside the cylinder wall
-    assert  numpy.max(numpy.linalg.norm(pos[:,:2],axis=1))-sphere_radius <= 5 
-    assert len(pos) > 1
+    if snapshot.communicator.rank == 0:
+        pos = snapshot.particles.position
+        # Test if inserted spheres are inside the cylinder wall
+        assert numpy.max(numpy.linalg.norm(pos[:, :2],
+                                           axis=1)) - sphere_radius <= 5
+        assert len(pos) > 1
+
+    # We should have inserted particles successfully
+    assert muvt.insert_moves[0] > 0
+
+    # We should have successfully attempted some removes
+    assert sum(muvt.remove_moves) > 0

--- a/hoomd/hpmc/pytest/test_muvt.py
+++ b/hoomd/hpmc/pytest/test_muvt.py
@@ -172,6 +172,7 @@ def test_insertion_removal(device, simulation_factory,
     assert muvt.N["B"] > 0
 
 
+@pytest.mark.cpu
 @pytest.mark.skipif(not hoomd.version.llvm_enabled, reason="LLVM not enabled")
 def test_jit_remove_insert(device, simulation_factory,
                            one_particle_snapshot_factory):
@@ -228,6 +229,7 @@ def test_jit_remove_insert(device, simulation_factory,
     assert muvt.remove_moves[0] > 0
 
 
+@pytest.mark.cpu
 def test_plane_wall_insertion(device, simulation_factory,
                               one_particle_snapshot_factory):
     """Test that MuVT considers a planar wall when inserting particles."""
@@ -268,6 +270,7 @@ def test_plane_wall_insertion(device, simulation_factory,
     assert sum(muvt.remove_moves) > 0
 
 
+@pytest.mark.cpu
 def test_spherical_wall_insertion(device, simulation_factory,
                                   one_particle_snapshot_factory):
     """Test that MuVT considers a spherical wall when inserting particles."""
@@ -307,6 +310,7 @@ def test_spherical_wall_insertion(device, simulation_factory,
     assert sum(muvt.remove_moves) > 0
 
 
+@pytest.mark.cpu
 def test_cylindrical_wall_insertion(device, simulation_factory,
                                     one_particle_snapshot_factory):
     """Test that MuVT considers a cylindrical wall when inserting particles."""


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should be based on *trunk-patch*. -->
<!-- Backwards compatible new features should be based on *trunk-minor*. -->
<!-- Incompatible API changes should be based on *trunk-major*. -->

## Description

<!-- Describe your changes in detail. -->

Changes to the MuVT updater to calculate the energy of a particle insertion or removal for both hard walls and CPP potential field. 

Required implementation of an energy function for hard walls that checks if an inserted particle overlaps with the walls, and returns infinity. 

Required adding energy contributed by the wall to change in energy from inserting or removing a particle from the system. 

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

This solves the issue that hoomd does not consider walls when adding or removing particles in MuVT. Before this bug fix this means that when walls are added in a MuVT system, particles can be inserted intside the walls of the system where insertions should not be allowed or be otherwise highly energetically unfavoable in the case of jit. 

<!-- Replace ??? with the issue number that this pull request resolves. -->


## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
I indepentently tested each hard wall geometry available in hoomd (sphere, cylinder, and plane) by starting with a single sphere inside the wall and testing whether particles would only be inserted inside the cylinder wall. I also test whether insertion and removal moves are performed. Finally, I test at a high fugacity meaning that more that just the starting particle should be inserted within the wall. I checked that these tests passed for the bug fix and didn't pass without them. 

To test the jit funtionality of the code I built the code with LLVM enabled on cheme-hodges. I then build a box with an energy constraint that any particle in the bottom half of the box would return an energy of Infinity. I then started the simulation with a single particle in the lower half of the box and a high fugacity. If hoomd considers the jit walls, the particle in the bottom part of the box will be removed and particles will only be inserted into the top of the box, which is what I tested for: At least one successful accepted removal move, no particles in the bottom half of the box, and particles inserted into the top half of the box. 

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
MuVT ensembles considers walls when inserting or removing particles. 
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
