### PR TITLE
Refactor virtual particle interface

### DIFF
--- a/hoomd/mpcd/CMakeLists.txt
+++ b/hoomd/mpcd/CMakeLists.txt
@@ -12,6 +12,7 @@ set(_mpcd_cc_sources
     CollisionMethod.cc
     Communicator.cc
     Integrator.cc
+    ManualVirtualParticleFiller.cc
     ParallelPlateGeometryFiller.cc
     PlanarPoreGeometryFiller.cc
     Sorter.cc
@@ -34,6 +35,7 @@ set(_mpcd_headers
     Communicator.h
     CommunicatorUtilities.h
     Integrator.h
+    ManualVirtualParticleFiller.h
     ParticleData.h
     ParticleDataSnapshot.h
     ParticleDataUtilities.h

--- a/hoomd/mpcd/ManualVirtualParticleFiller.cc
+++ b/hoomd/mpcd/ManualVirtualParticleFiller.cc
@@ -1,0 +1,61 @@
+// Copyright (c) 2009-2023 The Regents of the University of Michigan.
+// Part of HOOMD-blue, released under the BSD 3-Clause License.
+
+/*!
+ * \file mpcd/ManualVirtualParticleFiller.cc
+ * \brief Definition of mpcd::ManualVirtualParticleFiller
+ */
+
+#include "ManualVirtualParticleFiller.h"
+
+namespace hoomd
+    {
+mpcd::ManualVirtualParticleFiller::ManualVirtualParticleFiller(
+    std::shared_ptr<SystemDefinition> sysdef,
+    const std::string& type,
+    Scalar density,
+    std::shared_ptr<Variant> T)
+    : mpcd::VirtualParticleFiller(sysdef, type, density, T), m_N_fill(0), m_first_tag(0),
+      m_first_idx(0)
+    {
+    }
+
+void mpcd::ManualVirtualParticleFiller::fill(uint64_t timestep)
+    {
+    if (!m_cl)
+        {
+        throw std::runtime_error("Cell list has not been set");
+        }
+
+    // update the fill volume
+    computeNumFill();
+
+    // get the first tag from the fill number
+    m_first_tag = computeFirstTag(m_N_fill);
+
+    // add the new virtual particles locally
+    m_first_idx = m_mpcd_pdata->addVirtualParticles(m_N_fill);
+
+    // draw the particles consistent with those tags
+    drawParticles(timestep);
+
+    m_mpcd_pdata->invalidateCellCache();
+    }
+
+/*!
+ * \param m Python module to export to
+ */
+void mpcd::detail::export_ManualVirtualParticleFiller(pybind11::module& m)
+    {
+    pybind11::class_<mpcd::ManualVirtualParticleFiller,
+                     mpcd::VirtualParticleFiller,
+                     std::shared_ptr<mpcd::ManualVirtualParticleFiller>>(
+        m,
+        "ManualVirtualParticleFiller")
+        .def(pybind11::init<std::shared_ptr<SystemDefinition>,
+                            const std::string&,
+                            Scalar,
+                            std::shared_ptr<Variant>>());
+    }
+
+    } // end namespace hoomd

--- a/hoomd/mpcd/ManualVirtualParticleFiller.h
+++ b/hoomd/mpcd/ManualVirtualParticleFiller.h
@@ -1,0 +1,67 @@
+// Copyright (c) 2009-2023 The Regents of the University of Michigan.
+// Part of HOOMD-blue, released under the BSD 3-Clause License.
+
+/*!
+ * \file mpcd/ManualVirtualParticleFiller.h
+ * \brief Definition of class for manually backfilling solid boundaries with virtual particles.
+ */
+
+#ifndef MPCD_MANUAL_VIRTUAL_PARTICLE_FILLER_H_
+#define MPCD_MANUAL_VIRTUAL_PARTICLE_FILLER_H_
+
+#ifdef __HIPCC__
+#error This header cannot be compiled by nvcc
+#endif
+
+#include "VirtualParticleFiller.h"
+
+#include <pybind11/pybind11.h>
+
+#include <string>
+
+namespace hoomd
+    {
+namespace mpcd
+    {
+//! Manually add virtual particles to the MPCD particle data
+/*!
+ * The ManualVirtualParticleFiller base class defines an interface for adding virtual particles
+ * using a prescribed formula. The fill() method handles the basic tasks of appending a certain
+ * number of virtual particles to the particle data. Each deriving class must then implement two
+ * methods:
+ *  1. computeNumFill(), which is the number of virtual particles to add.
+ *  2. drawParticles(), which is the rule to determine where to put the particles.
+ */
+class PYBIND11_EXPORT ManualVirtualParticleFiller : public VirtualParticleFiller
+    {
+    public:
+    ManualVirtualParticleFiller(std::shared_ptr<SystemDefinition> sysdef,
+                                const std::string& type,
+                                Scalar density,
+                                std::shared_ptr<Variant> T);
+
+    virtual ~ManualVirtualParticleFiller() { }
+
+    //! Fill up virtual particles
+    void fill(uint64_t timestep);
+
+    protected:
+    unsigned int m_N_fill;    //!< Number of particles to fill locally
+    unsigned int m_first_tag; //!< First tag of locally held particles
+    unsigned int m_first_idx; //!< Particle index to start adding from
+
+    //! Compute the total number of particles to fill
+    virtual void computeNumFill() { }
+
+    //! Draw particles within the fill volume
+    virtual void drawParticles(uint64_t timestep) { }
+    };
+
+namespace detail
+    {
+//! Export the ManualVirtualParticleFiller to python
+void export_ManualVirtualParticleFiller(pybind11::module& m);
+    }  // end namespace detail
+    }  // end namespace mpcd
+    }  // end namespace hoomd
+#endif // MPCD_MANUAL_VIRTUAL_PARTICLE_FILLER_H_

--- a/hoomd/mpcd/ParallelPlateGeometryFiller.cc
+++ b/hoomd/mpcd/ParallelPlateGeometryFiller.cc
@@ -18,7 +18,7 @@ mpcd::ParallelPlateGeometryFiller::ParallelPlateGeometryFiller(
     Scalar density,
     std::shared_ptr<Variant> T,
     std::shared_ptr<const mpcd::ParallelPlateGeometry> geom)
-    : mpcd::VirtualParticleFiller(sysdef, type, density, T), m_geom(geom)
+    : mpcd::ManualVirtualParticleFiller(sysdef, type, density, T), m_geom(geom)
     {
     m_exec_conf->msg->notice(5) << "Constructing MPCD ParallelPlateGeometryFiller" << std::endl;
     }
@@ -91,13 +91,12 @@ void mpcd::ParallelPlateGeometryFiller::drawParticles(uint64_t timestep)
     uint16_t seed = m_sysdef->getSeed();
 
     // index to start filling from
-    const unsigned int first_idx = m_mpcd_pdata->getN() + m_mpcd_pdata->getNVirtual() - m_N_fill;
     for (unsigned int i = 0; i < m_N_fill; ++i)
         {
         const unsigned int tag = m_first_tag + i;
         hoomd::RandomGenerator rng(
             hoomd::Seed(hoomd::RNGIdentifier::ParallelPlateGeometryFiller, timestep, seed),
-            hoomd::Counter(tag));
+            hoomd::Counter(tag, m_filler_id));
         signed char sign = (char)((i >= m_N_lo) - (i < m_N_lo));
         if (sign == -1) // bottom
             {
@@ -110,7 +109,7 @@ void mpcd::ParallelPlateGeometryFiller::drawParticles(uint64_t timestep)
             hi.y = m_y_max;
             }
 
-        const unsigned int pidx = first_idx + i;
+        const unsigned int pidx = m_first_idx + i;
         h_pos.data[pidx] = make_scalar4(hoomd::UniformDistribution<Scalar>(lo.x, hi.x)(rng),
                                         hoomd::UniformDistribution<Scalar>(lo.y, hi.y)(rng),
                                         hoomd::UniformDistribution<Scalar>(lo.z, hi.z)(rng),

--- a/hoomd/mpcd/ParallelPlateGeometryFiller.h
+++ b/hoomd/mpcd/ParallelPlateGeometryFiller.h
@@ -13,8 +13,8 @@
 #error This header cannot be compiled by nvcc
 #endif
 
+#include "ManualVirtualParticleFiller.h"
 #include "ParallelPlateGeometry.h"
-#include "VirtualParticleFiller.h"
 
 #include <pybind11/pybind11.h>
 
@@ -27,7 +27,7 @@ namespace mpcd
  * Particles are added to the volume that is overlapped by any of the cells that are also "inside"
  * the channel, subject to the grid shift.
  */
-class PYBIND11_EXPORT ParallelPlateGeometryFiller : public mpcd::VirtualParticleFiller
+class PYBIND11_EXPORT ParallelPlateGeometryFiller : public mpcd::ManualVirtualParticleFiller
     {
     public:
     ParallelPlateGeometryFiller(std::shared_ptr<SystemDefinition> sysdef,

--- a/hoomd/mpcd/ParallelPlateGeometryFillerGPU.cc
+++ b/hoomd/mpcd/ParallelPlateGeometryFillerGPU.cc
@@ -40,8 +40,6 @@ void mpcd::ParallelPlateGeometryFillerGPU::drawParticles(uint64_t timestep)
                                     access_location::device,
                                     access_mode::readwrite);
 
-    const unsigned int first_idx = m_mpcd_pdata->getN() + m_mpcd_pdata->getNVirtual() - m_N_fill;
-
     uint16_t seed = m_sysdef->getSeed();
 
     m_tuner->begin();
@@ -57,7 +55,7 @@ void mpcd::ParallelPlateGeometryFillerGPU::drawParticles(uint64_t timestep)
                                    m_N_lo,
                                    m_N_hi,
                                    m_first_tag,
-                                   first_idx,
+                                   m_first_idx,
                                    (*m_T)(timestep),
                                    timestep,
                                    seed,

--- a/hoomd/mpcd/ParticleData.cc
+++ b/hoomd/mpcd/ParticleData.cc
@@ -876,12 +876,16 @@ unsigned int mpcd::ParticleData::getTag(unsigned int idx) const
     }
 
 /*!
- * \param N Allocate space for \a N additional virtualq particles in the particle data arrays
+ * \param N Allocate space for \a N additional virtual particles in the particle data arrays
+ * \returns The first index of the new virtual particles in the arrays.
  */
-void mpcd::ParticleData::addVirtualParticles(unsigned int N)
+unsigned int mpcd::ParticleData::addVirtualParticles(unsigned int N)
     {
+    const unsigned int first_idx = m_N + m_N_virtual;
     if (N == 0)
-        return;
+        {
+        return first_idx;
+        }
 
     // increase number of virtual particles
     m_N_virtual += N;
@@ -901,6 +905,8 @@ void mpcd::ParticleData::addVirtualParticles(unsigned int N)
         }
 
     notifyNumVirtual();
+
+    return first_idx;
     }
 
 #ifdef ENABLE_MPI

--- a/hoomd/mpcd/ParticleData.h
+++ b/hoomd/mpcd/ParticleData.h
@@ -336,7 +336,7 @@ class PYBIND11_EXPORT ParticleData : public Autotuned
         }
 
     //! Allocate memory for virtual particles
-    void addVirtualParticles(unsigned int N);
+    unsigned int addVirtualParticles(unsigned int N);
 
     //! Remove all virtual particles
     /*!

--- a/hoomd/mpcd/PlanarPoreGeometryFiller.cc
+++ b/hoomd/mpcd/PlanarPoreGeometryFiller.cc
@@ -20,7 +20,7 @@ mpcd::PlanarPoreGeometryFiller::PlanarPoreGeometryFiller(
     Scalar density,
     std::shared_ptr<Variant> T,
     std::shared_ptr<const mpcd::PlanarPoreGeometry> geom)
-    : mpcd::VirtualParticleFiller(sysdef, type, density, T), m_num_boxes(0),
+    : mpcd::ManualVirtualParticleFiller(sysdef, type, density, T), m_num_boxes(0),
       m_boxes(MAX_BOXES, m_exec_conf), m_ranges(MAX_BOXES, m_exec_conf)
     {
     m_exec_conf->msg->notice(5) << "Constructing MPCD PlanarPoreGeometryFiller" << std::endl;
@@ -167,13 +167,12 @@ void mpcd::PlanarPoreGeometryFiller::drawParticles(uint64_t timestep)
     uint16_t seed = m_sysdef->getSeed();
 
     // index to start filling from
-    const unsigned int first_idx = m_mpcd_pdata->getN() + m_mpcd_pdata->getNVirtual() - m_N_fill;
     for (unsigned int i = 0; i < m_N_fill; ++i)
         {
         const unsigned int tag = m_first_tag + i;
         hoomd::RandomGenerator rng(
             hoomd::Seed(hoomd::RNGIdentifier::PlanarPoreGeometryFiller, timestep, seed),
-            hoomd::Counter(tag));
+            hoomd::Counter(tag, m_filler_id));
 
         // advanced past end of this box range, take the next
         if (i >= boxlast)
@@ -187,7 +186,7 @@ void mpcd::PlanarPoreGeometryFiller::drawParticles(uint64_t timestep)
             hi.y = fillbox.w;
             }
 
-        const unsigned int pidx = first_idx + i;
+        const unsigned int pidx = m_first_idx + i;
         h_pos.data[pidx] = make_scalar4(hoomd::UniformDistribution<Scalar>(lo.x, hi.x)(rng),
                                         hoomd::UniformDistribution<Scalar>(lo.y, hi.y)(rng),
                                         hoomd::UniformDistribution<Scalar>(lo.z, hi.z)(rng),

--- a/hoomd/mpcd/PlanarPoreGeometryFiller.h
+++ b/hoomd/mpcd/PlanarPoreGeometryFiller.h
@@ -13,8 +13,8 @@
 #error This header cannot be compiled by nvcc
 #endif
 
+#include "ManualVirtualParticleFiller.h"
 #include "PlanarPoreGeometry.h"
-#include "VirtualParticleFiller.h"
 
 #include <pybind11/pybind11.h>
 
@@ -27,7 +27,7 @@ namespace mpcd
  * Particles are added to the volume that is overlapped by any of the cells that are also "inside"
  * the channel, subject to the grid shift.
  */
-class PYBIND11_EXPORT PlanarPoreGeometryFiller : public mpcd::VirtualParticleFiller
+class PYBIND11_EXPORT PlanarPoreGeometryFiller : public mpcd::ManualVirtualParticleFiller
     {
     public:
     PlanarPoreGeometryFiller(std::shared_ptr<SystemDefinition> sysdef,

--- a/hoomd/mpcd/PlanarPoreGeometryFillerGPU.cc
+++ b/hoomd/mpcd/PlanarPoreGeometryFillerGPU.cc
@@ -44,8 +44,6 @@ void mpcd::PlanarPoreGeometryFillerGPU::drawParticles(uint64_t timestep)
     ArrayHandle<Scalar4> d_boxes(m_boxes, access_location::device, access_mode::read);
     ArrayHandle<uint2> d_ranges(m_ranges, access_location::device, access_mode::read);
 
-    const unsigned int first_idx = m_mpcd_pdata->getN() + m_mpcd_pdata->getNVirtual() - m_N_fill;
-
     uint16_t seed = m_sysdef->getSeed();
 
     m_tuner->begin();
@@ -60,7 +58,7 @@ void mpcd::PlanarPoreGeometryFillerGPU::drawParticles(uint64_t timestep)
                                         m_mpcd_pdata->getMass(),
                                         m_type,
                                         m_first_tag,
-                                        first_idx,
+                                        m_first_idx,
                                         (*m_T)(timestep),
                                         timestep,
                                         seed,

--- a/hoomd/mpcd/VirtualParticleFiller.cc
+++ b/hoomd/mpcd/VirtualParticleFiller.cc
@@ -10,52 +10,25 @@
 
 namespace hoomd
     {
+unsigned int mpcd::VirtualParticleFiller::s_filler_count = 0;
+
 mpcd::VirtualParticleFiller::VirtualParticleFiller(std::shared_ptr<SystemDefinition> sysdef,
                                                    const std::string& type,
                                                    Scalar density,
                                                    std::shared_ptr<Variant> T)
     : m_sysdef(sysdef), m_pdata(m_sysdef->getParticleData()), m_exec_conf(m_pdata->getExecConf()),
-      m_mpcd_pdata(m_sysdef->getMPCDParticleData()), m_density(density), m_T(T), m_N_fill(0),
-      m_first_tag(0)
+      m_mpcd_pdata(m_sysdef->getMPCDParticleData()), m_density(density), m_T(T)
     {
     setType(type);
-    }
 
-void mpcd::VirtualParticleFiller::fill(uint64_t timestep)
-    {
-    if (!m_cl)
-        {
-        throw std::runtime_error("Cell list has not been set");
-        }
-
-    // update the fill volume
-    computeNumFill();
-
-    // in mpi, do a prefix scan on the tag offset in this range
-    // then shift the first tag by the current number of particles, which ensures a compact tag
-    // array
-    m_first_tag = 0;
+    // assign ID from count, but synchronize with root in case count got off somewhere
+    m_filler_id = s_filler_count++;
 #ifdef ENABLE_MPI
     if (m_exec_conf->getNRanks() > 1)
         {
-        // scan the number to fill to get the tag range I own
-        MPI_Exscan(&m_N_fill,
-                   &m_first_tag,
-                   1,
-                   MPI_UNSIGNED,
-                   MPI_SUM,
-                   m_exec_conf->getMPICommunicator());
+        bcast(m_filler_id, 0, m_exec_conf->getMPICommunicator());
         }
 #endif // ENABLE_MPI
-    m_first_tag += m_mpcd_pdata->getNGlobal() + m_mpcd_pdata->getNVirtualGlobal();
-
-    // add the new virtual particles locally
-    m_mpcd_pdata->addVirtualParticles(m_N_fill);
-
-    // draw the particles consistent with those tags
-    drawParticles(timestep);
-
-    m_mpcd_pdata->invalidateCellCache();
     }
 
 void mpcd::VirtualParticleFiller::setDensity(Scalar density)
@@ -76,6 +49,32 @@ std::string mpcd::VirtualParticleFiller::getType() const
 void mpcd::VirtualParticleFiller::setType(const std::string& type)
     {
     m_type = m_mpcd_pdata->getTypeByName(type);
+    }
+
+/*!
+ * \param N_fill Number of virtual particles to add on each rank
+ * \returns First tag to assign to a virtual particle on each rank.
+ */
+unsigned int mpcd::VirtualParticleFiller::computeFirstTag(unsigned int N_fill) const
+    {
+    // exclusive scan of number on each rank in MPI
+    unsigned int first_tag = 0;
+#ifdef ENABLE_MPI
+    if (m_exec_conf->getNRanks() > 1)
+        {
+        MPI_Exscan(&N_fill,
+                   &first_tag,
+                   1,
+                   MPI_UNSIGNED,
+                   MPI_SUM,
+                   m_exec_conf->getMPICommunicator());
+        }
+#endif // ENABLE_MPI
+
+    // shift the first tag based on the number of particles (real and virtual) already used
+    first_tag += m_mpcd_pdata->getNGlobal() + m_mpcd_pdata->getNVirtualGlobal();
+
+    return first_tag;
     }
 
 /*!

--- a/hoomd/mpcd/VirtualParticleFiller.h
+++ b/hoomd/mpcd/VirtualParticleFiller.h
@@ -3,7 +3,7 @@
 
 /*!
  * \file mpcd/VirtualParticleFiller.h
- * \brief Definition of class for backfilling solid boundaries with virtual particles.
+ * \brief Definition of abstract base class for backfilling solid boundaries with virtual particles.
  */
 
 #ifndef MPCD_VIRTUAL_PARTICLE_FILLER_H_
@@ -30,11 +30,7 @@ namespace mpcd
 /*!
  * Virtual particles are used to pad cells sliced by solid boundaries so that their viscosity does
  * not get too low. The VirtualParticleFiller base class defines an interface for adding these
- * particles. The base VirtualParticleFiller implements a fill() method, which handles the basic
- * tasks of appending a certain number of virtual particles to the particle data. Each deriving
- * class must then implement two methods:
- *  1. computeNumFill(), which is the number of virtual particles to add.
- *  2. drawParticles(), which is the rule to determine where to put the particles.
+ * particles. Deriving classes must implement a fill() method that adds the particles.
  */
 class PYBIND11_EXPORT VirtualParticleFiller : public Autotuned
     {
@@ -47,8 +43,9 @@ class PYBIND11_EXPORT VirtualParticleFiller : public Autotuned
     virtual ~VirtualParticleFiller() { }
 
     //! Fill up virtual particles
-    void fill(uint64_t timestep);
+    virtual void fill(uint64_t timestep) { }
 
+    //! Get the fill particle density
     Scalar getDensity() const
         {
         return m_density;
@@ -57,11 +54,13 @@ class PYBIND11_EXPORT VirtualParticleFiller : public Autotuned
     //! Set the fill particle density
     void setDensity(Scalar density);
 
+    //! Get the filler particle type
     std::string getType() const;
 
     //! Set the fill particle type
     void setType(const std::string& type);
 
+    //! Get the fill particle temperature
     std::shared_ptr<Variant> getTemperature() const
         {
         return m_T;
@@ -89,15 +88,12 @@ class PYBIND11_EXPORT VirtualParticleFiller : public Autotuned
     Scalar m_density;             //!< Fill density
     unsigned int m_type;          //!< Fill type
     std::shared_ptr<Variant> m_T; //!< Temperature for filled particles
+    unsigned int m_filler_id;     //!< Unique ID of this filler
 
-    unsigned int m_N_fill;    //!< Number of particles to fill locally
-    unsigned int m_first_tag; //!< First tag of locally held particles
+    unsigned int computeFirstTag(unsigned int N_fill) const;
 
-    //! Compute the total number of particles to fill
-    virtual void computeNumFill() { }
-
-    //! Draw particles within the fill volume
-    virtual void drawParticles(uint64_t timestep) { }
+    private:
+    static unsigned int s_filler_count; //!< Total count of fillers, used to assign unique ID
     };
 
 namespace detail

--- a/hoomd/mpcd/module.cc
+++ b/hoomd/mpcd/module.cc
@@ -50,6 +50,7 @@
 #endif
 
 // virtual particle fillers
+#include "ManualVirtualParticleFiller.h"
 #include "ParallelPlateGeometryFiller.h"
 #include "PlanarPoreGeometryFiller.h"
 #include "VirtualParticleFiller.h"
@@ -196,6 +197,7 @@ PYBIND11_MODULE(_mpcd, m)
 #endif // ENABLE_HIP
 
     mpcd::detail::export_VirtualParticleFiller(m);
+    mpcd::detail::export_ManualVirtualParticleFiller(m);
     mpcd::detail::export_ParallelPlateGeometryFiller(m);
     mpcd::detail::export_PlanarPoreGeometryFiller(m);
 #ifdef ENABLE_HIP


### PR DESCRIPTION
## Description

This PR refactors the `VirtualParticleFiller` base class to be more general. It now has a pure virtual `fill` method that deriving classes must implement. The old `fill` method that calls virtual methods that compute the number of particles & draw them using known geometric properties has been moved to a `ManualVirtualParticleFiller` derived class. Implementations for the two geometries we have now derive from `ManualVirtualParticleFiller`. These are C++-only changes that could break plugins (like mine... *sigh*).

This PR also fixes a minor bug we identified where attaching multiple `VirtualParticleFiller`s would lead to the same sequence of drawn particles, due to having a common see and class identifier. I now assign a unique identifier for the class when it is created, and I use this as a counter in the PRNG.

## Motivation and context

The old base class required developers to implement methods to compute the number of particles to fill and to randomly draw the particles. This seemed like a flexible design at the time, but there are actually quite a few simple geometries where this no longer works, mainly when run under MPI. For example, it's easy to draw particles in a shell around a sphere using spherical coordinates on 1 processor, but this is hard to do with MPI because the local box of each rank is orthorhombic. You would need to know the volume defined by the intersection of the shell and the box in order to implement both required methods, and a formula for this is not known.

Rejection sampling is a solution to this problem, but then the number of particles is not deterministic, so the method that computes the number cannot be implemented.

Resolves #772 

## How has this been tested?

Everything still compiles and existing tests still pass.

## Change log

N/A

@kkritikak should be credited for helping with this implementation in a fork!

## Checklist:

- [X] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.rst).
- [X] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [X] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
