### PR TITLE
Enable slow compression with QuickCompress

### DIFF
--- a/hoomd/BoxDim.h
+++ b/hoomd/BoxDim.h
@@ -601,22 +601,7 @@ struct
         return L1 == L2 && xy1 == xy2 && xz1 == xz2 && yz1 == yz2;
         }
 
-    HOSTDEVICE bool operator==(const std::array<Scalar, 6>& other) const
-        {
-        Scalar3 L = getL();
-        Scalar xy = getTiltFactorXY();
-        Scalar xz = getTiltFactorXZ();
-        Scalar yz = getTiltFactorYZ();
-        std::array<Scalar, 6> box = {L.x, L.y, L.z, xy, xz, yz};
-        return box == other;
-        }
-
     HOSTDEVICE bool operator!=(const BoxDim& other) const
-        {
-        return !((*this) == other);
-        }
-
-    HOSTDEVICE bool operator!=(const std::array<Scalar, 6>& other) const
         {
         return !((*this) == other);
         }

--- a/hoomd/BoxDim.h
+++ b/hoomd/BoxDim.h
@@ -11,7 +11,9 @@
 #include "HOOMDMath.h"
 #include "VectorMath.h"
 
+#if !defined(HOOMD_LLVMJIT_BUILD)
 #include <array>
+#endif
 
 // Don't include MPI when compiling with __HIPCC__ or an LLVM JIT build
 #if defined(ENABLE_MPI) && !defined(__HIPCC__) && !defined(HOOMD_LLVMJIT_BUILD)
@@ -143,6 +145,7 @@ struct
         m_xz = m_xy = m_yz = Scalar(0.0);
         }
 
+#if !defined(HOOMD_LLVMJIT_BUILD)
     /// Constructs a box from a std::array<Scalar, 6>
     /** @param array Box parameters
      */
@@ -152,6 +155,7 @@ struct
         setTiltFactors(array[3], array[4], array[5]);
         m_periodic = make_uchar3(1, 1, 1);
         }
+#endif
 
     //! Get the periodic flags
     /*! \return Periodic flags

--- a/hoomd/BoxDim.h
+++ b/hoomd/BoxDim.h
@@ -141,6 +141,16 @@ struct
         m_xz = m_xy = m_yz = Scalar(0.0);
         }
 
+    /// Constructs a box from a std::array<Scalar, 6>
+    /** @param array Box parameters
+    */
+    HOSTDEVICE explicit BoxDim(const std::array<Scalar, 6>& array)
+        {
+        setL(make_scalar3(array[0], array[1], array[2]));
+        setTiltFactors(array[3], array[4], array[5]);
+        m_periodic = make_uchar3(1, 1, 1);
+        }
+
     //! Get the periodic flags
     /*! \return Periodic flags
      */

--- a/hoomd/BoxDim.h
+++ b/hoomd/BoxDim.h
@@ -11,6 +11,8 @@
 #include "HOOMDMath.h"
 #include "VectorMath.h"
 
+#include <array>
+
 // Don't include MPI when compiling with __HIPCC__ or an LLVM JIT build
 #if defined(ENABLE_MPI) && !defined(__HIPCC__) && !defined(HOOMD_LLVMJIT_BUILD)
 #include "HOOMDMPI.h"

--- a/hoomd/BoxDim.h
+++ b/hoomd/BoxDim.h
@@ -601,7 +601,22 @@ struct
         return L1 == L2 && xy1 == xy2 && xz1 == xz2 && yz1 == yz2;
         }
 
+    HOSTDEVICE bool operator==(const std::array<Scalar, 6>& other) const
+        {
+        Scalar3 L = getL();
+        Scalar xy = getTiltFactorXY();
+        Scalar xz = getTiltFactorXZ();
+        Scalar yz = getTiltFactorYZ();
+        std::array<Scalar, 6> box = {L.x, L.y, L.z, xy, xz, yz};
+        return box == other;
+        }
+
     HOSTDEVICE bool operator!=(const BoxDim& other) const
+        {
+        return !((*this) == other);
+        }
+
+    HOSTDEVICE bool operator!=(const std::array<Scalar, 6>& other) const
         {
         return !((*this) == other);
         }

--- a/hoomd/BoxDim.h
+++ b/hoomd/BoxDim.h
@@ -143,7 +143,7 @@ struct
 
     /// Constructs a box from a std::array<Scalar, 6>
     /** @param array Box parameters
-    */
+     */
     HOSTDEVICE explicit BoxDim(const std::array<Scalar, 6>& array)
         {
         setL(make_scalar3(array[0], array[1], array[2]));

--- a/hoomd/data/typeconverter.py
+++ b/hoomd/data/typeconverter.py
@@ -10,6 +10,7 @@ from inspect import isclass
 from hoomd.error import TypeConversionError
 from hoomd.util import _is_iterable
 from hoomd.variant import Variant, Constant
+from hoomd.variant.box import Constant as ConstantBox
 from hoomd.trigger import Trigger, Periodic
 from hoomd.filter import ParticleFilter, CustomFilter
 import hoomd
@@ -61,6 +62,22 @@ def box_preprocessing(box):
         except Exception:
             raise ValueError(f"{box} is not convertible into a hoomd.Box object"
                              f". using hoomd.Box.from_box")
+
+
+def box_variant_preprocessing(input):
+    """Process box variants.
+
+    Convert boxes and length-6 array-like objects to
+    `hoomd.variant.box.Constant`.
+    """
+    if isinstance(input, hoomd.vector.box.BoxVariant):
+        return input
+    else:
+        try:
+            return ConstantBox(box_preprocessing(input))
+        except Exception:
+            raise ValueError(f"{input} is not convertible into a "
+                             f"hoomd.variant.box.BoxVariant object.")
 
 
 def positive_real(number):
@@ -391,6 +408,9 @@ class _BaseConverter:
             OnlyTypes(Trigger, preprocess=trigger_preprocessing),
         hoomd.Box:
             OnlyTypes(hoomd.Box, preprocess=box_preprocessing),
+        hoomd.variant.box.BoxVariant:
+            OnlyTypes(hoomd.variant.box.BoxVariant,
+                      preprocess=box_variant_preprocessing),
         # arrays default to float of one dimension of arbitrary length and
         # ordering
         np.ndarray:

--- a/hoomd/data/typeconverter.py
+++ b/hoomd/data/typeconverter.py
@@ -73,7 +73,7 @@ def box_variant_preprocessing(input):
         return input
     else:
         try:
-            return hoomd.variant.box.ConstantBox(box_preprocessing(input))
+            return hoomd.variant.box.Constant(box_preprocessing(input))
         except Exception:
             raise ValueError(f"{input} is not convertible into a "
                              f"hoomd.variant.box.BoxVariant object.")

--- a/hoomd/data/typeconverter.py
+++ b/hoomd/data/typeconverter.py
@@ -10,7 +10,6 @@ from inspect import isclass
 from hoomd.error import TypeConversionError
 from hoomd.util import _is_iterable
 from hoomd.variant import Variant, Constant
-from hoomd.variant.box import Constant as ConstantBox
 from hoomd.trigger import Trigger, Periodic
 from hoomd.filter import ParticleFilter, CustomFilter
 import hoomd
@@ -70,11 +69,11 @@ def box_variant_preprocessing(input):
     Convert boxes and length-6 array-like objects to
     `hoomd.variant.box.Constant`.
     """
-    if isinstance(input, hoomd.vector.box.BoxVariant):
+    if isinstance(input, hoomd.variant.box.BoxVariant):
         return input
     else:
         try:
-            return ConstantBox(box_preprocessing(input))
+            return hoomd.variant.box.ConstantBox(box_preprocessing(input))
         except Exception:
             raise ValueError(f"{input} is not convertible into a "
                              f"hoomd.variant.box.BoxVariant object.")

--- a/hoomd/hpmc/UpdaterQuickCompress.cc
+++ b/hoomd/hpmc/UpdaterQuickCompress.cc
@@ -47,7 +47,6 @@ void UpdaterQuickCompress::update(uint64_t timestep)
     // count the number of overlaps in the current configuration
     auto n_overlaps = m_mc->countOverlaps(false);
     BoxDim current_box = m_pdata->getGlobalBox();
-
     BoxDim target_box = BoxDim((*m_target_box)(timestep));
     if (n_overlaps == 0 && current_box != target_box)
         {
@@ -61,9 +60,9 @@ void UpdaterQuickCompress::update(uint64_t timestep)
         m_is_complete = false;
     }
 
-void UpdaterQuickCompress::performBoxScale(uint64_t timestep)
+void UpdaterQuickCompress::performBoxScale(uint64_t timestep, const BoxDim& target_box)
     {
-    auto new_box = getNewBox(timestep);
+    auto new_box = getNewBox(timestep, target_box);
     auto old_box = m_pdata->getGlobalBox();
 
     Scalar3 old_origin = m_pdata->getOrigin();
@@ -140,7 +139,7 @@ static inline double scaleTilt(double current, double target, double s)
         }
     }
 
-BoxDim UpdaterQuickCompress::getNewBox(uint64_t timestep)
+BoxDim UpdaterQuickCompress::getNewBox(uint64_t timestep, const BoxDim& target_box)
     {
     // compute the current MC translate acceptance ratio
     auto current_counters = m_mc->getCounters();
@@ -191,23 +190,23 @@ BoxDim UpdaterQuickCompress::getNewBox(uint64_t timestep)
     Scalar new_xy, new_xz, new_yz;
     if (m_sysdef->getNDimensions() == 3)
         {
-        new_L.x = scaleLength(current_box.getL().x, target_Lx, scale);
-        new_L.y = scaleLength(current_box.getL().y, target_Ly, scale);
-        new_L.z = scaleLength(current_box.getL().z, target_Lz, scale);
-        new_xy = scaleTilt(current_box.getTiltFactorXY(), target_xy, scale);
-        new_xz = scaleTilt(current_box.getTiltFactorXZ(), target_xz, scale);
-        new_yz = scaleTilt(current_box.getTiltFactorYZ(), target_yz, scale);
+        new_L.x = scaleLength(current_box.getL().x, target_box.getL().x, scale);
+        new_L.y = scaleLength(current_box.getL().y, target_box.getL().y, scale);
+        new_L.z = scaleLength(current_box.getL().z, target_box.getL().z, scale);
+        new_xy = scaleTilt(current_box.getTiltFactorXY(), target_box.getTiltFactorXY(), scale);
+        new_xz = scaleTilt(current_box.getTiltFactorXZ(), target_box.getTiltFactorXZ(), scale);
+        new_yz = scaleTilt(current_box.getTiltFactorYZ(), target_box.getTiltFactorYZ(), scale);
         }
     else
         {
-        new_L.x = scaleLength(current_box.getL().x, target_Lx, scale);
-        new_L.y = scaleLength(current_box.getL().y, target_Ly, scale);
-        new_xy = scaleTilt(current_box.getTiltFactorXY(), target_xy, scale);
+        new_L.x = scaleLength(current_box.getL().x, target_box.getL().x, scale);
+        new_L.y = scaleLength(current_box.getL().y, target_box.getL().y, scale);
+        new_xy = scaleTilt(current_box.getTiltFactorXY(), target_box.getTiltFactorXY(), scale);
 
         // assume that the unused fields in the 2D target box are valid
-        new_L.z = target_Lz;
-        new_xz = target_xz;
-        new_yz = target_yz;
+        new_L.z = target_box.getL().z;
+        new_xz = target_box.getTiltFactorXZ();
+        new_yz = target_box.getTiltFactorYZ();
         }
 
     BoxDim new_box = current_box;

--- a/hoomd/hpmc/UpdaterQuickCompress.cc
+++ b/hoomd/hpmc/UpdaterQuickCompress.cc
@@ -183,7 +183,6 @@ BoxDim UpdaterQuickCompress::getNewBox(uint64_t timestep, const BoxDim& target_b
     hoomd::UniformDistribution<double> uniform(min_scale, 1.0);
     double scale = uniform(rng);
 
-
     // construct the scaled box
     BoxDim current_box = m_pdata->getGlobalBox();
     Scalar3 new_L;

--- a/hoomd/hpmc/UpdaterQuickCompress.cc
+++ b/hoomd/hpmc/UpdaterQuickCompress.cc
@@ -48,13 +48,14 @@ void UpdaterQuickCompress::update(uint64_t timestep)
     auto n_overlaps = m_mc->countOverlaps(false);
     BoxDim current_box = m_pdata->getGlobalBox();
 
-    if (n_overlaps == 0 && current_box != (*m_target_box)(timestep))
+    BoxDim target_box = BoxDim((*m_target_box)(timestep));
+    if (n_overlaps == 0 && current_box != target_box)
         {
-        performBoxScale(timestep);
+        performBoxScale(timestep, target_box);
         }
 
     // The compression is complete when we have reached the target box and there are no overlaps.
-    if (n_overlaps == 0 && current_box == (*m_target_box)(timestep))
+    if (n_overlaps == 0 && current_box == target_box)
         m_is_complete = true;
     else
         m_is_complete = false;
@@ -183,13 +184,6 @@ BoxDim UpdaterQuickCompress::getNewBox(uint64_t timestep)
     hoomd::UniformDistribution<double> uniform(min_scale, 1.0);
     double scale = uniform(rng);
 
-    const auto& target_box_dims = (*m_target_box)(timestep);
-    Scalar target_Lx = target_box_dims[0];
-    Scalar target_Ly = target_box_dims[1];
-    Scalar target_Lz = target_box_dims[2];
-    Scalar target_xy = target_box_dims[3];
-    Scalar target_xz = target_box_dims[4];
-    Scalar target_yz = target_box_dims[5];
 
     // construct the scaled box
     BoxDim current_box = m_pdata->getGlobalBox();

--- a/hoomd/hpmc/UpdaterQuickCompress.h
+++ b/hoomd/hpmc/UpdaterQuickCompress.h
@@ -20,9 +20,9 @@ namespace hpmc
     {
 /** Quick compression algorithm
 
-    Quickly compress HPMC systems to a (time-varying) target box volume. The quick compression algorithm performs
-    random box moves to compress the box and *temporarily* allows overlaps. Local trial moves
-    remove these overlaps over time.
+    Quickly compress HPMC systems to a (time-varying) target box volume. The quick compression
+   algorithm performs random box moves to compress the box and *temporarily* allows overlaps. Local
+   trial moves remove these overlaps over time.
 */
 class UpdaterQuickCompress : public Updater
     {

--- a/hoomd/hpmc/UpdaterQuickCompress.h
+++ b/hoomd/hpmc/UpdaterQuickCompress.h
@@ -8,6 +8,7 @@
 #include <hoomd/RandomNumbers.h>
 #include <hoomd/Updater.h>
 #include <hoomd/Variant.h>
+#include <hoomd/VectorVariant.h>
 
 #include "IntegratorHPMC.h"
 
@@ -19,7 +20,7 @@ namespace hpmc
     {
 /** Quick compression algorithm
 
-    Quickly compress HPMC systems to a target box volume. The quick compression algorithm performs
+    Quickly compress HPMC systems to a (time-varying) target box volume. The quick compression algorithm performs
     random box moves to compress the box and *temporarily* allows overlaps. Local trial moves
     remove these overlaps over time.
 */
@@ -39,7 +40,7 @@ class UpdaterQuickCompress : public Updater
                          std::shared_ptr<IntegratorHPMC> mc,
                          double max_overlaps_per_particle,
                          double min_scale,
-                         std::shared_ptr<BoxDim> target_box);
+                         std::shared_ptr<VectorVariantBox> target_box);
 
     /// Destructor
     virtual ~UpdaterQuickCompress();
@@ -101,13 +102,13 @@ class UpdaterQuickCompress : public Updater
         }
 
     /// Get the target box
-    std::shared_ptr<BoxDim> getTargetBox()
+    std::shared_ptr<VectorVariantBox> getTargetBox()
         {
         return m_target_box;
         }
 
     /// Set the target box
-    void setTargetBox(std::shared_ptr<BoxDim> target_box)
+    void setTargetBox(std::shared_ptr<VectorVariantBox> target_box)
         {
         m_target_box = target_box;
         }
@@ -141,7 +142,7 @@ class UpdaterQuickCompress : public Updater
     double m_min_scale;
 
     /// The target box dimensions
-    std::shared_ptr<BoxDim> m_target_box;
+    std::shared_ptr<VectorVariantBox> m_target_box;
 
     /// Unique ID for RNG seeding
     unsigned int m_instance = 0;

--- a/hoomd/hpmc/UpdaterQuickCompress.h
+++ b/hoomd/hpmc/UpdaterQuickCompress.h
@@ -154,10 +154,10 @@ class UpdaterQuickCompress : public Updater
     bool m_allow_unsafe_resize = false;
 
     /// Perform the box scale move
-    void performBoxScale(uint64_t timestep);
+    void performBoxScale(uint64_t timestep, const BoxDim& target_box);
 
     /// Get the new box to set
-    BoxDim getNewBox(uint64_t timestep);
+    BoxDim getNewBox(uint64_t timestep, const BoxDim& target_box);
 
     /// Store the last HPMC counters
     hpmc_counters_t m_last_move_counters;

--- a/hoomd/hpmc/pytest/test_quick_compress.py
+++ b/hoomd/hpmc/pytest/test_quick_compress.py
@@ -278,7 +278,7 @@ def test_inverse_volume_slow_compress(ndim, simulation_factory,
                                       lattice_snapshot_factory):
     """Test that InverseVolumeRamp compresses at an appropriate rate.
 
-    Ensure that the volume is no less than the set point determined by the
+    Ensure that the density is no greater than the set point determined by the
     specified t_start and t_ramp.
     """
     n = 6
@@ -297,7 +297,7 @@ def test_inverse_volume_slow_compress(ndim, simulation_factory,
     else:
         final_packing_fraction = fraction_close_packing * close_packing
         final_volume = n**ndim * v_p / final_packing_fraction
-    t_ramp = 1000
+    t_ramp = 10000
     target_box = hoomd.variant.box.InverseVolumeRamp(sim.state.box,
                                                      final_volume, 0, t_ramp)
     qc = hoomd.hpmc.update.QuickCompress(trigger=hoomd.trigger.Periodic(10),
@@ -311,7 +311,7 @@ def test_inverse_volume_slow_compress(ndim, simulation_factory,
 
     while sim.timestep < t_ramp or (not qc.complete):
         sim.run(10)
-        assert not sim.state.box.volume < hoomd.Box(
+        assert not 1 / sim.state.box.volume > 1 / hoomd.Box(
             *qc.target_box(sim.timestep)).volume
 
 

--- a/hoomd/hpmc/pytest/test_quick_compress.py
+++ b/hoomd/hpmc/pytest/test_quick_compress.py
@@ -313,7 +313,8 @@ def test_inverse_volume_slow_compress(ndim, simulation_factory,
         sim.run(10)
         simulation_density = 1 / sim.state.box.volume
         target_density = 1 / hoomd.Box(*qc.target_box(sim.timestep)).volume
-        assert simulation_density < target_density or simulation_density == pytest.approx(target_density)
+        assert simulation_density < target_density or (
+            simulation_density == pytest.approx(target_density))
 
 
 def test_pickling(simulation_factory, two_particle_snapshot_factory):

--- a/hoomd/hpmc/pytest/test_quick_compress.py
+++ b/hoomd/hpmc/pytest/test_quick_compress.py
@@ -13,20 +13,31 @@ import numpy as np
 # here that require preprocessing
 valid_constructor_args = [
     dict(trigger=hoomd.trigger.Periodic(10),
-         target_box=hoomd.Box.from_box([10, 10, 10])),
+         target_box=hoomd.variant.box.Constant(hoomd.Box.from_box([10, 10, 10]))),
     dict(trigger=hoomd.trigger.After(100),
-         target_box=hoomd.Box.from_box([10, 20, 40]),
+         target_box=hoomd.variant.box.Constant(hoomd.Box.from_box([10, 20, 40])),
          max_overlaps_per_particle=0.2),
     dict(trigger=hoomd.trigger.Before(100),
-         target_box=hoomd.Box.from_box([50, 50]),
+         target_box=hoomd.variant.box.Constant(hoomd.Box.from_box([50, 50])),
          min_scale=0.75),
     dict(trigger=hoomd.trigger.Periodic(1000),
-         target_box=hoomd.Box.from_box([80, 50, 40, 0.2, 0.4, 0.5]),
+         target_box=hoomd.variant.box.Constant(hoomd.Box.from_box([80, 50, 40, 0.2, 0.4, 0.5])),
          max_overlaps_per_particle=0.2,
          min_scale=0.999,
          allow_unsafe_resize=True),
     dict(trigger=hoomd.trigger.Periodic(1000),
-         target_box=hoomd.Box.from_box([80, 50, 40, -0.2, 0.4, 0.5]),
+         target_box=hoomd.variant.box.Constant(hoomd.Box.from_box([80, 50, 40, -0.2, 0.4, 0.5])),
+         max_overlaps_per_particle=0.2,
+         min_scale=0.999),
+    dict(trigger=hoomd.trigger.Periodic(1000),
+         target_box=hoomd.variant.box.Interpolate(
+            hoomd.Box.from_box([10, 20, 30]),
+            hoomd.Box.from_box([24, 7, 365]),
+            hoomd.variant.Ramp(0, 1, 0, 100)),
+         max_overlaps_per_particle=0.2,
+         min_scale=0.999),
+    dict(trigger=hoomd.trigger.Periodic(1000),
+         target_box=hoomd.variant.box.InverseVolumeRamp(hoomd.Box.from_box([10, 20, 30]), 3000, 10, 100),
          max_overlaps_per_particle=0.2,
          min_scale=0.999),
 ]
@@ -35,8 +46,14 @@ valid_attrs = [
     ('trigger', hoomd.trigger.Periodic(10000)),
     ('trigger', hoomd.trigger.After(100)),
     ('trigger', hoomd.trigger.Before(12345)),
-    ('target_box', hoomd.Box.from_box([10, 20, 30])),
-    ('target_box', hoomd.Box.from_box([50, 50])),
+    ('target_box', hoomd.variant.box.Constant(hoomd.Box.from_box([10, 20, 30]))),
+    ('target_box', hoomd.variant.box.Constant(hoomd.Box.from_box([50, 50]))),
+    ('target_box', hoomd.variant.box.Constant(hoomd.Box.from_box([50, 50]))),
+    ('target_box', hoomd.variant.box.Interpolate(
+        hoomd.Box.from_box([10, 20, 30]),
+        hoomd.Box.from_box([24, 7, 365]),
+        hoomd.variant.Ramp(0, 1, 0, 100))),
+    ('target_box', hoomd.variant.box.InverseVolumeRamp(hoomd.Box.from_box([10, 20, 30]), 3000, 10, 100)),
     ('max_overlaps_per_particle', 0.2),
     ('max_overlaps_per_particle', 0.5),
     ('max_overlaps_per_particle', 2.5),
@@ -95,8 +112,8 @@ def test_valid_setattr_attached(attr, value, simulation_factory,
                                 two_particle_snapshot_factory):
     """Test that QuickCompress can get and set attributes while attached."""
     qc = hoomd.hpmc.update.QuickCompress(trigger=hoomd.trigger.Periodic(10),
-                                         target_box=hoomd.Box.from_box(
-                                             [10, 10, 10]))
+                                         target_box=hoomd.variant.box.Constant(hoomd.Box.from_box(
+                                             [10, 10, 10])))
 
     sim = simulation_factory(two_particle_snapshot_factory())
     sim.operations.updaters.append(qc)

--- a/hoomd/hpmc/pytest/test_quick_compress.py
+++ b/hoomd/hpmc/pytest/test_quick_compress.py
@@ -67,6 +67,7 @@ valid_attrs = [
     ('target_box',
      hoomd.variant.box.InverseVolumeRamp(hoomd.Box.from_box([10, 20, 30]), 3000,
                                          10, 100)),
+    ('target_box', hoomd.Box.cube(5)),
     ('max_overlaps_per_particle', 0.2),
     ('max_overlaps_per_particle', 0.5),
     ('max_overlaps_per_particle', 2.5),
@@ -123,6 +124,8 @@ def test_valid_setattr(attr, value):
                                              [10, 10, 10]))
 
     setattr(qc, attr, value)
+    if type(value) is hoomd.Box:
+        value = hoomd.variant.box.Constant(value)
     assert getattr(qc, attr) == value
 
 
@@ -145,6 +148,8 @@ def test_valid_setattr_attached(attr, value, simulation_factory,
     sim.operations._schedule()
 
     setattr(qc, attr, value)
+    if type(value) is hoomd.Box:
+        value = hoomd.variant.box.Constant(value)
     assert getattr(qc, attr) == value
 
 

--- a/hoomd/hpmc/pytest/test_quick_compress.py
+++ b/hoomd/hpmc/pytest/test_quick_compress.py
@@ -311,8 +311,9 @@ def test_inverse_volume_slow_compress(ndim, simulation_factory,
 
     while sim.timestep < t_ramp or (not qc.complete):
         sim.run(10)
-        assert not 1 / sim.state.box.volume > 1 / hoomd.Box(
-            *qc.target_box(sim.timestep)).volume
+        simulation_density = 1 / sim.state.box.volume
+        target_density = 1 / hoomd.Box(*qc.target_box(sim.timestep)).volume
+        assert simulation_density < target_density or simulation_density == pytest.approx(target_density)
 
 
 def test_pickling(simulation_factory, two_particle_snapshot_factory):

--- a/hoomd/hpmc/pytest/test_quick_compress.py
+++ b/hoomd/hpmc/pytest/test_quick_compress.py
@@ -273,7 +273,8 @@ def test_disk_compression(phi, simulation_factory, lattice_snapshot_factory):
 
 @pytest.mark.parametrize("ndim", [2, 3])
 @pytest.mark.parametrize("same_initial_and_final_box", [True, False])
-def test_inverse_volume_slow_compress(ndim, simulation_factory, same_initial_and_final_box,
+def test_inverse_volume_slow_compress(ndim, simulation_factory,
+                                      same_initial_and_final_box,
                                       lattice_snapshot_factory):
     """Test that InverseVolumeRamp compresses at an appropriate rate.
 
@@ -296,7 +297,6 @@ def test_inverse_volume_slow_compress(ndim, simulation_factory, same_initial_and
     else:
         final_packing_fraction = fraction_close_packing * close_packing
         final_volume = n**ndim * v_p / final_packing_fraction
-    initial_volume = sim.state.box.volume
     t_ramp = 1000
     target_box = hoomd.variant.box.InverseVolumeRamp(sim.state.box,
                                                      final_volume, 0, t_ramp)
@@ -308,11 +308,12 @@ def test_inverse_volume_slow_compress(ndim, simulation_factory, same_initial_and
     mc = hoomd.hpmc.integrate.Sphere(default_d=0.05)
     mc.shape['A'] = dict(diameter=1)
     sim.operations.integrator = mc
-    scale = hoomd.variant.Ramp(0, 1, 0, t_ramp)
 
     while sim.timestep < t_ramp or (not qc.complete):
         sim.run(10)
-        assert not sim.state.box.volume < hoomd.Box(*qc.target_box(sim.timestep)).volume
+        assert not sim.state.box.volume < hoomd.Box(
+            *qc.target_box(sim.timestep)).volume
+
 
 def test_pickling(simulation_factory, two_particle_snapshot_factory):
     """Test that QuickCompress objects are picklable."""

--- a/hoomd/hpmc/pytest/test_quick_compress.py
+++ b/hoomd/hpmc/pytest/test_quick_compress.py
@@ -13,31 +13,35 @@ import numpy as np
 # here that require preprocessing
 valid_constructor_args = [
     dict(trigger=hoomd.trigger.Periodic(10),
-         target_box=hoomd.variant.box.Constant(hoomd.Box.from_box([10, 10, 10]))),
+         target_box=hoomd.variant.box.Constant(hoomd.Box.from_box([10, 10,
+                                                                   10]))),
     dict(trigger=hoomd.trigger.After(100),
-         target_box=hoomd.variant.box.Constant(hoomd.Box.from_box([10, 20, 40])),
+         target_box=hoomd.variant.box.Constant(hoomd.Box.from_box([10, 20,
+                                                                   40])),
          max_overlaps_per_particle=0.2),
     dict(trigger=hoomd.trigger.Before(100),
          target_box=hoomd.variant.box.Constant(hoomd.Box.from_box([50, 50])),
          min_scale=0.75),
     dict(trigger=hoomd.trigger.Periodic(1000),
-         target_box=hoomd.variant.box.Constant(hoomd.Box.from_box([80, 50, 40, 0.2, 0.4, 0.5])),
+         target_box=hoomd.variant.box.Constant(
+             hoomd.Box.from_box([80, 50, 40, 0.2, 0.4, 0.5])),
          max_overlaps_per_particle=0.2,
          min_scale=0.999,
          allow_unsafe_resize=True),
     dict(trigger=hoomd.trigger.Periodic(1000),
-         target_box=hoomd.variant.box.Constant(hoomd.Box.from_box([80, 50, 40, -0.2, 0.4, 0.5])),
+         target_box=hoomd.variant.box.Constant(
+             hoomd.Box.from_box([80, 50, 40, -0.2, 0.4, 0.5])),
          max_overlaps_per_particle=0.2,
          min_scale=0.999),
     dict(trigger=hoomd.trigger.Periodic(1000),
          target_box=hoomd.variant.box.Interpolate(
-            hoomd.Box.from_box([10, 20, 30]),
-            hoomd.Box.from_box([24, 7, 365]),
-            hoomd.variant.Ramp(0, 1, 0, 100)),
+             hoomd.Box.from_box([10, 20, 30]), hoomd.Box.from_box([24, 7, 365]),
+             hoomd.variant.Ramp(0, 1, 0, 100)),
          max_overlaps_per_particle=0.2,
          min_scale=0.999),
     dict(trigger=hoomd.trigger.Periodic(1000),
-         target_box=hoomd.variant.box.InverseVolumeRamp(hoomd.Box.from_box([10, 20, 30]), 3000, 10, 100),
+         target_box=hoomd.variant.box.InverseVolumeRamp(
+             hoomd.Box.from_box([10, 20, 30]), 3000, 10, 100),
          max_overlaps_per_particle=0.2,
          min_scale=0.999),
 ]
@@ -46,14 +50,17 @@ valid_attrs = [
     ('trigger', hoomd.trigger.Periodic(10000)),
     ('trigger', hoomd.trigger.After(100)),
     ('trigger', hoomd.trigger.Before(12345)),
-    ('target_box', hoomd.variant.box.Constant(hoomd.Box.from_box([10, 20, 30]))),
+    ('target_box', hoomd.variant.box.Constant(hoomd.Box.from_box([10, 20,
+                                                                  30]))),
     ('target_box', hoomd.variant.box.Constant(hoomd.Box.from_box([50, 50]))),
     ('target_box', hoomd.variant.box.Constant(hoomd.Box.from_box([50, 50]))),
-    ('target_box', hoomd.variant.box.Interpolate(
-        hoomd.Box.from_box([10, 20, 30]),
-        hoomd.Box.from_box([24, 7, 365]),
-        hoomd.variant.Ramp(0, 1, 0, 100))),
-    ('target_box', hoomd.variant.box.InverseVolumeRamp(hoomd.Box.from_box([10, 20, 30]), 3000, 10, 100)),
+    ('target_box',
+     hoomd.variant.box.Interpolate(hoomd.Box.from_box([10, 20, 30]),
+                                   hoomd.Box.from_box([24, 7, 365]),
+                                   hoomd.variant.Ramp(0, 1, 0, 100))),
+    ('target_box',
+     hoomd.variant.box.InverseVolumeRamp(hoomd.Box.from_box([10, 20, 30]), 3000,
+                                         10, 100)),
     ('max_overlaps_per_particle', 0.2),
     ('max_overlaps_per_particle', 0.5),
     ('max_overlaps_per_particle', 2.5),
@@ -112,8 +119,8 @@ def test_valid_setattr_attached(attr, value, simulation_factory,
                                 two_particle_snapshot_factory):
     """Test that QuickCompress can get and set attributes while attached."""
     qc = hoomd.hpmc.update.QuickCompress(trigger=hoomd.trigger.Periodic(10),
-                                         target_box=hoomd.variant.box.Constant(hoomd.Box.from_box(
-                                             [10, 10, 10])))
+                                         target_box=hoomd.variant.box.Constant(
+                                             hoomd.Box.from_box([10, 10, 10])))
 
     sim = simulation_factory(two_particle_snapshot_factory())
     sim.operations.updaters.append(qc)
@@ -253,9 +260,10 @@ def test_disk_compression(phi, simulation_factory, lattice_snapshot_factory):
 
 
 @pytest.mark.parametrize("ndim", [2, 3])
-def test_inverse_volume_slow_compress(ndim, simulation_factory, lattice_snapshot_factory):
+def test_inverse_volume_slow_compress(ndim, simulation_factory,
+                                      lattice_snapshot_factory):
     """Test that InverseVolumeRamp compresses at an appropriate rate.
-    
+
     Ensure that the volume is no less than the set point determined by the
     specified t_start and t_ramp.
     """
@@ -264,11 +272,12 @@ def test_inverse_volume_slow_compress(ndim, simulation_factory, lattice_snapshot
     snap = lattice_snapshot_factory(dimensions=ndim, n=n, a=3.0)
     v_particle = math.pi * (0.5)**2
     target_box = hoomd.Box.square((n * n * v_particle / phi)**(1 / 2))
-    final_volume = n ** ndim * v_particle / phi
+    final_volume = n**ndim * v_particle / phi
     sim = simulation_factory(snap)
     initial_volume = sim.state.box.volume
     t_ramp = 100
-    target_box = hoomd.variant.box.InverseVolumeRamp(sim.state.box, final_volume, 0, t_ramp)
+    target_box = hoomd.variant.box.InverseVolumeRamp(sim.state.box,
+                                                     final_volume, 0, t_ramp)
     qc = hoomd.hpmc.update.QuickCompress(trigger=hoomd.trigger.Periodic(1),
                                          target_box=target_box)
 
@@ -282,7 +291,8 @@ def test_inverse_volume_slow_compress(ndim, simulation_factory, lattice_snapshot
 
     while sim.timestep < t_ramp:
         sim.run(10)
-        target_density = scale(sim.timestep) / final_volume + (1 - scale(sim.timestep)) / initial_volume
+        target_density = scale(sim.timestep) / final_volume + (
+            1 - scale(sim.timestep)) / initial_volume
         target_volume = 1 / target_density
         assert sim.state.box.volume >= target_volume
 

--- a/hoomd/hpmc/update.py
+++ b/hoomd/hpmc/update.py
@@ -858,7 +858,9 @@ class QuickCompress(Updater):
         target_box = hoomd.variant.box.InverseVolumeRamp(
             sim.state.box, sim.state.box.volume / 2, 0, 1_000)
         qc = hoomd.hpmc.update.QuickCompress(10, target_box)
-        while sim.timestep < target_box.t_ramp + target_box.t_start or (not qc.complete):
+        while (
+            sim.timestep < target_box.t_ramp + target_box.t_start or
+            not qc.complete):
             sim.run(100)
 
     Tip:

--- a/hoomd/hpmc/update.py
+++ b/hoomd/hpmc/update.py
@@ -894,9 +894,11 @@ class QuickCompress(Updater):
 
         param_dict = ParameterDict(max_overlaps_per_particle=float,
                                    min_scale=float,
-                                   target_box=hoomd.Box,
+                                   target_box=hoomd.variant.box.BoxVariant,
                                    instance=int,
                                    allow_unsafe_resize=bool)
+        if isinstance(target_box, hoomd.Box):
+            target_box = hoomd.variant.box.Constant(target_box)
         param_dict['max_overlaps_per_particle'] = max_overlaps_per_particle
         param_dict['min_scale'] = min_scale
         param_dict['target_box'] = target_box
@@ -919,7 +921,7 @@ class QuickCompress(Updater):
         self._cpp_obj = _hpmc.UpdaterQuickCompress(
             self._simulation.state._cpp_sys_def, self.trigger,
             integrator._cpp_obj, self.max_overlaps_per_particle, self.min_scale,
-            self.target_box._cpp_obj)
+            self.target_box)
 
     @property
     def complete(self):

--- a/hoomd/hpmc/update.py
+++ b/hoomd/hpmc/update.py
@@ -856,9 +856,9 @@ class QuickCompress(Updater):
     simulation timestep. For example::
 
         target_box = hoomd.variant.box.InverseVolumeRamp(
-            sim.state.box, sim.state.box.volume / 2, 0, 10000)
+            sim.state.box, sim.state.box.volume / 2, 0, 1_000)
         qc = hoomd.hpmc.update.QuickCompress(10, target_box)
-        while (not qc.complete) and sim.timestep < qc.target_box.t_ramp:
+        while sim.timestep < target_box.t_ramp + target_box.t_start or (not qc.complete):
             sim.run(100)
 
     Tip:

--- a/hoomd/hpmc/update.py
+++ b/hoomd/hpmc/update.py
@@ -736,7 +736,7 @@ class QuickCompress(Updater):
         trigger (hoomd.trigger.trigger_like): Update the box dimensions on
             triggered time steps.
 
-        target_box (hoomd.box.box_like): Dimensions of the target box.
+        target_box (hoomd.box.box_like or hoomd.variant.box.BoxVariant): Dimensions of the target box.
 
         max_overlaps_per_particle (float): The maximum number of overlaps to
             allow per particle (may be less than 1 - e.g.
@@ -751,7 +751,7 @@ class QuickCompress(Updater):
     Use `QuickCompress` in conjunction with an HPMC integrator to scale the
     system to a target box size. `QuickCompress` can typically compress dilute
     systems to near random close packing densities in tens of thousands of time
-    steps.
+    steps. For more control over the rate of compression, use a `BoxVariant` for `target_box`.
 
     It operates by making small changes toward the `target_box`, but only
     when there are no particle overlaps in the current simulation state. In 3D:
@@ -867,7 +867,7 @@ class QuickCompress(Updater):
     Attributes:
         trigger (Trigger): Update the box dimensions on triggered time steps.
 
-        target_box (Box): Dimensions of the target box.
+        target_box (BoxVariant): The variant for the dimensions of the target box.
 
         max_overlaps_per_particle (float): The maximum number of overlaps to
             allow per particle (may be less than 1 - e.g.

--- a/hoomd/hpmc/update.py
+++ b/hoomd/hpmc/update.py
@@ -736,7 +736,7 @@ class QuickCompress(Updater):
         trigger (hoomd.trigger.trigger_like): Update the box dimensions on
             triggered time steps.
 
-        target_box (hoomd.box.box_like or hoomd.variant.box.BoxVariant):
+        target_box (`hoomd.box.box_like` or `hoomd.variant.box.BoxVariant`):
             Dimensions of the target box.
 
         max_overlaps_per_particle (float): The maximum number of overlaps to

--- a/hoomd/hpmc/update.py
+++ b/hoomd/hpmc/update.py
@@ -780,21 +780,21 @@ class QuickCompress(Updater):
           & L_{\mathrm{target},z} \ge L_z
           \end{cases} \\
           xy' &= \begin{cases}
-          \max( xy \cdot s, xy_\mathrm{target} )
+          \min( xy + (1-s) \cdot xy_\mathrm{target}, xy_\mathrm{target} )
           & xy_\mathrm{target} < xy \\
-          \min( xy / s, xy_\mathrm{target} )
+          \max( xy + (1-s) \cdot xy_\mathrm{target}, xy_\mathrm{target} )
           & xy_\mathrm{target} \ge xy
           \end{cases} \\
           xz' &= \begin{cases}
-          \max( xz \cdot s, xz_\mathrm{target} )
+          \min( xz + (1-s) \cdot xz_\mathrm{target}, xz_\mathrm{target} )
           & xz_\mathrm{target} < xz \\
-          \min( xz / s, xz_\mathrm{target} )
+          \max( xz + (1-s) \cdot xz_\mathrm{target}, xz_\mathrm{target} )
           & xz_\mathrm{target} \ge xz
           \end{cases} \\
           yz' &= \begin{cases}
-          \max( yz \cdot s, yz_\mathrm{target} )
+          \min( yz + (1-s) \cdot yz_\mathrm{target}, yz_\mathrm{target} )
           & yz_\mathrm{target} < yz \\
-          \min( yz / s, yz_\mathrm{target} )
+          \max( yz + (1-s) \cdot yz_\mathrm{target}, yz_\mathrm{target} )
           & yz_\mathrm{target} \ge yz
           \end{cases} \\
 
@@ -816,9 +816,9 @@ class QuickCompress(Updater):
           \end{cases} \\
           L_z' &= L_z \\
           xy' &= \begin{cases}
-          \max( xy \cdot s, xy_\mathrm{target} )
+          \min( xy + (1-s) \cdot xy_\mathrm{target}, xy_\mathrm{target} )
           & xy_\mathrm{target} < xy \\
-          \min( xy / s, xy_\mathrm{target} )
+          \max( xy + (1-s) \cdot xy_\mathrm{target}, xy_\mathrm{target} )
           & xy_\mathrm{target} \ge xy
           \end{cases} \\
           xz' &= xz \\

--- a/hoomd/hpmc/update.py
+++ b/hoomd/hpmc/update.py
@@ -736,7 +736,8 @@ class QuickCompress(Updater):
         trigger (hoomd.trigger.trigger_like): Update the box dimensions on
             triggered time steps.
 
-        target_box (hoomd.box.box_like or hoomd.variant.box.BoxVariant): Dimensions of the target box.
+        target_box (hoomd.box.box_like or hoomd.variant.box.BoxVariant):
+            Dimensions of the target box.
 
         max_overlaps_per_particle (float): The maximum number of overlaps to
             allow per particle (may be less than 1 - e.g.
@@ -751,7 +752,8 @@ class QuickCompress(Updater):
     Use `QuickCompress` in conjunction with an HPMC integrator to scale the
     system to a target box size. `QuickCompress` can typically compress dilute
     systems to near random close packing densities in tens of thousands of time
-    steps. For more control over the rate of compression, use a `BoxVariant` for `target_box`.
+    steps. For more control over the rate of compression, use a `BoxVariant` for
+    `target_box`.
 
     It operates by making small changes toward the `target_box`, but only
     when there are no particle overlaps in the current simulation state. In 3D:
@@ -867,7 +869,8 @@ class QuickCompress(Updater):
     Attributes:
         trigger (Trigger): Update the box dimensions on triggered time steps.
 
-        target_box (BoxVariant): The variant for the dimensions of the target box.
+        target_box (BoxVariant): The variant for the dimensions of the target
+            box.
 
         max_overlaps_per_particle (float): The maximum number of overlaps to
             allow per particle (may be less than 1 - e.g.

--- a/hoomd/hpmc/update.py
+++ b/hoomd/hpmc/update.py
@@ -755,8 +755,9 @@ class QuickCompress(Updater):
     steps. For more control over the rate of compression, use a `BoxVariant` for
     `target_box`.
 
-    It operates by making small changes toward the `target_box`, but only
-    when there are no particle overlaps in the current simulation state. In 3D:
+    `QuickCompress` operates by making small changes toward the `target_box`,
+    but only when there are no particle overlaps in the current simulation
+    state. In 3D:
 
     .. math::
 
@@ -847,10 +848,24 @@ class QuickCompress(Updater):
     box move sizes will be uniformly distributed between ``min_scale`` and 1.0
     (with no consideration of ``min_move_size``).
 
+    When using a `BoxVariant` for `target_box`, `complete` returns `True` if the
+    current simulation box is equal to the box corresponding to `target_box`
+    evaluated at the current timestep and there are no overlaps in the system.
+    To ensure the updater has compressed the system to the final target box, use
+    a condition that checks both the `complete` attribute of the updater and the
+    simulation timestep. For example::
+
+        target_box = hoomd.variant.box.InverseVolumeRamp(
+            sim.state.box, sim.state.box.volume / 2, 0, 10000)
+        qc = hoomd.hpmc.update.QuickCompress(10, target_box)
+        while (not qc.complete) and sim.timestep < qc.target_box.t_ramp:
+            sim.run(100)
+
     Tip:
         Use the `hoomd.hpmc.tune.MoveSize` in conjunction with
         `QuickCompress` to adjust the move sizes to maintain a constant
         acceptance ratio as the density of the system increases.
+
 
     Warning:
         When the smallest MC translational move size is 0, `allow_unsafe_resize`

--- a/hoomd/variant/box.py
+++ b/hoomd/variant/box.py
@@ -37,7 +37,16 @@ class BoxVariant(_hoomd.VectorVariantBox):
         :return: The value of the function at the given time step.
         :rtype: [float, float, float, float, float, float]
     """
-    pass
+
+    def _private_eq(self, other):
+        """Return whether two vector variants are equivalent."""
+        if not isinstance(other, BoxVariant):
+            return NotImplemented
+        if not isinstance(other, type(self)):
+            return False
+        return all(
+            getattr(self, attr) == getattr(other, attr)
+            for attr in self._eq_attrs)
 
 
 class Constant(_hoomd.VectorVariantBoxConstant, BoxVariant):
@@ -49,11 +58,18 @@ class Constant(_hoomd.VectorVariantBoxConstant, BoxVariant):
     `Constant` returns ``[box.Lx, box.Ly, box.Lz, box.xz, box.xz, box.yz]`` at
     all time steps.
     """
+    _eq_attrs = ("box",)
+    __eq__ = BoxVariant._private_eq
 
     def __init__(self, box):
         box = box_preprocessing(box)
         BoxVariant.__init__(self)
         _hoomd.VectorVariantBoxConstant.__init__(self, box._cpp_obj)
+
+    def __reduce__(self):
+        """Reduce values to picklable format."""
+        return (type(self), (Box(*self.box.L, *self.box.tilts),))
+
 
     @property
     def box(self):
@@ -99,6 +115,8 @@ class Interpolate(_hoomd.VectorVariantBoxInterpolate, BoxVariant):
         variant (hoomd.variant.Variant): A variant used to interpolate between
             the two boxes.
     """
+    _eq_attrs = ("initial_box", "final_box",)
+    __eq__ = BoxVariant._private_eq
 
     def __init__(self, initial_box, final_box, variant):
         box1 = box_preprocessing(initial_box)
@@ -162,6 +180,8 @@ class InverseVolumeRamp(_hoomd.VectorVariantBoxInverseVolumeRamp, BoxVariant):
         t_start (int): The time step at the start of the ramp.
         t_ramp (int): The length of the ramp.
     """
+    _eq_attrs = ("initial_box", "final_volume", "t_start", "t_ramp")
+    __eq__ = BoxVariant._private_eq
 
     def __init__(self, initial_box, final_volume, t_start, t_ramp):
         BoxVariant.__init__(self)

--- a/hoomd/variant/box.py
+++ b/hoomd/variant/box.py
@@ -70,7 +70,6 @@ class Constant(_hoomd.VectorVariantBoxConstant, BoxVariant):
         """Reduce values to picklable format."""
         return (type(self), (Box(*self.box.L, *self.box.tilts),))
 
-
     @property
     def box(self):
         """hoomd.Box: The box."""
@@ -115,7 +114,10 @@ class Interpolate(_hoomd.VectorVariantBoxInterpolate, BoxVariant):
         variant (hoomd.variant.Variant): A variant used to interpolate between
             the two boxes.
     """
-    _eq_attrs = ("initial_box", "final_box",)
+    _eq_attrs = (
+        "initial_box",
+        "final_box",
+    )
     __eq__ = BoxVariant._private_eq
 
     def __init__(self, initial_box, final_box, variant):

--- a/hoomd/variant/box.py
+++ b/hoomd/variant/box.py
@@ -4,7 +4,7 @@
 """Implement variants that return box parameters as a function of time."""
 
 from hoomd import _hoomd, Box
-from hoomd.data.typeconverter import box_preprocessing, variant_preprocessing
+import hoomd
 
 
 class BoxVariant(_hoomd.VectorVariantBox):
@@ -62,7 +62,7 @@ class Constant(_hoomd.VectorVariantBoxConstant, BoxVariant):
     __eq__ = BoxVariant._private_eq
 
     def __init__(self, box):
-        box = box_preprocessing(box)
+        box = hoomd.data.typeconverter.box_preprocessing(box)
         BoxVariant.__init__(self)
         _hoomd.VectorVariantBoxConstant.__init__(self, box._cpp_obj)
 
@@ -77,7 +77,7 @@ class Constant(_hoomd.VectorVariantBoxConstant, BoxVariant):
 
     @box.setter
     def box(self, box):
-        box = box_preprocessing(box)
+        box = hoomd.data.typeconverter.box_preprocessing(box)
         self._box = box._cpp_obj
 
 
@@ -121,9 +121,9 @@ class Interpolate(_hoomd.VectorVariantBoxInterpolate, BoxVariant):
     __eq__ = BoxVariant._private_eq
 
     def __init__(self, initial_box, final_box, variant):
-        box1 = box_preprocessing(initial_box)
-        box2 = box_preprocessing(final_box)
-        variant = variant_preprocessing(variant)
+        box1 = hoomd.data.typeconverter.box_preprocessing(initial_box)
+        box2 = hoomd.data.typeconverter.box_preprocessing(final_box)
+        variant = hoomd.data.typeconverter.variant_preprocessing(variant)
         BoxVariant.__init__(self)
         _hoomd.VectorVariantBoxInterpolate.__init__(self, box1._cpp_obj,
                                                     box2._cpp_obj, variant)
@@ -135,7 +135,7 @@ class Interpolate(_hoomd.VectorVariantBoxInterpolate, BoxVariant):
 
     @initial_box.setter
     def initial_box(self, box):
-        box = box_preprocessing(box)
+        box = hoomd.data.typeconverter.box_preprocessing(box)
         self._initial_box = box._cpp_obj
 
     @property
@@ -145,7 +145,7 @@ class Interpolate(_hoomd.VectorVariantBoxInterpolate, BoxVariant):
 
     @final_box.setter
     def final_box(self, box):
-        box = box_preprocessing(box)
+        box = hoomd.data.typeconverter.box_preprocessing(box)
         self._final_box = box._cpp_obj
 
 
@@ -187,7 +187,7 @@ class InverseVolumeRamp(_hoomd.VectorVariantBoxInverseVolumeRamp, BoxVariant):
 
     def __init__(self, initial_box, final_volume, t_start, t_ramp):
         BoxVariant.__init__(self)
-        box = box_preprocessing(initial_box)
+        box = hoomd.data.typeconverter.box_preprocessing(initial_box)
         _hoomd.VectorVariantBoxInverseVolumeRamp.__init__(
             self, box._cpp_obj, final_volume, t_start, t_ramp)
 
@@ -198,5 +198,5 @@ class InverseVolumeRamp(_hoomd.VectorVariantBoxInverseVolumeRamp, BoxVariant):
 
     @initial_box.setter
     def initial_box(self, box):
-        box = box_preprocessing(box)
+        box = hoomd.data.typeconverter.box_preprocessing(box)
         self._initial_box = box._cpp_obj


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should be based on *trunk-patch*. -->
<!-- Backwards compatible new features should be based on *trunk-minor*. -->
<!-- Incompatible API changes should be based on *trunk-major*. -->

## Description

This PR changes the `target_box` member of `UpdaterQuickCompress` from a box object to a `VectorVariantBox` to enable a time-varying target box, which enables slow compression of the box in HPMC.

## Motivation and context

Resolves #1641 

## How has this been tested?

Added a validation test that uses QuickCompress with a `BoxVariant` and ensures that the box compression occurs no faster than what the time-varying target box dictates.

## Change log

```
`hoomd.hpmc.update.QuickCompress` now accepts a `hoomd.variant.box.BoxVariant` object for `target_box`, enabling slow compression of simulation boxes in HPMC simulations.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
