### PR TITLE
Remove unused code.

### DIFF
--- a/hoomd/md/integrate.py
+++ b/hoomd/md/integrate.py
@@ -95,18 +95,6 @@ class _DynamicIntegrator(BaseIntegrator):
     def methods(self, value):
         _set_synced_list(self._methods, value)
 
-    @property
-    def _children(self):
-        children = list(self.forces)
-        children.extend(self.constraints)
-        children.extend(self.methods)
-
-        for child in itertools.chain(self.forces, self.constraints,
-                                     self.methods):
-            children.extend(child._children)
-
-        return children
-
     def _setattr_param(self, attr, value):
         if attr == "rigid":
             self._set_rigid(value)

--- a/hoomd/md/integrate.py
+++ b/hoomd/md/integrate.py
@@ -3,8 +3,6 @@
 
 """Implement MD Integrator."""
 
-import itertools
-
 import hoomd
 from hoomd.md import _md
 from hoomd.data.parameterdicts import ParameterDict

--- a/hoomd/md/long_range/pppm.py
+++ b/hoomd/md/long_range/pppm.py
@@ -271,10 +271,6 @@ class Coulomb(Force):
             # ensure that the pair force uses the same neighbor list
             self._pair_force.nlist = value
 
-    @property
-    def _children(self):
-        return [self.nlist]
-
 
 def _diffpr(hx, hy, hz, xprd, yprd, zprd, N, order, kappa, q2, rcut):
     """Part of the algorithm that computes the estimated error of the method."""


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should be based on *trunk-patch*. -->
<!-- Backwards compatible new features should be based on *trunk-minor*. -->
<!-- Incompatible API changes should be based on *trunk-major*. -->

## Description

<!-- Describe your changes in detail. -->
Remove unused `_children` methods.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
There is no need to keep unused code.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
Unit tests pass.

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
Changed:

* Removed unused ``Operation._children`` methods
  (`#1713 <https://github.com/glotzerlab/hoomd-blue/pull/1713>`__).
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
