### PR TITLE
Fix cmake warnings.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
     name: Build release tarball
     runs-on: ubuntu-latest
     container:
-      image: glotzerlab/ci:2023.10.09-ubuntu20.04
+      image: glotzerlab/ci:2024.03.01-ubuntu20.04
 
     steps:
       - name: Checkout

--- a/.github/workflows/templates/workflow.yml
+++ b/.github/workflows/templates/workflow.yml
@@ -1,5 +1,5 @@
 <% block name %><% endblock %>
-<% set container_prefix="glotzerlab/ci:2023.10.09" %>
+<% set container_prefix="glotzerlab/ci:2024.03.01" %>
 
 <% block concurrency %>
 concurrency:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,7 +61,7 @@ jobs:
     name: Build [${{ join(matrix.config, '_') }}]
     runs-on: ${{ matrix.build_runner }}
     container:
-      image: glotzerlab/ci:2023.10.09-${{ matrix.config[0] }}
+      image: glotzerlab/ci:2024.03.01-${{ matrix.config[0] }}
     strategy:
       matrix:
         include:
@@ -170,7 +170,7 @@ jobs:
     needs: build
     runs-on: ${{ matrix.test_runner }}
     container:
-      image: glotzerlab/ci:2023.10.09-${{ matrix.config[0] }}
+      image: glotzerlab/ci:2024.03.01-${{ matrix.config[0] }}
       options: ${{ matrix.test_docker_options }} -e CUDA_VISIBLE_DEVICES
     strategy:
       matrix:
@@ -231,7 +231,7 @@ jobs:
     needs: build
     runs-on: ${{ matrix.test_runner }}
     container:
-      image: glotzerlab/ci:2023.10.09-${{ matrix.config[0] }}
+      image: glotzerlab/ci:2024.03.01-${{ matrix.config[0] }}
       options: ${{ matrix.test_docker_options }} -e CUDA_VISIBLE_DEVICES
     strategy:
       matrix:
@@ -285,7 +285,7 @@ jobs:
     needs: build
     runs-on: ${{ matrix.test_runner }}
     container:
-      image: glotzerlab/ci:2023.10.09-${{ matrix.config[0] }}
+      image: glotzerlab/ci:2024.03.01-${{ matrix.config[0] }}
       options: ${{ matrix.test_docker_options }} -e CUDA_VISIBLE_DEVICES
     strategy:
       matrix:
@@ -336,7 +336,7 @@ jobs:
     name: Build [${{ join(matrix.config, '_') }}]
     runs-on: ${{ matrix.build_runner }}
     container:
-      image: glotzerlab/ci:2023.10.09-${{ matrix.config[0] }}
+      image: glotzerlab/ci:2024.03.01-${{ matrix.config[0] }}
     strategy:
       matrix:
         include:
@@ -450,7 +450,7 @@ jobs:
     needs: build_release
     runs-on: ${{ matrix.test_runner }}
     container:
-      image: glotzerlab/ci:2023.10.09-${{ matrix.config[0] }}
+      image: glotzerlab/ci:2024.03.01-${{ matrix.config[0] }}
       options: ${{ matrix.test_docker_options }} -e CUDA_VISIBLE_DEVICES
     strategy:
       matrix:
@@ -520,7 +520,7 @@ jobs:
     needs: build_release
     runs-on: ${{ matrix.test_runner }}
     container:
-      image: glotzerlab/ci:2023.10.09-${{ matrix.config[0] }}
+      image: glotzerlab/ci:2024.03.01-${{ matrix.config[0] }}
       options: ${{ matrix.test_docker_options }} -e CUDA_VISIBLE_DEVICES
     strategy:
       matrix:

--- a/BUILDING.rst
+++ b/BUILDING.rst
@@ -80,7 +80,7 @@ Install prerequisites
 - C++17 capable compiler (tested with ``gcc`` 9 - 13 and ``clang`` 10 - 16)
 - Python >= 3.8
 - NumPy >= 1.17.3
-- pybind11 >= 2.2
+- pybind11 >= 2.6
 - Eigen >= 3.2
 - CMake >= 3.15
 

--- a/BUILDING.rst
+++ b/BUILDING.rst
@@ -200,9 +200,10 @@ Options that find libraries and executables only take effect on a clean invocati
 these options, first remove ``CMakeCache.txt`` from the build directory and then run ``cmake`` with
 these options on the command line.
 
-- ``PYTHON_EXECUTABLE`` - Specify which ``python`` to build against. Example: ``/usr/bin/python3``.
+- ``Python_EXECUTABLE`` - Specify which ``python`` to build against. Example: ``/usr/bin/python3``.
 
-  - Default: ``python3.X`` detected on ``$PATH``.
+  - Default: ``python3.x`` found by `CMake's FindPython
+    <https://cmake.org/cmake/help/latest/module/FindPython.html>`__.
 
 - ``CMAKE_CUDA_COMPILER`` - Specify which ``nvcc`` or ``hipcc`` to build with.
 

--- a/BUILDING.rst
+++ b/BUILDING.rst
@@ -82,7 +82,7 @@ Install prerequisites
 - NumPy >= 1.17.3
 - pybind11 >= 2.2
 - Eigen >= 3.2
-- CMake >= 3.9
+- CMake >= 3.15
 
 **For MPI parallel execution** (required when ``ENABLE_MPI=on``):
 

--- a/CMake/hoomd/HOOMDPythonSetup.cmake
+++ b/CMake/hoomd/HOOMDPythonSetup.cmake
@@ -1,4 +1,22 @@
 set(PYBIND11_PYTHON_VERSION 3)
+if (${CMAKE_VERSION} VERSION_GREATER_EQUAL 3.15)
+    set(Python_FIND_UNVERSIONED_NAMES "FIRST")
+    find_package(Python REQUIRED COMPONENTS Interpreter Development)
+
+    set(PYTHON_SITE_PACKAGES ${Python_SITEARCH})
+
+    if (Python_FOUND)
+        execute_process(COMMAND ${Python_EXECUTABLE} "-c" "import sys; print(sys.prefix, end='')"
+                        RESULT_VARIABLE _success
+                        OUTPUT_VARIABLE PYTHON_PREFIX
+                        ERROR_VARIABLE _error)
+
+        if(NOT _success MATCHES 0)
+            message(FATAL_ERROR "Unable to determine python prefix: \n${_error}")
+        endif()
+
+    endif()
+endif()
 find_package(pybind11 2.2 CONFIG REQUIRED)
 
 if (pybind11_FOUND)

--- a/CMake/hoomd/HOOMDPythonSetup.cmake
+++ b/CMake/hoomd/HOOMDPythonSetup.cmake
@@ -40,22 +40,3 @@ if((CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT OR "${_python_prefix}" STREQUAL 
 endif()
 
 find_package_message(hoomd_install "Installing hoomd python module to: ${CMAKE_INSTALL_PREFIX}/${PYTHON_SITE_INSTALL_DIR}" "[${CMAKE_INSTALL_PREFIX}][${PYTHON_SITE_INSTALL_DIR}]")
-
-# hoomd_add_module links shared libraries to libpython, which breaks lots of things
-function(hoomd_add_module target_name)
-    cmake_parse_arguments(PARSE_ARGV 1 ARG "STATIC;SHARED;MODULE;NO_EXTRAS" "" "")
-
-    if(ARG_STATIC)
-        set(lib_type STATIC)
-    elseif(ARG_SHARED)
-        set(lib_type SHARED)
-    else()
-        set(lib_type MODULE)
-    endif()
-
-    add_library(${target_name} ${lib_type} ${ARG_UNPARSED_ARGUMENTS})
-    target_link_libraries(${target_name} PRIVATE pybind11::module)
-    set_target_properties(${target_name} PROPERTIES CXX_VISIBILITY_PRESET "hidden")
-    set_target_properties(${target_name} PROPERTIES CUDA_VISIBILITY_PRESET "hidden")
-    pybind11_extension(${target_name})
-endfunction()

--- a/CMake/hoomd/HOOMDPythonSetup.cmake
+++ b/CMake/hoomd/HOOMDPythonSetup.cmake
@@ -1,22 +1,17 @@
-set(PYBIND11_PYTHON_VERSION 3)
-if (${CMAKE_VERSION} VERSION_GREATER_EQUAL 3.15)
-    set(Python_FIND_UNVERSIONED_NAMES "FIRST")
-    find_package(Python REQUIRED COMPONENTS Interpreter Development)
+set(Python_FIND_UNVERSIONED_NAMES "FIRST")
+find_package(Python REQUIRED COMPONENTS Interpreter Development)
 
-    set(PYTHON_SITE_PACKAGES ${Python_SITEARCH})
+if (Python_FOUND)
+    execute_process(COMMAND ${Python_EXECUTABLE} "-c" "import sys; print(sys.prefix, end='')"
+                    RESULT_VARIABLE _success
+                    OUTPUT_VARIABLE _python_prefix
+                    ERROR_VARIABLE _error)
 
-    if (Python_FOUND)
-        execute_process(COMMAND ${Python_EXECUTABLE} "-c" "import sys; print(sys.prefix, end='')"
-                        RESULT_VARIABLE _success
-                        OUTPUT_VARIABLE PYTHON_PREFIX
-                        ERROR_VARIABLE _error)
-
-        if(NOT _success MATCHES 0)
-            message(FATAL_ERROR "Unable to determine python prefix: \n${_error}")
-        endif()
-
+    if(NOT _success MATCHES 0)
+        message(FATAL_ERROR "Unable to determine python prefix: \n${_error}")
     endif()
 endif()
+
 find_package(pybind11 2.2 CONFIG REQUIRED)
 
 if (pybind11_FOUND)
@@ -28,20 +23,39 @@ set(PYTHON_SITE_INSTALL_DIR "hoomd" CACHE PATH
     "Python site-packages directory (relative to CMAKE_INSTALL_PREFIX)")
 
 # when no CMAKE_INSTALL_PREFIX is set, default to python's install prefix
-if((CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT OR "${PYTHON_PREFIX}" STREQUAL "${CMAKE_INSTALL_PREFIX}") AND PYTHON_SITE_PACKAGES)
-    string(LENGTH "${PYTHON_PREFIX}" _python_prefix_len)
-    string(SUBSTRING "${PYTHON_SITE_PACKAGES}" 0 ${_python_prefix_len} _python_site_package_prefix)
-    math(EXPR _shart_char "${_python_prefix_len}+1")
-    string(SUBSTRING "${PYTHON_SITE_PACKAGES}" ${_shart_char} -1 _python_site_package_rel)
-    string(COMPARE EQUAL "${_python_site_package_prefix}" "${PYTHON_PREFIX}" _prefix_equal)
+if((CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT OR "${_python_prefix}" STREQUAL "${CMAKE_INSTALL_PREFIX}") AND Python_SITEARCH)
+    string(LENGTH "${_python_prefix}" __python_prefix_len)
+    string(SUBSTRING "${Python_SITEARCH}" 0 ${__python_prefix_len} _python_site_package_prefix)
+    math(EXPR _shart_char "${__python_prefix_len}+1")
+    string(SUBSTRING "${Python_SITEARCH}" ${_shart_char} -1 _python_site_package_rel)
+    string(COMPARE EQUAL "${_python_site_package_prefix}" "${_python_prefix}" _prefix_equal)
     if (NOT _prefix_equal)
-        message(STATUS "Python site packages (${PYTHON_SITE_PACKAGES}) does not start with python prefix (${PYTHON_PREFIX})")
+        message(STATUS "Python site packages (${Python_SITEARCH}) does not start with python prefix (${_python_prefix})")
         message(STATUS "HOOMD may not install to the correct location")
     endif()
 
-    set(CMAKE_INSTALL_PREFIX "${PYTHON_PREFIX}" CACHE PATH "HOOMD installation path" FORCE)
+    set(CMAKE_INSTALL_PREFIX "${_python_prefix}" CACHE PATH "HOOMD installation path" FORCE)
     set(PYTHON_SITE_INSTALL_DIR "${_python_site_package_rel}/hoomd" CACHE PATH
         "Python site-packages directory (relative to CMAKE_INSTALL_PREFIX)" FORCE)
 endif()
 
 find_package_message(hoomd_install "Installing hoomd python module to: ${CMAKE_INSTALL_PREFIX}/${PYTHON_SITE_INSTALL_DIR}" "[${CMAKE_INSTALL_PREFIX}][${PYTHON_SITE_INSTALL_DIR}]")
+
+# hoomd_add_module links shared libraries to libpython, which breaks lots of things
+function(hoomd_add_module target_name)
+    cmake_parse_arguments(PARSE_ARGV 1 ARG "STATIC;SHARED;MODULE;NO_EXTRAS" "" "")
+
+    if(ARG_STATIC)
+        set(lib_type STATIC)
+    elseif(ARG_SHARED)
+        set(lib_type SHARED)
+    else()
+        set(lib_type MODULE)
+    endif()
+
+    add_library(${target_name} ${lib_type} ${ARG_UNPARSED_ARGUMENTS})
+    target_link_libraries(${target_name} PRIVATE pybind11::module)
+    set_target_properties(${target_name} PROPERTIES CXX_VISIBILITY_PRESET "hidden")
+    set_target_properties(${target_name} PROPERTIES CUDA_VISIBILITY_PRESET "hidden")
+    pybind11_extension(${target_name})
+endfunction()

--- a/CMake/hoomd/hoomd-macros.cmake
+++ b/CMake/hoomd/hoomd-macros.cmake
@@ -55,3 +55,22 @@ else()
     endif()
 endif()
 endmacro()
+
+# hoomd_add_module links shared libraries to libpython, which breaks lots of things
+function(hoomd_add_module target_name)
+    cmake_parse_arguments(PARSE_ARGV 1 ARG "STATIC;SHARED;MODULE;NO_EXTRAS" "" "")
+
+    if(ARG_STATIC)
+        set(lib_type STATIC)
+    elseif(ARG_SHARED)
+        set(lib_type SHARED)
+    else()
+        set(lib_type MODULE)
+    endif()
+
+    add_library(${target_name} ${lib_type} ${ARG_UNPARSED_ARGUMENTS})
+    target_link_libraries(${target_name} PRIVATE pybind11::module)
+    set_target_properties(${target_name} PROPERTIES CXX_VISIBILITY_PRESET "hidden")
+    set_target_properties(${target_name} PROPERTIES CUDA_VISIBILITY_PRESET "hidden")
+    pybind11_extension(${target_name})
+endfunction()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -158,7 +158,7 @@ endif()
 
 #######################
 ## Get the compile date
-exec_program("date +%Y-%m-%d" OUTPUT_VARIABLE COMPILE_DATE)
+execute_process(COMMAND "date" "+%Y-%m-%d" OUTPUT_VARIABLE COMPILE_DATE)
 
 ################################
 # set up unit tests

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,12 +116,13 @@ include (HOOMDHIPSetup)
 
 # Find CUDA and set it up
 include (HOOMDCUDASetup)
-include (hoomd-macros)
 
 # setup MPI support
 include (HOOMDMPISetup)
 # find the python libraries to link to
 include(HOOMDPythonSetup)
+
+include (hoomd-macros)
 
 if (NOT ENABLE_HIP OR HIP_PLATFORM STREQUAL "nvcc")
     option(BUILD_MPCD "Build the mpcd package" on)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,10 @@
-CMAKE_MINIMUM_REQUIRED(VERSION 3.9 FATAL_ERROR)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.9...3.27 FATAL_ERROR)
 # >= 3.8 is required for CUDA language support
 # >= 3.9 is required for MPI::MPI_CXX target
+
+# Search for Python and other libraries in unix-like locations first and frameworks last.
+# This allows FindPython to find virtual environment Pythons before a homebrew or system Pythons.
+set(CMAKE_FIND_FRAMEWORK LAST)
 
 project (HOOMD LANGUAGES C CXX)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-CMAKE_MINIMUM_REQUIRED(VERSION 3.9...3.27 FATAL_ERROR)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.15...3.27 FATAL_ERROR)
 # >= 3.8 is required for CUDA language support
 # >= 3.9 is required for MPI::MPI_CXX target
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -162,7 +162,7 @@ endif()
 
 #######################
 ## Get the compile date
-execute_process(COMMAND "date" "+%Y-%m-%d" OUTPUT_VARIABLE COMPILE_DATE)
+execute_process(COMMAND "date" "+%Y-%m-%d" OUTPUT_VARIABLE COMPILE_DATE OUTPUT_STRIP_TRAILING_WHITESPACE)
 
 ################################
 # set up unit tests

--- a/example_plugins/CMakeLists.txt
+++ b/example_plugins/CMakeLists.txt
@@ -1,6 +1,10 @@
 # CMakeLists.txt template for building a plugin as an external component.
 
-CMAKE_MINIMUM_REQUIRED(VERSION 3.9 FATAL_ERROR)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.9...3.27 FATAL_ERROR)
+
+# Search for Python and other libraries in unix-like locations first and frameworks last.
+# This allows FindPython to find virtual environment Pythons before a homebrew or system Pythons.
+set(CMAKE_FIND_FRAMEWORK LAST)
 
 # Name the plugin project
 project(example_plugins LANGUAGES C CXX)

--- a/example_plugins/CMakeLists.txt
+++ b/example_plugins/CMakeLists.txt
@@ -1,6 +1,6 @@
 # CMakeLists.txt template for building a plugin as an external component.
 
-CMAKE_MINIMUM_REQUIRED(VERSION 3.9...3.27 FATAL_ERROR)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.15...3.27 FATAL_ERROR)
 
 # Search for Python and other libraries in unix-like locations first and frameworks last.
 # This allows FindPython to find virtual environment Pythons before a homebrew or system Pythons.

--- a/example_plugins/pair_plugin/CMakeLists.txt
+++ b/example_plugins/pair_plugin/CMakeLists.txt
@@ -23,7 +23,7 @@ if (ENABLE_HIP)
 set(_cuda_sources ${_${COMPONENT_NAME}_cu_sources})
 endif (ENABLE_HIP)
 
-pybind11_add_module(_${COMPONENT_NAME} SHARED ${_${COMPONENT_NAME}_sources} ${_cuda_sources} NO_EXTRAS)
+hoomd_add_module(_${COMPONENT_NAME} SHARED ${_${COMPONENT_NAME}_sources} ${_cuda_sources} NO_EXTRAS)
 # Alias into the HOOMD namespace so that plugins and symlinked components both work.
 add_library(HOOMD::_${COMPONENT_NAME} ALIAS _${COMPONENT_NAME})
 

--- a/example_plugins/shape_plugin/CMakeLists.txt
+++ b/example_plugins/shape_plugin/CMakeLists.txt
@@ -24,7 +24,7 @@ set(_cuda_sources ${_${COMPONENT_NAME}_cu_sources}
     )
 endif (ENABLE_HIP)
 
-pybind11_add_module(_${COMPONENT_NAME} SHARED ${_${COMPONENT_NAME}_sources} ${_cuda_sources} NO_EXTRAS)
+hoomd_add_module(_${COMPONENT_NAME} SHARED ${_${COMPONENT_NAME}_sources} ${_cuda_sources} NO_EXTRAS)
 # Alias into the HOOMD namespace so that plugins and symlinked components both work.
 add_library(HOOMD::_${COMPONENT_NAME} ALIAS _${COMPONENT_NAME})
 

--- a/example_plugins/updater_plugin/CMakeLists.txt
+++ b/example_plugins/updater_plugin/CMakeLists.txt
@@ -17,7 +17,7 @@ if (ENABLE_HIP)
 set(_cuda_sources ${_${COMPONENT_NAME}_cu_sources})
 endif (ENABLE_HIP)
 
-pybind11_add_module(_${COMPONENT_NAME} SHARED ${_${COMPONENT_NAME}_sources} ${_cuda_sources} NO_EXTRAS)
+hoomd_add_module(_${COMPONENT_NAME} SHARED ${_${COMPONENT_NAME}_sources} ${_cuda_sources} NO_EXTRAS)
 # Alias into the HOOMD namespace so that plugins and symlinked components both work.
 add_library(HOOMD::_${COMPONENT_NAME} ALIAS _${COMPONENT_NAME})
 

--- a/hoomd-config.cmake.in
+++ b/hoomd-config.cmake.in
@@ -37,26 +37,8 @@ set(HOOMD_INSTALL_PREFIX "@PACKAGE_CMAKE_INSTALL_PREFIX@")
 set(PYTHON_SITE_INSTALL_DIR "@PYTHON_SITE_INSTALL_DIR@")
 
 # configure python
-set(PYBIND11_PYTHON_VERSION 3)
-if (${CMAKE_VERSION} VERSION_GREATER_EQUAL 3.15)
-    set(Python_FIND_UNVERSIONED_NAMES "FIRST")
-    find_package(Python REQUIRED COMPONENTS Interpreter Development)
-
-    set(PYTHON_SITE_PACKAGES ${Python_SITEARCH})
-
-    if (Python_FOUND)
-        execute_process(COMMAND ${Python_EXECUTABLE} "-c" "import sys; print(sys.prefix, end='')"
-                        RESULT_VARIABLE _success
-                        OUTPUT_VARIABLE PYTHON_PREFIX
-                        ERROR_VARIABLE _error)
-
-        if(NOT _success MATCHES 0)
-            message(FATAL_ERROR "Unable to determine python prefix: \n${_error}")
-        endif()
-
-    endif()
-endif()
-
+set(Python_FIND_UNVERSIONED_NAMES "FIRST")
+find_package(Python REQUIRED COMPONENTS Interpreter Development)
 find_package(pybind11 2.2 CONFIG REQUIRED)
 find_package_message(pybind11 "Found pybind11: ${pybind11_DIR} ${pybind11_INCLUDE_DIR} (version ${pybind11_VERSION})" "[${pybind11_DIR}][${pybind11_INCLUDE_DIR}]")
 

--- a/hoomd-config.cmake.in
+++ b/hoomd-config.cmake.in
@@ -38,6 +38,25 @@ set(PYTHON_SITE_INSTALL_DIR "@PYTHON_SITE_INSTALL_DIR@")
 
 # configure python
 set(PYBIND11_PYTHON_VERSION 3)
+if (${CMAKE_VERSION} VERSION_GREATER_EQUAL 3.15)
+    set(Python_FIND_UNVERSIONED_NAMES "FIRST")
+    find_package(Python REQUIRED COMPONENTS Interpreter Development)
+
+    set(PYTHON_SITE_PACKAGES ${Python_SITEARCH})
+
+    if (Python_FOUND)
+        execute_process(COMMAND ${Python_EXECUTABLE} "-c" "import sys; print(sys.prefix, end='')"
+                        RESULT_VARIABLE _success
+                        OUTPUT_VARIABLE PYTHON_PREFIX
+                        ERROR_VARIABLE _error)
+
+        if(NOT _success MATCHES 0)
+            message(FATAL_ERROR "Unable to determine python prefix: \n${_error}")
+        endif()
+
+    endif()
+endif()
+
 find_package(pybind11 2.2 CONFIG REQUIRED)
 find_package_message(pybind11 "Found pybind11: ${pybind11_DIR} ${pybind11_INCLUDE_DIR} (version ${pybind11_VERSION})" "[${pybind11_DIR}][${pybind11_INCLUDE_DIR}]")
 

--- a/hoomd/CMakeLists.txt
+++ b/hoomd/CMakeLists.txt
@@ -231,7 +231,7 @@ endif (ENABLE_HIP)
 
 #########################
 ## Build the module
-pybind11_add_module(_hoomd SHARED module.cc ${_hoomd_sources} ${_cuda_sources} ${_hoomd_headers} NO_EXTRAS)
+hoomd_add_module(_hoomd SHARED module.cc ${_hoomd_sources} ${_cuda_sources} ${_hoomd_headers} NO_EXTRAS)
 
 # alias into the HOOMD namespace so that plugins and symlinked components both work
 add_library(HOOMD::_hoomd ALIAS _hoomd)
@@ -239,11 +239,7 @@ add_library(HOOMD::_hoomd ALIAS _hoomd)
 # Work around support for the delete operator with pybind11 and older versions of clang
 # https://github.com/pybind/pybind11/issues/1604
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-    if (${CMAKE_VERSION} VERSION_GREATER_EQUAL 3.11)
-        target_compile_options(_hoomd PUBLIC $<$<AND:$<COMPILE_LANGUAGE:CUDA>,$<STREQUAL:${HIP_PLATFORM},nvcc>>:-Xcompiler=>;-fsized-deallocation)
-    else()
-        target_compile_options(_hoomd PUBLIC -fsized-deallocation)
-    endif()
+    target_compile_options(_hoomd PUBLIC $<$<AND:$<COMPILE_LANGUAGE:CUDA>,$<STREQUAL:${HIP_PLATFORM},nvcc>>:-Xcompiler=>;-fsized-deallocation)
 endif()
 
 # add quick hull as its own library so that it's symbols can be public

--- a/hoomd/hpmc/CMakeLists.txt
+++ b/hoomd/hpmc/CMakeLists.txt
@@ -147,7 +147,7 @@ set(_cuda_sources ${_hpmc_cu_sources})
 set_source_files_properties(${_hpmc_cu_sources} PROPERTIES LANGUAGE ${HOOMD_DEVICE_LANGUAGE})
 endif (ENABLE_HIP)
 
-pybind11_add_module(_hpmc SHARED ${_hpmc_sources} ${_cuda_sources} ${_hpmc_headers} NO_EXTRAS)
+hoomd_add_module(_hpmc SHARED ${_hpmc_sources} ${_cuda_sources} ${_hpmc_headers} NO_EXTRAS)
 # alias into the HOOMD namespace so that plugins and symlinked components both work
 add_library(HOOMD::_hpmc ALIAS _hpmc)
 if (APPLE)
@@ -246,7 +246,7 @@ if (ENABLE_LLVM)
                                  ClangCompiler.h
        )
 
-    pybind11_add_module(_${PACKAGE_NAME} SHARED ${_${PACKAGE_NAME}_sources} ${_${PACKAGE_NAME}_cu_sources} ${_${PACKAGE_NAME}_llvm_sources} NO_EXTRAS)
+    hoomd_add_module(_${PACKAGE_NAME} SHARED ${_${PACKAGE_NAME}_sources} ${_${PACKAGE_NAME}_cu_sources} ${_${PACKAGE_NAME}_llvm_sources} NO_EXTRAS)
     # alias into the HOOMD namespace so that plugins and symlinked components both work
     add_library(HOOMD::_${PACKAGE_NAME} ALIAS _${PACKAGE_NAME})
 

--- a/hoomd/hpmc/test/CMakeLists.txt
+++ b/hoomd/hpmc/test/CMakeLists.txt
@@ -26,11 +26,11 @@ foreach (CUR_TEST ${TEST_LIST})
     endif()
 
     add_executable(${CUR_TEST} EXCLUDE_FROM_ALL ${CUR_TEST}.cc ${_cuda_sources})
-    target_include_directories(${CUR_TEST} PRIVATE ${PYTHON_INCLUDE_DIR})
+    target_include_directories(${CUR_TEST} PRIVATE ${PYTHON_INCLUDE_DIR} ${Python_INCLUDE_DIRS})
 
     add_dependencies(test_all ${CUR_TEST})
 
-    target_link_libraries(${CUR_TEST} _hpmc ${PYTHON_LIBRARIES})
+    target_link_libraries(${CUR_TEST} _hpmc ${PYTHON_LIBRARIES} ${Python_LIBRARIES})
 
 endforeach (CUR_TEST)
 

--- a/hoomd/hpmc/test/CMakeLists.txt
+++ b/hoomd/hpmc/test/CMakeLists.txt
@@ -26,11 +26,10 @@ foreach (CUR_TEST ${TEST_LIST})
     endif()
 
     add_executable(${CUR_TEST} EXCLUDE_FROM_ALL ${CUR_TEST}.cc ${_cuda_sources})
-    target_include_directories(${CUR_TEST} PRIVATE ${PYTHON_INCLUDE_DIR} ${Python_INCLUDE_DIRS})
 
     add_dependencies(test_all ${CUR_TEST})
 
-    target_link_libraries(${CUR_TEST} _hpmc ${PYTHON_LIBRARIES} ${Python_LIBRARIES})
+    target_link_libraries(${CUR_TEST} _hpmc pybind11::embed)
 
 endforeach (CUR_TEST)
 

--- a/hoomd/md/CMakeLists.txt
+++ b/hoomd/md/CMakeLists.txt
@@ -562,7 +562,7 @@ foreach(_evaluator ${_alchemical_pair_evaluators})
     set(_md_sources ${_md_sources} export_PotentialPairAlchemical${_evaluator}.cc)
 endforeach()
 
-pybind11_add_module(_md SHARED ${_md_sources} ${_cuda_sources} ${DFFT_SOURCES} ${_md_headers} NO_EXTRAS)
+hoomd_add_module(_md SHARED ${_md_sources} ${_cuda_sources} ${DFFT_SOURCES} ${_md_headers} NO_EXTRAS)
 # alias into the HOOMD namespace so that plugins and symlinked components both work
 add_library(HOOMD::_md ALIAS _md)
 

--- a/hoomd/md/test/CMakeLists.txt
+++ b/hoomd/md/test/CMakeLists.txt
@@ -40,7 +40,7 @@ foreach (CUR_TEST ${TEST_LIST} ${MPI_TEST_LIST})
     endif()
 
     add_executable(${CUR_TEST} EXCLUDE_FROM_ALL ${CUR_TEST}.cc ${_cuda_sources})
-    target_include_directories(${CUR_TEST} PRIVATE ${PYTHON_INCLUDE_DIR})
+    target_include_directories(${CUR_TEST} PRIVATE ${PYTHON_INCLUDE_DIR} ${Python_INCLUDE_DIRS})
 
     add_dependencies(test_all ${CUR_TEST})
 
@@ -48,7 +48,7 @@ foreach (CUR_TEST ${TEST_LIST} ${MPI_TEST_LIST})
         # these options are needed to avoid linker errors with GCC
         set(additional_link_options "-Wl,--allow-shlib-undefined -Wl,--no-as-needed")
     endif()
-    target_link_libraries(${CUR_TEST} _md ${additional_link_options} ${PYTHON_LIBRARIES})
+    target_link_libraries(${CUR_TEST} _md ${additional_link_options} ${PYTHON_LIBRARIES} ${Python_LIBRARIES})
 
 endforeach (CUR_TEST)
 

--- a/hoomd/md/test/CMakeLists.txt
+++ b/hoomd/md/test/CMakeLists.txt
@@ -40,7 +40,6 @@ foreach (CUR_TEST ${TEST_LIST} ${MPI_TEST_LIST})
     endif()
 
     add_executable(${CUR_TEST} EXCLUDE_FROM_ALL ${CUR_TEST}.cc ${_cuda_sources})
-    target_include_directories(${CUR_TEST} PRIVATE ${PYTHON_INCLUDE_DIR} ${Python_INCLUDE_DIRS})
 
     add_dependencies(test_all ${CUR_TEST})
 
@@ -48,7 +47,7 @@ foreach (CUR_TEST ${TEST_LIST} ${MPI_TEST_LIST})
         # these options are needed to avoid linker errors with GCC
         set(additional_link_options "-Wl,--allow-shlib-undefined -Wl,--no-as-needed")
     endif()
-    target_link_libraries(${CUR_TEST} _md ${additional_link_options} ${PYTHON_LIBRARIES} ${Python_LIBRARIES})
+    target_link_libraries(${CUR_TEST} _md ${additional_link_options} pybind11::embed)
 
 endforeach (CUR_TEST)
 

--- a/hoomd/metal/CMakeLists.txt
+++ b/hoomd/metal/CMakeLists.txt
@@ -23,7 +23,7 @@ if (ENABLE_HIP)
 set(_cuda_sources ${_${PACKAGE_NAME}_cu_sources})
 endif (ENABLE_HIP)
 
-pybind11_add_module(_${PACKAGE_NAME} SHARED ${_${PACKAGE_NAME}_sources} ${_cuda_sources} ${_${PACKAGE_NAME}_headers} NO_EXTRAS)
+hoomd_add_module(_${PACKAGE_NAME} SHARED ${_${PACKAGE_NAME}_sources} ${_cuda_sources} ${_${PACKAGE_NAME}_headers} NO_EXTRAS)
 # alias into the HOOMD namespace so that plugins and symlinked components both work
 add_library(HOOMD::_${PACKAGE_NAME} ALIAS _${PACKAGE_NAME})
 

--- a/hoomd/mpcd/CMakeLists.txt
+++ b/hoomd/mpcd/CMakeLists.txt
@@ -106,7 +106,7 @@ if (ENABLE_HIP)
     set(_cuda_sources ${_mpcd_cu_sources})
 endif (ENABLE_HIP)
 
-pybind11_add_module(_mpcd SHARED ${_mpcd_sources} ${LINK_OBJ} ${_cuda_sources} ${_mpcd_headers} NO_EXTRAS)
+hoomd_add_module(_mpcd SHARED ${_mpcd_sources} ${LINK_OBJ} ${_cuda_sources} ${_mpcd_headers} NO_EXTRAS)
 # alias into the HOOMD namespace so that plugins and symlinked components both work
 add_library(HOOMD::_mpcd ALIAS _mpcd)
 

--- a/hoomd/mpcd/test/CMakeLists.txt
+++ b/hoomd/mpcd/test/CMakeLists.txt
@@ -37,13 +37,12 @@ macro(compile_test TEST_EXE TEST_SRC)
 
     # add and link the unit test executable
     add_executable(${TEST_EXE} EXCLUDE_FROM_ALL ${TEST_SRC} ${_cuda_sources})
-    target_include_directories(${TEST_EXE} PRIVATE ${PYTHON_INCLUDE_DIR} ${Python_INCLUDE_DIRS})
     add_dependencies(test_all ${TEST_EXE})
     if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" AND NOT APPLE)
         # these options are needed to avoid linker errors with GCC
         set(additional_link_options "-Wl,--allow-shlib-undefined -Wl,--no-as-needed")
     endif()
-    target_link_libraries(${TEST_EXE} _mpcd ${additional_link_options} ${PYTHON_LIBRARIES} ${Python_LIBRARIES})
+    target_link_libraries(${TEST_EXE} _mpcd ${additional_link_options} pybind11::embed)
 endmacro(compile_test)
 
 # add non-MPI tests to test list first

--- a/hoomd/mpcd/test/CMakeLists.txt
+++ b/hoomd/mpcd/test/CMakeLists.txt
@@ -37,13 +37,13 @@ macro(compile_test TEST_EXE TEST_SRC)
 
     # add and link the unit test executable
     add_executable(${TEST_EXE} EXCLUDE_FROM_ALL ${TEST_SRC} ${_cuda_sources})
-    target_include_directories(${TEST_EXE} PRIVATE ${PYTHON_INCLUDE_DIR})
+    target_include_directories(${TEST_EXE} PRIVATE ${PYTHON_INCLUDE_DIR} ${Python_INCLUDE_DIRS})
     add_dependencies(test_all ${TEST_EXE})
     if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" AND NOT APPLE)
         # these options are needed to avoid linker errors with GCC
         set(additional_link_options "-Wl,--allow-shlib-undefined -Wl,--no-as-needed")
     endif()
-    target_link_libraries(${TEST_EXE} _mpcd ${additional_link_options} ${PYTHON_LIBRARIES})
+    target_link_libraries(${TEST_EXE} _mpcd ${additional_link_options} ${PYTHON_LIBRARIES} ${Python_LIBRARIES})
 endmacro(compile_test)
 
 # add non-MPI tests to test list first

--- a/hoomd/test/CMakeLists.txt
+++ b/hoomd/test/CMakeLists.txt
@@ -55,10 +55,9 @@ foreach (CUR_TEST ${TEST_LIST} ${MPI_TEST_LIST})
     if(CMAKE_COMPILER_IS_GNUCXX OR "${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
         set_source_files_properties(${CUR_TEST}.cc PROPERTIES COMPILE_FLAGS "-Wno-self-assign-overloaded")
     endif()
-    target_include_directories(${CUR_TEST} PRIVATE ${PYTHON_INCLUDE_DIR} ${Python_INCLUDE_DIRS})
 
     add_dependencies(test_all ${CUR_TEST})
-    target_link_libraries(${CUR_TEST} _hoomd ${PYTHON_LIBRARIES} ${Python_LIBRARIES})
+    target_link_libraries(${CUR_TEST} _hoomd pybind11::embed)
 
 endforeach (CUR_TEST)
 

--- a/hoomd/test/CMakeLists.txt
+++ b/hoomd/test/CMakeLists.txt
@@ -55,10 +55,10 @@ foreach (CUR_TEST ${TEST_LIST} ${MPI_TEST_LIST})
     if(CMAKE_COMPILER_IS_GNUCXX OR "${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
         set_source_files_properties(${CUR_TEST}.cc PROPERTIES COMPILE_FLAGS "-Wno-self-assign-overloaded")
     endif()
-    target_include_directories(${CUR_TEST} PRIVATE ${PYTHON_INCLUDE_DIR})
+    target_include_directories(${CUR_TEST} PRIVATE ${PYTHON_INCLUDE_DIR} ${Python_INCLUDE_DIRS})
 
     add_dependencies(test_all ${CUR_TEST})
-    target_link_libraries(${CUR_TEST} _hoomd ${PYTHON_LIBRARIES})
+    target_link_libraries(${CUR_TEST} _hoomd ${PYTHON_LIBRARIES} ${Python_LIBRARIES})
 
 endforeach (CUR_TEST)
 


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should be based on *trunk-patch*. -->
<!-- Backwards compatible new features should be based on *trunk-minor*. -->
<!-- Incompatible API changes should be based on *trunk-major*. -->

## Description

<!-- Describe your changes in detail. -->
* Use `execute_process`.
* Use the new `FindPython` machinery when it is available.

Adjust CMake settings so that the new `FindPython` behaves similarly to the old. Especially in the case where Mac users expect their virtual environment Python to found before a system or homebrew installed one.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Address the following CMake warnings:
```
CMake Warning (dev) at /Users/joaander/miniforge3/share/cmake/pybind11/FindPythonLibsNew.cmake:98 (find_package):
  Policy CMP0148 is not set: The FindPythonInterp and FindPythonLibs modules
  are removed.  Run "cmake --help-policy CMP0148" for policy details.  Use
  the cmake_policy command to set the policy and suppress this warning.

Call Stack (most recent call first):
  /Users/joaander/miniforge3/share/cmake/pybind11/pybind11Tools.cmake:50 (find_package)
  /Users/joaander/miniforge3/share/cmake/pybind11/pybind11Common.cmake:188 (include)
  /Users/joaander/miniforge3/share/cmake/pybind11/pybind11Config.cmake:250 (include)
  CMake/hoomd/HOOMDPythonSetup.cmake:2 (find_package)
  CMakeLists.txt:120 (include)
This warning is for project developers.  Use -Wno-dev to suppress it.
```

```
CMake Warning (dev) at CMakeLists.txt:161 (exec_program):
  Policy CMP0153 is not set: The exec_program command should not be called.
  Run "cmake --help-policy CMP0153" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.

  Use execute_process() instead.
This warning is for project developers.  Use -Wno-dev to suppress it.
```

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
I tested these changes locally on my Mac. CI will check Linux builds.

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
Changed:

* Use ``FindPython`` on modern CMake installations. You may need to adjust build scripts
  in cases where the new behavior does not exactly match the old (i.e. use 
  `-DPython_EXECUTABLE` in place of `-DPYTHON_EXECUTABLE`)
  (`#1730 <https://github.com/glotzerlab/hoomd-blue/pull/1730>`__).
* External components must switch from ``pybind11_add_module`` to ``hoomd_add_module``
  (`#1730 <https://github.com/glotzerlab/hoomd-blue/pull/1730>`__).
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.

## Todo:

- [ ] After release: update the CMakeLists.txt in `hoomd-component-template` to match.