### PR TITLE
Fix segfault when using `md.methods.rattle.Brownian` with domain decomposition.

### DIFF
--- a/hoomd/md/TwoStepRATTLEBD.h
+++ b/hoomd/md/TwoStepRATTLEBD.h
@@ -158,7 +158,7 @@ template<class Manifold> void TwoStepRATTLEBD<Manifold>::integrateStepOne(uint64
                                access_location::host,
                                access_mode::readwrite);
     ArrayHandle<int3> h_image(m_pdata->getImages(), access_location::host, access_mode::readwrite);
-    ArrayHandle<unsigned int> h_rtag(m_pdata->getRTags(), access_location::host, access_mode::read);
+    ArrayHandle<unsigned int> h_tag(m_pdata->getTags(), access_location::host, access_mode::read);
 
     ArrayHandle<Scalar4> h_net_force(net_force, access_location::host, access_mode::read);
     ArrayHandle<Scalar> h_gamma(m_gamma, access_location::host, access_mode::read);
@@ -197,8 +197,8 @@ template<class Manifold> void TwoStepRATTLEBD<Manifold>::integrateStepOne(uint64
     // v(t+deltaT) = random distribution consistent with T
     for (unsigned int group_idx = 0; group_idx < group_size; group_idx++)
         {
-        unsigned int ptag = m_group->getMemberTag(group_idx);
-        unsigned int j = h_rtag.data[ptag];
+        unsigned int j = m_group->getMemberIndex(group_idx);
+        unsigned int ptag = h_tag.data[j];
 
         // Initialize the RNG
         RandomGenerator rng(hoomd::Seed(RNGIdentifier::TwoStepBD, timestep, seed),
@@ -397,7 +397,7 @@ template<class Manifold> void TwoStepRATTLEBD<Manifold>::includeRATTLEForce(uint
     const GlobalArray<Scalar4>& net_force = m_pdata->getNetForce();
     const GlobalArray<Scalar>& net_virial = m_pdata->getNetVirial();
     ArrayHandle<Scalar4> h_pos(m_pdata->getPositions(), access_location::host, access_mode::read);
-    ArrayHandle<unsigned int> h_rtag(m_pdata->getRTags(), access_location::host, access_mode::read);
+    ArrayHandle<unsigned int> h_tag(m_pdata->getTags(), access_location::host, access_mode::read);
 
     ArrayHandle<Scalar4> h_net_force(net_force, access_location::host, access_mode::readwrite);
     ArrayHandle<Scalar> h_net_virial(net_virial, access_location::host, access_mode::readwrite);
@@ -413,8 +413,8 @@ template<class Manifold> void TwoStepRATTLEBD<Manifold>::includeRATTLEForce(uint
     // v(t+deltaT) = random distribution consistent with T
     for (unsigned int group_idx = 0; group_idx < group_size; group_idx++)
         {
-        unsigned int ptag = m_group->getMemberTag(group_idx);
-        unsigned int j = h_rtag.data[ptag];
+        unsigned int j = m_group->getMemberIndex(group_idx);
+        unsigned int ptag = h_tag.data[j];
 
         // Initialize the RNG
         RandomGenerator rng_b(hoomd::Seed(RNGIdentifier::TwoStepBD, timestep, seed),


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should be based on *trunk-patch*. -->
<!-- Backwards compatible new features should be based on *trunk-minor*. -->
<!-- Incompatible API changes should be based on *trunk-major*. -->

## Description

<!-- Describe your changes in detail. -->
Access local group indices, not global group tags.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Prevent a seg fault when using domain decomposition.

<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves #1742

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
The test case in #1742 passes.

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
* `md.methods.rattle.Brownian` executes without causing a segmentation fault on the CPU with domain decomposition.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.rst).
- [] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
