### PR TITLE
Howto: tune mc moves in multicomponent systems

### DIFF
--- a/sphinx-doc/how-to.rst
+++ b/sphinx-doc/how-to.rst
@@ -16,3 +16,4 @@ How-to
     howto/prevent-particles-from-moving
     howto/compute-the-free-energy-of-solids
     howto/cpppotential
+    howto/tune-mc-move-sizes-binary-system

--- a/sphinx-doc/howto/tune-mc-move-sizes-binary-system.py
+++ b/sphinx-doc/howto/tune-mc-move-sizes-binary-system.py
@@ -6,7 +6,6 @@ simulation.state.replicate(nx=3, ny=3, nz=3)
 mc = hoomd.hpmc.integrate.Ellipsoid()
 mc.shape['A'] = dict(a=1.0, b=1.0, c=0.25)
 mc.shape['B'] = dict(a=1.0, b=1.0, c=0.5)
-mc.shape['C'] = dict(a=1.0, b=1.0, c=1.0)
 simulation.operations.integrator = mc
 
 # loop over particle types and set ignore_statistics = True

--- a/sphinx-doc/howto/tune-mc-move-sizes-binary-system.py
+++ b/sphinx-doc/howto/tune-mc-move-sizes-binary-system.py
@@ -15,11 +15,10 @@ for ignored_type in simulation.state.particle_types:
 # loop over particle types to tune move sizes for
 for tuned_type in simulation.state.particle_types:
     move_size_tuner = hoomd.hpmc.tune.MoveSize.scale_solver(
-        10, ['a', 'd'], 0.2, [tuned_type])
+        100, ['a', 'd'], 0.2, [tuned_type])
     simulation.operations.add(move_size_tuner)
     mc.shape[tuned_type]['ignore_statistics'] = False
-    for _ in range(10):
-        simulation.run(100)
+    simulation.run(1000)
     mc.shape[tuned_type]['ignore_statistics'] = True
     simulation.operations.remove(move_size_tuner)
 

--- a/sphinx-doc/howto/tune-mc-move-sizes-binary-system.py
+++ b/sphinx-doc/howto/tune-mc-move-sizes-binary-system.py
@@ -1,0 +1,29 @@
+import hoomd
+
+simulation = hoomd.util.make_example_simulation(particle_types=['A', 'B'])
+simulation.state.replicate(nx=3, ny=3, nz=3)
+
+mc = hoomd.hpmc.integrate.Ellipsoid()
+mc.shape['A'] = dict(a=1.0, b=1.0, c=0.25)
+mc.shape['B'] = dict(a=1.0, b=1.0, c=0.5)
+mc.shape['C'] = dict(a=1.0, b=1.0, c=1.0)
+simulation.operations.integrator = mc
+
+# loop over particle types and set ignore_statistics = True
+for ignored_type in simulation.state.particle_types:
+    mc.shape[ignored_type]['ignore_statistics'] = True
+
+# loop over particle types to tune move sizes for
+for tuned_type in simulation.state.particle_types:
+    move_size_tuner = hoomd.hpmc.tune.MoveSize.scale_solver(
+        10, ['a', 'd'], 0.2, [tuned_type])
+    simulation.operations.add(move_size_tuner)
+    mc.shape[tuned_type]['ignore_statistics'] = False
+    for _ in range(10):
+        simulation.run(100)
+    mc.shape[tuned_type]['ignore_statistics'] = True
+    simulation.operations.remove(move_size_tuner)
+
+# stop ignoring statistics after tuning
+for ignored_type in simulation.state.particle_types:
+    mc.shape[ignored_type]['ignore_statistics'] = False

--- a/sphinx-doc/howto/tune-mc-move-sizes-binary-system.rst
+++ b/sphinx-doc/howto/tune-mc-move-sizes-binary-system.rst
@@ -1,0 +1,13 @@
+.. Copyright (c) 2009-2024 The Regents of the University of Michigan.
+.. Part of HOOMD-blue, released under the BSD 3-Clause License.
+
+How to tune move sizes in multicomponent HPMC systems
+=====================================================
+
+Set ``ignore_statistics`` in the HPMC integrator shape parameter dictionary to ``False`` for every
+type except for one and run the tuner.
+Repeat until every particle type has been the one with ``ignore_statistics`` set to ``True``.
+For example:
+
+.. literalinclude:: tune-mc-move-sizes-binary-system.py
+    :language: python

--- a/sphinx-doc/howto/tune-mc-move-sizes-binary-system.rst
+++ b/sphinx-doc/howto/tune-mc-move-sizes-binary-system.rst
@@ -4,9 +4,9 @@
 How to tune move sizes in multicomponent HPMC systems
 =====================================================
 
-Set ``ignore_statistics`` in the HPMC integrator shape parameter dictionary to ``False`` for every
+Set ``ignore_statistics`` in the HPMC integrator shape parameter dictionary to ``True`` for every
 type except for one and run the tuner.
-Repeat until every particle type has been the one with ``ignore_statistics`` set to ``True``.
+Repeat until every particle type has been the one with ``ignore_statistics`` set to ``False``.
 For example:
 
 .. literalinclude:: tune-mc-move-sizes-binary-system.py


### PR DESCRIPTION
## Description

Adds a how-to for tuning move sizes in HPMC simulations with multiple particle types.

## Motivation and context

Resolves #1518 

## How has this been tested?

The docs build and the example code runs.

## Change log

<!-- Propose a change log entry. -->
```
Added: Documentation page: "How to tune move sizes in multicomponent HPMC systems"
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
