### PR TITLE
Add examples to MPCD documentation

### DIFF
--- a/hoomd/mpcd/__init__.py
+++ b/hoomd/mpcd/__init__.py
@@ -4,38 +4,34 @@
 """ Multiparticle collision dynamics.
 
 Simulating complex fluids and soft matter using conventional molecular dynamics
-methods (`hoomd.md`) can be computationally demanding due to large
-disparities in the relevant length and time scales between molecular-scale
-solvents and mesoscale solutes such as polymers, colloids, and deformable
-materials like cells. One way to overcome this challenge is to simplify the model
-for the solvent while retaining its most important interactions with the solute.
-MPCD is a particle-based simulation method for resolving solvent-mediated
-fluctuating hydrodynamic interactions with a microscopically detailed solute
-model. This method has been successfully applied to a simulate a broad class
-of problems, including polymer solutions and colloidal suspensions both in and
-out of equilibrium.
+methods (`hoomd.md`) can be computationally demanding due to large disparities
+in the relevant length and time scales between molecular-scale solvents and
+mesoscale solutes such as polymers, colloids, or cells. One way to overcome this
+challenge is to simplify the model for the solvent while retaining its most
+important interactions with the solute. MPCD is a particle-based simulation
+method for resolving solvent-mediated fluctuating hydrodynamic interactions with
+a microscopically detailed solute model.
 
 .. rubric:: Algorithm
 
 In MPCD, the solvent is represented by point particles having continuous
 positions and velocities. The solvent particles propagate in alternating
 streaming and collision steps. During the streaming step, particles evolve
-according to Newton's equations of motion. Typically, no external forces are
-applied to the solvent, and streaming is straightforward with a large time step.
-Particles are then binned into local cells and undergo a stochastic multiparticle
-collision within the cell. Collisions lead to the build up of hydrodynamic
-interactions, and the frequency and nature of the collisions, along with the
-solvent properties, determine the transport coefficients. All standard collision
-rules conserve linear momentum within the cell and can optionally be made to
-enforce angular-momentum conservation. Currently, we have implemented
-the following collision rules with linear-momentum conservation only:
+according to Newton's equations of motion. Particles are then binned into local
+cells and undergo a stochastic collision within the cell. Collisions lead to the
+build up of hydrodynamic interactions, and the frequency and nature of the
+collisions, along with the solvent properties, determine the transport
+coefficients. All standard collision rules conserve linear momentum within the
+cell and can optionally be made to enforce angular-momentum conservation.
+Currently, we have implemented the following collision rules with
+linear-momentum conservation only:
 
 * :class:`~hoomd.mpcd.collide.StochasticRotationDynamics`
 * :class:`~hoomd.mpcd.collide.AndersenThermostat`
 
 Solute particles can be coupled to the solvent during the collision step. This
 is particularly useful for soft materials like polymers. Standard molecular
-dynamics integration can be applied to the solute. Coupling to the MPCD
+dynamics methods can be applied to the solute. Coupling to the MPCD
 solvent introduces both hydrodynamic interactions and a heat bath that acts as
 a thermostat.
 
@@ -62,11 +58,6 @@ MPCD is intended to be used as an add-on to the standard MD methods in
 
 
 """
-
-# these imports are necessary in order to link derived types between modules
-import hoomd
-from hoomd import _hoomd
-from hoomd.md import _md
 
 from hoomd.mpcd import collide
 from hoomd.mpcd import fill

--- a/hoomd/mpcd/collide.py
+++ b/hoomd/mpcd/collide.py
@@ -99,13 +99,9 @@ class CollisionMethod(Operation):
         period (int): Number of integration steps between collisions.
         embedded_particles (hoomd.filter.filter_like): HOOMD particles to include in collision.
 
-    .. invisible-code-block: python
-
-        collision_method = hoomd.mpcd.collide.CollisionMethod(period=1)
-        simulation.operations.integrator.collision_method = collision_method
-
     Attributes:
-        embedded_particles (hoomd.filter.filter_like): HOOMD particles to include in collision.
+        embedded_particles (hoomd.filter.filter_like): HOOMD particles to include
+            in collision (*read only*).
 
             These particles are included in per-cell quantities and have their
             velocities updated along with the MPCD particles.
@@ -122,13 +118,7 @@ class CollisionMethod(Operation):
                 will not be correctly transferred to the body. Support for this
                 is planned in future.
 
-            .. rubric:: Example:
-
-            .. code-block:: python
-
-                collision_method.embedded_particles = hoomd.filter.All()
-
-        period (int): Number of integration steps between collisions.
+        period (int): Number of integration steps between collisions (*read only*).
 
             A collision is executed each time the :attr:`~hoomd.Simulation.timestep`
             is a multiple of `period`. It must be a multiple of `period` for the

--- a/hoomd/mpcd/collide.py
+++ b/hoomd/mpcd/collide.py
@@ -166,18 +166,18 @@ class AndersenThermostat(CollisionMethod):
 
     .. code-block:: python
 
-        at = hoomd.mpcd.collide.AndersenThermostat(period=1, kT=1.0)
-        simulation.operations.integrator.collision_method = at
+        andersen_thermostat = hoomd.mpcd.collide.AndersenThermostat(period=1, kT=1.0)
+        simulation.operations.integrator.collision_method = andersen_thermostat
 
     Collision including embedded particles.
 
     .. code-block:: python
 
-        at = hoomd.mpcd.collide.AndersenThermostat(
+        andersen_thermostat = hoomd.mpcd.collide.AndersenThermostat(
             period=20,
             kT=1.0,
             embedded_particles=hoomd.filter.All())
-        simulation.operations.integrator.collision_method = at
+        simulation.operations.integrator.collision_method = andersen_thermostat
 
     Attributes:
         kT (hoomd.variant.variant_like): Temperature of the solvent
@@ -192,13 +192,13 @@ class AndersenThermostat(CollisionMethod):
 
             .. code-block:: python
 
-                at.kT = 1.0
+                andersen_thermostat.kT = 1.0
 
             Variable temperature.
 
             .. code-block:: python
 
-                at.kT = hoomd.variant.Ramp(1.0, 2.0, 0, 100)
+                andersen_thermostat.kT = hoomd.variant.Ramp(1.0, 2.0, 0, 100)
 
     """
 
@@ -238,7 +238,7 @@ class StochasticRotationDynamics(CollisionMethod):
         embedded_particles (hoomd.filter.ParticleFilter): HOOMD particles to
             include in collision.
 
-    This class implements the stochastic rotation dynamics collision
+    This class implements the stochastic rotation dynamics (SRD) collision
     rule for MPCD proposed by `Malevanets and Kapral
     <http://doi.org/10.1063/1.478857>`_. Every :attr:`~CollisionMethod.period`
     steps, the particles are binned into cells. The particle velocities are then

--- a/hoomd/mpcd/collide.py
+++ b/hoomd/mpcd/collide.py
@@ -206,6 +206,8 @@ class AndersenThermostat(CollisionMethod):
 
             Variable temperature.
 
+            .. code-block:: python
+
                 at.kT = hoomd.variant.Ramp(1.0, 2.0, 0, 100)
 
     """
@@ -316,6 +318,8 @@ class StochasticRotationDynamics(CollisionMethod):
                 srd.kT = 1.0
 
             Variable temperature.
+
+            .. code-block:: python
 
                 srd.kT = hoomd.variant.Ramp(1.0, 2.0, 0, 100)
 

--- a/hoomd/mpcd/collide.py
+++ b/hoomd/mpcd/collide.py
@@ -11,6 +11,11 @@ also conserve angular momentum The stochastic collisions lead to a build up of
 hydrodynamic interactions, and the choice of collision rule and solvent
 properties determine the transport coefficients.
 
+.. invisible-code-block: python
+
+    simulation = hoomd.util.make_example_simulation(mpcd_types=["A"])
+    simulation.operations.integrator = hoomd.mpcd.Integrator(dt=0.1)
+
 """
 
 import hoomd
@@ -38,10 +43,30 @@ class CellList(Compute):
     penalty from grid shifting is small, so it is recommended to enable it in
     all simulations.
 
+    .. rubric:: Example:
+
+    Access default cell list from integrator.
+
+    .. code-block:: python
+
+        cell_list = simulation.operations.integrator.cell_list
+
     Attributes:
         cell_size (float): Edge length of a collision cell.
 
+            .. rubric:: Example:
+
+            .. code-block:: python
+
+                cell_list.cell_size = 1.0
+
         shift (bool): When True, randomly shift underlying collision cells.
+
+            .. rubric:: Example:
+
+            .. code-block:: python
+
+                cell_list.shift = True
 
     """
 
@@ -74,6 +99,11 @@ class CollisionMethod(Operation):
         period (int): Number of integration steps between collisions.
         embedded_particles (hoomd.filter.filter_like): HOOMD particles to include in collision.
 
+    .. invisible-code-block: python
+
+        collision_method = hoomd.mpcd.collide.CollisionMethod(period=1)
+        simulation.operations.integrator.collision_method = collision_method
+
     Attributes:
         embedded_particles (hoomd.filter.filter_like): HOOMD particles to include in collision.
 
@@ -91,6 +121,12 @@ class CollisionMethod(Operation):
                 Do not embed particles that are part of a rigid body. Momentum
                 will not be correctly transferred to the body. Support for this
                 is planned in future.
+
+            .. rubric:: Example:
+
+            .. code-block:: python
+
+                collision_method.embedded_particles = hoomd.filter.All()
 
         period (int): Number of integration steps between collisions.
 
@@ -114,7 +150,7 @@ class CollisionMethod(Operation):
 
 
 class AndersenThermostat(CollisionMethod):
-    r"""Andersen thermostat method.
+    r"""Andersen thermostat collision method.
 
     Args:
         period (int): Number of integration steps between collisions.
@@ -126,12 +162,32 @@ class AndersenThermostat(CollisionMethod):
 
     This class implements the Andersen thermostat collision rule for MPCD, as
     described by `Allahyarov and Gompper
-    <https://doi.org/10.1103/PhysRevE.66.036702>`_. Every ``period`` steps, the
-    particles are binned into cells. New particle velocities are then randomly
-    drawn from a Gaussian distribution relative to the center-of-mass velocity
-    for the cell. The random velocities are given zero-mean so that the cell
-    linear momentum is conserved. This collision rule naturally imparts the
-    constant-temperature ensemble consistent with `kT`.
+    <https://doi.org/10.1103/PhysRevE.66.036702>`_. Every
+    :attr:`~CollisionMethod.period` steps, the particles are binned into cells.
+    New particle velocities are then randomly drawn from a Gaussian distribution
+    relative to the center-of-mass velocity for the cell. The random velocities
+    are given zero mean so that the cell linear momentum is conserved. This
+    collision rule naturally imparts the constant-temperature ensemble
+    consistent with `kT`.
+
+    .. rubric:: Examples:
+
+    Solvent collision.
+
+    .. code-block:: python
+
+        at = hoomd.mpcd.collide.AndersenThermostat(period=1, kT=1.0)
+        simulation.operations.integrator.collision_method = at
+
+    Collision including embedded particles.
+
+    .. code-block:: python
+
+        at = hoomd.mpcd.collide.AndersenThermostat(
+            period=20,
+            kT=1.0,
+            embedded_particles=hoomd.filter.All())
+        simulation.operations.integrator.collision_method = at
 
     Attributes:
         kT (hoomd.variant.variant_like): Temperature of the solvent
@@ -139,6 +195,18 @@ class AndersenThermostat(CollisionMethod):
 
             This temperature determines the distribution used to generate the
             random numbers.
+
+            .. rubric:: Examples:
+
+            Constant temperature.
+
+            .. code-block:: python
+
+                at.kT = 1.0
+
+            Variable temperature.
+
+                at.kT = hoomd.variant.Ramp(1.0, 2.0, 0, 100)
 
     """
 
@@ -167,7 +235,7 @@ class AndersenThermostat(CollisionMethod):
 
 
 class StochasticRotationDynamics(CollisionMethod):
-    r"""Stochastic rotation dynamics method.
+    r"""Stochastic rotation dynamics collision method.
 
     Args:
         period (int): Number of integration steps between collisions.
@@ -178,31 +246,78 @@ class StochasticRotationDynamics(CollisionMethod):
         embedded_particles (hoomd.filter.ParticleFilter): HOOMD particles to
             include in collision.
 
-    This class implements the classic stochastic rotation dynamics collision
+    This class implements the stochastic rotation dynamics collision
     rule for MPCD proposed by `Malevanets and Kapral
-    <http://doi.org/10.1063/1.478857>`_. Every ``period`` steps, the particles
-    are binned into cells. The particle velocities are then rotated by `angle`
-    around an axis randomly drawn from the unit sphere. The rotation is done
-    relative to the average velocity, so this rotation rule conserves linear
-    momentum and kinetic energy within each cell.
+    <http://doi.org/10.1063/1.478857>`_. Every :attr:`~CollisionMethod.period`
+    steps, the particles are binned into cells. The particle velocities are then
+    rotated by `angle` around an axis randomly drawn from the unit sphere. The
+    rotation is done relative to the average velocity, so this rotation rule
+    conserves linear momentum and kinetic energy within each cell.
 
     The SRD method naturally imparts the NVE ensemble to the system comprising
     the MPCD particles and the `embedded_particles`. Accordingly, the system
-    must be properly initialized to the correct temperature. (SRD has an H
-    theorem, and so particles exchange momentum to reach an equilibrium
-    temperature.) A thermostat can be applied in conjunction with the SRD method
-    through the `kT` parameter. SRD employs a `Maxwell-Boltzmann thermostat
+    must be properly initialized to the correct temperature. A thermostat can be
+    applied in conjunction with the SRD method through the `kT` parameter. SRD
+    employs a `Maxwell-Boltzmann thermostat
     <https://doi.org/10.1016/j.jcp.2009.09.024>`_ on the cell level, which
-    generates the (correct) isothermal ensemble. The temperature is defined
+    generates a constant-temperature ensemble. The temperature is defined
     relative to the cell-average velocity, and so can be used to dissipate heat
     in nonequilibrium simulations. Under this thermostat, the SRD algorithm
     still conserves linear momentum, but kinetic energy is no longer conserved.
 
+    .. rubric:: Examples:
+
+    Standard solvent collision.
+
+    .. code-block:: python
+
+        srd = hoomd.mpcd.collide.StochasticRotationDynamics(period=1, angle=130)
+        simulation.operations.integrator.collision_method = srd
+
+    Solvent collision with thermostat.
+
+    .. code-block:: python
+
+        srd = hoomd.mpcd.collide.StochasticRotationDynamics(
+            period=1,
+            angle=130,
+            kT=1.0)
+        simulation.operations.integrator.collision_method = srd
+
+    Collision including embedded particles.
+
+    .. code-block:: python
+
+        srd = hoomd.mpcd.collide.StochasticRotationDynamics(
+            period=20,
+            angle=130,
+            kT=1.0,
+            embedded_particles=hoomd.filter.All())
+        simulation.operations.integrator.collision_method = srd
+
     Attributes:
         angle (float): Rotation angle (in degrees)
 
+            .. rubric:: Example:
+
+            .. code-block:: python
+
+                srd.angle = 130
+
         kT (hoomd.variant.variant_like): Temperature for the collision
             thermostat :math:`[\mathrm{energy}]`.
+
+            .. rubric:: Examples:
+
+            Constant temperature.
+
+            .. code-block:: python
+
+                srd.kT = 1.0
+
+            Variable temperature.
+
+                srd.kT = hoomd.variant.Ramp(1.0, 2.0, 0, 100)
 
     """
 

--- a/hoomd/mpcd/fill.py
+++ b/hoomd/mpcd/fill.py
@@ -7,8 +7,14 @@ Virtual particles are MPCD solvent particles that are added to ensure MPCD
 collision cells that are sliced by solid boundaries do not become "underfilled".
 From the perspective of the MPCD algorithm, the number density of particles in
 these sliced cells is lower than the average density, and so the solvent
-properties may differ. In practice, this means that the boundary conditions do
-not appear to be properly enforced.
+properties may differ. In practice, this usually means that the boundary
+conditions do not appear to be properly enforced.
+
+.. invisible-code-block: python
+
+    simulation = hoomd.util.make_example_simulation(mpcd_types=["A"])
+    simulation.operations.integrator = hoomd.mpcd.Integrator(dt=0.1)
+
 """
 
 import hoomd
@@ -30,12 +36,44 @@ class VirtualParticleFiller(Operation):
     Their velocities will be drawn from a Maxwell--Boltzmann distribution
     consistent with `kT`.
 
+    .. invisible-code-block: python
+
+        filler = hoomd.mpcd.fill.VirtualParticleFiller(
+            type="A",
+            density=5.0,
+            kT=1.0)
+        simulation.operations.integrator.virtual_particle_fillers = [filler]
+
     Attributes:
         type (str): Type of particles to fill.
 
+            .. rubric:: Example:
+
+            .. code-block:: python
+
+                filler.type = "A"
+
         density (float): Particle number density.
 
+            .. rubric:: Example:
+
+            .. code-block:: python
+
+                filler.density = 5.0
+
         kT (hoomd.variant.variant_like): Temperature of particles.
+
+            .. rubric:: Examples:
+
+            Constant temperature.
+
+            .. code-block:: python
+
+                filler.kT = 1.0
+
+            Variable temperature.
+
+                filler.kT = hoomd.variant.Ramp(1.0, 2.0, 0, 100)
 
     """
 
@@ -52,7 +90,7 @@ class VirtualParticleFiller(Operation):
 
 
 class GeometryFiller(VirtualParticleFiller):
-    """Virtual-particle filler for known geometry.
+    """Virtual-particle filler for a bounce-back geometry.
 
     Args:
         type (str): Type of particles to fill.
@@ -63,6 +101,20 @@ class GeometryFiller(VirtualParticleFiller):
     Virtual particles are inserted in cells whose volume is sliced by the
     specified `geometry`. The algorithm for doing the filling depends on the
     specific `geometry`.
+
+    .. rubric:: Example:
+
+    Filler for parallel plate geometry.
+
+    .. code-block:: python
+
+        plates = hoomd.mpcd.geometry.ParallelPlates(H=3.0)
+        filler = hoomd.mpcd.fill.GeometryFiller(
+            type="A",
+            density=5.0,
+            kT=1.0,
+            geometry=plates)
+        simulation.operations.integrator.virtual_particle_fillers = [filler]
 
     Attributes:
         geometry (hoomd.mpcd.geometry.Geometry): Surface to fill around.

--- a/hoomd/mpcd/fill.py
+++ b/hoomd/mpcd/fill.py
@@ -119,7 +119,7 @@ class GeometryFiller(VirtualParticleFiller):
         simulation.operations.integrator.virtual_particle_fillers = [filler]
 
     Attributes:
-        geometry (hoomd.mpcd.geometry.Geometry): Surface to fill around.
+        geometry (hoomd.mpcd.geometry.Geometry): Surface to fill around (*read only*).
 
     """
 

--- a/hoomd/mpcd/fill.py
+++ b/hoomd/mpcd/fill.py
@@ -73,6 +73,8 @@ class VirtualParticleFiller(Operation):
 
             Variable temperature.
 
+            .. code-block:: python
+
                 filler.kT = hoomd.variant.Ramp(1.0, 2.0, 0, 100)
 
     """

--- a/hoomd/mpcd/force.py
+++ b/hoomd/mpcd/force.py
@@ -4,13 +4,18 @@
 r""" MPCD solvent forces.
 
 MPCD can apply a body force to each MPCD particle as a function of position.
-The external force should be compatible with the chosen :mod:`~hoomd.mpcd.geometry`.
+The external force should be compatible with the chosen `~hoomd.mpcd.geometry.Geometry`.
 Global momentum conservation can be broken by adding a solvent force, so
 care should be chosen that the entire model is designed so that the system
 does not have net acceleration. For example, solid boundaries can be used to
 dissipate momentum, or a balancing force can be applied to particles that are
-coupled to the solvent through the collision step. Additionally, a thermostat
+embedded in the solvent through the collision step. Additionally, a thermostat
 will likely be required to maintain temperature control in the driven system.
+
+.. invisible-code-block: python
+
+    simulation = hoomd.util.make_example_simulation(mpcd_types=["A"])
+    simulation.operations.integrator = hoomd.mpcd.Integrator(dt=0.1)
 
 """
 
@@ -40,9 +45,9 @@ class BlockForce(SolventForce):
             blocks.
         half_width (float): Half the width of each block.
 
-    The ``force`` magnitude *F* is applied in the *x* direction on the particles
-    in blocks defined along the *y* direction by the ``half_separation`` *H* and
-    the ``half_width`` *w*. The force in *x* is :math:`+F` in the upper block,
+    The `force` magnitude *F* is applied in the *x* direction on the solvent particles
+    in blocks defined along the *y* direction by the `half_separation` *H* and
+    the `half_width` *w*. The force in *x* is :math:`+F` in the upper block,
     :math:`-F` in the lower block, and zero otherwise.
 
     .. math::
@@ -64,13 +69,44 @@ class BlockForce(SolventForce):
         You should define the blocks to lie fully within the simulation box and
         to not overlap each other.
 
+    .. rubric:: Example:
+
+    Block force for double-parabola method.
+
+    .. code-block:: python
+
+        Ly = simulation.state.box.Ly
+        force = hoomd.mpcd.force.BlockForce(force=1.0, half_separation=Ly/4, half_width=Ly/4)
+        stream = hoomd.mpcd.stream.Bulk(period=1, solvent_force=force)
+        simulation.operations.integrator.streaming_method = stream
+
     Attributes:
         force (float): Magnitude of the force in *x* per particle.
+
+            .. rubric:: Example:
+
+            .. code-block:: python
+
+                force.force = 1.0
 
         half_separation (float): Half the distance between the centers of the
             blocks.
 
+            .. rubric:: Example:
+
+            .. code-block:: python
+
+                Ly = simulation.state.box.Ly
+                force.half_separation = Ly / 4
+
         half_width (float): Half the width of each block.
+
+            .. rubric:: Example:
+
+            .. code-block:: python
+
+                Ly = simulation.state.box.Ly
+                force.half_width = Ly / 4
 
     """
 
@@ -96,14 +132,28 @@ class ConstantForce(SolventForce):
     Args:
         force (`tuple` [`float`, `float`, `float`]): Force vector per particle.
 
-    The same constant force is applied to all particles, independently of time
-    and their positions. This force is useful for simulating pressure-driven
+    The same constant force is applied to all solvent particles, independently
+    of time and position. This force is useful for simulating pressure-driven
     flow in conjunction with a confined geometry having no-slip boundary conditions.
     It is also useful for measuring diffusion coefficients with nonequilibrium
     methods.
 
+    .. rubric:: Example:
+
+    .. code-block:: python
+
+        force = hoomd.mpcd.force.ConstantForce((1.0, 0, 0))
+        stream = hoomd.mpcd.stream.Bulk(period=1, solvent_force=force)
+        simulation.operations.integrator.streaming_method = stream
+
     Attributes:
         force (`tuple` [`float`, `float`, `float`]): Force vector per particle.
+
+            .. rubric:: Example:
+
+            .. code-block:: python
+
+                force.force = (1.0, 0.0, 0.0)
 
     """
 
@@ -128,7 +178,7 @@ class SineForce(SolventForce):
         wavenumber (float): Wavenumber for the sinusoid.
 
     `SineForce` applies a force with amplitude *F* in *x* that is sinusoidally
-    varying in *y* with wavenumber *k*:
+    varying in *y* with wavenumber *k* to all solvent particles:
 
     .. math::
 
@@ -138,10 +188,36 @@ class SineForce(SolventForce):
     with the simulation box. For example, :math:`k = 2\pi/L_y` will generate
     one period of the sine.
 
+    .. rubric:: Example:
+
+    Sine force with one period.
+
+    .. code-block:: python
+
+        Ly = simulation.state.box.Ly
+        force = hoomd.mpcd.force.SineForce(
+            amplitude=1.0,
+            wavenumber=2 * numpy.pi / Ly)
+        stream = hoomd.mpcd.stream.Bulk(period=1, solvent_force=force)
+        simulation.operations.integrator.streaming_method = stream
+
     Attributes:
         amplitude (float): Amplitude of the sinusoid.
 
+            .. rubric:: Example:
+
+            .. code-block:: python
+
+                force.amplitude = 1.0
+
         wavenumber (float): Wavenumber for the sinusoid.
+
+            .. rubric:: Example:
+
+            .. code-block:: python
+
+                Ly = simulation.state.box.Ly
+                force.wavenumber = 2 * numpy.pi / Ly
 
     """
 

--- a/hoomd/mpcd/force.py
+++ b/hoomd/mpcd/force.py
@@ -4,13 +4,14 @@
 r""" MPCD solvent forces.
 
 MPCD can apply a body force to each MPCD particle as a function of position.
-The external force should be compatible with the chosen `~hoomd.mpcd.geometry.Geometry`.
-Global momentum conservation can be broken by adding a solvent force, so
-care should be chosen that the entire model is designed so that the system
-does not have net acceleration. For example, solid boundaries can be used to
-dissipate momentum, or a balancing force can be applied to particles that are
-embedded in the solvent through the collision step. Additionally, a thermostat
-will likely be required to maintain temperature control in the driven system.
+The external force should be compatible with the chosen
+:class:`~hoomd.mpcd.geometry.Geometry`. Global momentum conservation can be
+broken by adding a solvent force, so care should be chosen that the entire model
+is designed so that the system does not have net acceleration. For example,
+solid boundaries can be used to dissipate momentum, or a balancing force can be
+applied to particles that are embedded in the solvent through the collision
+step. Additionally, a thermostat will likely be required to maintain temperature
+control in the driven system.
 
 .. invisible-code-block: python
 

--- a/hoomd/mpcd/geometry.py
+++ b/hoomd/mpcd/geometry.py
@@ -38,18 +38,12 @@ class Geometry(_HOOMDBaseObject):
 
     Attributes:
         no_slip (bool): If True, plates have a no-slip boundary condition.
-            Otherwise, they have a slip boundary condition.
+            Otherwise, they have a slip boundary condition (*read only*).
 
             A no-slip boundary condition means that the average velocity is
             zero at the surface. A slip boundary condition means that the
             average *normal* velocity is zero at the surface, but there
             is no friction against the *tangential* velocity.
-
-            .. rubric:: Example:
-
-            .. code-block:: python
-
-                geometry.no_slip = True
 
     """
 
@@ -103,9 +97,9 @@ class ParallelPlates(Geometry):
         simulation.operations.integrator.streaming_method = stream
 
     Attributes:
-        H (float): Channel half-width.
+        H (float): Channel half-width (*read only*).
 
-        V (float): Wall speed.
+        V (float): Wall speed (*read only*).
 
             `V` will have no effect if `no_slip` is False because the slip
             surface cannot generate shear stress.
@@ -151,9 +145,9 @@ class PlanarPore(Geometry):
         simulation.operations.integrator.streaming_method = stream
 
     Attributes:
-        H (float): Pore half-width.
+        H (float): Pore half-width (*read only*).
 
-        L (float): Pore half-length.
+        L (float): Pore half-length (*read only*).
 
     """
 

--- a/hoomd/mpcd/geometry.py
+++ b/hoomd/mpcd/geometry.py
@@ -6,12 +6,17 @@ r"""MPCD geometries.
 A geometry defines solid boundaries that cannot be penetrated. These
 geometries are used for various operations in the MPCD algorithm including:
 
-* :class:`~hoomd.mpcd.stream.BounceBack` streaming for the solvent
-* Bounce back integration for MD particles
-* Virtual particle filling
+* Bounce-back streaming for MPCD particles (:class:`hoomd.mpcd.stream.BounceBack`)
+* Bounce-back integration for MD particles (:class:`hoomd.mpcd.methods.BounceBack`)
+* Virtual particle filling (:class:`hoomd.mpcd.fill.GeometryFiller`)
 
 Each geometry may put constraints on the size of the simulation and where
 particles are allowed. These constraints will be documented by each object.
+
+.. invisible-code-block: python
+
+    simulation = hoomd.util.make_example_simulation(mpcd_types=["A"])
+    simulation.operations.integrator = hoomd.mpcd.Integrator(dt=0.1)
 
 """
 
@@ -24,15 +29,27 @@ class Geometry(_HOOMDBaseObject):
     r"""Geometry.
 
     Args:
-        no_slip (bool): If True, surfaces have no-slip boundary condition.
-            Otherwise, they have the slip boundary condition.
+        no_slip (bool): If True, surfaces have a no-slip boundary condition.
+            Otherwise, they have a slip boundary condition.
+
+    .. invisible-code-block: python
+
+        geometry = hoomd.mpcd.geometry.Geometry(no_slip=True)
 
     Attributes:
-        no_slip (bool): If True, plates have no-slip boundary condition.
-            Otherwise, they have the slip boundary condition.
+        no_slip (bool): If True, plates have a no-slip boundary condition.
+            Otherwise, they have a slip boundary condition.
 
-            `V` will have no effect if `no_slip` is False because the slip
-            surface cannot generate shear stress.
+            A no-slip boundary condition means that the average velocity is
+            zero at the surface. A slip boundary condition means that the
+            average *normal* velocity is zero at the surface, but there
+            is no friction against the *tangential* velocity.
+
+            .. rubric:: Example:
+
+            .. code-block:: python
+
+                geometry.no_slip = True
 
     """
 
@@ -52,17 +69,46 @@ class ParallelPlates(Geometry):
         no_slip (bool): If True, surfaces have no-slip boundary condition.
             Otherwise, they have the slip boundary condition.
 
-    `ParallelPlates` confines the MPCD particles between two infinite parallel
+    `ParallelPlates` confines particles between two infinite parallel
     plates centered around the origin. The plates are placed at :math:`y=-H`
     and :math:`y=+H`, so the total channel width is :math:`2H`. The plates may
     be put into motion, moving with speeds :math:`-V` and :math:`+V` in the *x*
     direction, respectively. If combined with a no-slip boundary condition,
     this motion can be used to generate simple shear flow.
 
+    .. rubric:: Examples:
+
+    Stationary parallel plates with no-slip boundary condition.
+
+    .. code-block:: python
+
+        plates = hoomd.mpcd.geometry.ParallelPlates(H=3.0)
+        stream = hoomd.mpcd.stream.BounceBack(period=1, geometry=plates)
+        simulation.operations.integrator.streaming_method = stream
+
+    Stationary parallel plates with slip boundary condition.
+
+    .. code-block:: python
+
+        plates = hoomd.mpcd.geometry.ParallelPlates(H=3.0, no_slip=False)
+        stream = hoomd.mpcd.stream.BounceBack(period=1, geometry=plates)
+        simulation.operations.integrator.streaming_method = stream
+
+    Moving parallel plates.
+
+    .. code-block:: python
+
+        plates = hoomd.mpcd.geometry.ParallelPlates(H=3.0, V=1.0, no_slip=True)
+        stream = hoomd.mpcd.stream.BounceBack(period=1, geometry=plates)
+        simulation.operations.integrator.streaming_method = stream
+
     Attributes:
         H (float): Channel half-width.
 
         V (float): Wall speed.
+
+            `V` will have no effect if `no_slip` is False because the slip
+            surface cannot generate shear stress.
 
     """
 
@@ -95,6 +141,14 @@ class PlanarPore(Geometry):
     plates. The plates are infinite in *z*. Outside the pore, the simulation box
     has full periodic boundaries; it is not confined by any walls. This model
     hence mimics a narrow pore in, e.g., a membrane.
+
+    .. rubric:: Example:
+
+    .. code-block:: python
+
+        pore = hoomd.mpcd.geometry.PlanarPore(H=3.0, L=2.0)
+        stream = hoomd.mpcd.stream.BounceBack(period=1, geometry=pore)
+        simulation.operations.integrator.streaming_method = stream
 
     Attributes:
         H (float): Pore half-width.

--- a/hoomd/mpcd/integrate.py
+++ b/hoomd/mpcd/integrate.py
@@ -99,8 +99,7 @@ class Integrator(_MDIntegrator):
     .. code-block:: python
 
         dt_md = 0.005
-        dt_mpcd = 0.1
-        md_steps_per_collision = numpy.round(dt_mpcd / dt_md).astype(int)
+        md_steps_per_collision = 20 # collision time = 0.1
 
         stream = hoomd.mpcd.stream.Bulk(period=md_steps_per_collision)
         collide = hoomd.mpcd.collide.StochasticRotationDynamics(

--- a/hoomd/mpcd/integrate.py
+++ b/hoomd/mpcd/integrate.py
@@ -207,7 +207,7 @@ class Integrator(_MDIntegrator):
 
         A `CellList` is automatically created with each `Integrator`
         using typical defaults of cell size 1 and random grid shifting enabled.
-        You can change this configuration if desired.
+        You can change this parameter configuration if desired.
 
         """
         return self._cell_list

--- a/hoomd/mpcd/methods.py
+++ b/hoomd/mpcd/methods.py
@@ -3,10 +3,15 @@
 
 r""" MPCD integration methods
 
-Defines extra integration methods useful for solutes (MD particles) embedded in
-an MPCD solvent. However, these methods are not restricted to MPCD
-simulations: they can be used as methods of `hoomd.md.Integrator`. For example,
-`BounceBack` might be used to run DPD simulations with surfaces.
+Extra integration methods for solutes (MD particles) embedded in an MPCD
+solvent. These methods are not restricted to MPCD simulations: they can be used
+as methods of `hoomd.md.Integrator`. For example, `BounceBack` might be used to
+run DPD simulations with surfaces.
+
+.. invisible-code-block: python
+
+    simulation = hoomd.util.make_example_simulation(mpcd_types=["A"])
+    simulation.operations.integrator = hoomd.mpcd.Integrator(dt=0.1)
 
 """
 
@@ -19,7 +24,7 @@ from hoomd.mpcd.geometry import Geometry
 
 
 class BounceBack(Method):
-    r"""Velocity Verlet integration method with bounce-back rule for surfaces.
+    r"""Velocity Verlet integration method with bounce-back from surfaces.
 
     Args:
         filter (hoomd.filter.filter_like): Subset of particles on which to
@@ -59,6 +64,16 @@ class BounceBack(Method):
         complicated to validate easily, so it is the user's responsibility to
         choose the `filter` correctly.
 
+    .. rubric:: Example:
+
+    .. code-block:: python
+
+        plates = hoomd.mpcd.geometry.ParallelPlates(H=3.0)
+        nve = hoomd.mpcd.methods.BounceBack(
+            filter=hoomd.filter.All(),
+            geometry=plates)
+        simulation.operations.integrator.methods.append(nve)
+
     Attributes:
         filter (hoomd.filter.filter_like): Subset of particles on which to apply
             this method.
@@ -85,8 +100,14 @@ class BounceBack(Method):
         Returns:
             True if all particles are inside `geometry`.
 
+        .. rubric:: Example:
+
+        .. code-block:: python
+
+            assert nve.check_particles()
+
         """
-        self._cpp_obj.check_particles()
+        return self._cpp_obj.check_particles()
 
     def _attach_hook(self):
         sim = self._simulation

--- a/hoomd/mpcd/methods.py
+++ b/hoomd/mpcd/methods.py
@@ -76,9 +76,9 @@ class BounceBack(Method):
 
     Attributes:
         filter (hoomd.filter.filter_like): Subset of particles on which to apply
-            this method.
+            this method (*read only*).
 
-        geometry (hoomd.mpcd.geometry.Geometry): Surface to bounce back from.
+        geometry (hoomd.mpcd.geometry.Geometry): Surface to bounce back from (*read only*).
 
     """
 

--- a/hoomd/mpcd/pytest/test_methods.py
+++ b/hoomd/mpcd/pytest/test_methods.py
@@ -152,8 +152,8 @@ class TestBounceBack:
                 snap.particles.velocity, [[1.2, 1.4, -1.2], [-0.9, -0.8, -1.1]])
 
     @pytest.mark.parametrize("H,expected_result", [(4.0, True), (3.8, False)])
-    def test_test_out_of_bounds(self, simulation_factory, snap, integrator, H,
-                                expected_result):
+    def test_check_particles(self, simulation_factory, snap, integrator, H,
+                             expected_result):
         """Test box validation raises an error on run."""
         integrator.methods[0].geometry.H = H
 

--- a/hoomd/mpcd/pytest/test_methods.py
+++ b/hoomd/mpcd/pytest/test_methods.py
@@ -151,15 +151,17 @@ class TestBounceBack:
             np.testing.assert_array_almost_equal(
                 snap.particles.velocity, [[1.2, 1.4, -1.2], [-0.9, -0.8, -1.1]])
 
-    def test_test_out_of_bounds(self, simulation_factory, snap, integrator):
+    @pytest.mark.parametrize("H,expected_result", [(4.0, True), (3.8, False)])
+    def test_test_out_of_bounds(self, simulation_factory, snap, integrator, H,
+                                expected_result):
         """Test box validation raises an error on run."""
-        integrator.methods[0].geometry.H = 3.8
+        integrator.methods[0].geometry.H = H
 
         sim = simulation_factory(snap)
         sim.operations.integrator = integrator
 
         sim.run(0)
-        assert not integrator.methods[0].check_particles()
+        assert integrator.methods[0].check_particles() is expected_result
 
     def test_md_integrator(self, simulation_factory, snap):
         """Test we can also attach to a normal MD integrator."""

--- a/hoomd/mpcd/pytest/test_stream.py
+++ b/hoomd/mpcd/pytest/test_stream.py
@@ -290,17 +290,19 @@ class TestParallelPlates:
             np.testing.assert_array_almost_equal(
                 snap.mpcd.velocity, [[1.0, -1.0, 1.0], [0.0, 1.0, 1.0]])
 
-    def test_test_out_of_bounds(self, simulation_factory, snap):
+    @pytest.mark.parametrize("H,expected_result", [(4.0, True), (3.8, False)])
+    def test_test_out_of_bounds(self, simulation_factory, snap, H,
+                                expected_result):
         if snap.communicator.rank == 0:
             snap.mpcd.position[0] = [0, 3.85, 0]
         sim = simulation_factory(snap)
         sm = hoomd.mpcd.stream.BounceBack(
-            period=1, geometry=hoomd.mpcd.geometry.ParallelPlates(H=3.8))
+            period=1, geometry=hoomd.mpcd.geometry.ParallelPlates(H=H))
         ig = hoomd.mpcd.Integrator(dt=0.1, streaming_method=sm)
         sim.operations.integrator = ig
 
         sim.run(0)
-        assert not sm.check_solvent_particles()
+        assert sm.check_solvent_particles() is expected_result
 
 
 class TestPlanarPore:
@@ -474,6 +476,11 @@ class TestPlanarPore:
         sim = simulation_factory(snap)
         ig = hoomd.mpcd.Integrator(dt=0.1)
         sim.operations.integrator = ig
+
+        ig.streaming_method = hoomd.mpcd.stream.BounceBack(
+            period=1, geometry=hoomd.mpcd.geometry.PlanarPore(H=4, L=3))
+        sim.run(0)
+        assert ig.streaming_method.check_solvent_particles()
 
         ig.streaming_method = hoomd.mpcd.stream.BounceBack(
             period=1, geometry=hoomd.mpcd.geometry.PlanarPore(H=3.8, L=3))

--- a/hoomd/mpcd/pytest/test_stream.py
+++ b/hoomd/mpcd/pytest/test_stream.py
@@ -291,8 +291,8 @@ class TestParallelPlates:
                 snap.mpcd.velocity, [[1.0, -1.0, 1.0], [0.0, 1.0, 1.0]])
 
     @pytest.mark.parametrize("H,expected_result", [(4.0, True), (3.8, False)])
-    def test_test_out_of_bounds(self, simulation_factory, snap, H,
-                                expected_result):
+    def test_check_solvent_particles(self, simulation_factory, snap, H,
+                                     expected_result):
         if snap.communicator.rank == 0:
             snap.mpcd.position[0] = [0, 3.85, 0]
         sim = simulation_factory(snap)
@@ -470,7 +470,7 @@ class TestPlanarPore:
             np.testing.assert_array_almost_equal(snap.mpcd.position[7],
                                                  [3.18, -4.17, 0])
 
-    def test_test_out_of_bounds(self, simulation_factory, snap):
+    def test_check_solvent_particles(self, simulation_factory, snap):
         """Test box validation raises an error on run."""
         snap = self._make_particles(snap)
         sim = simulation_factory(snap)

--- a/hoomd/mpcd/stream.py
+++ b/hoomd/mpcd/stream.py
@@ -45,12 +45,9 @@ class StreamingMethod(Operation):
         period (int): Number of integration steps covered by streaming step.
         solvent_force (SolventForce): Force on solvent.
 
-    .. invisible-code-block: python
-
-        streaming_method = hoomd.mpcd.stream.StreamingMethod(period=1)
-
     Attributes:
-        period (int): Number of integration steps covered by streaming step.
+        period (int): Number of integration steps covered by streaming step
+            (*read only*).
 
             The MPCD particles will be streamed every time the
             :attr:`~hoomd.Simulation.timestep` is a multiple of `period`. The
@@ -61,13 +58,10 @@ class StreamingMethod(Operation):
             used if an external force is applied, and more faithful numerical
             integration is needed.
 
-            .. rubric:: Example:
-
-            .. code-block:: python
-
-                streaming_method.period = 1
-
         solvent_force (SolventForce): Force on solvent.
+
+            The `solvent_force` cannot be changed after the `StreamingMethod` is
+            constructed, but its attributes can be modified.
 
     """
 
@@ -215,7 +209,8 @@ class BounceBack(StreamingMethod):
         simulation.operations.integrator.streaming_method = stream
 
     Attributes:
-        geometry (hoomd.mpcd.geometry.Geometry): Surface to bounce back from.
+        geometry (hoomd.mpcd.geometry.Geometry): Surface to bounce back from
+            (*read only*).
 
     """
 

--- a/hoomd/mpcd/tune.py
+++ b/hoomd/mpcd/tune.py
@@ -6,6 +6,11 @@ r"""MPCD tuning operations.
 These operations will affect the performance of MPCD simulations but not
 their correctness.
 
+.. invisible-code-block: python
+
+    simulation = hoomd.util.make_example_simulation(mpcd_types=["A"])
+    simulation.operations.integrator = hoomd.mpcd.Integrator(dt=0.1)
+
 """
 
 import hoomd
@@ -38,9 +43,22 @@ class ParticleSorter(TriggeredOperation):
     Essentially all MPCD systems benefit from sorting, so it is recommended
     to use one for all simulations!
 
+    .. rubric:: Example:
+
+    .. code-block:: python
+
+        sorter = hoomd.mpcd.tune.ParticleSorter(trigger=20)
+        simulation.operations.integrator.solvent_sorter = sorter
+
     Attributes:
         trigger (hoomd.trigger.Trigger): Number of integration steps
             between sorting.
+
+            .. rubric:: Example:
+
+            .. code-block:: python
+
+                sorter.trigger = 20
 
     """
 

--- a/hoomd/util.py
+++ b/hoomd/util.py
@@ -265,7 +265,10 @@ class _NoGPU:
             "This build of HOOMD-blue does not support GPUs.")
 
 
-def make_example_simulation(device=None, dimensions=3, particle_types=['A']):
+def make_example_simulation(device=None,
+                            dimensions=3,
+                            particle_types=['A'],
+                            mpcd_types=None):
     """Make an example Simulation object.
 
     The simulation state contains two particles at positions (-1, 0, 0) and
@@ -278,6 +281,9 @@ def make_example_simulation(device=None, dimensions=3, particle_types=['A']):
         dimensions (int): Number of dimensions (2 or 3).
 
         particle_types (list[str]): Particle type names.
+
+        mpcd_types (list[str]): If not `None`, also create two MPCD particles,
+            and include these type names in the snapshot.
 
     Returns:
         hoomd.Simulation: The simulation object.
@@ -292,6 +298,7 @@ def make_example_simulation(device=None, dimensions=3, particle_types=['A']):
     .. code-block:: python
 
         simulation = hoomd.util.make_example_simulation()
+
     """
     if device is None:
         device = hoomd.device.CPU()
@@ -305,6 +312,13 @@ def make_example_simulation(device=None, dimensions=3, particle_types=['A']):
         if dimensions == 2:
             Lz = 0
         snapshot.configuration.box = [10, 10, Lz, 0, 0, 0]
+
+        if mpcd_types is not None:
+            if not hoomd.version.mpcd_built:
+                raise RuntimeError("MPCD component not built")
+            snapshot.mpcd.N = 2
+            snapshot.mpcd.position[:] = [(-1, 0, 0), (1, 0, 0)]
+            snapshot.mpcd.types = mpcd_types
 
     simulation = hoomd.Simulation(device=device)
     simulation.create_state_from_snapshot(snapshot)


### PR DESCRIPTION
## Description

This PR adds sybil examples to all the MPCD Python code. It also does some light editing since I reviewed all the MPCD docs while making the examples. The doc testing also caught some mistakes in `check_particles` and `check_solvent_particles` that the normal pytest missed—cool!

## Motivation and context

These examples were missing but are helpful. This addresses a major item in the checklist for #775.

## How has this been tested?

I checked that the documentation compiles correctly, and the examples pass sybil tests.

## Change log

N/A

## Checklist:

- [X] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.rst).
- [X] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [X] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
