### PR TITLE
Allow setting None parameter in hpmc.pair.Step.

### DIFF
--- a/hoomd/hpmc/PairPotentialStep.cc
+++ b/hoomd/hpmc/PairPotentialStep.cc
@@ -80,7 +80,7 @@ LongReal PairPotentialStep::energy(const LongReal r_squared,
         }
     }
 
-void PairPotentialStep::setParamsPython(pybind11::tuple typ, pybind11::dict params)
+void PairPotentialStep::setParamsPython(pybind11::tuple typ, pybind11::object params)
     {
     auto pdata = m_sysdef->getParticleData();
     auto type_i = pdata->getTypeByName(typ[0].cast<std::string>());
@@ -102,15 +102,16 @@ pybind11::dict PairPotentialStep::getParamsPython(pybind11::tuple typ)
     return m_params[param_index].asDict();
     }
 
-PairPotentialStep::ParamType::ParamType(pybind11::dict v)
+PairPotentialStep::ParamType::ParamType(pybind11::object params)
     {
-    if (v.is_none())
+    if (params.is_none())
         {
         m_epsilon.clear();
         m_r_squared.clear();
         return;
         }
 
+    pybind11::dict v = params;
     pybind11::list epsilon_list = v["epsilon"];
     pybind11::list r_list = v["r"];
 

--- a/hoomd/hpmc/PairPotentialStep.cc
+++ b/hoomd/hpmc/PairPotentialStep.cc
@@ -140,11 +140,6 @@ PairPotentialStep::ParamType::ParamType(pybind11::object params)
 pybind11::dict PairPotentialStep::ParamType::asDict()
     {
     size_t N = m_epsilon.size();
-    if (N == 0)
-        {
-        return pybind11::none();
-        }
-
     pybind11::list epsilon;
     pybind11::list r;
 

--- a/hoomd/hpmc/PairPotentialStep.h
+++ b/hoomd/hpmc/PairPotentialStep.h
@@ -33,7 +33,7 @@ class PairPotentialStep : public hpmc::PairPotential
     virtual LongReal computeRCutNonAdditive(unsigned int type_i, unsigned int type_j) const;
 
     /// Set type pair dependent parameters to the potential.
-    void setParamsPython(pybind11::tuple typ, pybind11::dict params);
+    void setParamsPython(pybind11::tuple typ, pybind11::object params);
 
     /// Get type pair dependent parameters.
     pybind11::dict getParamsPython(pybind11::tuple typ);
@@ -45,7 +45,7 @@ class PairPotentialStep : public hpmc::PairPotential
         ParamType() { }
 
         /// Construct a parameter set from a dictionary.
-        ParamType(pybind11::dict v);
+        ParamType(pybind11::object v);
 
         /// Convert a parameter set to a dictionary.
         pybind11::dict asDict();

--- a/hoomd/hpmc/pytest/test_pair_step.py
+++ b/hoomd/hpmc/pytest/test_pair_step.py
@@ -83,83 +83,67 @@ def test_invalid_params_on_attach(mc_simulation_factory, parameters):
 # (pair params,
 #  distance between particles,
 #  expected energy)
-step_test_parameters = [
-    (
-        dict(epsilon=[-1.125], r=[0.5]),
-        3.0,
-        0.0,
-    ),
-    (
-        dict(epsilon=[-1.125], r=[0.5]),
-        0.5125,
-        0.0,
-    ),
-    (
-        dict(epsilon=[-1.125], r=[0.5]),
-        0.5,
-        0,
-    ),
-    (
-        dict(epsilon=[-1.125], r=[0.5]),
-        0.25,
-        -1.125,
-    ),
-    (
-        dict(epsilon=[-1.125], r=[0.5]),
-        0.0,
-        -1.125,
-    ),
-    (
-        dict(epsilon=[1, 2, 3], r=[0.5, 1.5, 2.5]),
-        2.5,
-        0,
-    ),
-    (
-        dict(epsilon=[1, 2, 3], r=[0.5, 1.5, 2.5]),
-        2.4,
-        3,
-    ),
-    (
-        dict(epsilon=[1, 2, 3], r=[0.5, 1.5, 2.5]),
-        1.6,
-        3,
-    ),
-    (
-        dict(epsilon=[1, 2, 3], r=[0.5, 1.5, 2.5]),
-        1.5,
-        3,
-    ),
-    (
-        dict(epsilon=[1, 2, 3], r=[0.5, 1.5, 2.5]),
-        1.49,
-        2,
-    ),
-    (
-        dict(epsilon=[1, 2, 3], r=[0.5, 1.5, 2.5]),
-        0.6,
-        2,
-    ),
-    (
-        dict(epsilon=[1, 2, 3], r=[0.5, 1.5, 2.5]),
-        0.5,
-        2,
-    ),
-    (
-        dict(epsilon=[1, 2, 3], r=[0.5, 1.5, 2.5]),
-        0.49,
-        1,
-    ),
-    (
-        dict(epsilon=[1, 2, 3], r=[0.5, 1.5, 2.5]),
-        0.0,
-        1,
-    ),
-    (
-        None,
-        0.0,
-        0.0,
-    )
-]
+step_test_parameters = [(
+    dict(epsilon=[-1.125], r=[0.5]),
+    3.0,
+    0.0,
+), (
+    dict(epsilon=[-1.125], r=[0.5]),
+    0.5125,
+    0.0,
+), (
+    dict(epsilon=[-1.125], r=[0.5]),
+    0.5,
+    0,
+), (
+    dict(epsilon=[-1.125], r=[0.5]),
+    0.25,
+    -1.125,
+), (
+    dict(epsilon=[-1.125], r=[0.5]),
+    0.0,
+    -1.125,
+), (
+    dict(epsilon=[1, 2, 3], r=[0.5, 1.5, 2.5]),
+    2.5,
+    0,
+), (
+    dict(epsilon=[1, 2, 3], r=[0.5, 1.5, 2.5]),
+    2.4,
+    3,
+), (
+    dict(epsilon=[1, 2, 3], r=[0.5, 1.5, 2.5]),
+    1.6,
+    3,
+), (
+    dict(epsilon=[1, 2, 3], r=[0.5, 1.5, 2.5]),
+    1.5,
+    3,
+), (
+    dict(epsilon=[1, 2, 3], r=[0.5, 1.5, 2.5]),
+    1.49,
+    2,
+), (
+    dict(epsilon=[1, 2, 3], r=[0.5, 1.5, 2.5]),
+    0.6,
+    2,
+), (
+    dict(epsilon=[1, 2, 3], r=[0.5, 1.5, 2.5]),
+    0.5,
+    2,
+), (
+    dict(epsilon=[1, 2, 3], r=[0.5, 1.5, 2.5]),
+    0.49,
+    1,
+), (
+    dict(epsilon=[1, 2, 3], r=[0.5, 1.5, 2.5]),
+    0.0,
+    1,
+), (
+    None,
+    0.0,
+    0.0,
+)]
 
 
 @pytest.mark.parametrize('params, d, expected_energy', step_test_parameters)

--- a/hoomd/hpmc/pytest/test_pair_step.py
+++ b/hoomd/hpmc/pytest/test_pair_step.py
@@ -154,6 +154,11 @@ step_test_parameters = [
         0.0,
         1,
     ),
+    (
+        None,
+        0.0,
+        0.0,
+    )
 ]
 
 

--- a/hoomd/hpmc/pytest/test_pair_union.py
+++ b/hoomd/hpmc/pytest/test_pair_union.py
@@ -53,6 +53,8 @@ def _valid_body_dicts():
              charges=[-0.5, 0.5]),
         # orientations and charges should have defaults
         dict(types=["A", "A"], positions=[(0, 0, 1.0), (0, 0, -1.0)]),
+        # No constituents
+        None,
     ]
     return valid_dicts
 


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should be based on *trunk-patch*. -->
<!-- Backwards compatible new features should be based on *trunk-minor*. -->
<!-- Incompatible API changes should be based on *trunk-major*. -->

## Description

<!-- Describe your changes in detail. -->
Test that `step.params[('A', 'A')] = None` works as intended.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Users should be able to use this shorthand to define no interactions between particles.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
Added unit tests to ensure that both Step and Union support this mode of operation.

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

No change log necessary, this is a tweak to an unreleased feature.

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
