### PR TITLE
fix condition when dipole-dipole interactions are calculated

### DIFF
--- a/hoomd/md/EvaluatorPairDipole.h
+++ b/hoomd/md/EvaluatorPairDipole.h
@@ -233,7 +233,7 @@ class EvaluatorPairDipole
 
         bool dipole_i_interactions = (mu_i != vec3<Scalar>(0, 0, 0));
         bool dipole_j_interactions = (mu_j != vec3<Scalar>(0, 0, 0));
-        bool dipole_interactions = dipole_j_interactions && dipole_j_interactions;
+        bool dipole_interactions = dipole_i_interactions && dipole_j_interactions;
         // dipole-dipole
         if (dipole_interactions)
             {


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should be based on *trunk-patch*. -->
<!-- Backwards compatible new features should be based on *trunk-minor*. -->
<!-- Incompatible API changes should be based on *trunk-major*. -->

## Description

Fixes a tiny bug in the dipole pair interactions. 

## Motivation and context

The bug didn't cause any wrong results but can cause the algorithm to calculate dipole-dipole interaction when unnecessary. 

## How has this been tested?

Pytests work.

## Change log

<!-- Propose a change log entry. -->
```
Fix bug when to calculate dipole-dipole interactions
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
