### PR TITLE
Deprecate the box1 box2 arguments to BoxResize.

### DIFF
--- a/hoomd/BoxResizeUpdater.cc
+++ b/hoomd/BoxResizeUpdater.cc
@@ -15,21 +15,16 @@ using namespace std;
 
 namespace hoomd
     {
-/*! \param sysdef System definition containing the particle data to set the box size on
-    \param Lx length of the x dimension over time
-    \param Ly length of the y dimension over time
-    \param Lz length of the z dimension over time
-
-    The default setting is to scale particle positions along with the box.
+/** @param sysdef System definition containing the particle data to set the box size on
+    @param trigger Steps on which to execute.
+    @param box Box as a function of time.
+    @param group Particles to scale.
 */
-
 BoxResizeUpdater::BoxResizeUpdater(std::shared_ptr<SystemDefinition> sysdef,
                                    std::shared_ptr<Trigger> trigger,
-                                   std::shared_ptr<BoxDim> box1,
-                                   std::shared_ptr<BoxDim> box2,
-                                   std::shared_ptr<Variant> variant,
+                                   std::shared_ptr<VectorVariantBox> box,
                                    std::shared_ptr<ParticleGroup> group)
-    : Updater(sysdef, trigger), m_box1(box1), m_box2(box2), m_variant(variant), m_group(group)
+    : Updater(sysdef, trigger), m_box(box), m_group(group)
     {
     assert(m_pdata);
     assert(m_variant);
@@ -41,60 +36,13 @@ BoxResizeUpdater::~BoxResizeUpdater()
     m_exec_conf->msg->notice(5) << "Destroying BoxResizeUpdater" << endl;
     }
 
-/// Get box1
-std::shared_ptr<BoxDim> BoxResizeUpdater::getBox1()
-    {
-    return m_box1;
-    }
-
-/// Set a new box1
-void BoxResizeUpdater::setBox1(std::shared_ptr<BoxDim> box1)
-    {
-    m_box1 = box1;
-    }
-
-/// Get box2
-std::shared_ptr<BoxDim> BoxResizeUpdater::getBox2()
-    {
-    return m_box2;
-    }
-
-void BoxResizeUpdater::setBox2(std::shared_ptr<BoxDim> box2)
-    {
-    m_box2 = box2;
-    }
-
-/// Get the current box based on the timestep
 BoxDim BoxResizeUpdater::getCurrentBox(uint64_t timestep)
     {
-    Scalar min = m_variant->min();
-    Scalar max = m_variant->max();
-    Scalar cur_value = (*m_variant)(timestep);
-    Scalar scale = 0;
-    if (cur_value == max)
-        {
-        scale = 1;
-        }
-    else if (cur_value > min)
-        {
-        scale = (cur_value - min) / (max - min);
-        }
-
-    const auto& box1 = *m_box1;
-    const auto& box2 = *m_box2;
-    Scalar3 new_L = box2.getL() * scale + box1.getL() * (1.0 - scale);
-    Scalar xy = box2.getTiltFactorXY() * scale + (1.0 - scale) * box1.getTiltFactorXY();
-    Scalar xz = box2.getTiltFactorXZ() * scale + (1.0 - scale) * box1.getTiltFactorXZ();
-    Scalar yz = box2.getTiltFactorYZ() * scale + (1.0 - scale) * box1.getTiltFactorYZ();
-
-    BoxDim new_box = BoxDim(new_L);
-    new_box.setTiltFactors(xy, xz, yz);
-    return new_box;
+    return BoxDim((*m_box)(timestep));
     }
 
-/** Perform the needed calculations to scale the box size
-    \param timestep Current time step of the simulation
-*/
+/** @param timestep Current time step of the simulation
+ */
 void BoxResizeUpdater::update(uint64_t timestep)
     {
     Updater::update(timestep);
@@ -124,7 +72,6 @@ void BoxResizeUpdater::update(uint64_t timestep)
         }
     }
 
-/// Scale particles to the new box and wrap any others back into the box
 void BoxResizeUpdater::scaleAndWrapParticles(const BoxDim& cur_box, const BoxDim& new_box)
     {
     ArrayHandle<Scalar4> h_pos(m_pdata->getPositions(),
@@ -171,13 +118,9 @@ void export_BoxResizeUpdater(pybind11::module& m)
         "BoxResizeUpdater")
         .def(pybind11::init<std::shared_ptr<SystemDefinition>,
                             std::shared_ptr<Trigger>,
-                            std::shared_ptr<BoxDim>,
-                            std::shared_ptr<BoxDim>,
-                            std::shared_ptr<Variant>,
+                            std::shared_ptr<VectorVariantBox>,
                             std::shared_ptr<ParticleGroup>>())
-        .def_property("box1", &BoxResizeUpdater::getBox1, &BoxResizeUpdater::setBox1)
-        .def_property("box2", &BoxResizeUpdater::getBox2, &BoxResizeUpdater::setBox2)
-        .def_property("variant", &BoxResizeUpdater::getVariant, &BoxResizeUpdater::setVariant)
+        .def_property("box", &BoxResizeUpdater::getBox, &BoxResizeUpdater::setBox)
         .def_property_readonly("filter",
                                [](const std::shared_ptr<BoxResizeUpdater> method)
                                { return method->getGroup()->getFilter(); })

--- a/hoomd/BoxResizeUpdater.cc
+++ b/hoomd/BoxResizeUpdater.cc
@@ -27,7 +27,6 @@ BoxResizeUpdater::BoxResizeUpdater(std::shared_ptr<SystemDefinition> sysdef,
     : Updater(sysdef, trigger), m_box(box), m_group(group)
     {
     assert(m_pdata);
-    assert(m_variant);
     m_exec_conf->msg->notice(5) << "Constructing BoxResizeUpdater" << endl;
     }
 

--- a/hoomd/BoxResizeUpdater.h
+++ b/hoomd/BoxResizeUpdater.h
@@ -13,14 +13,14 @@
 #include "ParticleGroup.h"
 #include "Updater.h"
 #include "Variant.h"
+#include "VectorVariant.h"
 
 #include <memory>
 #include <pybind11/pybind11.h>
 #include <stdexcept>
 #include <string>
 
-#ifndef __BOXRESIZEUPDATER_H__
-#define __BOXRESIZEUPDATER_H__
+#pragma once
 
 namespace hoomd
     {
@@ -37,42 +37,28 @@ class PYBIND11_EXPORT BoxResizeUpdater : public Updater
     /// Constructor
     BoxResizeUpdater(std::shared_ptr<SystemDefinition> sysdef,
                      std::shared_ptr<Trigger> trigger,
-                     std::shared_ptr<BoxDim> box1,
-                     std::shared_ptr<BoxDim> box2,
-                     std::shared_ptr<Variant> variant,
+                     std::shared_ptr<VectorVariantBox> box,
                      std::shared_ptr<ParticleGroup> m_group);
 
     /// Destructor
     virtual ~BoxResizeUpdater();
 
-    /// Get the current m_box2
-    std::shared_ptr<BoxDim> getBox1();
+    /// Set the box variant
+    void setBox(std::shared_ptr<VectorVariantBox> box)
+        {
+        m_box = box;
+        }
 
-    /// Set a new m_box_1
-    void setBox1(std::shared_ptr<BoxDim> box1);
-
-    /// Get the current m_box2
-    std::shared_ptr<BoxDim> getBox2();
-
-    /// Set a new m_box_2
-    void setBox2(std::shared_ptr<BoxDim> box2);
+    /// Get the box variant
+    std::shared_ptr<VectorVariantBox> getBox()
+        {
+        return m_box;
+        }
 
     /// Gets particle scaling filter
     std::shared_ptr<ParticleGroup> getGroup()
         {
         return m_group;
-        }
-
-    /// Set the variant for interpolation
-    void setVariant(std::shared_ptr<Variant> variant)
-        {
-        m_variant = variant;
-        }
-
-    /// Get the variant for interpolation
-    std::shared_ptr<Variant> getVariant()
-        {
-        return m_variant;
         }
 
     /// Get the current box for the given timestep
@@ -85,10 +71,11 @@ class PYBIND11_EXPORT BoxResizeUpdater : public Updater
     virtual void scaleAndWrapParticles(const BoxDim& cur_box, const BoxDim& new_box);
 
     protected:
-    std::shared_ptr<BoxDim> m_box1;         ///< C++ box assoc with min
-    std::shared_ptr<BoxDim> m_box2;         ///< C++ box assoc with max
-    std::shared_ptr<Variant> m_variant;     //!< Variant that interpolates between boxes
-    std::shared_ptr<ParticleGroup> m_group; //!< Selected particles to scale when resizing the box.
+    /// Box as a function of time.
+    std::shared_ptr<VectorVariantBox> m_box;
+
+    /// Selected particles to scale when resizing the box.
+    std::shared_ptr<ParticleGroup> m_group;
     };
 
 namespace detail
@@ -97,4 +84,3 @@ namespace detail
 void export_BoxResizeUpdater(pybind11::module& m);
     } // end namespace detail
     } // end namespace hoomd
-#endif

--- a/hoomd/BoxResizeUpdaterGPU.cc
+++ b/hoomd/BoxResizeUpdaterGPU.cc
@@ -10,21 +10,11 @@
 
 namespace hoomd
     {
-/*! \param sysdef System definition containing the particle data to set the box size on
-    \param Lx length of the x dimension over time
-    \param Ly length of the y dimension over time
-    \param Lz length of the z dimension over time
-
-    The default setting is to scale particle positions along with the box.
-*/
-
 BoxResizeUpdaterGPU::BoxResizeUpdaterGPU(std::shared_ptr<SystemDefinition> sysdef,
                                          std::shared_ptr<Trigger> trigger,
-                                         std::shared_ptr<BoxDim> box1,
-                                         std::shared_ptr<BoxDim> box2,
-                                         std::shared_ptr<Variant> variant,
+                                         std::shared_ptr<VectorVariantBox> box,
                                          std::shared_ptr<ParticleGroup> group)
-    : BoxResizeUpdater(sysdef, trigger, box1, box2, variant, group)
+    : BoxResizeUpdater(sysdef, trigger, box, group)
     {
     // only one GPU is supported
     if (!m_exec_conf->isCUDAEnabled())
@@ -87,9 +77,7 @@ void export_BoxResizeUpdaterGPU(pybind11::module& m)
         "BoxResizeUpdaterGPU")
         .def(pybind11::init<std::shared_ptr<SystemDefinition>,
                             std::shared_ptr<Trigger>,
-                            std::shared_ptr<BoxDim>,
-                            std::shared_ptr<BoxDim>,
-                            std::shared_ptr<Variant>,
+                            std::shared_ptr<VectorVariantBox>,
                             std::shared_ptr<ParticleGroup>>());
     }
 

--- a/hoomd/BoxResizeUpdaterGPU.h
+++ b/hoomd/BoxResizeUpdaterGPU.h
@@ -29,9 +29,7 @@ class PYBIND11_EXPORT BoxResizeUpdaterGPU : public BoxResizeUpdater
     /// Constructor
     BoxResizeUpdaterGPU(std::shared_ptr<SystemDefinition> sysdef,
                         std::shared_ptr<Trigger> trigger,
-                        std::shared_ptr<BoxDim> box1,
-                        std::shared_ptr<BoxDim> box2,
-                        std::shared_ptr<Variant> variant,
+                        std::shared_ptr<VectorVariantBox> box,
                         std::shared_ptr<ParticleGroup> m_group);
 
     /// Destructor

--- a/hoomd/pytest/test_box_resize.py
+++ b/hoomd/pytest/test_box_resize.py
@@ -9,11 +9,6 @@ from hoomd.conftest import operation_pickling_check
 from hoomd.error import MutabilityError
 
 
-@pytest.fixture(scope="function")
-def rng():
-    return np.random.default_rng(42)
-
-
 _n_points = 10
 
 
@@ -256,3 +251,62 @@ def test_mutability_error(simulation_factory, two_particle_snapshot_factory):
 
     with pytest.raises(MutabilityError):
         box_op.filter = filt
+
+
+def test_new_api(simulation_factory, two_particle_snapshot_factory):
+    sim = simulation_factory(two_particle_snapshot_factory())
+    inverse_volume_ramp = hoomd.variant.box.InverseVolumeRamp(
+        initial_box=hoomd.Box.cube(6),
+        final_volume=100,
+        t_start=1_000,
+        t_ramp=21_000)
+
+    box_resize = hoomd.update.BoxResize(trigger=hoomd.trigger.Periodic(1),
+                                        filter=hoomd.filter.All(),
+                                        box=inverse_volume_ramp)
+    sim.operations.updaters.append(box_resize)
+
+    sim.run(0)
+
+    assert box_resize.box is inverse_volume_ramp
+
+def test_invalid_api(variant, trigger):
+    box_variant = hoomd.variant.box.InverseVolumeRamp(
+        initial_box=hoomd.Box.cube(6),
+        final_volume=100,
+        t_start=1_000,
+        t_ramp=21_000)    
+
+    box1 = hoomd.Box.cube(10)
+    box2 = hoomd.Box.cube(20)
+
+    with pytest.raises(ValueError):
+        hoomd.update.BoxResize(trigger=trigger)
+    with pytest.raises(ValueError):
+        hoomd.update.BoxResize(trigger=trigger, box1=box1)
+    with pytest.raises(ValueError):
+        hoomd.update.BoxResize(trigger=trigger, box1=box1, box2=box2)
+    with pytest.raises(ValueError):
+        hoomd.update.BoxResize(trigger=trigger, box2=box2, variant=variant)
+    with pytest.raises(ValueError):
+        hoomd.update.BoxResize(trigger=trigger, box1=box1, box2=box2, variant=variant, box=box_variant)
+    with pytest.raises(ValueError):
+        hoomd.update.BoxResize(trigger=trigger, box1=box1, box=box_variant)
+    with pytest.raises(ValueError):
+        hoomd.update.BoxResize(trigger=trigger, box2=box2, box=box_variant)
+    with pytest.raises(ValueError):
+        hoomd.update.BoxResize(trigger=trigger, variant=variant, box=box_variant)
+
+    box_resize = hoomd.update.BoxResize(trigger=trigger, box=box_variant)
+    with pytest.raises(RuntimeError):
+        box_resize.box1
+    with pytest.raises(RuntimeError):
+        box_resize.box2
+    with pytest.raises(RuntimeError):
+        box_resize.variant
+    with pytest.raises(RuntimeError):
+        box_resize.box1 = box1
+    with pytest.raises(RuntimeError):
+        box_resize.box2 = box2
+    with pytest.raises(RuntimeError):
+        box_resize.variant = variant

--- a/hoomd/pytest/test_box_resize.py
+++ b/hoomd/pytest/test_box_resize.py
@@ -8,7 +8,6 @@ import hoomd
 from hoomd.conftest import operation_pickling_check
 from hoomd.error import MutabilityError
 
-
 _n_points = 10
 
 
@@ -270,12 +269,13 @@ def test_new_api(simulation_factory, two_particle_snapshot_factory):
 
     assert box_resize.box is inverse_volume_ramp
 
+
 def test_invalid_api(variant, trigger):
     box_variant = hoomd.variant.box.InverseVolumeRamp(
         initial_box=hoomd.Box.cube(6),
         final_volume=100,
         t_start=1_000,
-        t_ramp=21_000)    
+        t_ramp=21_000)
 
     box1 = hoomd.Box.cube(10)
     box2 = hoomd.Box.cube(20)
@@ -289,13 +289,19 @@ def test_invalid_api(variant, trigger):
     with pytest.raises(ValueError):
         hoomd.update.BoxResize(trigger=trigger, box2=box2, variant=variant)
     with pytest.raises(ValueError):
-        hoomd.update.BoxResize(trigger=trigger, box1=box1, box2=box2, variant=variant, box=box_variant)
+        hoomd.update.BoxResize(trigger=trigger,
+                               box1=box1,
+                               box2=box2,
+                               variant=variant,
+                               box=box_variant)
     with pytest.raises(ValueError):
         hoomd.update.BoxResize(trigger=trigger, box1=box1, box=box_variant)
     with pytest.raises(ValueError):
         hoomd.update.BoxResize(trigger=trigger, box2=box2, box=box_variant)
     with pytest.raises(ValueError):
-        hoomd.update.BoxResize(trigger=trigger, variant=variant, box=box_variant)
+        hoomd.update.BoxResize(trigger=trigger,
+                               variant=variant,
+                               box=box_variant)
 
     box_resize = hoomd.update.BoxResize(trigger=trigger, box=box_variant)
     with pytest.raises(RuntimeError):

--- a/hoomd/update/box_resize.py
+++ b/hoomd/update/box_resize.py
@@ -51,10 +51,10 @@ class BoxResize(Updater):
                                s_z \\vec{a}_3' -
                     \\frac{\\vec{a}_1' + \\vec{a}_2' + \\vec{a}_3'}{2}
 
-    where :math:`\\vec{a}_k'` are the new box vectors determined by
-    :math:`box` evaluated at the current time step and the scale factors are
-    determined by the current particle position :math:`\\vec{r}_i` and the old
-    box vectors :math:`\\vec{a}_k`:
+    where :math:`\\vec{a}_k'` are the new box vectors determined by `box`
+    evaluated at the current time step and the scale factors are determined
+    by the current particle position :math:`\\vec{r}_i` and the previous box
+    vectors :math:`\\vec{a}_k`:
 
     .. math::
 
@@ -97,13 +97,15 @@ class BoxResize(Updater):
     .. code-block:: python
 
         box_resize = hoomd.update.BoxResize(trigger=hoomd.trigger.Periodic(10),
-                                            box1=inverse_volume_ramp)
+                                            box=inverse_volume_ramp)
         simulation.operations.updaters.append(box_resize)
 
     Attributes:
         box (hoomd.variant.box.BoxVariant): The box as a function of time.
 
             .. rubric:: Example:
+
+            .. code-block:: python
 
                 box_resize.box = inverse_volume_ramp
 

--- a/hoomd/update/box_resize.py
+++ b/hoomd/update/box_resize.py
@@ -6,24 +6,27 @@
 .. invisible-code-block: python
 
     simulation = hoomd.util.make_example_simulation()
-    initial_box = simulation.state.box
-    box = initial_box
-    final_box = hoomd.Box.from_box(initial_box)
-    final_box.volume = final_box.volume * 2
+
+    inverse_volume_ramp = hoomd.variant.box.InverseVolumeRamp(
+        initial_box=hoomd.Box.cube(6),
+        final_volume=100,
+        t_start=1_000,
+        t_ramp=21_000)
 """
+
+import warnings
 
 import hoomd
 from hoomd.operation import Updater
 from hoomd.box import Box
 from hoomd.data.parameterdicts import ParameterDict
-from hoomd.variant import Variant, Constant
 from hoomd import _hoomd
 from hoomd.filter import ParticleFilter, All
 from hoomd.trigger import Periodic
 
 
 class BoxResize(Updater):
-    """Resizes the box between an initial and final box.
+    """Vary the simulation box size as a function of time.
 
     Args:
         trigger (hoomd.trigger.trigger_like): The trigger to activate this
@@ -36,30 +39,11 @@ class BoxResize(Updater):
             between the two boxes.
         filter (hoomd.filter.filter_like): The subset of particle positions
             to update (defaults to `hoomd.filter.All`).
+        box (hoomd.variant.box.BoxVariant): Box as a function of time.
 
-    `BoxResize` resizes the box between gradually from the initial box to the
-    final box. The simulation box follows the linear interpolation between the
-    initial and final boxes where the minimum of the variant gives `box1` and
-    the maximum gives `box2`:
-
-    .. math::
-
-        \\begin{align*}
-        L_{x}' &= \\lambda L_{2x} + (1 - \\lambda) L_{1x} \\\\
-        L_{y}' &= \\lambda L_{2y} + (1 - \\lambda) L_{1y} \\\\
-        L_{z}' &= \\lambda L_{2z} + (1 - \\lambda) L_{1z} \\\\
-        xy' &= \\lambda xy_{2} + (1 - \\lambda) xy_{1} \\\\
-        xz' &= \\lambda xz_{2} + (1 - \\lambda) xz_{1} \\\\
-        yz' &= \\lambda yz_{2} + (1 - \\lambda) yz_{1} \\\\
-        \\end{align*}
-
-    Where `box1` is :math:`(L_{1x}, L_{1y}, L_{1z}, xy_1, xz_1, yz_1)`,
-    `box2` is :math:`(L_{2x}, L_{2y}, L_{2z}, xy_2, xz_2, yz_2)`,
-    :math:`\\lambda = \\frac{f(t) - \\min f}{\\max f - \\min f}`, :math:`t`
-    is the timestep, and :math:`f(t)` is given by `variant`.
-
-    For each particle :math:`i` matched by `filter`, `BoxResize` scales the
-    particle to fit in the new box:
+    `BoxResize` resizes the simulation box as a function of time. For each
+    particle :math:`i` matched by `filter`, `BoxResize` scales the particle to
+    fit in the new box:
 
     .. math::
 
@@ -68,7 +52,7 @@ class BoxResize(Updater):
                     \\frac{\\vec{a}_1' + \\vec{a}_2' + \\vec{a}_3'}{2}
 
     where :math:`\\vec{a}_k'` are the new box vectors determined by
-    :math:`(L_x', L_y', L_z', xy', xz', yz')` and the scale factors are
+    :math:`box` evaluated at the current time step and the scale factors are
     determined by the current particle position :math:`\\vec{r}_i` and the old
     box vectors :math:`\\vec{a}_k`:
 
@@ -85,13 +69,17 @@ class BoxResize(Updater):
         \\vec{r_j} \\leftarrow \\mathrm{minimum\\_image}_{\\vec{a}_k}'
                                (\\vec{r}_j)
 
-    Important:
-        The passed `Variant` must be bounded on the interval :math:`t \\in
-        [0,\\infty)` or the behavior of the updater is undefined.
+    Note:
+        For backward compatibility, you may set ``box1``, ``box2``, and
+        ``variant`` which is equivalent to::
+
+            box = hoomd.variant.box.Interpolate(initial_box=box1,
+                                                final_box=box2,
+                                                variant=variant)
 
     Warning:
-        Rescaling particles fails in HPMC simulations with more than one MPI
-        rank.
+        Rescaling particles in HPMC simulations with hard particles may
+        introduce overlaps.
 
     Note:
         When using rigid bodies, ensure that the `BoxResize` updater is last in
@@ -100,48 +88,24 @@ class BoxResize(Updater):
         deformed. `hoomd.md.Integrator` will run after the last updater and
         resets the constituent particle positions before computing forces.
 
+    .. deprecated:: 4.6.0
+        The arguments ``box1``, ``box2``, and ``variant`` are deprecated. Use
+        ``box``.
+
     .. rubric:: Example:
 
     .. code-block:: python
 
         box_resize = hoomd.update.BoxResize(trigger=hoomd.trigger.Periodic(10),
-                                            box1=initial_box,
-                                            box2=final_box,
-                                            variant=hoomd.variant.Ramp(
-                                                A=0,
-                                                B=1,
-                                                t_start=simulation.timestep,
-                                                t_ramp=20000))
+                                            box1=inverse_volume_ramp)
         simulation.operations.updaters.append(box_resize)
 
     Attributes:
-        box1 (hoomd.Box): The box associated with the minimum of the
-            passed variant.
+        box (hoomd.variant.box.BoxVariant): The box as a function of time.
 
             .. rubric:: Example:
 
-            .. code-block:: python
-
-                box_resize.box1 = initial_box
-
-        box2 (hoomd.Box): The box associated with the maximum of the
-            passed variant.
-
-            .. rubric:: Example:
-
-            .. code-block:: python
-
-                box_resize.box2 = final_box
-
-        variant (hoomd.variant.Variant): A variant used to interpolate between
-            the two boxes.
-
-            .. rubric:: Example:
-
-            .. code-block:: python
-
-                box_resize.variant = hoomd.variant.Ramp(
-                    A=0, B=1, t_start=simulation.timestep, t_ramp=20000)
+                box_resize.box = inverse_volume_ramp
 
         filter (hoomd.filter.filter_like): The subset of particles to
             update.
@@ -153,16 +117,40 @@ class BoxResize(Updater):
                 filter_ = box_resize.filter
     """
 
-    def __init__(self, trigger, box1, box2, variant, filter=All()):
-        params = ParameterDict(box1=Box,
-                               box2=Box,
-                               variant=Variant,
+    def __init__(
+            self,
+            trigger,
+            box1=None,
+            box2=None,
+            variant=None,
+            filter=All(),
+            box=None,
+    ):
+        params = ParameterDict(box=hoomd.variant.box.BoxVariant,
                                filter=ParticleFilter)
-        params['box1'] = box1
-        params['box2'] = box2
-        params['variant'] = variant
-        params['trigger'] = trigger
-        params['filter'] = filter
+
+        if box is not None and (box1 is not None or box2 is not None
+                                or variant is not None):
+            raise ValueError(
+                'box1, box2, and variant must be None when box is set')
+
+        if box is None and not (box1 is not None and box2 is not None
+                                and variant is not None):
+            raise ValueError(
+                'box1, box2, and variant must not be None when box is None')
+
+        if box is not None:
+            self._using_deprecated_box = False
+        else:
+            warnings.warn('box1, box2, and variant are deprecated, use `box`',
+                          FutureWarning)
+
+            box = hoomd.variant.box.Interpolate(initial_box=box1,
+                                                final_box=box2,
+                                                variant=variant)
+            self._using_deprecated_box = True
+
+        params.update({'box': box, 'filter': filter})
         self._param_dict.update(params)
         super().__init__(trigger)
 
@@ -170,12 +158,78 @@ class BoxResize(Updater):
         group = self._simulation.state._get_group(self.filter)
         if isinstance(self._simulation.device, hoomd.device.CPU):
             self._cpp_obj = _hoomd.BoxResizeUpdater(
-                self._simulation.state._cpp_sys_def, self.trigger,
-                self.box1._cpp_obj, self.box2._cpp_obj, self.variant, group)
+                self._simulation.state._cpp_sys_def, self.trigger, self.box,
+                group)
         else:
             self._cpp_obj = _hoomd.BoxResizeUpdaterGPU(
-                self._simulation.state._cpp_sys_def, self.trigger,
-                self.box1._cpp_obj, self.box2._cpp_obj, self.variant, group)
+                self._simulation.state._cpp_sys_def, self.trigger, self.box,
+                group)
+
+    @property
+    def box1(self):
+        """hoomd.Box: The box associated with the minimum of the passed variant.
+
+        .. deprecated:: 4.6.0
+
+            Use `box`.
+        """
+        warnings.warn('box1 is deprecated, use `box`.', FutureWarning)
+        if self._using_deprecated_box:
+            return self.box.initial_box
+
+        raise RuntimeError('box1 is not available when box is not None.')
+
+    @box1.setter
+    def box1(self, box):
+        warnings.warn('box1 is deprecated, use `box`.', FutureWarning)
+        if self._using_deprecated_box:
+            self.box.initial_box = box
+
+        raise RuntimeError('box1 is not available when box is not None.')
+
+    @property
+    def box2(self):
+        """hoomd.Box: The box associated with the maximum of the passed variant.
+
+        .. deprecated:: 4.6.0
+
+            Use `box`.
+        """
+        warnings.warn('box2 is deprecated, use `box`.', FutureWarning)
+        if self._using_deprecated_box:
+            return self.box.final_box
+
+        raise RuntimeError('box2 is not available when box is not None.')
+
+    @box2.setter
+    def box2(self, box):
+        warnings.warn('box2 is deprecated, use `box`.', FutureWarning)
+        if self._using_deprecated_box:
+            self.box.final_box = box
+
+        raise RuntimeError('box2 is not available when box is not None.')
+
+    @property
+    def variant(self):
+        """hoomd.variant.Variant: A variant used to interpolate boxes.
+
+        .. deprecated:: 4.6.0
+
+            Use `box`.
+        """
+        warnings.warn('variant is deprecated, use `box`.', FutureWarning)
+        if self._using_deprecated_box:
+            return self.box.variant
+
+        raise RuntimeError('variant is not available when box is not None.')
+
+    @variant.setter
+    def variant(self, variant):
+        warnings.warn('variant is deprecated, use `box`.', FutureWarning)
+        if self._using_deprecated_box:
+            self.box.final_box = variant
+
+        raise RuntimeError('variant is not available when box is not None.')
 
     def get_box(self, timestep):
         """Get the box for a given timestep.
@@ -221,14 +275,13 @@ class BoxResize(Updater):
         """
         group = state._get_group(filter)
 
+        box_variant = hoomd.variant.box.Constant(box)
+
         if isinstance(state._simulation.device, hoomd.device.CPU):
             updater = _hoomd.BoxResizeUpdater(state._cpp_sys_def, Periodic(1),
-                                              state.box._cpp_obj, box._cpp_obj,
-                                              Constant(1), group)
+                                              box_variant, group)
         else:
             updater = _hoomd.BoxResizeUpdaterGPU(state._cpp_sys_def,
-                                                 Periodic(1),
-                                                 state.box._cpp_obj,
-                                                 box._cpp_obj, Constant(1),
+                                                 Periodic(1), box_variant,
                                                  group)
         updater.update(state._simulation.timestep)

--- a/hoomd/variant/box.py
+++ b/hoomd/variant/box.py
@@ -128,6 +128,10 @@ class Interpolate(_hoomd.VectorVariantBoxInterpolate, BoxVariant):
         _hoomd.VectorVariantBoxInterpolate.__init__(self, box1._cpp_obj,
                                                     box2._cpp_obj, variant)
 
+    def __reduce__(self):
+        """Reduce values to picklable format."""
+        return (type(self), (self.initial_box, self.final_box, self.variant))
+
     @property
     def initial_box(self):
         """hoomd.Box: The initial box."""
@@ -190,6 +194,11 @@ class InverseVolumeRamp(_hoomd.VectorVariantBoxInverseVolumeRamp, BoxVariant):
         box = hoomd.data.typeconverter.box_preprocessing(initial_box)
         _hoomd.VectorVariantBoxInverseVolumeRamp.__init__(
             self, box._cpp_obj, final_volume, t_start, t_ramp)
+
+    def __reduce__(self):
+        """Reduce values to picklable format."""
+        return (type(self), (self.initial_box, self.final_volume, self.t_start,
+                             self.t_ramp))
 
     @property
     def initial_box(self):

--- a/sphinx-doc/deprecated.rst
+++ b/sphinx-doc/deprecated.rst
@@ -47,3 +47,7 @@ documentation for more information on warning filters.
 * ``GPU.devices`` (since 4.5.0)
 
   * Use ``device``.
+
+* ``box1``, ``box2``, and ``variant`` arguments to ``hoomd.update.BoxResize``.
+
+  * Use ``box``.


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should be based on *trunk-patch*. -->
<!-- Backwards compatible new features should be based on *trunk-minor*. -->
<!-- Incompatible API changes should be based on *trunk-major*. -->

## Description

<!-- Describe your changes in detail. -->
Add the `box` argument to `BoxResize`. Deprecate `box1`, `box2`, and `variant`.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Box variants provide a more flexible solution.

<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves #1640

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
Added unit tests.

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
Added:

* ``box`` argument to ``hoomd.update.BoxResize`` that accepts a ``BoxVariant``.

Deprecated:

* ``box1``, ``box2``, and ``variant`` arguments to ``hoomd.update.BoxResize``.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
