### PR TITLE
Tweaks to MPCD v4 API

### DIFF
--- a/hoomd/mpcd/BlockForce.cc
+++ b/hoomd/mpcd/BlockForce.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2009-2023 The Regents of the University of Michigan.
+// Copyright (c) 2009-2024 The Regents of the University of Michigan.
 // Part of HOOMD-blue, released under the BSD 3-Clause License.
 
 /*!
@@ -20,10 +20,8 @@ void export_BlockForce(pybind11::module& m)
     pybind11::class_<BlockForce, std::shared_ptr<BlockForce>>(m, "BlockForce")
         .def(pybind11::init<Scalar, Scalar, Scalar>())
         .def_property("force", &BlockForce::getForce, &BlockForce::setForce)
-        .def_property("half_separation",
-                      &BlockForce::getHalfSeparation,
-                      &BlockForce::setHalfSeparation)
-        .def_property("half_width", &BlockForce::getHalfWidth, &BlockForce::setHalfWidth);
+        .def_property("separation", &BlockForce::getSeparation, &BlockForce::setSeparation)
+        .def_property("width", &BlockForce::getWidth, &BlockForce::setWidth);
     }
 
     } // end namespace detail

--- a/hoomd/mpcd/BlockForce.h
+++ b/hoomd/mpcd/BlockForce.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2009-2023 The Regents of the University of Michigan.
+// Copyright (c) 2009-2024 The Regents of the University of Michigan.
 // Part of HOOMD-blue, released under the BSD 3-Clause License.
 
 /*!
@@ -52,13 +52,13 @@ class __attribute__((visibility("default"))) BlockForce
     //! Constructor
     /*!
      * \param F Force on all particles.
-     * \param H Half-width between block regions.
-     * \param w Half-width of blocks.
+     * \param separation Separation between centers of blocks.
+     * \param width Width of each block.
      */
-    HOSTDEVICE BlockForce(Scalar F, Scalar H, Scalar w) : m_F(F)
+    HOSTDEVICE BlockForce(Scalar F, Scalar separation, Scalar width) : m_F(F)
         {
-        m_H_plus_w = H + w;
-        m_H_minus_w = H - w;
+        m_H_plus_w = 0.5 * (separation + width);
+        m_H_minus_w = 0.5 * (separation - width);
         }
 
     //! Force evaluation method
@@ -86,32 +86,32 @@ class __attribute__((visibility("default"))) BlockForce
         m_F = F;
         }
 
-    //! Get the half separation distance between blocks
-    Scalar getHalfSeparation() const
+    //! Get the separation distance between block centers
+    Scalar getSeparation() const
         {
-        return 0.5 * (m_H_plus_w + m_H_minus_w);
+        return (m_H_plus_w + m_H_minus_w);
         }
 
-    //! Set the half separation distance between blocks
-    void setHalfSeparation(Scalar H)
+    //! Set the separation distance between block centers
+    void setSeparation(Scalar H)
         {
-        const Scalar w = getHalfWidth();
-        m_H_plus_w = H + w;
-        m_H_minus_w = H - w;
+        const Scalar w = getWidth();
+        m_H_plus_w = 0.5 * (H + w);
+        m_H_minus_w = 0.5 * (H - w);
         }
 
-    //! Get the block half width
-    Scalar getHalfWidth() const
+    //! Get the block width
+    Scalar getWidth() const
         {
-        return 0.5 * (m_H_plus_w - m_H_minus_w);
+        return (m_H_plus_w - m_H_minus_w);
         }
 
-    //! Set the block half width
-    void setHalfWidth(Scalar w)
+    //! Set the block width
+    void setWidth(Scalar w)
         {
-        const Scalar H = getHalfSeparation();
-        m_H_plus_w = H + w;
-        m_H_minus_w = H - w;
+        const Scalar H = getSeparation();
+        m_H_plus_w = 0.5 * (H + w);
+        m_H_minus_w = 0.5 * (H - w);
         }
 
 #ifndef __HIPCC__
@@ -124,8 +124,8 @@ class __attribute__((visibility("default"))) BlockForce
 
     private:
     Scalar m_F;         //!< Constant force
-    Scalar m_H_plus_w;  //!< Upper bound on upper block, H + w
-    Scalar m_H_minus_w; //!< Lower bound on upper block, H - w
+    Scalar m_H_plus_w;  //!< Upper bound on upper block
+    Scalar m_H_minus_w; //!< Lower bound on upper block
     };
 
 #ifndef __HIPCC__

--- a/hoomd/mpcd/BlockForce.h
+++ b/hoomd/mpcd/BlockForce.h
@@ -57,8 +57,8 @@ class __attribute__((visibility("default"))) BlockForce
      */
     HOSTDEVICE BlockForce(Scalar F, Scalar separation, Scalar width) : m_F(F)
         {
-        m_H_plus_w = 0.5 * (separation + width);
-        m_H_minus_w = 0.5 * (separation - width);
+        m_H_plus_w = Scalar(0.5) * (separation + width);
+        m_H_minus_w = Scalar(0.5) * (separation - width);
         }
 
     //! Force evaluation method
@@ -96,8 +96,8 @@ class __attribute__((visibility("default"))) BlockForce
     void setSeparation(Scalar H)
         {
         const Scalar w = getWidth();
-        m_H_plus_w = 0.5 * (H + w);
-        m_H_minus_w = 0.5 * (H - w);
+        m_H_plus_w = Scalar(0.5) * (H + w);
+        m_H_minus_w = Scalar(0.5) * (H - w);
         }
 
     //! Get the block width
@@ -110,8 +110,8 @@ class __attribute__((visibility("default"))) BlockForce
     void setWidth(Scalar w)
         {
         const Scalar H = getSeparation();
-        m_H_plus_w = 0.5 * (H + w);
-        m_H_minus_w = 0.5 * (H - w);
+        m_H_plus_w = Scalar(0.5) * (H + w);
+        m_H_minus_w = Scalar(0.5) * (H - w);
         }
 
 #ifndef __HIPCC__

--- a/hoomd/mpcd/BounceBackStreamingMethod.cc.inc
+++ b/hoomd/mpcd/BounceBackStreamingMethod.cc.inc
@@ -1,4 +1,4 @@
-// Copyright (c) 2009-2023 The Regents of the University of Michigan.
+// Copyright (c) 2009-2024 The Regents of the University of Michigan.
 // Part of HOOMD-blue, released under the BSD 3-Clause License.
 
 /*!

--- a/hoomd/mpcd/BounceBackStreamingMethod.h
+++ b/hoomd/mpcd/BounceBackStreamingMethod.h
@@ -222,10 +222,9 @@ template<class Geometry, class Force> void export_BounceBackStreamingMethod(pybi
                             std::shared_ptr<Force>>())
         .def_property_readonly("geometry",
                                &mpcd::BounceBackStreamingMethod<Geometry, Force>::getGeometry)
-        .def_property_readonly("solvent_force",
+        .def_property_readonly("mpcd_particle_force",
                                &mpcd::BounceBackStreamingMethod<Geometry, Force>::getForce)
-        .def("check_solvent_particles",
-             &BounceBackStreamingMethod<Geometry, Force>::checkParticles);
+        .def("check_mpcd_particles", &BounceBackStreamingMethod<Geometry, Force>::checkParticles);
     }
     }  // end namespace detail
     }  // end namespace mpcd

--- a/hoomd/mpcd/BounceBackStreamingMethodGPU.cc.inc
+++ b/hoomd/mpcd/BounceBackStreamingMethodGPU.cc.inc
@@ -1,4 +1,4 @@
-// Copyright (c) 2009-2023 The Regents of the University of Michigan.
+// Copyright (c) 2009-2024 The Regents of the University of Michigan.
 // Part of HOOMD-blue, released under the BSD 3-Clause License.
 
 /*!

--- a/hoomd/mpcd/BounceBackStreamingMethodGPU.cu.inc
+++ b/hoomd/mpcd/BounceBackStreamingMethodGPU.cu.inc
@@ -1,4 +1,4 @@
-// Copyright (c) 2009-2023 The Regents of the University of Michigan.
+// Copyright (c) 2009-2024 The Regents of the University of Michigan.
 // Part of HOOMD-blue, released under the BSD 3-Clause License.
 
 /*!

--- a/hoomd/mpcd/BulkStreamingMethod.cc.inc
+++ b/hoomd/mpcd/BulkStreamingMethod.cc.inc
@@ -1,4 +1,4 @@
-// Copyright (c) 2009-2023 The Regents of the University of Michigan.
+// Copyright (c) 2009-2024 The Regents of the University of Michigan.
 // Part of HOOMD-blue, released under the BSD 3-Clause License.
 
 /*!

--- a/hoomd/mpcd/BulkStreamingMethod.h
+++ b/hoomd/mpcd/BulkStreamingMethod.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2009-2023 The Regents of the University of Michigan.
+// Copyright (c) 2009-2024 The Regents of the University of Michigan.
 // Part of HOOMD-blue, released under the BSD 3-Clause License.
 
 /*!

--- a/hoomd/mpcd/BulkStreamingMethod.h
+++ b/hoomd/mpcd/BulkStreamingMethod.h
@@ -60,7 +60,7 @@ template<class Force> void export_BulkStreamingMethod(pybind11::module& m)
                             unsigned int,
                             int,
                             std::shared_ptr<Force>>())
-        .def_property_readonly("solvent_force", &mpcd::BulkStreamingMethod<Force>::getForce);
+        .def_property_readonly("mpcd_particle_force", &mpcd::BulkStreamingMethod<Force>::getForce);
     }
 
     } // end namespace detail

--- a/hoomd/mpcd/BulkStreamingMethodGPU.cc.inc
+++ b/hoomd/mpcd/BulkStreamingMethodGPU.cc.inc
@@ -1,4 +1,4 @@
-// Copyright (c) 2009-2023 The Regents of the University of Michigan.
+// Copyright (c) 2009-2024 The Regents of the University of Michigan.
 // Part of HOOMD-blue, released under the BSD 3-Clause License.
 
 /*!

--- a/hoomd/mpcd/BulkStreamingMethodGPU.cu.inc
+++ b/hoomd/mpcd/BulkStreamingMethodGPU.cu.inc
@@ -1,4 +1,4 @@
-// Copyright (c) 2009-2023 The Regents of the University of Michigan.
+// Copyright (c) 2009-2024 The Regents of the University of Michigan.
 // Part of HOOMD-blue, released under the BSD 3-Clause License.
 
 /*!

--- a/hoomd/mpcd/BulkStreamingMethodGPU.h
+++ b/hoomd/mpcd/BulkStreamingMethodGPU.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2009-2023 The Regents of the University of Michigan.
+// Copyright (c) 2009-2024 The Regents of the University of Michigan.
 // Part of HOOMD-blue, released under the BSD 3-Clause License.
 
 /*!

--- a/hoomd/mpcd/ConstantForce.cc
+++ b/hoomd/mpcd/ConstantForce.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2009-2023 The Regents of the University of Michigan.
+// Copyright (c) 2009-2024 The Regents of the University of Michigan.
 // Part of HOOMD-blue, released under the BSD 3-Clause License.
 
 /*!

--- a/hoomd/mpcd/ConstantForce.h
+++ b/hoomd/mpcd/ConstantForce.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2009-2023 The Regents of the University of Michigan.
+// Copyright (c) 2009-2024 The Regents of the University of Michigan.
 // Part of HOOMD-blue, released under the BSD 3-Clause License.
 
 /*!

--- a/hoomd/mpcd/Integrator.cc
+++ b/hoomd/mpcd/Integrator.cc
@@ -183,7 +183,9 @@ void mpcd::detail::export_Integrator(pybind11::module& m)
         .def_property("streaming_method",
                       &mpcd::Integrator::getStreamingMethod,
                       &mpcd::Integrator::setStreamingMethod)
-        .def_property("solvent_sorter", &mpcd::Integrator::getSorter, &mpcd::Integrator::setSorter)
+        .def_property("mpcd_particle_sorter",
+                      &mpcd::Integrator::getSorter,
+                      &mpcd::Integrator::setSorter)
         .def_property_readonly("fillers", &mpcd::Integrator::getFillers);
     }
     } // end namespace hoomd

--- a/hoomd/mpcd/ManualVirtualParticleFiller.cc
+++ b/hoomd/mpcd/ManualVirtualParticleFiller.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2009-2023 The Regents of the University of Michigan.
+// Copyright (c) 2009-2024 The Regents of the University of Michigan.
 // Part of HOOMD-blue, released under the BSD 3-Clause License.
 
 /*!

--- a/hoomd/mpcd/ManualVirtualParticleFiller.h
+++ b/hoomd/mpcd/ManualVirtualParticleFiller.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2009-2023 The Regents of the University of Michigan.
+// Copyright (c) 2009-2024 The Regents of the University of Michigan.
 // Part of HOOMD-blue, released under the BSD 3-Clause License.
 
 /*!

--- a/hoomd/mpcd/NoForce.cc
+++ b/hoomd/mpcd/NoForce.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2009-2023 The Regents of the University of Michigan.
+// Copyright (c) 2009-2024 The Regents of the University of Michigan.
 // Part of HOOMD-blue, released under the BSD 3-Clause License.
 
 /*!

--- a/hoomd/mpcd/NoForce.h
+++ b/hoomd/mpcd/NoForce.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2009-2023 The Regents of the University of Michigan.
+// Copyright (c) 2009-2024 The Regents of the University of Michigan.
 // Part of HOOMD-blue, released under the BSD 3-Clause License.
 
 /*!

--- a/hoomd/mpcd/ParallelPlateGeometry.h
+++ b/hoomd/mpcd/ParallelPlateGeometry.h
@@ -54,12 +54,12 @@ class __attribute__((visibility("default"))) ParallelPlateGeometry
     public:
     //! Constructor
     /*!
-     * \param H Channel half-width
-     * \param V Velocity of the wall
+     * \param separation Distance between plates
+     * \param speed Speed of the wall
      * \param no_slip Boundary condition at the wall (slip or no-slip)
      */
-    HOSTDEVICE ParallelPlateGeometry(Scalar H, Scalar V, bool no_slip)
-        : m_H(H), m_V(V), m_no_slip(no_slip)
+    HOSTDEVICE ParallelPlateGeometry(Scalar separation, Scalar speed, bool no_slip)
+        : m_H(Scalar(0.5) * separation), m_V(speed), m_no_slip(no_slip)
         {
         }
 
@@ -143,11 +143,20 @@ class __attribute__((visibility("default"))) ParallelPlateGeometry
         return m_H;
         }
 
-    //! Get the wall velocity
+    //! Get distance between plates
     /*!
-     * \returns Wall velocity
+     * \returns Distance between plates
      */
-    HOSTDEVICE Scalar getVelocity() const
+    HOSTDEVICE Scalar getSeparation() const
+        {
+        return 2 * m_H;
+        }
+
+    //! Get the wall speed
+    /*!
+     * \returns Wall speed
+     */
+    HOSTDEVICE Scalar getSpeed() const
         {
         return m_V;
         }

--- a/hoomd/mpcd/ParallelPlateGeometryFiller.cc
+++ b/hoomd/mpcd/ParallelPlateGeometryFiller.cc
@@ -121,7 +121,7 @@ void mpcd::ParallelPlateGeometryFiller::drawParticles(uint64_t timestep)
         vel.z = gen(rng);
         // TODO: should these be given zero net-momentum contribution (relative to the frame of
         // reference?)
-        h_vel.data[pidx] = make_scalar4(vel.x + sign * m_geom->getVelocity(),
+        h_vel.data[pidx] = make_scalar4(vel.x + sign * m_geom->getSpeed(),
                                         vel.y,
                                         vel.z,
                                         __int_as_scalar(mpcd::detail::NO_CELL));

--- a/hoomd/mpcd/ParallelPlateGeometryFiller.h
+++ b/hoomd/mpcd/ParallelPlateGeometryFiller.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2009-2023 The Regents of the University of Michigan.
+// Copyright (c) 2009-2024 The Regents of the University of Michigan.
 // Part of HOOMD-blue, released under the BSD 3-Clause License.
 
 /*!

--- a/hoomd/mpcd/ParallelPlateGeometryFillerGPU.cu
+++ b/hoomd/mpcd/ParallelPlateGeometryFillerGPU.cu
@@ -98,7 +98,7 @@ __global__ void slit_draw_particles(Scalar4* d_pos,
     vel.z = gen(rng);
     // TODO: should these be given zero net-momentum contribution (relative to the frame of
     // reference?)
-    d_vel[pidx] = make_scalar4(vel.x + sign * geom.getVelocity(),
+    d_vel[pidx] = make_scalar4(vel.x + sign * geom.getSpeed(),
                                vel.y,
                                vel.z,
                                __int_as_scalar(mpcd::detail::NO_CELL));

--- a/hoomd/mpcd/ParallelPlateGeometryFillerGPU.h
+++ b/hoomd/mpcd/ParallelPlateGeometryFillerGPU.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2009-2023 The Regents of the University of Michigan.
+// Copyright (c) 2009-2024 The Regents of the University of Michigan.
 // Part of HOOMD-blue, released under the BSD 3-Clause License.
 
 /*!

--- a/hoomd/mpcd/PlanarPoreGeometry.h
+++ b/hoomd/mpcd/PlanarPoreGeometry.h
@@ -45,12 +45,12 @@ class __attribute__((visibility("default"))) PlanarPoreGeometry
     public:
     //! Constructor
     /*!
-     * \param H Channel half-width
-     * \param L Pore half-length
+     * \param separation Distance between pore walls
+     * \param length Pore length
      * \param no_slip Boundary condition at the wall (slip or no-slip)
      */
-    HOSTDEVICE PlanarPoreGeometry(Scalar H, Scalar L, bool no_slip)
-        : m_H(H), m_L(L), m_no_slip(no_slip)
+    HOSTDEVICE PlanarPoreGeometry(Scalar separation, Scalar length, bool no_slip)
+        : m_H(Scalar(0.5) * separation), m_L(Scalar(0.5) * length), m_no_slip(no_slip)
         {
         }
 
@@ -177,6 +177,15 @@ class __attribute__((visibility("default"))) PlanarPoreGeometry
         return m_H;
         }
 
+    //! Get distance between pore walls
+    /*!
+     * \returns Distance between pore walls
+     */
+    HOSTDEVICE Scalar getSeparation() const
+        {
+        return Scalar(2.0) * m_H;
+        }
+
     //! Get pore half length
     /*!
      * \returns Pore half length
@@ -184,6 +193,15 @@ class __attribute__((visibility("default"))) PlanarPoreGeometry
     HOSTDEVICE Scalar getL() const
         {
         return m_L;
+        }
+
+    //! Get pore length
+    /*!
+     * \returns Pore length
+     */
+    HOSTDEVICE Scalar getLength() const
+        {
+        return Scalar(2.0) * m_L;
         }
 
     //! Get the wall boundary condition

--- a/hoomd/mpcd/SineForce.cc
+++ b/hoomd/mpcd/SineForce.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2009-2023 The Regents of the University of Michigan.
+// Copyright (c) 2009-2024 The Regents of the University of Michigan.
 // Part of HOOMD-blue, released under the BSD 3-Clause License.
 
 /*!

--- a/hoomd/mpcd/SineForce.h
+++ b/hoomd/mpcd/SineForce.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2009-2023 The Regents of the University of Michigan.
+// Copyright (c) 2009-2024 The Regents of the University of Michigan.
 // Part of HOOMD-blue, released under the BSD 3-Clause License.
 
 /*!

--- a/hoomd/mpcd/StreamingGeometry.cc
+++ b/hoomd/mpcd/StreamingGeometry.cc
@@ -32,8 +32,8 @@ void export_PlanarPoreGeometry(pybind11::module& m)
         m,
         PlanarPoreGeometry::getName().c_str())
         .def(pybind11::init<Scalar, Scalar, bool>())
-        .def_property_readonly("H", &PlanarPoreGeometry::getH)
-        .def_property_readonly("L", &PlanarPoreGeometry::getL)
+        .def_property_readonly("separation", &PlanarPoreGeometry::getSeparation)
+        .def_property_readonly("length", &PlanarPoreGeometry::getLength)
         .def_property_readonly("no_slip", &PlanarPoreGeometry::getNoSlip);
     }
 

--- a/hoomd/mpcd/StreamingGeometry.cc
+++ b/hoomd/mpcd/StreamingGeometry.cc
@@ -21,8 +21,8 @@ void export_ParallelPlateGeometry(pybind11::module& m)
         m,
         ParallelPlateGeometry::getName().c_str())
         .def(pybind11::init<Scalar, Scalar, bool>())
-        .def_property_readonly("H", &ParallelPlateGeometry::getH)
-        .def_property_readonly("V", &ParallelPlateGeometry::getVelocity)
+        .def_property_readonly("separation", &ParallelPlateGeometry::getSeparation)
+        .def_property_readonly("speed", &ParallelPlateGeometry::getSpeed)
         .def_property_readonly("no_slip", &ParallelPlateGeometry::getNoSlip);
     }
 

--- a/hoomd/mpcd/__init__.py
+++ b/hoomd/mpcd/__init__.py
@@ -14,13 +14,13 @@ a microscopically detailed solute model.
 
 .. rubric:: Algorithm
 
-In MPCD, the solvent is represented by point particles having continuous
-positions and velocities. The solvent particles propagate in alternating
+In MPCD, a fluid is represented by point particles having continuous
+positions and velocities. The MPCD particles propagate in alternating
 streaming and collision steps. During the streaming step, particles evolve
 according to Newton's equations of motion. Particles are then binned into local
 cells and undergo a stochastic collision within the cell. Collisions lead to the
 build up of hydrodynamic interactions, and the frequency and nature of the
-collisions, along with the solvent properties, determine the transport
+collisions, along with the fluid properties, determine the transport
 coefficients. All standard collision rules conserve linear momentum within the
 cell and can optionally be made to enforce angular-momentum conservation.
 Currently, we have implemented the following collision rules with
@@ -29,14 +29,14 @@ linear-momentum conservation only:
 * :class:`~hoomd.mpcd.collide.StochasticRotationDynamics`
 * :class:`~hoomd.mpcd.collide.AndersenThermostat`
 
-Solute particles can be coupled to the solvent during the collision step. This
-is particularly useful for soft materials like polymers. Standard molecular
-dynamics methods can be applied to the solute. Coupling to the MPCD
-solvent introduces both hydrodynamic interactions and a heat bath that acts as
-a thermostat.
+Solute particles can be coupled to the MPCD particles during the collision step.
+This is particularly useful for soft materials like polymers. Standard molecular
+dynamics methods can be applied to the solute. Coupling to the MPCD particles
+introduces both hydrodynamic interactions and a heat bath that acts as a
+thermostat.
 
-The solvent can additionally be coupled to solid boundaries (with no-slip or
-slip boundary conditions) during the streaming step.
+The MPCD particles can additionally be coupled to solid boundaries (with no-slip
+or slip boundary conditions) during the streaming step.
 
 Details of HOOMD-blue's implementation of the MPCD algorithm can be found
 in `M. P. Howard et al. (2018) <https://doi.org/10.1016/j.cpc.2018.04.009>`_.
@@ -47,12 +47,12 @@ Note, though, that continued improvements to the code may cause some deviations.
 MPCD is intended to be used as an add-on to the standard MD methods in
 `hoomd.md`. Getting started can look like:
 
-1. Initialize the solvent through `Snapshot.mpcd`. You can include any solute
-   particles in the snapshot as well.
+1. Initialize the MPCD particles through `Snapshot.mpcd`. You can include any
+   solute particles in the snapshot as well.
 2. Create the MPCD `Integrator`. Setup solute particle integration methods
    and interactions as you normally would to use `hoomd.md`.
 3. Choose the streaming method from :mod:`.mpcd.stream`.
-4. Choose the collision rule from :mod:`.mpcd.collide`. Couple the solute to
+4. Choose the collision rule from :mod:`.mpcd.collide`. Couple the solute to the
    collision step.
 5. Run your simulation!
 

--- a/hoomd/mpcd/collide.py
+++ b/hoomd/mpcd/collide.py
@@ -81,6 +81,8 @@ class CellList(Compute):
 
     def _attach_hook(self):
         sim = self._simulation
+        sim._warn_if_seed_unset()
+
         if isinstance(sim.device, hoomd.device.GPU):
             cpp_class = _mpcd.CellListGPU
         else:
@@ -216,6 +218,8 @@ class AndersenThermostat(CollisionMethod):
 
     def _attach_hook(self):
         sim = self._simulation
+        sim._warn_if_seed_unset()
+
         if isinstance(sim.device, hoomd.device.GPU):
             cpp_class = _mpcd.ATCollisionMethodGPU
         else:
@@ -334,6 +338,8 @@ class StochasticRotationDynamics(CollisionMethod):
 
     def _attach_hook(self):
         sim = self._simulation
+        sim._warn_if_seed_unset()
+
         if isinstance(sim.device, hoomd.device.GPU):
             cpp_class = _mpcd.SRDCollisionMethodGPU
         else:

--- a/hoomd/mpcd/collide.py
+++ b/hoomd/mpcd/collide.py
@@ -8,8 +8,8 @@ time. Particles are binned into cells based on their positions, and all
 particles in a cell undergo a stochastic collision that updates their velocities
 while conserving linear momentum. Collision rules can optionally be extended to
 also conserve angular momentum The stochastic collisions lead to a build up of
-hydrodynamic interactions, and the choice of collision rule and solvent
-properties determine the transport coefficients.
+hydrodynamic interactions, and the choice of collision rule determines the
+transport coefficients.
 
 .. invisible-code-block: python
 
@@ -149,7 +149,7 @@ class AndersenThermostat(CollisionMethod):
 
     Args:
         period (int): Number of integration steps between collisions.
-        kT (hoomd.variant.variant_like): Temperature of the solvent
+        kT (hoomd.variant.variant_like): Temperature of the thermostat
             :math:`[\mathrm{energy}]`.
         embedded_particles (hoomd.filter.ParticleFilter): HOOMD particles to
             include in collision.
@@ -167,7 +167,7 @@ class AndersenThermostat(CollisionMethod):
 
     .. rubric:: Examples:
 
-    Solvent collision.
+    Collision for only MPCD particles.
 
     .. code-block:: python
 
@@ -187,7 +187,7 @@ class AndersenThermostat(CollisionMethod):
         simulation.operations.integrator.collision_method = andersen_thermostat
 
     Attributes:
-        kT (hoomd.variant.variant_like): Temperature of the solvent
+        kT (hoomd.variant.variant_like): Temperature of the thermostat
             :math:`[\mathrm{energy}]`.
 
             This temperature determines the distribution used to generate the
@@ -268,14 +268,14 @@ class StochasticRotationDynamics(CollisionMethod):
 
     .. rubric:: Examples:
 
-    Standard solvent collision.
+    Collision of MPCD particles.
 
     .. code-block:: python
 
         srd = hoomd.mpcd.collide.StochasticRotationDynamics(period=1, angle=130)
         simulation.operations.integrator.collision_method = srd
 
-    Solvent collision with thermostat.
+    Collision of MPCD particles with thermostat.
 
     .. code-block:: python
 

--- a/hoomd/mpcd/fill.py
+++ b/hoomd/mpcd/fill.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2009-2023 The Regents of the University of Michigan.
+# Copyright (c) 2009-2024 The Regents of the University of Michigan.
 # Part of HOOMD-blue, released under the BSD 3-Clause License.
 
 r"""MPCD virtual-particle fillers.
@@ -110,7 +110,7 @@ class GeometryFiller(VirtualParticleFiller):
 
     .. code-block:: python
 
-        plates = hoomd.mpcd.geometry.ParallelPlates(H=3.0)
+        plates = hoomd.mpcd.geometry.ParallelPlates(separation=6.0)
         filler = hoomd.mpcd.fill.GeometryFiller(
             type="A",
             density=5.0,

--- a/hoomd/mpcd/fill.py
+++ b/hoomd/mpcd/fill.py
@@ -3,10 +3,10 @@
 
 r"""MPCD virtual-particle fillers.
 
-Virtual particles are MPCD solvent particles that are added to ensure MPCD
+Virtual particles are MPCD particles that are added to ensure MPCD
 collision cells that are sliced by solid boundaries do not become "underfilled".
 From the perspective of the MPCD algorithm, the number density of particles in
-these sliced cells is lower than the average density, and so the solvent
+these sliced cells is lower than the average density, and so the transport
 properties may differ. In practice, this usually means that the boundary
 conditions do not appear to be properly enforced.
 
@@ -149,8 +149,8 @@ class GeometryFiller(VirtualParticleFiller):
         if isinstance(sim.device, hoomd.device.GPU):
             class_info[1] += "GPU"
         class_ = getattr(*class_info, None)
-        assert class_ is not None, ("Virtual particle filler for geometry"
-                                    " not found")
+        assert class_ is not None, ("Virtual particle filler for geometry "
+                                    "not found")
 
         self._cpp_obj = class_(
             sim.state._cpp_sys_def,

--- a/hoomd/mpcd/fill.py
+++ b/hoomd/mpcd/fill.py
@@ -135,6 +135,7 @@ class GeometryFiller(VirtualParticleFiller):
 
     def _attach_hook(self):
         sim = self._simulation
+        sim._warn_if_seed_unset()
 
         self.geometry._attach(sim)
 

--- a/hoomd/mpcd/force.py
+++ b/hoomd/mpcd/force.py
@@ -1,17 +1,17 @@
 # Copyright (c) 2009-2024 The Regents of the University of Michigan.
 # Part of HOOMD-blue, released under the BSD 3-Clause License.
 
-r"""MPCD solvent forces.
+r"""MPCD particle body forces.
 
 MPCD can apply a body force to each MPCD particle as a function of position.
 The external force should be compatible with the chosen
 :class:`~hoomd.mpcd.geometry.Geometry`. Global momentum conservation can be
-broken by adding a solvent force, so care should be chosen that the entire model
+broken by adding a body force, so care should be chosen that the entire model
 is designed so that the system does not have net acceleration. For example,
 solid boundaries can be used to dissipate momentum, or a balancing force can be
-applied to particles that are embedded in the solvent through the collision
-step. Additionally, a thermostat will likely be required to maintain temperature
-control in the driven system.
+applied to particles that are embedded in the MPCD particles through the
+collision step. Additionally, a thermostat will likely be required to maintain
+temperature control in the driven system.
 
 .. invisible-code-block: python
 
@@ -26,10 +26,10 @@ from hoomd.mpcd import _mpcd
 from hoomd.operation import _HOOMDBaseObject
 
 
-class SolventForce(_HOOMDBaseObject):
-    """Solvent force.
+class BodyForce(_HOOMDBaseObject):
+    """Body force.
 
-    The `SolventForce` is a body force applied to each solvent particle. This
+    The `BodyForce` is a body force applied to each MPCD particle. This
     class should not be instantiated directly. It exists for type checking.
 
     """
@@ -37,7 +37,7 @@ class SolventForce(_HOOMDBaseObject):
     pass
 
 
-class BlockForce(SolventForce):
+class BlockForce(BodyForce):
     r"""Block force.
 
     Args:
@@ -45,7 +45,7 @@ class BlockForce(SolventForce):
         separation (float): Distance between the centers of the blocks.
         width (float): Width of each block.
 
-    The `force` magnitude *F* is applied in the *x* direction on the solvent
+    The `force` magnitude *F* is applied in the *x* direction on the MPCD
     particles in blocks defined along the *y* direction by the `separation`
     :math:`2H` and the `width` :math:`2w`. The force in *x* is :math:`+F` in the
     upper block, :math:`-F` in the lower block, and zero otherwise.
@@ -78,7 +78,7 @@ class BlockForce(SolventForce):
         Ly = simulation.state.box.Ly
         force = hoomd.mpcd.force.BlockForce(
             force=1.0, separation=Ly/2, width=Ly/2)
-        stream = hoomd.mpcd.stream.Bulk(period=1, solvent_force=force)
+        stream = hoomd.mpcd.stream.Bulk(period=1, mpcd_particle_force=force)
         simulation.operations.integrator.streaming_method = stream
 
     Attributes:
@@ -126,13 +126,13 @@ class BlockForce(SolventForce):
         super()._attach_hook()
 
 
-class ConstantForce(SolventForce):
+class ConstantForce(BodyForce):
     r"""Constant force.
 
     Args:
         force (`tuple` [`float`, `float`, `float`]): Force vector per particle.
 
-    The same constant force is applied to all solvent particles, independently
+    The same constant force is applied to all MPCD particles, independently
     of time and position. This force is useful for simulating pressure-driven
     flow in conjunction with a confined geometry having no-slip boundary
     conditions. It is also useful for measuring diffusion coefficients with
@@ -143,7 +143,7 @@ class ConstantForce(SolventForce):
     .. code-block:: python
 
         force = hoomd.mpcd.force.ConstantForce((1.0, 0, 0))
-        stream = hoomd.mpcd.stream.Bulk(period=1, solvent_force=force)
+        stream = hoomd.mpcd.stream.Bulk(period=1, mpcd_particle_force=force)
         simulation.operations.integrator.streaming_method = stream
 
     Attributes:
@@ -170,7 +170,7 @@ class ConstantForce(SolventForce):
         super()._attach_hook()
 
 
-class SineForce(SolventForce):
+class SineForce(BodyForce):
     r"""Sine force.
 
     Args:
@@ -178,7 +178,7 @@ class SineForce(SolventForce):
         wavenumber (float): Wavenumber for the sinusoid.
 
     `SineForce` applies a force with amplitude *F* in *x* that is sinusoidally
-    varying in *y* with wavenumber *k* to all solvent particles:
+    varying in *y* with wavenumber *k* to all MPCD particles:
 
     .. math::
 
@@ -198,7 +198,7 @@ class SineForce(SolventForce):
         force = hoomd.mpcd.force.SineForce(
             amplitude=1.0,
             wavenumber=2 * numpy.pi / Ly)
-        stream = hoomd.mpcd.stream.Bulk(period=1, solvent_force=force)
+        stream = hoomd.mpcd.stream.Bulk(period=1, mpcd_particle_force=force)
         simulation.operations.integrator.streaming_method = stream
 
     Attributes:

--- a/hoomd/mpcd/force.py
+++ b/hoomd/mpcd/force.py
@@ -42,14 +42,13 @@ class BlockForce(SolventForce):
 
     Args:
         force (float): Magnitude of the force in *x* per particle.
-        half_separation (float): Half the distance between the centers of the
-            blocks.
-        half_width (float): Half the width of each block.
+        separation (float): Distance between the centers of the blocks.
+        width (float): Width of each block.
 
     The `force` magnitude *F* is applied in the *x* direction on the solvent
-    particles in blocks defined along the *y* direction by the `half_separation`
-    *H* and the `half_width` *w*. The force in *x* is :math:`+F` in the upper
-    block, :math:`-F` in the lower block, and zero otherwise.
+    particles in blocks defined along the *y* direction by the `separation`
+    :math:`2H` and the `width` :math:`2w`. The force in *x* is :math:`+F` in the
+    upper block, :math:`-F` in the lower block, and zero otherwise.
 
     .. math::
         :nowrap:
@@ -63,7 +62,7 @@ class BlockForce(SolventForce):
         \end{equation}
 
     The `BlockForce` can be used to implement the double-parabola method for
-    measuring viscosity by setting :math:`H = L_y/4` and :math:`w = L_y/4`,
+    measuring viscosity using separation :math:`L_y/2` and width :math:`L_y/2`,
     where :math:`L_y` is the size of the simulation box in *y*.
 
     Warning:
@@ -78,9 +77,7 @@ class BlockForce(SolventForce):
 
         Ly = simulation.state.box.Ly
         force = hoomd.mpcd.force.BlockForce(
-            force=1.0,
-            half_separation=Ly/4,
-            half_width=Ly/4)
+            force=1.0, separation=Ly/2, width=Ly/2)
         stream = hoomd.mpcd.stream.Bulk(period=1, solvent_force=force)
         simulation.operations.integrator.streaming_method = stream
 
@@ -93,40 +90,39 @@ class BlockForce(SolventForce):
 
                 force.force = 1.0
 
-        half_separation (float): Half the distance between the centers of the
-            blocks.
+        separation (float): Ddistance between the centers of the blocks.
 
             .. rubric:: Example:
 
             .. code-block:: python
 
                 Ly = simulation.state.box.Ly
-                force.half_separation = Ly / 4
+                force.separation = Ly / 2
 
-        half_width (float): Half the width of each block.
+        width (float): Width of each block.
 
             .. rubric:: Example:
 
             .. code-block:: python
 
                 Ly = simulation.state.box.Ly
-                force.half_width = Ly / 4
+                force.width = Ly / 2
 
     """
 
-    def __init__(self, force, half_separation=None, half_width=None):
+    def __init__(self, force, separation=None, width=None):
         super().__init__()
 
         param_dict = ParameterDict(
             force=float(force),
-            half_separation=float(half_separation),
-            half_width=float(half_width),
+            separation=float(separation),
+            width=float(width),
         )
         self._param_dict.update(param_dict)
 
     def _attach_hook(self):
-        self._cpp_obj = _mpcd.BlockForce(self.force, self.half_separation,
-                                         self.half_width)
+        self._cpp_obj = _mpcd.BlockForce(self.force, self.separation,
+                                         self.width)
         super()._attach_hook()
 
 

--- a/hoomd/mpcd/force.py
+++ b/hoomd/mpcd/force.py
@@ -90,7 +90,7 @@ class BlockForce(BodyForce):
 
                 force.force = 1.0
 
-        separation (float): Ddistance between the centers of the blocks.
+        separation (float): Distance between the centers of the blocks.
 
             .. rubric:: Example:
 

--- a/hoomd/mpcd/geometry.py
+++ b/hoomd/mpcd/geometry.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2009-2023 The Regents of the University of Michigan.
+# Copyright (c) 2009-2024 The Regents of the University of Michigan.
 # Part of HOOMD-blue, released under the BSD 3-Clause License.
 
 r"""MPCD geometries.
@@ -60,17 +60,17 @@ class ParallelPlates(Geometry):
     r"""Parallel-plate channel.
 
     Args:
-        H (float): Channel half-width.
-        V (float): Wall speed.
+        separation (float): Distance between plates.
+        speed (float): Wall speed.
         no_slip (bool): If True, surfaces have no-slip boundary condition.
             Otherwise, they have the slip boundary condition.
 
-    `ParallelPlates` confines particles between two infinite parallel
-    plates centered around the origin. The plates are placed at :math:`y=-H`
-    and :math:`y=+H`, so the total channel width is :math:`2H`. The plates may
-    be put into motion, moving with speeds :math:`-V` and :math:`+V` in the *x*
-    direction, respectively. If combined with a no-slip boundary condition,
-    this motion can be used to generate simple shear flow.
+    `ParallelPlates` confines particles between two infinite parallel plates
+    centered around the origin. The plates are placed at :math:`y=-H` and
+    :math:`y=+H`, where the total `separation` is :math:`2H`. The plates may be
+    put into motion with `speed` *V*, having velocity :math:`-V` and :math:`+V`
+    in the *x* direction, respectively. If combined with a no-slip boundary
+    condition, this motion can be used to generate simple shear flow.
 
     .. rubric:: Examples:
 
@@ -78,7 +78,7 @@ class ParallelPlates(Geometry):
 
     .. code-block:: python
 
-        plates = hoomd.mpcd.geometry.ParallelPlates(H=3.0)
+        plates = hoomd.mpcd.geometry.ParallelPlates(separation=6.0)
         stream = hoomd.mpcd.stream.BounceBack(period=1, geometry=plates)
         simulation.operations.integrator.streaming_method = stream
 
@@ -86,7 +86,8 @@ class ParallelPlates(Geometry):
 
     .. code-block:: python
 
-        plates = hoomd.mpcd.geometry.ParallelPlates(H=3.0, no_slip=False)
+        plates = hoomd.mpcd.geometry.ParallelPlates(
+            separation=6.0, no_slip=False)
         stream = hoomd.mpcd.stream.BounceBack(period=1, geometry=plates)
         simulation.operations.integrator.streaming_method = stream
 
@@ -94,30 +95,32 @@ class ParallelPlates(Geometry):
 
     .. code-block:: python
 
-        plates = hoomd.mpcd.geometry.ParallelPlates(H=3.0, V=1.0, no_slip=True)
+        plates = hoomd.mpcd.geometry.ParallelPlates(
+            separation=6.0, speed=1.0, no_slip=True)
         stream = hoomd.mpcd.stream.BounceBack(period=1, geometry=plates)
         simulation.operations.integrator.streaming_method = stream
 
     Attributes:
-        H (float): Channel half-width (*read only*).
+        separation (float): Distance between plates (*read only*).
 
-        V (float): Wall speed (*read only*).
+        speed (float): Wall speed (*read only*).
 
-            `V` will have no effect if `no_slip` is False because the slip
+            `speed` will have no effect if `no_slip` is False because the slip
             surface cannot generate shear stress.
 
     """
 
-    def __init__(self, H, V=0.0, no_slip=True):
+    def __init__(self, separation, speed=0.0, no_slip=True):
         super().__init__(no_slip)
         param_dict = ParameterDict(
-            H=float(H),
-            V=float(V),
+            separation=float(separation),
+            speed=float(speed),
         )
         self._param_dict.update(param_dict)
 
     def _attach_hook(self):
-        self._cpp_obj = _mpcd.ParallelPlates(self.H, self.V, self.no_slip)
+        self._cpp_obj = _mpcd.ParallelPlates(self.separation, self.speed,
+                                             self.no_slip)
         super()._attach_hook()
 
 

--- a/hoomd/mpcd/geometry.py
+++ b/hoomd/mpcd/geometry.py
@@ -128,14 +128,14 @@ class PlanarPore(Geometry):
     r"""Pore with parallel plate opening.
 
     Args:
-        H (float): Pore half-width.
-        L (float): Pore half-length.
+        separation (float): Distance between pore walls.
+        length (float): Pore length.
         no_slip (bool): If True, surfaces have no-slip boundary condition.
             Otherwise, they have the slip boundary condition.
 
     `PlanarPore` is a finite-length version of `ParallelPlates`. The
     geometry is similar, except that the plates extend from :math:`x=-L` to
-    :math:`x=+L` (total length *2L*). Additional solid walls
+    :math:`x=+L` (total `length` *2L*). Additional solid walls
     with normals in *x* prevent penetration into the regions above / below the
     plates. The plates are infinite in *z*. Outside the pore, the simulation box
     has full periodic boundaries; it is not confined by any walls. This model
@@ -145,26 +145,27 @@ class PlanarPore(Geometry):
 
     .. code-block:: python
 
-        pore = hoomd.mpcd.geometry.PlanarPore(H=3.0, L=2.0)
+        pore = hoomd.mpcd.geometry.PlanarPore(separation=6.0, length=4.0)
         stream = hoomd.mpcd.stream.BounceBack(period=1, geometry=pore)
         simulation.operations.integrator.streaming_method = stream
 
     Attributes:
-        H (float): Pore half-width (*read only*).
+        separation (float): Distance between pore walls (*read only*).
 
-        L (float): Pore half-length (*read only*).
+        length (float): Pore length (*read only*).
 
     """
 
-    def __init__(self, H, L, no_slip=True):
+    def __init__(self, separation, length, no_slip=True):
         super().__init__(no_slip)
 
         param_dict = ParameterDict(
-            H=float(H),
-            L=float(L),
+            separation=float(separation),
+            length=float(length),
         )
         self._param_dict.update(param_dict)
 
     def _attach_hook(self):
-        self._cpp_obj = _mpcd.PlanarPore(self.H, self.L, self.no_slip)
+        self._cpp_obj = _mpcd.PlanarPore(self.separation, self.length,
+                                         self.no_slip)
         super()._attach_hook()

--- a/hoomd/mpcd/integrate.py
+++ b/hoomd/mpcd/integrate.py
@@ -126,7 +126,7 @@ class Integrator(_MDIntegrator):
 
     .. code-block:: python
 
-        plates = hoomd.mpcd.geometry.ParallelPlates(H=3.0)
+        plates = hoomd.mpcd.geometry.ParallelPlates(separation=6.0)
         stream = hoomd.mpcd.stream.BounceBack(period=1, geometry=plates)
         collide = hoomd.mpcd.collide.StochasticRotationDynamics(
             period=1,

--- a/hoomd/mpcd/integrate.py
+++ b/hoomd/mpcd/integrate.py
@@ -45,17 +45,17 @@ class Integrator(_MDIntegrator):
             arbitrary computations during the half-step of the integration.
 
         streaming_method (hoomd.mpcd.stream.StreamingMethod): Streaming method
-            for the MPCD solvent.
+            for the MPCD particles.
 
         collision_method (hoomd.mpcd.collide.CollisionMethod): Collision method
-            for the MPCD solvent and any embedded particles.
+            for the MPCD particles and any embedded particles.
 
         virtual_particle_fillers
-            (Sequence[hoomd.mpcd.fill.VirtualParticleFiller]): Solvent
+            (Sequence[hoomd.mpcd.fill.VirtualParticleFiller]): MPCD
             virtual-particle filler(s).
 
-        solvent_sorter (hoomd.mpcd.tune.ParticleSorter): Tuner for sorting the
-            MPCD particles.
+        mpcd_particle_sorter (hoomd.mpcd.tune.ParticleSorter): Tuner that sorts
+            the MPCD particles.
 
     The MPCD `Integrator` enables the MPCD algorithm concurrently with standard
     MD methods.
@@ -84,7 +84,7 @@ class Integrator(_MDIntegrator):
 
         simulation = hoomd.util.make_example_simulation(mpcd_types=["A"])
 
-    MPCD integrator for pure solvent.
+    Integrator for only MPCD particles.
 
     .. code-block:: python
 
@@ -96,7 +96,7 @@ class Integrator(_MDIntegrator):
             dt=0.1,
             streaming_method=stream,
             collision_method=collide,
-            solvent_sorter=hoomd.mpcd.tune.ParticleSorter(trigger=20))
+            mpcd_particle_sorter=hoomd.mpcd.tune.ParticleSorter(trigger=20))
         simulation.operations.integrator = integrator
 
     MPCD integrator with solutes.
@@ -119,7 +119,9 @@ class Integrator(_MDIntegrator):
             methods=[solute_method],
             streaming_method=stream,
             collision_method=collide,
-            solvent_sorter=hoomd.mpcd.tune.ParticleSorter(trigger=20*md_steps_per_collision))
+            mpcd_particle_sorter=hoomd.mpcd.tune.ParticleSorter(
+                trigger=20*md_steps_per_collision)
+            )
         simulation.operations.integrator = integrator
 
     MPCD integrator with virtual particle filler.
@@ -143,18 +145,18 @@ class Integrator(_MDIntegrator):
             streaming_method=stream,
             collision_method=collide,
             virtual_particle_fillers=[filler],
-            solvent_sorter=hoomd.mpcd.tune.ParticleSorter(trigger=20))
+            mpcd_particle_sorter=hoomd.mpcd.tune.ParticleSorter(trigger=20))
         simulation.operations.integrator = integrator
 
     Attributes:
         collision_method (hoomd.mpcd.collide.CollisionMethod): Collision method
-            for the MPCD solvent and any embedded particles.
+            for the MPCD particles and any embedded particles.
 
-        solvent_sorter (hoomd.mpcd.tune.ParticleSorter): Tuner for sorting the
-            MPCD particles (recommended).
+        mpcd_particle_sorter (hoomd.mpcd.tune.ParticleSorter): Tuner that sorts
+            the MPCD particles (recommended).
 
         streaming_method (hoomd.mpcd.stream.StreamingMethod): Streaming method
-            for the MPCD solvent.
+            for the MPCD particles.
 
     """
 
@@ -170,7 +172,7 @@ class Integrator(_MDIntegrator):
         streaming_method=None,
         collision_method=None,
         virtual_particle_fillers=None,
-        solvent_sorter=None,
+        mpcd_particle_sorter=None,
     ):
         super().__init__(
             dt,
@@ -195,13 +197,13 @@ class Integrator(_MDIntegrator):
         param_dict = ParameterDict(
             streaming_method=OnlyTypes(StreamingMethod, allow_none=True),
             collision_method=OnlyTypes(CollisionMethod, allow_none=True),
-            solvent_sorter=OnlyTypes(ParticleSorter, allow_none=True),
+            mpcd_particle_sorter=OnlyTypes(ParticleSorter, allow_none=True),
         )
         param_dict.update(
             dict(
                 streaming_method=streaming_method,
                 collision_method=collision_method,
-                solvent_sorter=solvent_sorter,
+                mpcd_particle_sorter=mpcd_particle_sorter,
             ))
         self._param_dict.update(param_dict)
 
@@ -218,7 +220,7 @@ class Integrator(_MDIntegrator):
 
     @property
     def virtual_particle_fillers(self):
-        """Sequence[hoomd.mpcd.fill.VirtualParticleFiller]: Solvent \
+        """Sequence[hoomd.mpcd.fill.VirtualParticleFiller]: MPCD \
         virtual-particle fillers."""
         return self._virtual_particle_fillers
 
@@ -232,8 +234,8 @@ class Integrator(_MDIntegrator):
             self.streaming_method._attach(self._simulation)
         if self.collision_method is not None:
             self.collision_method._attach(self._simulation)
-        if self.solvent_sorter is not None:
-            self.solvent_sorter._attach(self._simulation)
+        if self.mpcd_particle_sorter is not None:
+            self.mpcd_particle_sorter._attach(self._simulation)
 
         self._cpp_obj = _mpcd.Integrator(self._simulation.state._cpp_sys_def,
                                          self.dt)
@@ -250,13 +252,14 @@ class Integrator(_MDIntegrator):
             self.streaming_method._detach()
         if self.collision_method is not None:
             self.collision_method._detach()
-        if self.solvent_sorter is not None:
-            self.solvent_sorter._detach()
+        if self.mpcd_particle_sorter is not None:
+            self.mpcd_particle_sorter._detach()
 
         super()._detach_hook()
 
     def _setattr_param(self, attr, value):
-        if attr in ("streaming_method", "collision_method", "solvent_sorter"):
+        if attr in ("streaming_method", "collision_method",
+                    "mpcd_particle_sorter"):
             cur_value = getattr(self, attr)
             if value is cur_value:
                 return

--- a/hoomd/mpcd/methods.py
+++ b/hoomd/mpcd/methods.py
@@ -4,7 +4,7 @@
 r"""MPCD integration methods.
 
 Extra integration methods for solutes (MD particles) embedded in an MPCD
-solvent. These methods are not restricted to MPCD simulations: they can be used
+fluid. These methods are not restricted to MPCD simulations: they can be used
 as methods of `hoomd.md.Integrator`. For example, `BounceBack` might be used to
 run DPD simulations with surfaces.
 
@@ -32,7 +32,7 @@ class BounceBack(Method):
         geometry (hoomd.mpcd.geometry.Geometry): Surface to bounce back from.
 
     A bounce-back method for integrating solutes (MD particles) embedded in an
-    MPCD solvent. The integration scheme is velocity Verlet with bounce-back
+    MPCD fluid. The integration scheme is velocity Verlet with bounce-back
     performed at the solid boundaries defined by a geometry, as in
     `hoomd.mpcd.stream.BounceBack`. This gives a simple approximation of the
     interactions required to keep a solute bounded in a geometry, and more
@@ -45,7 +45,7 @@ class BounceBack(Method):
     1. The simulation box is periodic, but the `geometry` may impose
        non-periodic boundary conditions. You must ensure that the box is
        sufficiently large to enclose the `geometry` and that all particles lie
-       inside it, or an error will be raised at runtime.
+       inside it
     2. You must also ensure that particles do not self-interact through the
        periodic boundaries. This is usually achieved for simple pair potentials
        by padding the box size by the largest cutoff radius. Failure to do so

--- a/hoomd/mpcd/methods.py
+++ b/hoomd/mpcd/methods.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2009-2023 The Regents of the University of Michigan.
+# Copyright (c) 2009-2024 The Regents of the University of Michigan.
 # Part of HOOMD-blue, released under the BSD 3-Clause License.
 
 r"""MPCD integration methods.
@@ -68,7 +68,7 @@ class BounceBack(Method):
 
     .. code-block:: python
 
-        plates = hoomd.mpcd.geometry.ParallelPlates(H=3.0)
+        plates = hoomd.mpcd.geometry.ParallelPlates(separation=6.0)
         nve = hoomd.mpcd.methods.BounceBack(
             filter=hoomd.filter.All(), geometry=plates)
         simulation.operations.integrator.methods.append(nve)

--- a/hoomd/mpcd/pytest/test_collide.py
+++ b/hoomd/mpcd/pytest/test_collide.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2009-2023 The Regents of the University of Michigan.
+# Copyright (c) 2009-2024 The Regents of the University of Michigan.
 # Part of HOOMD-blue, released under the BSD 3-Clause License.
 
 import pytest

--- a/hoomd/mpcd/pytest/test_fill.py
+++ b/hoomd/mpcd/pytest/test_fill.py
@@ -26,8 +26,8 @@ def snap():
             "separation": 8.0
         }),
         (hoomd.mpcd.geometry.PlanarPore, {
-            "H": 4.0,
-            "L": 5.0
+            "separation": 8.0,
+            "length": 10.0
         }),
     ],
     ids=["ParallelPlates", "PlanarPore"],

--- a/hoomd/mpcd/pytest/test_fill.py
+++ b/hoomd/mpcd/pytest/test_fill.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2009-2023 The Regents of the University of Michigan.
+# Copyright (c) 2009-2024 The Regents of the University of Michigan.
 # Part of HOOMD-blue, released under the BSD 3-Clause License.
 
 import pytest
@@ -23,7 +23,7 @@ def snap():
     "cls, init_args",
     [
         (hoomd.mpcd.geometry.ParallelPlates, {
-            "H": 4.0
+            "separation": 8.0
         }),
         (hoomd.mpcd.geometry.PlanarPore, {
             "H": 4.0,

--- a/hoomd/mpcd/pytest/test_force.py
+++ b/hoomd/mpcd/pytest/test_force.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2009-2023 The Regents of the University of Michigan.
+# Copyright (c) 2009-2024 The Regents of the University of Michigan.
 # Part of HOOMD-blue, released under the BSD 3-Clause License.
 
 import numpy as np
@@ -9,36 +9,34 @@ from hoomd.conftest import pickling_check
 
 def test_block_force(simulation_factory):
     # make the force
-    force = hoomd.mpcd.force.BlockForce(force=2.0,
-                                        half_separation=3.0,
-                                        half_width=0.5)
+    force = hoomd.mpcd.force.BlockForce(force=2.0, separation=6.0, width=1.0)
     assert force.force == 2.0
-    assert force.half_separation == 3.0
-    assert force.half_width == 0.5
+    assert force.separation == 6.0
+    assert force.width == 1.0
     pickling_check(force)
 
     # try changing the values
     force.force = 1.0
-    force.half_separation = 2.0
-    force.half_width = 0.25
+    force.separation = 4.0
+    force.width = 0.5
     assert force.force == 1.0
-    assert force.half_separation == 2.0
-    assert force.half_width == 0.25
+    assert force.separation == 4.0
+    assert force.width == 0.5
 
     # now attach and check again
     sim = simulation_factory()
     force._attach(sim)
     assert force.force == 1.0
-    assert force.half_separation == 2.0
-    assert force.half_width == 0.25
+    assert force.separation == 4.0
+    assert force.width == 0.5
 
     # change values while attached
     force.force = 2.0
-    force.half_separation = 3.0
-    force.half_width = 0.5
+    force.separation = 6.0
+    force.width = 1.0
     assert force.force == 2.0
-    assert force.half_separation == 3.0
-    assert force.half_width == 0.5
+    assert force.separation == 6.0
+    assert force.width == 1.0
     pickling_check(force)
 
 

--- a/hoomd/mpcd/pytest/test_geometry.py
+++ b/hoomd/mpcd/pytest/test_geometry.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2009-2023 The Regents of the University of Michigan.
+# Copyright (c) 2009-2024 The Regents of the University of Michigan.
 # Part of HOOMD-blue, released under the BSD 3-Clause License.
 
 import pytest
@@ -22,31 +22,33 @@ def snap():
 class TestParallelPlates:
 
     def test_default_init(self, simulation_factory, snap):
-        geom = hoomd.mpcd.geometry.ParallelPlates(H=4.0)
-        assert geom.H == 4.0
-        assert geom.V == 0.0
+        geom = hoomd.mpcd.geometry.ParallelPlates(separation=8.0)
+        assert geom.separation == 8.0
+        assert geom.speed == 0.0
         assert geom.no_slip
 
         sim = simulation_factory(snap)
         geom._attach(sim)
-        assert geom.H == 4.0
-        assert geom.V == 0.0
+        assert geom.separation == 8.0
+        assert geom.speed == 0.0
         assert geom.no_slip
 
     def test_nondefault_init(self, simulation_factory, snap):
-        geom = hoomd.mpcd.geometry.ParallelPlates(H=5.0, V=1.0, no_slip=False)
-        assert geom.H == 5.0
-        assert geom.V == 1.0
+        geom = hoomd.mpcd.geometry.ParallelPlates(separation=10.0,
+                                                  speed=1.0,
+                                                  no_slip=False)
+        assert geom.separation == 10.0
+        assert geom.speed == 1.0
         assert not geom.no_slip
 
         sim = simulation_factory(snap)
         geom._attach(sim)
-        assert geom.H == 5.0
-        assert geom.V == 1.0
+        assert geom.separation == 10.0
+        assert geom.speed == 1.0
         assert not geom.no_slip
 
     def test_pickling(self, simulation_factory, snap):
-        geom = hoomd.mpcd.geometry.ParallelPlates(H=4.0)
+        geom = hoomd.mpcd.geometry.ParallelPlates(separation=8.0)
         pickling_check(geom)
 
         sim = simulation_factory(snap)

--- a/hoomd/mpcd/pytest/test_geometry.py
+++ b/hoomd/mpcd/pytest/test_geometry.py
@@ -59,31 +59,33 @@ class TestParallelPlates:
 class TestPlanarPore:
 
     def test_default_init(self, simulation_factory, snap):
-        geom = hoomd.mpcd.geometry.PlanarPore(H=4.0, L=5.0)
-        assert geom.H == 4.0
-        assert geom.L == 5.0
+        geom = hoomd.mpcd.geometry.PlanarPore(separation=8.0, length=10.0)
+        assert geom.separation == 8.0
+        assert geom.length == 10.0
         assert geom.no_slip
 
         sim = simulation_factory(snap)
         geom._attach(sim)
-        assert geom.H == 4.0
-        assert geom.L == 5.0
+        assert geom.separation == 8.0
+        assert geom.length == 10.0
         assert geom.no_slip
 
     def test_nondefault_init(self, simulation_factory, snap):
-        geom = hoomd.mpcd.geometry.PlanarPore(H=5.0, L=4.0, no_slip=False)
-        assert geom.H == 5.0
-        assert geom.L == 4.0
+        geom = hoomd.mpcd.geometry.PlanarPore(separation=10.0,
+                                              length=8.0,
+                                              no_slip=False)
+        assert geom.separation == 10.0
+        assert geom.length == 8.0
         assert not geom.no_slip
 
         sim = simulation_factory(snap)
         geom._attach(sim)
-        assert geom.H == 5.0
-        assert geom.L == 4.0
+        assert geom.separation == 10.0
+        assert geom.length == 8.0
         assert not geom.no_slip
 
     def test_pickling(self, simulation_factory, snap):
-        geom = hoomd.mpcd.geometry.PlanarPore(H=4.0, L=5.0)
+        geom = hoomd.mpcd.geometry.PlanarPore(separation=8.0, length=10.0)
         pickling_check(geom)
 
         sim = simulation_factory(snap)

--- a/hoomd/mpcd/pytest/test_integrator.py
+++ b/hoomd/mpcd/pytest/test_integrator.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2009-2023 The Regents of the University of Michigan.
+# Copyright (c) 2009-2024 The Regents of the University of Michigan.
 # Part of HOOMD-blue, released under the BSD 3-Clause License.
 
 import pytest
@@ -85,7 +85,7 @@ def test_streaming_method(make_simulation):
 
 def test_virtual_particle_fillers(make_simulation):
     sim = make_simulation()
-    geom = hoomd.mpcd.geometry.ParallelPlates(H=4.0)
+    geom = hoomd.mpcd.geometry.ParallelPlates(separation=8.0)
     filler = hoomd.mpcd.fill.GeometryFiller(
         type="A",
         density=5.0,

--- a/hoomd/mpcd/pytest/test_integrator.py
+++ b/hoomd/mpcd/pytest/test_integrator.py
@@ -129,28 +129,28 @@ def test_virtual_particle_fillers(make_simulation):
     assert len(ig.virtual_particle_fillers) == 0
 
 
-def test_solvent_sorter(make_simulation):
+def test_mpcd_particle_sorter(make_simulation):
     sim = make_simulation()
     sorter = hoomd.mpcd.tune.ParticleSorter(trigger=1)
 
     # check that constructor assigns right
-    ig = hoomd.mpcd.Integrator(dt=0.1, solvent_sorter=sorter)
+    ig = hoomd.mpcd.Integrator(dt=0.1, mpcd_particle_sorter=sorter)
     sim.operations.integrator = ig
-    assert ig.solvent_sorter is sorter
+    assert ig.mpcd_particle_sorter is sorter
     sim.run(0)
-    assert ig.solvent_sorter is sorter
+    assert ig.mpcd_particle_sorter is sorter
 
     # clear out by setter
-    ig.solvent_sorter = None
-    assert ig.solvent_sorter is None
+    ig.mpcd_particle_sorter = None
+    assert ig.mpcd_particle_sorter is None
     sim.run(0)
-    assert ig.solvent_sorter is None
+    assert ig.mpcd_particle_sorter is None
 
     # assign by setter
-    ig.solvent_sorter = sorter
-    assert ig.solvent_sorter is sorter
+    ig.mpcd_particle_sorter = sorter
+    assert ig.mpcd_particle_sorter is sorter
     sim.run(0)
-    assert ig.solvent_sorter is sorter
+    assert ig.mpcd_particle_sorter is sorter
 
 
 def test_attach_and_detach(make_simulation):
@@ -165,17 +165,17 @@ def test_attach_and_detach(make_simulation):
     assert ig.streaming_method is None
     assert ig.collision_method is None
     assert len(ig.virtual_particle_fillers) == 0
-    assert ig.solvent_sorter is None
+    assert ig.mpcd_particle_sorter is None
 
     # attach with both methods
     ig.streaming_method = hoomd.mpcd.stream.Bulk(period=1)
     ig.collision_method = hoomd.mpcd.collide.StochasticRotationDynamics(
         period=1, angle=130)
-    ig.solvent_sorter = hoomd.mpcd.tune.ParticleSorter(trigger=1)
+    ig.mpcd_particle_sorter = hoomd.mpcd.tune.ParticleSorter(trigger=1)
     sim.run(0)
     assert ig.streaming_method._attached
     assert ig.collision_method._attached
-    assert ig.solvent_sorter._attached
+    assert ig.mpcd_particle_sorter._attached
 
     # detach with everything
     sim.operations._unschedule()
@@ -183,7 +183,7 @@ def test_attach_and_detach(make_simulation):
     assert not ig.cell_list._attached
     assert not ig.streaming_method._attached
     assert not ig.collision_method._attached
-    assert not ig.solvent_sorter._attached
+    assert not ig.mpcd_particle_sorter._attached
 
 
 def test_pickling(make_simulation):

--- a/hoomd/mpcd/pytest/test_methods.py
+++ b/hoomd/mpcd/pytest/test_methods.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2009-2023 The Regents of the University of Michigan.
+# Copyright (c) 2009-2024 The Regents of the University of Michigan.
 # Part of HOOMD-blue, released under the BSD 3-Clause License.
 
 import numpy as np
@@ -25,7 +25,7 @@ def snap():
 def integrator():
     bb = hoomd.mpcd.methods.BounceBack(
         filter=hoomd.filter.All(),
-        geometry=hoomd.mpcd.geometry.ParallelPlates(H=4))
+        geometry=hoomd.mpcd.geometry.ParallelPlates(separation=8.0))
     ig = hoomd.mpcd.Integrator(dt=0.1, methods=[bb])
     return ig
 
@@ -116,7 +116,7 @@ class TestBounceBack:
 
     def test_step_moving_wall(self, simulation_factory, snap, integrator):
         integrator.dt = 0.3
-        integrator.methods[0].geometry.V = 1.0
+        integrator.methods[0].geometry.speed = 1.0
 
         if snap.communicator.rank == 0:
             snap.particles.velocity[1] = [-2.0, -1.0, -1.0]
@@ -156,7 +156,7 @@ class TestBounceBack:
     def test_check_particles(self, simulation_factory, snap, integrator, H,
                              expected_result):
         """Test box validation raises an error on run."""
-        integrator.methods[0].geometry.H = H
+        integrator.methods[0].geometry.separation = 2 * H
 
         sim = simulation_factory(snap)
         sim.operations.integrator = integrator
@@ -168,7 +168,7 @@ class TestBounceBack:
         """Test we can also attach to a normal MD integrator."""
         bb = hoomd.mpcd.methods.BounceBack(
             filter=hoomd.filter.All(),
-            geometry=hoomd.mpcd.geometry.ParallelPlates(H=4))
+            geometry=hoomd.mpcd.geometry.ParallelPlates(separation=8.0))
         integrator = hoomd.md.Integrator(dt=0.1, methods=[bb])
 
         sim = simulation_factory(snap)

--- a/hoomd/mpcd/pytest/test_stream.py
+++ b/hoomd/mpcd/pytest/test_stream.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2009-2023 The Regents of the University of Michigan.
+# Copyright (c) 2009-2024 The Regents of the University of Michigan.
 # Part of HOOMD-blue, released under the BSD 3-Clause License.
 
 import numpy as np
@@ -70,8 +70,7 @@ class TestStreamingMethod:
         "force",
         [
             None,
-            hoomd.mpcd.force.BlockForce(
-                force=2.0, half_separation=3.0, half_width=0.5),
+            hoomd.mpcd.force.BlockForce(force=2.0, separation=3.0, width=0.5),
             hoomd.mpcd.force.ConstantForce(force=(1, -2, 3)),
             hoomd.mpcd.force.SineForce(amplitude=2.0, wavenumber=1),
         ],

--- a/hoomd/mpcd/pytest/test_stream.py
+++ b/hoomd/mpcd/pytest/test_stream.py
@@ -29,7 +29,7 @@ def snap():
             {
                 "geometry":
                     hoomd.mpcd.geometry.ParallelPlates(
-                        H=4.0, V=0.0, no_slip=True),
+                        separation=8.0, speed=0.0, no_slip=True),
             },
         ),
         (
@@ -192,7 +192,8 @@ class TestParallelPlates:
             snap.mpcd.velocity[:] = [[1.0, 1.0, -1.0], [-1.0, -1.0, -1.0]]
         sim = simulation_factory(snap)
         sm = hoomd.mpcd.stream.BounceBack(
-            period=1, geometry=hoomd.mpcd.geometry.ParallelPlates(H=4))
+            period=1,
+            geometry=hoomd.mpcd.geometry.ParallelPlates(separation=8.0))
         ig = hoomd.mpcd.Integrator(dt=0.1, streaming_method=sm)
         sim.operations.integrator = ig
 
@@ -232,7 +233,8 @@ class TestParallelPlates:
         sim = simulation_factory(snap)
         sm = hoomd.mpcd.stream.BounceBack(
             period=1,
-            geometry=hoomd.mpcd.geometry.ParallelPlates(H=4, no_slip=False))
+            geometry=hoomd.mpcd.geometry.ParallelPlates(separation=8.0,
+                                                        no_slip=False))
         ig = hoomd.mpcd.Integrator(dt=0.1, streaming_method=sm)
         sim.operations.integrator = ig
 
@@ -280,7 +282,9 @@ class TestParallelPlates:
         sim = simulation_factory(snap)
         sm = hoomd.mpcd.stream.BounceBack(
             period=1,
-            geometry=hoomd.mpcd.geometry.ParallelPlates(H=4, V=1, no_slip=True),
+            geometry=hoomd.mpcd.geometry.ParallelPlates(separation=8.0,
+                                                        speed=1,
+                                                        no_slip=True),
         )
         ig = hoomd.mpcd.Integrator(dt=0.3, streaming_method=sm)
         sim.operations.integrator = ig
@@ -301,7 +305,8 @@ class TestParallelPlates:
             snap.mpcd.position[0] = [0, 3.85, 0]
         sim = simulation_factory(snap)
         sm = hoomd.mpcd.stream.BounceBack(
-            period=1, geometry=hoomd.mpcd.geometry.ParallelPlates(H=H))
+            period=1,
+            geometry=hoomd.mpcd.geometry.ParallelPlates(separation=2 * H))
         ig = hoomd.mpcd.Integrator(dt=0.1, streaming_method=sm)
         sim.operations.integrator = ig
 

--- a/hoomd/mpcd/pytest/test_stream.py
+++ b/hoomd/mpcd/pytest/test_stream.py
@@ -36,7 +36,8 @@ def snap():
             hoomd.mpcd.stream.BounceBack,
             {
                 "geometry":
-                    hoomd.mpcd.geometry.PlanarPore(H=4.0, L=3.0, no_slip=True)
+                    hoomd.mpcd.geometry.PlanarPore(
+                        separation=8.0, length=6.0, no_slip=True)
             },
         ),
     ],
@@ -346,7 +347,9 @@ class TestPlanarPore:
         sim = simulation_factory(snap)
         sm = hoomd.mpcd.stream.BounceBack(
             period=1,
-            geometry=hoomd.mpcd.geometry.PlanarPore(H=4, L=3, no_slip=True))
+            geometry=hoomd.mpcd.geometry.PlanarPore(separation=8.0,
+                                                    length=6.0,
+                                                    no_slip=True))
         ig = hoomd.mpcd.Integrator(dt=0.1, streaming_method=sm)
         sim.operations.integrator = ig
 
@@ -417,7 +420,9 @@ class TestPlanarPore:
         sim = simulation_factory(snap)
         sm = hoomd.mpcd.stream.BounceBack(
             period=1,
-            geometry=hoomd.mpcd.geometry.PlanarPore(H=4, L=3, no_slip=False))
+            geometry=hoomd.mpcd.geometry.PlanarPore(separation=8.0,
+                                                    length=6.0,
+                                                    no_slip=False))
         ig = hoomd.mpcd.Integrator(dt=0.1, streaming_method=sm)
         sim.operations.integrator = ig
 
@@ -491,15 +496,18 @@ class TestPlanarPore:
         sim.operations.integrator = ig
 
         ig.streaming_method = hoomd.mpcd.stream.BounceBack(
-            period=1, geometry=hoomd.mpcd.geometry.PlanarPore(H=4, L=3))
+            period=1,
+            geometry=hoomd.mpcd.geometry.PlanarPore(separation=8.0, length=6.0))
         sim.run(0)
         assert ig.streaming_method.check_solvent_particles()
 
         ig.streaming_method = hoomd.mpcd.stream.BounceBack(
-            period=1, geometry=hoomd.mpcd.geometry.PlanarPore(H=3.8, L=3))
+            period=1,
+            geometry=hoomd.mpcd.geometry.PlanarPore(separation=7.6, length=6.0))
         sim.run(0)
         assert not ig.streaming_method.check_solvent_particles()
 
         ig.streaming_method = hoomd.mpcd.stream.BounceBack(
-            period=1, geometry=hoomd.mpcd.geometry.PlanarPore(H=4, L=3.5))
+            period=1,
+            geometry=hoomd.mpcd.geometry.PlanarPore(separation=8.0, length=7.0))
         assert not ig.streaming_method.check_solvent_particles()

--- a/hoomd/mpcd/pytest/test_tune.py
+++ b/hoomd/mpcd/pytest/test_tune.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2009-2023 The Regents of the University of Michigan.
+# Copyright (c) 2009-2024 The Regents of the University of Michigan.
 # Part of HOOMD-blue, released under the BSD 3-Clause License.
 
 import pytest

--- a/hoomd/mpcd/pytest/test_tune.py
+++ b/hoomd/mpcd/pytest/test_tune.py
@@ -31,7 +31,7 @@ class TestParticleSorter:
         sorter.trigger = trigger
         assert sorter.trigger is trigger
 
-        ig = hoomd.mpcd.Integrator(dt=0.02, solvent_sorter=sorter)
+        ig = hoomd.mpcd.Integrator(dt=0.02, mpcd_particle_sorter=sorter)
         sim.operations.integrator = ig
         sim.run(0)
         assert sorter.trigger is trigger
@@ -44,7 +44,7 @@ class TestParticleSorter:
         pickling_check(sorter)
 
         sim = simulation_factory(snap)
-        sim.operations.integrator = hoomd.mpcd.Integrator(dt=0.02,
-                                                          solvent_sorter=sorter)
+        sim.operations.integrator = hoomd.mpcd.Integrator(
+            dt=0.02, mpcd_particle_sorter=sorter)
         sim.run(0)
         pickling_check(sorter)

--- a/hoomd/mpcd/stream.py
+++ b/hoomd/mpcd/stream.py
@@ -198,7 +198,7 @@ class BounceBack(StreamingMethod):
         stream = hoomd.mpcd.stream.BounceBack(
             period=1,
             geometry=hoomd.mpcd.geometry.ParallelPlates(
-                H=3.0, V=1.0, no_slip=True))
+                separation=6.0, speed=1.0, no_slip=True))
         simulation.operations.integrator.streaming_method = stream
 
     Pressure driven flow between parallel plates.
@@ -207,7 +207,8 @@ class BounceBack(StreamingMethod):
 
         stream = hoomd.mpcd.stream.BounceBack(
             period=1,
-            geometry=hoomd.mpcd.geometry.ParallelPlates(H=3.0, no_slip=True),
+            geometry=hoomd.mpcd.geometry.ParallelPlates(
+                separation=6.0, no_slip=True),
             solvent_force=hoomd.mpcd.force.ConstantForce((1, 0, 0)))
         simulation.operations.integrator.streaming_method = stream
 

--- a/hoomd/mpcd/stream.py
+++ b/hoomd/mpcd/stream.py
@@ -33,7 +33,7 @@ import hoomd
 from hoomd.data.parameterdicts import ParameterDict
 from hoomd.data.typeconverter import OnlyTypes
 from hoomd.mpcd import _mpcd
-from hoomd.mpcd.force import SolventForce
+from hoomd.mpcd.force import BodyForce
 from hoomd.mpcd.geometry import Geometry
 from hoomd.operation import Operation
 
@@ -43,7 +43,7 @@ class StreamingMethod(Operation):
 
     Args:
         period (int): Number of integration steps covered by streaming step.
-        solvent_force (SolventForce): Force on solvent.
+        mpcd_particle_force (BodyForce): Force on MPCD particles.
 
     Attributes:
         period (int): Number of integration steps covered by streaming step
@@ -58,20 +58,22 @@ class StreamingMethod(Operation):
             used if an external force is applied, and more faithful numerical
             integration is needed.
 
-        solvent_force (SolventForce): Force on solvent.
+        mpcd_particle_force (BodyForce): Body force on MPCD particles.
 
-            The `solvent_force` cannot be changed after the `StreamingMethod` is
-            constructed, but its attributes can be modified.
+            The `mpcd_particle_force` cannot be changed after the
+            `StreamingMethod` is constructed, but its attributes can be
+            modified.
 
     """
 
-    def __init__(self, period, solvent_force=None):
+    def __init__(self, period, mpcd_particle_force=None):
         super().__init__()
 
-        param_dict = ParameterDict(period=int(period),
-                                   solvent_force=OnlyTypes(SolventForce,
-                                                           allow_none=True))
-        param_dict["solvent_force"] = solvent_force
+        param_dict = ParameterDict(
+            period=int(period),
+            mpcd_particle_force=OnlyTypes(BodyForce, allow_none=True),
+        )
+        param_dict["mpcd_particle_force"] = mpcd_particle_force
         self._param_dict.update(param_dict)
 
 
@@ -80,7 +82,7 @@ class Bulk(StreamingMethod):
 
     Args:
         period (int): Number of integration steps covered by streaming step.
-        solvent_force (SolventForce): Force on solvent.
+        mpcd_particle_force (BodyForce): Body force on MPCD particles.
 
     `Bulk` streams the MPCD particles in a fully periodic geometry (2D or 3D).
     This geometry is appropriate for modeling bulk fluids, i.e., those that
@@ -101,7 +103,7 @@ class Bulk(StreamingMethod):
 
         stream = hoomd.mpcd.stream.Bulk(
             period=1,
-            solvent_force=hoomd.mpcd.force.ConstantForce((1, 0, 0)))
+            mpcd_particle_force=hoomd.mpcd.force.ConstantForce((1, 0, 0)))
         simulation.operations.integrator.streaming_method = stream
 
     """
@@ -109,19 +111,19 @@ class Bulk(StreamingMethod):
     def _attach_hook(self):
         sim = self._simulation
 
-        # attach and use solvent force if present
-        if self.solvent_force is not None:
-            self.solvent_force._attach(sim)
-            solvent_force = self.solvent_force._cpp_obj
+        # attach and use body force if present
+        if self.mpcd_particle_force is not None:
+            self.mpcd_particle_force._attach(sim)
+            mpcd_particle_force = self.mpcd_particle_force._cpp_obj
         else:
-            solvent_force = None
+            mpcd_particle_force = None
 
         # try to find force in map, otherwise use default
-        force_type = type(self.solvent_force)
+        force_type = type(self.mpcd_particle_force)
         try:
             class_info = self._cpp_class_map[force_type]
         except KeyError:
-            if self.solvent_force is not None:
+            if self.mpcd_particle_force is not None:
                 force_name = force_type.__name__
             else:
                 force_name = "NoForce"
@@ -133,22 +135,22 @@ class Bulk(StreamingMethod):
         if isinstance(sim.device, hoomd.device.GPU):
             class_info[1] += "GPU"
         class_ = getattr(*class_info, None)
-        assert class_ is not None, ("C++ streaming method could not be"
-                                    " determined")
+        assert class_ is not None, ("C++ streaming method could not be "
+                                    "determined")
 
         self._cpp_obj = class_(
             sim.state._cpp_sys_def,
             sim.timestep,
             self.period,
             0,
-            solvent_force,
+            mpcd_particle_force,
         )
 
         super()._attach_hook()
 
     def _detach_hook(self):
-        if self.solvent_force is not None:
-            self.solvent_force._detach()
+        if self.mpcd_particle_force is not None:
+            self.mpcd_particle_force._detach()
         super()._detach_hook()
 
     _cpp_class_map = {}
@@ -164,16 +166,16 @@ class BounceBack(StreamingMethod):
     Args:
         period (int): Number of integration steps covered by streaming step.
         geometry (hoomd.mpcd.geometry.Geometry): Surface to bounce back from.
-        solvent_force (SolventForce): Force on solvent.
+        mpcd_particle_force (BodyForce): Body force on MPCD particles.
 
     One of the main strengths of the MPCD algorithm is that it can be coupled to
     complex boundaries, defined by a `geometry`. This `StreamingMethod` reflects
-    the MPCD solvent particles from boundary surfaces using specular reflections
+    the MPCD particles from boundary surfaces using specular reflections
     (bounce-back) rules consistent with either "slip" or "no-slip" hydrodynamic
     boundary conditions. The external force is only applied to the particles at
     the beginning and the end of this process.
 
-    Although a streaming geometry is enforced on the MPCD solvent particles,
+    Although a streaming geometry is enforced on the MPCD particles,
     there are a few important caveats:
 
     1. Embedded particles are not coupled to the boundary walls. They must be
@@ -187,7 +189,7 @@ class BounceBack(StreamingMethod):
        simulation box will be validated by the `geometry`.
     3. It is an error for MPCD particles to lie "outside" the `geometry`.
        You must initialize your system carefully to ensure all particles are
-       "inside" the geometry. An error will be raised otherwise.
+       "inside" the geometry.
 
     .. rubric:: Examples:
 
@@ -209,7 +211,7 @@ class BounceBack(StreamingMethod):
             period=1,
             geometry=hoomd.mpcd.geometry.ParallelPlates(
                 separation=6.0, no_slip=True),
-            solvent_force=hoomd.mpcd.force.ConstantForce((1, 0, 0)))
+            mpcd_particle_force=hoomd.mpcd.force.ConstantForce((1, 0, 0)))
         simulation.operations.integrator.streaming_method = stream
 
     Attributes:
@@ -220,50 +222,50 @@ class BounceBack(StreamingMethod):
 
     _cpp_class_map = {}
 
-    def __init__(self, period, geometry, solvent_force=None):
-        super().__init__(period, solvent_force)
+    def __init__(self, period, geometry, mpcd_particle_force=None):
+        super().__init__(period, mpcd_particle_force)
 
         param_dict = ParameterDict(geometry=Geometry)
         param_dict["geometry"] = geometry
         self._param_dict.update(param_dict)
 
-    def check_solvent_particles(self):
-        """Check if solvent particles are inside `geometry`.
+    def check_mpcd_particles(self):
+        """Check if MPCD particles are inside `geometry`.
 
         This method can only be called after this object is attached to a
         simulation.
 
         Returns:
-            True if all solvent particles are inside `geometry`.
+            True if all MPCD particles are inside `geometry`.
 
         .. rubric:: Examples:
 
         .. code-block:: python
 
-            assert stream.check_solvent_particles()
+            assert stream.check_mpcd_particles()
 
         """
-        return self._cpp_obj.check_solvent_particles()
+        return self._cpp_obj.check_mpcd_particles()
 
     def _attach_hook(self):
         sim = self._simulation
 
         self.geometry._attach(sim)
 
-        # attach and use solvent force if present
-        if self.solvent_force is not None:
-            self.solvent_force._attach(sim)
-            solvent_force = self.solvent_force._cpp_obj
+        # attach and use body force if present
+        if self.mpcd_particle_force is not None:
+            self.mpcd_particle_force._attach(sim)
+            mpcd_particle_force = self.mpcd_particle_force._cpp_obj
         else:
-            solvent_force = None
+            mpcd_particle_force = None
 
         # try to find force in map, otherwise use default
         geom_type = type(self.geometry)
-        force_type = type(self.solvent_force)
+        force_type = type(self.mpcd_particle_force)
         try:
             class_info = self._cpp_class_map[geom_type, force_type]
         except KeyError:
-            if self.solvent_force is not None:
+            if self.mpcd_particle_force is not None:
                 force_name = force_type.__name__
             else:
                 force_name = "NoForce"
@@ -284,15 +286,15 @@ class BounceBack(StreamingMethod):
             self.period,
             0,
             self.geometry._cpp_obj,
-            solvent_force,
+            mpcd_particle_force,
         )
 
         super()._attach_hook()
 
     def _detach_hook(self):
         self.geometry._detach()
-        if self.solvent_force is not None:
-            self.solvent_force._detach()
+        if self.mpcd_particle_force is not None:
+            self.mpcd_particle_force._detach()
         super()._detach_hook()
 
     @classmethod

--- a/hoomd/mpcd/test/force_test.cc
+++ b/hoomd/mpcd/test/force_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2009-2023 The Regents of the University of Michigan.
+// Copyright (c) 2009-2024 The Regents of the University of Michigan.
 // Part of HOOMD-blue, released under the BSD 3-Clause License.
 
 #include <vector>
@@ -33,7 +33,7 @@ void test_force(std::shared_ptr<Force> force,
 //! Test block force
 UP_TEST(block_force)
     {
-    auto force = std::make_shared<mpcd::BlockForce>(2, 3, 0.2);
+    auto force = std::make_shared<mpcd::BlockForce>(2, 6, 0.4);
     std::vector<Scalar3> ref_pos = {make_scalar3(0, 2.7, 0),
                                     make_scalar3(1, 2.9, 2),
                                     make_scalar3(2, 3.3, 1),

--- a/hoomd/mpcd/test/parallel_plate_geometry_filler_mpi_test.cc
+++ b/hoomd/mpcd/test/parallel_plate_geometry_filler_mpi_test.cc
@@ -40,7 +40,7 @@ void parallel_plate_fill_mpi_test(std::shared_ptr<ExecutionConfiguration> exec_c
     UP_ASSERT_EQUAL(pdata->getNVirtualGlobal(), 0);
 
     // create slit channel with half width 5
-    auto slit = std::make_shared<const mpcd::ParallelPlateGeometry>(5.0, 0.0, true);
+    auto slit = std::make_shared<const mpcd::ParallelPlateGeometry>(10.0, 0.0, true);
     std::shared_ptr<Variant> kT = std::make_shared<VariantConstant>(1.0);
     std::shared_ptr<mpcd::ParallelPlateGeometryFiller> filler
         = std::make_shared<F>(sysdef, "B", 2.0, kT, slit);

--- a/hoomd/mpcd/test/parallel_plate_geometry_filler_test.cc
+++ b/hoomd/mpcd/test/parallel_plate_geometry_filler_test.cc
@@ -31,7 +31,7 @@ void parallel_plate_fill_basic_test(std::shared_ptr<ExecutionConfiguration> exec
     UP_ASSERT_EQUAL(pdata->getNVirtual(), 0);
 
     // create slit channel with half width 5
-    auto slit = std::make_shared<const mpcd::ParallelPlateGeometry>(5.0, 1.0, true);
+    auto slit = std::make_shared<const mpcd::ParallelPlateGeometry>(10.0, 1.0, true);
     std::shared_ptr<Variant> kT = std::make_shared<VariantConstant>(1.5);
     std::shared_ptr<mpcd::ParallelPlateGeometryFiller> filler
         = std::make_shared<F>(sysdef, "B", 2.0, kT, slit);

--- a/hoomd/mpcd/test/parallel_plate_geometry_filler_test.cc
+++ b/hoomd/mpcd/test/parallel_plate_geometry_filler_test.cc
@@ -69,9 +69,9 @@ void parallel_plate_fill_basic_test(std::shared_ptr<ExecutionConfiguration> exec
             UP_ASSERT_EQUAL(__scalar_as_int(h_pos.data[i].w), 1);
 
             const Scalar y = h_pos.data[i].y;
-            if (y < Scalar(-5.0))
+            if (y >= Scalar(-7.0) && y < Scalar(-5.0))
                 ++N_lo;
-            else if (y >= Scalar(5.0))
+            else if (y >= Scalar(5.0) && y < Scalar(7.0))
                 ++N_hi;
             }
         UP_ASSERT_EQUAL(N_lo, 2 * (2 * 20 * 20));
@@ -98,9 +98,9 @@ void parallel_plate_fill_basic_test(std::shared_ptr<ExecutionConfiguration> exec
             UP_ASSERT_EQUAL(h_tag.data[i], i);
 
             const Scalar y = h_pos.data[i].y;
-            if (y < Scalar(-5.0))
+            if (y >= Scalar(-7.0) && y < Scalar(-5.0))
                 ++N_lo;
-            else if (y >= Scalar(5.0))
+            else if (y >= Scalar(5.0) && y < Scalar(7.0))
                 ++N_hi;
             }
         UP_ASSERT_EQUAL(N_lo, 2 * 2 * (2 * 20 * 20));
@@ -122,9 +122,9 @@ void parallel_plate_fill_basic_test(std::shared_ptr<ExecutionConfiguration> exec
         for (unsigned int i = pdata->getN(); i < pdata->getN() + pdata->getNVirtual(); ++i)
             {
             const Scalar y = h_pos.data[i].y;
-            if (y < Scalar(-5.0))
+            if (y >= Scalar(-5.5) && y < Scalar(-5.0))
                 ++N_lo;
-            else if (y >= Scalar(5.0))
+            else if (y >= Scalar(5.0) && y < Scalar(5.5))
                 ++N_hi;
             }
         UP_ASSERT_EQUAL(N_lo, 2 * (20 * 20 / 2));
@@ -154,13 +154,13 @@ void parallel_plate_fill_basic_test(std::shared_ptr<ExecutionConfiguration> exec
             const Scalar y = h_pos.data[i].y;
             const Scalar4 vel_cell = h_vel.data[i];
             const Scalar3 vel = make_scalar3(vel_cell.x, vel_cell.y, vel_cell.z);
-            if (y < Scalar(-5.0))
+            if (y >= Scalar(-7.0) && y < Scalar(-5.0))
                 {
                 v_lo += vel;
                 T_avg += dot(vel - make_scalar3(-1.0, 0, 0), vel - make_scalar3(-1.0, 0, 0));
                 ++N_lo;
                 }
-            else if (y >= Scalar(5.0))
+            else if (y >= Scalar(5.0) && y < Scalar(7.0))
                 {
                 v_hi += vel;
                 T_avg += dot(vel - make_scalar3(1.0, 0, 0), vel - make_scalar3(1.0, 0, 0));

--- a/hoomd/mpcd/test/planar_pore_geometry_filler_mpi_test.cc
+++ b/hoomd/mpcd/test/planar_pore_geometry_filler_mpi_test.cc
@@ -39,7 +39,7 @@ template<class F> void planar_pore_fill_mpi_test(std::shared_ptr<ExecutionConfig
     UP_ASSERT_EQUAL(pdata->getNVirtualGlobal(), 0);
 
     // create slit channel with half width 5 and half length 8
-    auto slit = std::make_shared<const mpcd::PlanarPoreGeometry>(5.0, 8.0, true);
+    auto slit = std::make_shared<const mpcd::PlanarPoreGeometry>(10.0, 16.0, true);
     std::shared_ptr<Variant> kT = std::make_shared<VariantConstant>(1.0);
     std::shared_ptr<mpcd::PlanarPoreGeometryFiller> filler
         = std::make_shared<F>(sysdef, "A", 2.0, kT, slit);

--- a/hoomd/mpcd/test/planar_pore_geometry_filler_test.cc
+++ b/hoomd/mpcd/test/planar_pore_geometry_filler_test.cc
@@ -31,7 +31,7 @@ void planar_pore_fill_basic_test(std::shared_ptr<ExecutionConfiguration> exec_co
     UP_ASSERT_EQUAL(pdata->getNVirtual(), 0);
 
     // create slit pore channel with half width 5, half length 8
-    auto slit = std::make_shared<const mpcd::PlanarPoreGeometry>(5.0, 8.0, true);
+    auto slit = std::make_shared<const mpcd::PlanarPoreGeometry>(10.0, 16.0, true);
     // fill density 2, temperature 1.5
     std::shared_ptr<Variant> kT = std::make_shared<VariantConstant>(1.5);
     std::shared_ptr<mpcd::PlanarPoreGeometryFiller> filler

--- a/hoomd/mpcd/tune.py
+++ b/hoomd/mpcd/tune.py
@@ -38,9 +38,9 @@ class ParticleSorter(TriggeredOperation):
     builds. Typically, using a small multiple (tens) of the collision period
     works best.
 
-    For best performance, the `ParticleSorter` should **not** be added to
+    To achieve the best performance, the `ParticleSorter` is not added to
     `hoomd.Operations.tuners`. Instead, set it in
-    `hoomd.mpcd.Integrator.solvent_sorter`.
+    `hoomd.mpcd.Integrator.mpcd_particle_sorter`.
 
     Essentially all MPCD systems benefit from sorting, so it is recommended
     to use one for all simulations!
@@ -50,7 +50,7 @@ class ParticleSorter(TriggeredOperation):
     .. code-block:: python
 
         sorter = hoomd.mpcd.tune.ParticleSorter(trigger=20)
-        simulation.operations.integrator.solvent_sorter = sorter
+        simulation.operations.integrator.mpcd_particle_sorter = sorter
 
     Attributes:
         trigger (hoomd.trigger.Trigger): Number of integration steps

--- a/hoomd/mpcd/tune.py
+++ b/hoomd/mpcd/tune.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2009-2023 The Regents of the University of Michigan.
+# Copyright (c) 2009-2024 The Regents of the University of Michigan.
 # Part of HOOMD-blue, released under the BSD 3-Clause License.
 
 r"""MPCD tuning operations.

--- a/sphinx-doc/module-mpcd-collide.rst
+++ b/sphinx-doc/module-mpcd-collide.rst
@@ -1,4 +1,4 @@
-.. Copyright (c) 2009-2023 The Regents of the University of Michigan.
+.. Copyright (c) 2009-2024 The Regents of the University of Michigan.
 .. Part of HOOMD-blue, released under the BSD 3-Clause License.
 
 mpcd.collide

--- a/sphinx-doc/module-mpcd-fill.rst
+++ b/sphinx-doc/module-mpcd-fill.rst
@@ -1,4 +1,4 @@
-.. Copyright (c) 2009-2023 The Regents of the University of Michigan.
+.. Copyright (c) 2009-2024 The Regents of the University of Michigan.
 .. Part of HOOMD-blue, released under the BSD 3-Clause License.
 
 mpcd.fill

--- a/sphinx-doc/module-mpcd-force.rst
+++ b/sphinx-doc/module-mpcd-force.rst
@@ -1,4 +1,4 @@
-.. Copyright (c) 2009-2023 The Regents of the University of Michigan.
+.. Copyright (c) 2009-2024 The Regents of the University of Michigan.
 .. Part of HOOMD-blue, released under the BSD 3-Clause License.
 
 mpcd.force

--- a/sphinx-doc/module-mpcd-force.rst
+++ b/sphinx-doc/module-mpcd-force.rst
@@ -11,7 +11,7 @@ mpcd.force
 .. autosummary::
     :nosignatures:
 
-    SolventForce
+    BodyForce
     BlockForce
     ConstantForce
     SineForce
@@ -19,8 +19,8 @@ mpcd.force
 .. rubric:: Details
 
 .. automodule:: hoomd.mpcd.force
-    :synopsis: Solvent forces.
-    :members: SolventForce,
+    :synopsis: Body forces on MPCD particles.
+    :members: BodyForce,
               BlockForce,
               ConstantForce,
               SineForce

--- a/sphinx-doc/module-mpcd-geometry.rst
+++ b/sphinx-doc/module-mpcd-geometry.rst
@@ -1,4 +1,4 @@
-.. Copyright (c) 2009-2023 The Regents of the University of Michigan.
+.. Copyright (c) 2009-2024 The Regents of the University of Michigan.
 .. Part of HOOMD-blue, released under the BSD 3-Clause License.
 
 mpcd.geometry

--- a/sphinx-doc/module-mpcd-methods.rst
+++ b/sphinx-doc/module-mpcd-methods.rst
@@ -1,4 +1,4 @@
-.. Copyright (c) 2009-2023 The Regents of the University of Michigan.
+.. Copyright (c) 2009-2024 The Regents of the University of Michigan.
 .. Part of HOOMD-blue, released under the BSD 3-Clause License.
 
 mpcd.methods

--- a/sphinx-doc/module-mpcd-stream.rst
+++ b/sphinx-doc/module-mpcd-stream.rst
@@ -1,4 +1,4 @@
-.. Copyright (c) 2009-2023 The Regents of the University of Michigan.
+.. Copyright (c) 2009-2024 The Regents of the University of Michigan.
 .. Part of HOOMD-blue, released under the BSD 3-Clause License.
 
 mpcd.stream

--- a/sphinx-doc/module-mpcd-tune.rst
+++ b/sphinx-doc/module-mpcd-tune.rst
@@ -1,4 +1,4 @@
-.. Copyright (c) 2009-2023 The Regents of the University of Michigan.
+.. Copyright (c) 2009-2024 The Regents of the University of Michigan.
 .. Part of HOOMD-blue, released under the BSD 3-Clause License.
 
 mpcd.tune

--- a/sphinx-doc/package-mpcd.rst
+++ b/sphinx-doc/package-mpcd.rst
@@ -1,4 +1,4 @@
-.. Copyright (c) 2009-2023 The Regents of the University of Michigan.
+.. Copyright (c) 2009-2024 The Regents of the University of Michigan.
 .. Part of HOOMD-blue, released under the BSD 3-Clause License.
 
 hoomd.mpcd


### PR DESCRIPTION
## Description

This is a final set of API changes for MPCD in v4 resulting from using the code in some tests. The main changes are to clarify variable names in the force and geometry modules to make them more descriptive.

The pre-commit check failing on this PR due to a recent merge up of `trunk-minor` into `mpcd-v4` bumping the license year, so I ran pre-commit to update those.

## Motivation and context

This makes the API more readable.

## How has this been tested?

Tests have been updated to match the new API.

## Change log

N/A

## Checklist:

- [X] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.rst).
- [X] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [X] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
