### PR TITLE
Enable flake8 for MPCD

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -93,7 +93,6 @@ repos:
     exclude: |
       (?x)(
         ^hoomd/extern/|
-        ^hoomd/mpcd/|
         ^hoomd/metal/
       )
 - repo: https://github.com/pre-commit/mirrors-clang-format

--- a/hoomd/mpcd/__init__.py
+++ b/hoomd/mpcd/__init__.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2009-2023 The Regents of the University of Michigan.
 # Part of HOOMD-blue, released under the BSD 3-Clause License.
 
-""" Multiparticle collision dynamics.
+"""Multiparticle collision dynamics.
 
 Simulating complex fluids and soft matter using conventional molecular dynamics
 methods (`hoomd.md`) can be computationally demanding due to large disparities

--- a/hoomd/mpcd/collide.py
+++ b/hoomd/mpcd/collide.py
@@ -97,11 +97,12 @@ class CollisionMethod(Operation):
 
     Args:
         period (int): Number of integration steps between collisions.
-        embedded_particles (hoomd.filter.filter_like): HOOMD particles to include in collision.
+        embedded_particles (hoomd.filter.filter_like): HOOMD particles to
+            include in collision.
 
     Attributes:
-        embedded_particles (hoomd.filter.filter_like): HOOMD particles to include
-            in collision (*read only*).
+        embedded_particles (hoomd.filter.filter_like): HOOMD particles to
+            include in collision (*read only*).
 
             These particles are included in per-cell quantities and have their
             velocities updated along with the MPCD particles.
@@ -118,10 +119,12 @@ class CollisionMethod(Operation):
                 will not be correctly transferred to the body. Support for this
                 is planned in future.
 
-        period (int): Number of integration steps between collisions (*read only*).
+        period (int): Number of integration steps between collisions
+            (*read only*).
 
-            A collision is executed each time the :attr:`~hoomd.Simulation.timestep`
-            is a multiple of `period`. It must be a multiple of `period` for the
+            A collision is executed each time the
+            :attr:`~hoomd.Simulation.timestep` is a multiple of `period`. It
+            must be a multiple of `period` for the
             :class:`~hoomd.mpcd.stream.StreamingMethod` if one is attached to
             the :class:`~hoomd.mpcd.Integrator`.
 
@@ -166,7 +169,9 @@ class AndersenThermostat(CollisionMethod):
 
     .. code-block:: python
 
-        andersen_thermostat = hoomd.mpcd.collide.AndersenThermostat(period=1, kT=1.0)
+        andersen_thermostat = hoomd.mpcd.collide.AndersenThermostat(
+            period=1,
+            kT=1.0)
         simulation.operations.integrator.collision_method = andersen_thermostat
 
     Collision including embedded particles.

--- a/hoomd/mpcd/fill.py
+++ b/hoomd/mpcd/fill.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2009-2023 The Regents of the University of Michigan.
 # Part of HOOMD-blue, released under the BSD 3-Clause License.
 
-r""" MPCD virtual-particle fillers.
+r"""MPCD virtual-particle fillers.
 
 Virtual particles are MPCD solvent particles that are added to ensure MPCD
 collision cells that are sliced by solid boundaries do not become "underfilled".
@@ -119,7 +119,8 @@ class GeometryFiller(VirtualParticleFiller):
         simulation.operations.integrator.virtual_particle_fillers = [filler]
 
     Attributes:
-        geometry (hoomd.mpcd.geometry.Geometry): Surface to fill around (*read only*).
+        geometry (hoomd.mpcd.geometry.Geometry): Surface to fill around
+            (*read only*).
 
     """
 
@@ -147,7 +148,8 @@ class GeometryFiller(VirtualParticleFiller):
         if isinstance(sim.device, hoomd.device.GPU):
             class_info[1] += "GPU"
         class_ = getattr(*class_info, None)
-        assert class_ is not None, "Virtual particle filler for geometry not found"
+        assert class_ is not None, ("Virtual particle filler for geometry"
+                                    " not found")
 
         self._cpp_obj = class_(
             sim.state._cpp_sys_def,

--- a/hoomd/mpcd/force.py
+++ b/hoomd/mpcd/force.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2009-2023 The Regents of the University of Michigan.
 # Part of HOOMD-blue, released under the BSD 3-Clause License.
 
-r""" MPCD solvent forces.
+r"""MPCD solvent forces.
 
 MPCD can apply a body force to each MPCD particle as a function of position.
 The external force should be compatible with the chosen
@@ -46,10 +46,10 @@ class BlockForce(SolventForce):
             blocks.
         half_width (float): Half the width of each block.
 
-    The `force` magnitude *F* is applied in the *x* direction on the solvent particles
-    in blocks defined along the *y* direction by the `half_separation` *H* and
-    the `half_width` *w*. The force in *x* is :math:`+F` in the upper block,
-    :math:`-F` in the lower block, and zero otherwise.
+    The `force` magnitude *F* is applied in the *x* direction on the solvent
+    particles in blocks defined along the *y* direction by the `half_separation`
+    *H* and the `half_width` *w*. The force in *x* is :math:`+F` in the upper
+    block, :math:`-F` in the lower block, and zero otherwise.
 
     .. math::
         :nowrap:
@@ -62,9 +62,9 @@ class BlockForce(SolventForce):
         \end{cases}
         \end{equation}
 
-    The `BlockForce` can be used to implement the double-parabola method for measuring
-    viscosity by setting :math:`H = L_y/4` and :math:`w = L_y/4`, where :math:`L_y` is
-    the size of the simulation box in *y*.
+    The `BlockForce` can be used to implement the double-parabola method for
+    measuring viscosity by setting :math:`H = L_y/4` and :math:`w = L_y/4`,
+    where :math:`L_y` is the size of the simulation box in *y*.
 
     Warning:
         You should define the blocks to lie fully within the simulation box and
@@ -77,7 +77,10 @@ class BlockForce(SolventForce):
     .. code-block:: python
 
         Ly = simulation.state.box.Ly
-        force = hoomd.mpcd.force.BlockForce(force=1.0, half_separation=Ly/4, half_width=Ly/4)
+        force = hoomd.mpcd.force.BlockForce(
+            force=1.0,
+            half_separation=Ly/4,
+            half_width=Ly/4)
         stream = hoomd.mpcd.stream.Bulk(period=1, solvent_force=force)
         simulation.operations.integrator.streaming_method = stream
 
@@ -135,9 +138,9 @@ class ConstantForce(SolventForce):
 
     The same constant force is applied to all solvent particles, independently
     of time and position. This force is useful for simulating pressure-driven
-    flow in conjunction with a confined geometry having no-slip boundary conditions.
-    It is also useful for measuring diffusion coefficients with nonequilibrium
-    methods.
+    flow in conjunction with a confined geometry having no-slip boundary
+    conditions. It is also useful for measuring diffusion coefficients with
+    nonequilibrium methods.
 
     .. rubric:: Example:
 

--- a/hoomd/mpcd/geometry.py
+++ b/hoomd/mpcd/geometry.py
@@ -6,8 +6,10 @@ r"""MPCD geometries.
 A geometry defines solid boundaries that cannot be penetrated. These
 geometries are used for various operations in the MPCD algorithm including:
 
-* Bounce-back streaming for MPCD particles (:class:`hoomd.mpcd.stream.BounceBack`)
-* Bounce-back integration for MD particles (:class:`hoomd.mpcd.methods.BounceBack`)
+* Bounce-back streaming for MPCD particles
+  (:class:`hoomd.mpcd.stream.BounceBack`)
+* Bounce-back integration for MD particles
+  (:class:`hoomd.mpcd.methods.BounceBack`)
 * Virtual particle filling (:class:`hoomd.mpcd.fill.GeometryFiller`)
 
 Each geometry may put constraints on the size of the simulation and where

--- a/hoomd/mpcd/integrate.py
+++ b/hoomd/mpcd/integrate.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2009-2023 The Regents of the University of Michigan.
 # Part of HOOMD-blue, released under the BSD 3-Clause License.
 
+"""Implement MPCD Integrator."""
+
 import hoomd
 from hoomd.data.parameterdicts import ParameterDict
 from hoomd.data import syncedlist
@@ -48,7 +50,8 @@ class Integrator(_MDIntegrator):
         collision_method (hoomd.mpcd.collide.CollisionMethod): Collision method
             for the MPCD solvent and any embedded particles.
 
-        virtual_particle_fillers (Sequence[hoomd.mpcd.fill.VirtualParticleFiller]): Solvent
+        virtual_particle_fillers
+            (Sequence[hoomd.mpcd.fill.VirtualParticleFiller]): Solvent
             virtual-particle filler(s).
 
         solvent_sorter (hoomd.mpcd.tune.ParticleSorter): Tuner for sorting the
@@ -86,7 +89,9 @@ class Integrator(_MDIntegrator):
     .. code-block:: python
 
         stream = hoomd.mpcd.stream.Bulk(period=1)
-        collide = hoomd.mpcd.collide.StochasticRotationDynamics(period=1, angle=130)
+        collide = hoomd.mpcd.collide.StochasticRotationDynamics(
+            period=1,
+            angle=130)
         integrator = hoomd.mpcd.Integrator(
             dt=0.1,
             streaming_method=stream,
@@ -214,9 +219,8 @@ class Integrator(_MDIntegrator):
     @property
     def virtual_particle_fillers(self):
         """Sequence[hoomd.mpcd.fill.VirtualParticleFiller]: Solvent
-            virtual-particle fillers.
-
-        """
+        virtual-particle fillers.
+        """  # noqa: D205,D415
         return self._virtual_particle_fillers
 
     @virtual_particle_fillers.setter
@@ -261,7 +265,7 @@ class Integrator(_MDIntegrator):
             if value is not None and value._attached:
                 raise ValueError("Cannot attach to multiple integrators.")
 
-            # if already attached, change out which is attached, then set parameter
+            # if already attached, change out and set parameter
             if self._attached:
                 if cur_value is not None:
                     cur_value._detach()

--- a/hoomd/mpcd/integrate.py
+++ b/hoomd/mpcd/integrate.py
@@ -218,9 +218,8 @@ class Integrator(_MDIntegrator):
 
     @property
     def virtual_particle_fillers(self):
-        """Sequence[hoomd.mpcd.fill.VirtualParticleFiller]: Solvent
-        virtual-particle fillers.
-        """  # noqa: D205,D415
+        """Sequence[hoomd.mpcd.fill.VirtualParticleFiller]: Solvent \
+        virtual-particle fillers."""
         return self._virtual_particle_fillers
 
     @virtual_particle_fillers.setter

--- a/hoomd/mpcd/methods.py
+++ b/hoomd/mpcd/methods.py
@@ -68,8 +68,8 @@ class BounceBack(Method):
 
     .. code-block:: python
 
-        plates = hoomd.mpcd.geometry.ParallelPlates(H=3.0) nve =
-        hoomd.mpcd.methods.BounceBack(
+        plates = hoomd.mpcd.geometry.ParallelPlates(H=3.0)
+        nve = hoomd.mpcd.methods.BounceBack(
             filter=hoomd.filter.All(), geometry=plates)
         simulation.operations.integrator.methods.append(nve)
 

--- a/hoomd/mpcd/methods.py
+++ b/hoomd/mpcd/methods.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2009-2023 The Regents of the University of Michigan.
 # Part of HOOMD-blue, released under the BSD 3-Clause License.
 
-r""" MPCD integration methods
+r"""MPCD integration methods.
 
 Extra integration methods for solutes (MD particles) embedded in an MPCD
 solvent. These methods are not restricted to MPCD simulations: they can be used
@@ -31,54 +31,54 @@ class BounceBack(Method):
             apply this method.
         geometry (hoomd.mpcd.geometry.Geometry): Surface to bounce back from.
 
-    A bounce-back method for integrating solutes (MD particles) embedded in
-    an MPCD solvent. The integration scheme is velocity Verlet with bounce-back
+    A bounce-back method for integrating solutes (MD particles) embedded in an
+    MPCD solvent. The integration scheme is velocity Verlet with bounce-back
     performed at the solid boundaries defined by a geometry, as in
     `hoomd.mpcd.stream.BounceBack`. This gives a simple approximation of the
-    interactions required to keep a solute bounded in a geometry, and more complex
-    interactions can be specified, for example, by writing custom external fields.
+    interactions required to keep a solute bounded in a geometry, and more
+    complex interactions can be specified, for example, by writing custom
+    external fields.
 
-    Similar caveats apply to these methods as for `hoomd.mpcd.stream.BounceBack`.
-    In particular:
+    Similar caveats apply to these methods as for
+    `hoomd.mpcd.stream.BounceBack`. In particular:
 
-    1. The simulation box is periodic, but the `geometry` may impose non-periodic
-       boundary conditions. You must ensure that the box is sufficiently large to
-       enclose the `geometry` and that all particles lie inside it, or an error will
-       be raised at runtime.
-    2. You must also ensure that particles do not self-interact through the periodic
-       boundaries. This is usually achieved for simple pair potentials by padding
-       the box size by the largest cutoff radius. Failure to do so may result in
-       unphysical interactions.
+    1. The simulation box is periodic, but the `geometry` may impose
+       non-periodic boundary conditions. You must ensure that the box is
+       sufficiently large to enclose the `geometry` and that all particles lie
+       inside it, or an error will be raised at runtime.
+    2. You must also ensure that particles do not self-interact through the
+       periodic boundaries. This is usually achieved for simple pair potentials
+       by padding the box size by the largest cutoff radius. Failure to do so
+       may result in unphysical interactions.
     3. Bounce-back rules do not always enforce no-slip conditions at surfaces
-       properly. It may still be necessary to add additional "ghost" MD particles in
-       the surface to achieve the right boundary conditions and reduce density
-       fluctuations.
+       properly. It may still be necessary to add additional "ghost" MD
+       particles in the surface to achieve the right boundary conditions and
+       reduce density fluctuations.
 
     Warning:
 
-        This method does not support anisotropic integration because
-        torques are not computed for collisions with the boundary.
-        Rigid bodies will also not be treated correctly because the
-        integrator is not aware of the extent of the particles. The surface
-        reflections are treated as point particles. These conditions are too
-        complicated to validate easily, so it is the user's responsibility to
-        choose the `filter` correctly.
+        This method does not support anisotropic integration because torques are
+        not computed for collisions with the boundary. Rigid bodies will also
+        not be treated correctly because the integrator is not aware of the
+        extent of the particles. The surface reflections are treated as point
+        particles. These conditions are too complicated to validate easily, so
+        it is the user's responsibility to choose the `filter` correctly.
 
     .. rubric:: Example:
 
     .. code-block:: python
 
-        plates = hoomd.mpcd.geometry.ParallelPlates(H=3.0)
-        nve = hoomd.mpcd.methods.BounceBack(
-            filter=hoomd.filter.All(),
-            geometry=plates)
+        plates = hoomd.mpcd.geometry.ParallelPlates(H=3.0) nve =
+        hoomd.mpcd.methods.BounceBack(
+            filter=hoomd.filter.All(), geometry=plates)
         simulation.operations.integrator.methods.append(nve)
 
     Attributes:
         filter (hoomd.filter.filter_like): Subset of particles on which to apply
             this method (*read only*).
 
-        geometry (hoomd.mpcd.geometry.Geometry): Surface to bounce back from (*read only*).
+        geometry (hoomd.mpcd.geometry.Geometry): Surface to bounce back from
+            (*read only*).
 
     """
 

--- a/hoomd/mpcd/pytest/test_collide.py
+++ b/hoomd/mpcd/pytest/test_collide.py
@@ -1,9 +1,10 @@
 # Copyright (c) 2009-2023 The Regents of the University of Michigan.
 # Part of HOOMD-blue, released under the BSD 3-Clause License.
 
+import pytest
+
 import hoomd
 from hoomd.conftest import pickling_check
-import pytest
 
 
 @pytest.fixture

--- a/hoomd/mpcd/pytest/test_fill.py
+++ b/hoomd/mpcd/pytest/test_fill.py
@@ -1,10 +1,10 @@
 # Copyright (c) 2009-2023 The Regents of the University of Michigan.
 # Part of HOOMD-blue, released under the BSD 3-Clause License.
 
+import pytest
+
 import hoomd
 from hoomd.conftest import pickling_check
-import numpy as np
-import pytest
 
 
 @pytest.fixture

--- a/hoomd/mpcd/pytest/test_force.py
+++ b/hoomd/mpcd/pytest/test_force.py
@@ -1,10 +1,10 @@
 # Copyright (c) 2009-2023 The Regents of the University of Michigan.
 # Part of HOOMD-blue, released under the BSD 3-Clause License.
 
+import numpy as np
+
 import hoomd
 from hoomd.conftest import pickling_check
-import numpy as np
-import pytest
 
 
 def test_block_force(simulation_factory):

--- a/hoomd/mpcd/pytest/test_geometry.py
+++ b/hoomd/mpcd/pytest/test_geometry.py
@@ -1,9 +1,10 @@
 # Copyright (c) 2009-2023 The Regents of the University of Michigan.
 # Part of HOOMD-blue, released under the BSD 3-Clause License.
 
+import pytest
+
 import hoomd
 from hoomd.conftest import pickling_check
-import pytest
 
 
 @pytest.fixture

--- a/hoomd/mpcd/pytest/test_integrator.py
+++ b/hoomd/mpcd/pytest/test_integrator.py
@@ -1,11 +1,10 @@
 # Copyright (c) 2009-2023 The Regents of the University of Michigan.
 # Part of HOOMD-blue, released under the BSD 3-Clause License.
 
+import pytest
+
 import hoomd
 from hoomd.conftest import pickling_check
-
-import numpy as np
-import pytest
 
 
 @pytest.fixture

--- a/hoomd/mpcd/pytest/test_methods.py
+++ b/hoomd/mpcd/pytest/test_methods.py
@@ -1,10 +1,11 @@
 # Copyright (c) 2009-2023 The Regents of the University of Michigan.
 # Part of HOOMD-blue, released under the BSD 3-Clause License.
 
-import hoomd
-from hoomd.conftest import pickling_check
 import numpy as np
 import pytest
+
+import hoomd
+from hoomd.conftest import pickling_check
 
 
 @pytest.fixture
@@ -103,7 +104,7 @@ class TestBounceBack:
                 snap.particles.velocity,
                 [[1.0, -1.0, -1.0], [-1.0, -1.0, -1.0]])
 
-        # take another step, reflecting the perpendicular motion of second particle
+        # take another step, reflecting perpendicular motion of second particle
         sim.run(1)
         snap = sim.state.get_snapshot()
         if snap.communicator.rank == 0:

--- a/hoomd/mpcd/pytest/test_snapshot.py
+++ b/hoomd/mpcd/pytest/test_snapshot.py
@@ -1,9 +1,10 @@
 # Copyright (c) 2009-2023 The Regents of the University of Michigan.
 # Part of HOOMD-blue, released under the BSD 3-Clause License.
 
+import pytest
+
 import hoomd
 import numpy as np
-import pytest
 
 # default testing configuration, used in setting values below
 test_positions = np.array([[1, 2, 3], [-9, -6, -3], [7, 8, 9]])
@@ -66,7 +67,8 @@ def test_resize(snap):
         np.testing.assert_array_equal(snap.mpcd.velocity, [test_velocities[0]])
         np.testing.assert_array_equal(snap.mpcd.typeid, [test_typeids[0]])
 
-        # grow the snapshot by one, and make sure first entry is retained, and it is padded by zeros
+        # grow the snapshot by one, and make sure first entry is retained, and
+        # it is padded by zeros
         snap.mpcd.N = 2
         np.testing.assert_array_equal(snap.mpcd.position,
                                       [test_positions[0], [0, 0, 0]])
@@ -134,7 +136,7 @@ def test_replicate(snap):
 
 
 def test_create_and_restore_from_snap(snap, simulation_factory):
-    """Test that simulation can be created and restored with MPCD data in snapshot."""
+    """Test simulation can be created and restored with MPCD data."""
     if snap.communicator.num_ranks > 2:
         pytest.skip("Test must be run on 1 or 2 ranks")
 

--- a/hoomd/mpcd/pytest/test_stream.py
+++ b/hoomd/mpcd/pytest/test_stream.py
@@ -1,10 +1,11 @@
 # Copyright (c) 2009-2023 The Regents of the University of Michigan.
 # Part of HOOMD-blue, released under the BSD 3-Clause License.
 
-import hoomd
-from hoomd.conftest import pickling_check
 import numpy as np
 import pytest
+
+import hoomd
+from hoomd.conftest import pickling_check
 
 
 @pytest.fixture
@@ -92,7 +93,10 @@ class TestStreamingMethod:
         pickling_check(sm)
 
     def test_forced_step(self, simulation_factory, snap, cls, init_args):
-        """Test a step with particle starting in the middle, constant force in +x and -z.
+        """Test a forced step.
+
+        The particle starts in the middle, and there is a constant force in +x
+        and -z.
 
         This test should be skipped or adapted if geometries are added for which
         this point is / will be out of bounds, but is legal for all the ones we
@@ -153,8 +157,9 @@ class TestBulk:
             np.testing.assert_array_almost_equal(
                 snap.mpcd.position, [[1.3, -4.85, 3.3], [-3.3, 4.95, -1.3]])
 
-        # change streaming method to use a different period, and change integrator step
-        # running again should not move the particles since we haven't hit next period
+        # change streaming method to use a different period, and change
+        # integrator step running again should not move the particles since we
+        # haven't hit next period
         ig.dt = 0.05
         ig.streaming_method = hoomd.mpcd.stream.Bulk(period=4)
         sim.run(1)
@@ -250,7 +255,7 @@ class TestParallelPlates:
             np.testing.assert_array_almost_equal(
                 snap.mpcd.velocity, [[1.0, -1.0, -1.0], [-1.0, -1.0, -1.0]])
 
-        # take another step, reflecting the perpendicular motion of second particle
+        # take another step, reflecting perpendicular motion of second particle
         sim.run(1)
         snap = sim.state.get_snapshot()
         if snap.communicator.rank == 0:
@@ -369,12 +374,14 @@ class TestPlanarPore:
                                                  [0, -3.95, 0])
             np.testing.assert_array_almost_equal(snap.mpcd.velocity[5],
                                                  [0, 1.0, 0])
-            # hits y = -4 after 0.02, then reverses. x is 3.01, so reverses to 3.09
+            # hits y = -4 after 0.02, then reverses.
+            # x is 3.01, so reverses to 3.09
             np.testing.assert_array_almost_equal(snap.mpcd.position[6],
                                                  [3.09, -3.92, 0])
             np.testing.assert_array_almost_equal(snap.mpcd.velocity[6],
                                                  [1, 1, 0])
-            # hits x = 3 after 0.02, then reverses. y is -3.99, so reverses to -3.91
+            # hits x = 3 after 0.02, then reverses.
+            # y is -3.99, so reverses to -3.91
             np.testing.assert_array_almost_equal(snap.mpcd.position[7],
                                                  [3.08, -3.91, 0])
             np.testing.assert_array_almost_equal(snap.mpcd.velocity[7],
@@ -438,12 +445,14 @@ class TestPlanarPore:
                                                  [0, -3.95, 0])
             np.testing.assert_array_almost_equal(snap.mpcd.velocity[5],
                                                  [0, 1.0, 0])
-            # hits y = -4 after 0.02, then reverses. x is not touched because slip
+            # hits y = -4 after 0.02, then reverses.
+            # x is not touched because slip
             np.testing.assert_array_almost_equal(snap.mpcd.position[6],
                                                  [2.93, -3.92, 0])
             np.testing.assert_array_almost_equal(snap.mpcd.velocity[6],
                                                  [-1, 1, 0])
-            # hits x = 3 after 0.02, then reverses. y is not touched because slip
+            # hits x = 3 after 0.02, then reverses.
+            # y is not touched because slip
             np.testing.assert_array_almost_equal(snap.mpcd.position[7],
                                                  [3.08, -4.07, 0])
             np.testing.assert_array_almost_equal(snap.mpcd.velocity[7],

--- a/hoomd/mpcd/pytest/test_tune.py
+++ b/hoomd/mpcd/pytest/test_tune.py
@@ -1,9 +1,10 @@
 # Copyright (c) 2009-2023 The Regents of the University of Michigan.
 # Part of HOOMD-blue, released under the BSD 3-Clause License.
 
+import pytest
+
 import hoomd
 from hoomd.conftest import pickling_check
-import pytest
 
 
 @pytest.fixture

--- a/hoomd/mpcd/stream.py
+++ b/hoomd/mpcd/stream.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2009-2023 The Regents of the University of Michigan.
 # Part of HOOMD-blue, released under the BSD 3-Clause License.
 
-r""" MPCD streaming methods.
+r"""MPCD streaming methods.
 
 An MPCD streaming method is required to update the particle positions over time.
 It is meant to be used in conjunction with an :class:`.mpcd.Integrator` and
@@ -133,7 +133,8 @@ class Bulk(StreamingMethod):
         if isinstance(sim.device, hoomd.device.GPU):
             class_info[1] += "GPU"
         class_ = getattr(*class_info, None)
-        assert class_ is not None, "C++ streaming method could not be determined"
+        assert class_ is not None, ("C++ streaming method could not be"
+                                    " determined")
 
         self._cpp_obj = class_(
             sim.state._cpp_sys_def,
@@ -165,19 +166,20 @@ class BounceBack(StreamingMethod):
         geometry (hoomd.mpcd.geometry.Geometry): Surface to bounce back from.
         solvent_force (SolventForce): Force on solvent.
 
-    One of the main strengths of the MPCD algorithm is that it can be coupled
-    to complex boundaries, defined by a `geometry`. This `StreamingMethod` reflects
+    One of the main strengths of the MPCD algorithm is that it can be coupled to
+    complex boundaries, defined by a `geometry`. This `StreamingMethod` reflects
     the MPCD solvent particles from boundary surfaces using specular reflections
     (bounce-back) rules consistent with either "slip" or "no-slip" hydrodynamic
-    boundary conditions. The external force is only applied to the particles at the
-    beginning and the end of this process.
+    boundary conditions. The external force is only applied to the particles at
+    the beginning and the end of this process.
 
-    Although a streaming geometry is enforced on the MPCD solvent particles, there
-    are a few important caveats:
+    Although a streaming geometry is enforced on the MPCD solvent particles,
+    there are a few important caveats:
 
     1. Embedded particles are not coupled to the boundary walls. They must be
        confined by an appropriate method, e.g., an external potential, an
-       explicit particle wall, or a bounce-back method (`hoomd.mpcd.methods.BounceBack`).
+       explicit particle wall, or a bounce-back method
+       (`hoomd.mpcd.methods.BounceBack`).
     2. The `geometry` exists inside a fully periodic simulation box.
        Hence, the box must be padded large enough that the MPCD cells do not
        interact through the periodic boundary. Usually, this means adding at
@@ -195,7 +197,8 @@ class BounceBack(StreamingMethod):
 
         stream = hoomd.mpcd.stream.BounceBack(
             period=1,
-            geometry=hoomd.mpcd.geometry.ParallelPlates(H=3.0, V=1.0, no_slip=True))
+            geometry=hoomd.mpcd.geometry.ParallelPlates(
+                H=3.0, V=1.0, no_slip=True))
         simulation.operations.integrator.streaming_method = stream
 
     Pressure driven flow between parallel plates.
@@ -292,8 +295,8 @@ class BounceBack(StreamingMethod):
         super()._detach_hook()
 
     @classmethod
-    def _register_cpp_class(cls, geometry, module, cpp_class_name):
-        # we will allow "None" for the force, but we need its class type not its value
+    def _register_cpp_class(cls, geometry, force, module, cpp_class_name):
+        # we will allow None for the force, but we need its class type not value
         if force is None:
             force = type(None)
         cls._cpp_cpp_class_map[geometry, force] = (module, cpp_class_name)

--- a/hoomd/mpcd/tune.py
+++ b/hoomd/mpcd/tune.py
@@ -33,12 +33,14 @@ class ParticleSorter(TriggeredOperation):
 
     The optimal frequency for sorting depends on the number of particles, so the
     `trigger` itself should be tuned to give the maximum performance. The
-    trigger's period should be a multiple of `hoomd.mpcd.collide.CollisionMethod.period`
-    to avoid unnecessary cell list builds. Typically, using a small multiple
-    (tens) of the collision period works best.
+    trigger's period should be a multiple of
+    `hoomd.mpcd.collide.CollisionMethod.period` to avoid unnecessary cell list
+    builds. Typically, using a small multiple (tens) of the collision period
+    works best.
 
     For best performance, the `ParticleSorter` should **not** be added to
-    `hoomd.Operations.tuners`. Instead, set it in `hoomd.mpcd.Integrator.solvent_sorter`.
+    `hoomd.Operations.tuners`. Instead, set it in
+    `hoomd.mpcd.Integrator.solvent_sorter`.
 
     Essentially all MPCD systems benefit from sorting, so it is recommended
     to use one for all simulations!

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,7 +41,6 @@ exclude = .git,
     build,
     hoomd/extern,
     hoomd/metal,
-    hoomd/mpcd,
 max_line_length = 80
 max_doc_length = 80
 hang_closing = True
@@ -56,6 +55,7 @@ rst-directives =
     versionchanged,
     todo,
 rst-roles =
+    attr,
     class,
     doc,
     file,


### PR DESCRIPTION
## Description

This PR reenables flake8 checks on the MPCD code. I also fixed errors that were identified.

## Motivation and context

We didn't have this on before, and MPCD should be fully compliant with HOOMD's style.

## How has this been tested?

N/A

## Change log

N/A

## Checklist:

- [X] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.rst).
- [X] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [X] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
