### PR TITLE
Fix compiler warning in BoxDim.

### DIFF
--- a/hoomd/BoxDim.h
+++ b/hoomd/BoxDim.h
@@ -149,7 +149,7 @@ struct
     /// Constructs a box from a std::array<Scalar, 6>
     /** @param array Box parameters
      */
-    HOSTDEVICE explicit BoxDim(const std::array<Scalar, 6>& array)
+    explicit BoxDim(const std::array<Scalar, 6>& array)
         {
         setL(make_scalar3(array[0], array[1], array[2]));
         setTiltFactors(array[3], array[4], array[5]);


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should be based on *trunk-patch*. -->
<!-- Backwards compatible new features should be based on *trunk-minor*. -->
<!-- Incompatible API changes should be based on *trunk-major*. -->

## Description

<!-- Describe your changes in detail. -->
Make `std::array` constructor host only.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
HOOMD-blue should compile without warnings.

<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves #1753.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
Will check the CUDA 12 build logs on GitHub Actions.

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
Fixed:

* Compile `BoxDim.h` without warnings.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
