### PR TITLE
Always read topology types from GSD file.

### DIFF
--- a/hoomd/GSDReader.cc
+++ b/hoomd/GSDReader.cc
@@ -248,41 +248,41 @@ void GSDReader::readParticles()
 void GSDReader::readTopology()
     {
     unsigned int N = 0;
+    m_snapshot->bond_data.type_mapping = readTypes(m_frame, "bonds/types");
     readChunk(&N, m_frame, "bonds/N", 4);
     if (N > 0)
         {
         m_snapshot->bond_data.resize(N);
-        m_snapshot->bond_data.type_mapping = readTypes(m_frame, "bonds/types");
         readChunk(&m_snapshot->bond_data.type_id[0], m_frame, "bonds/typeid", N * 4, N);
         readChunk(&m_snapshot->bond_data.groups[0], m_frame, "bonds/group", N * 8, N);
         }
 
     N = 0;
+    m_snapshot->angle_data.type_mapping = readTypes(m_frame, "angles/types");
     readChunk(&N, m_frame, "angles/N", 4);
     if (N > 0)
         {
         m_snapshot->angle_data.resize(N);
-        m_snapshot->angle_data.type_mapping = readTypes(m_frame, "angles/types");
         readChunk(&m_snapshot->angle_data.type_id[0], m_frame, "angles/typeid", N * 4, N);
         readChunk(&m_snapshot->angle_data.groups[0], m_frame, "angles/group", N * 12, N);
         }
 
     N = 0;
+    m_snapshot->dihedral_data.type_mapping = readTypes(m_frame, "dihedrals/types");
     readChunk(&N, m_frame, "dihedrals/N", 4);
     if (N > 0)
         {
         m_snapshot->dihedral_data.resize(N);
-        m_snapshot->dihedral_data.type_mapping = readTypes(m_frame, "dihedrals/types");
         readChunk(&m_snapshot->dihedral_data.type_id[0], m_frame, "dihedrals/typeid", N * 4, N);
         readChunk(&m_snapshot->dihedral_data.groups[0], m_frame, "dihedrals/group", N * 16, N);
         }
 
     N = 0;
+    m_snapshot->improper_data.type_mapping = readTypes(m_frame, "impropers/types");
     readChunk(&N, m_frame, "impropers/N", 4);
     if (N > 0)
         {
         m_snapshot->improper_data.resize(N);
-        m_snapshot->improper_data.type_mapping = readTypes(m_frame, "impropers/types");
         readChunk(&m_snapshot->improper_data.type_id[0], m_frame, "impropers/typeid", N * 4, N);
         readChunk(&m_snapshot->improper_data.groups[0], m_frame, "impropers/group", N * 16, N);
         }
@@ -303,11 +303,11 @@ void GSDReader::readTopology()
     if (m_handle.header.schema_version >= gsd_make_version(1, 1))
         {
         N = 0;
+        m_snapshot->pair_data.type_mapping = readTypes(m_frame, "pairs/types");
         readChunk(&N, m_frame, "pairs/N", 4);
         if (N > 0)
             {
             m_snapshot->pair_data.resize(N);
-            m_snapshot->pair_data.type_mapping = readTypes(m_frame, "pairs/types");
             readChunk(&m_snapshot->pair_data.type_id[0], m_frame, "pairs/typeid", N * 4, N);
             readChunk(&m_snapshot->pair_data.groups[0], m_frame, "pairs/group", N * 8, N);
             }


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should be based on *trunk-patch*. -->
<!-- Backwards compatible new features should be based on *trunk-minor*. -->
<!-- Incompatible API changes should be based on *trunk-major*. -->

## Description

<!-- Describe your changes in detail. -->
Read topology types from GSD files, even when there are no groups in that topology entry.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
The type names in the GSD file should be preserved.

<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves #1722

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
This test script passes:
```
import hoomd
import gsd.hoomd

L = 5
frame = gsd.hoomd.Frame()
frame.particles.N = 1
frame.particles.position = [0, 0, 0]
frame.particles.typeid = [0]
frame.configuration.box = [L, L, L, 0, 0, 0]
frame.particles.types = ['A']

frame.bonds.types = ['A-A']
frame.dihedrals.types = ['dihedralA']
frame.impropers.types = ['improperA']
frame.angles.types = ['anglesA']
frame.pairs.types = ['pairA']

with gsd.hoomd.open(name='init.gsd', mode='w') as f:
    f.append(frame)

sim = hoomd.Simulation(device=hoomd.device.CPU(), seed=1)

sim.create_state_from_gsd(filename='init.gsd')

print(sim.state.bond_types)
print(sim.state.angle_types)
print(sim.state.dihedral_types)
print(sim.state.improper_types)
print(sim.state.special_pair_types)
```

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
Fixed:

* ``create_state_from_gsd`` reads bond/angle/dihedral/improper/pair types when there are no
  corresponding groups (`#1694 <https://github.com/glotzerlab/hoomd-blue/pull/1694>`__).
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
