### PR TITLE
MPCD migration guide for HOOMD 4

### DIFF
--- a/hoomd/mpcd/BlockForce.h
+++ b/hoomd/mpcd/BlockForce.h
@@ -132,7 +132,7 @@ class __attribute__((visibility("default"))) BlockForce
 namespace detail
     {
 void export_BlockForce(pybind11::module& m);
-    }  // end namespace detail
+    } // end namespace detail
 #endif // __HIPCC__
 
     } // end namespace mpcd

--- a/hoomd/mpcd/BulkStreamingMethod.h
+++ b/hoomd/mpcd/BulkStreamingMethod.h
@@ -33,12 +33,12 @@ class PYBIND11_EXPORT BulkStreamingMethod
                         int phase,
                         std::shared_ptr<Force> force)
         : mpcd::BounceBackStreamingMethod<mpcd::detail::BulkGeometry, Force>(
-            sysdef,
-            cur_timestep,
-            period,
-            phase,
-            std::make_shared<mpcd::detail::BulkGeometry>(),
-            force)
+              sysdef,
+              cur_timestep,
+              period,
+              phase,
+              std::make_shared<mpcd::detail::BulkGeometry>(),
+              force)
         {
         }
     };

--- a/hoomd/mpcd/BulkStreamingMethodGPU.h
+++ b/hoomd/mpcd/BulkStreamingMethodGPU.h
@@ -33,12 +33,12 @@ class PYBIND11_EXPORT BulkStreamingMethodGPU
                            int phase,
                            std::shared_ptr<Force> force)
         : mpcd::BounceBackStreamingMethodGPU<mpcd::detail::BulkGeometry, Force>(
-            sysdef,
-            cur_timestep,
-            period,
-            phase,
-            std::make_shared<mpcd::detail::BulkGeometry>(),
-            force)
+              sysdef,
+              cur_timestep,
+              period,
+              phase,
+              std::make_shared<mpcd::detail::BulkGeometry>(),
+              force)
         {
         }
     };

--- a/hoomd/mpcd/ConstantForce.h
+++ b/hoomd/mpcd/ConstantForce.h
@@ -77,7 +77,7 @@ class __attribute__((visibility("default"))) ConstantForce
 namespace detail
     {
 void export_ConstantForce(pybind11::module& m);
-    }  // end namespace detail
+    } // end namespace detail
 #endif // __HIPCC__
 
     } // end namespace mpcd

--- a/hoomd/mpcd/ManualVirtualParticleFiller.h
+++ b/hoomd/mpcd/ManualVirtualParticleFiller.h
@@ -61,7 +61,7 @@ namespace detail
     {
 //! Export the ManualVirtualParticleFiller to python
 void export_ManualVirtualParticleFiller(pybind11::module& m);
-    }  // end namespace detail
-    }  // end namespace mpcd
-    }  // end namespace hoomd
+    } // end namespace detail
+    } // end namespace mpcd
+    } // end namespace hoomd
 #endif // MPCD_MANUAL_VIRTUAL_PARTICLE_FILLER_H_

--- a/hoomd/mpcd/NoForce.h
+++ b/hoomd/mpcd/NoForce.h
@@ -54,7 +54,7 @@ class NoForce
 namespace detail
     {
 void export_NoForce(pybind11::module& m);
-    }  // end namespace detail
+    } // end namespace detail
 #endif // __HIPCC__
 
     } // end namespace mpcd

--- a/hoomd/mpcd/ParallelPlateGeometryFiller.h
+++ b/hoomd/mpcd/ParallelPlateGeometryFiller.h
@@ -66,7 +66,7 @@ namespace detail
     {
 //! Export ParallelPlateGeometryFiller to python
 void export_ParallelPlateGeometryFiller(pybind11::module& m);
-    }  // end namespace detail
-    }  // end namespace mpcd
-    }  // end namespace hoomd
+    } // end namespace detail
+    } // end namespace mpcd
+    } // end namespace hoomd
 #endif // MPCD_PARALLEL_PLATE_GEOMETRY_FILLER_H_

--- a/hoomd/mpcd/ParallelPlateGeometryFillerGPU.h
+++ b/hoomd/mpcd/ParallelPlateGeometryFillerGPU.h
@@ -44,7 +44,7 @@ namespace detail
     {
 //! Export ParallelPlateGeometryFillerGPU to python
 void export_ParallelPlateGeometryFillerGPU(pybind11::module& m);
-    }  // end namespace detail
-    }  // end namespace mpcd
-    }  // end namespace hoomd
+    } // end namespace detail
+    } // end namespace mpcd
+    } // end namespace hoomd
 #endif // MPCD_PARALLEL_PLATE_GEOMETRY_FILLER_GPU_H_

--- a/hoomd/mpcd/PlanarPoreGeometryFiller.h
+++ b/hoomd/mpcd/PlanarPoreGeometryFiller.h
@@ -74,8 +74,8 @@ class PYBIND11_EXPORT PlanarPoreGeometryFiller : public mpcd::ManualVirtualParti
 
 namespace detail
     {
-//! Export SlitPoreGeometryFiller to python
-void export_SlitPoreGeometryFiller(pybind11::module& m);
+//! Export PlanarPoreGeometryFiller to python
+void export_PlanarPoreGeometryFiller(pybind11::module& m);
     } // end namespace detail
     } // end namespace mpcd
     } // end namespace hoomd

--- a/hoomd/mpcd/PlanarPoreGeometryFillerGPU.h
+++ b/hoomd/mpcd/PlanarPoreGeometryFillerGPU.h
@@ -42,8 +42,8 @@ class PYBIND11_EXPORT PlanarPoreGeometryFillerGPU : public mpcd::PlanarPoreGeome
 
 namespace detail
     {
-//! Export SlitPoreGeometryFillerGPU to python
-void export_SlitPoreGeometryFillerGPU(pybind11::module& m);
+//! Export PlanarPoreGeometryFillerGPU to python
+void export_PlanarPoreGeometryFillerGPU(pybind11::module& m);
     } // end namespace detail
     } // end namespace mpcd
     } // end namespace hoomd

--- a/hoomd/mpcd/SineForce.h
+++ b/hoomd/mpcd/SineForce.h
@@ -103,7 +103,7 @@ class __attribute__((visibility("default"))) SineForce
 namespace detail
     {
 void export_SineForce(pybind11::module& m);
-    }  // end namespace detail
+    } // end namespace detail
 #endif // __HIPCC__
 
     } // end namespace mpcd


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should be based on *trunk-patch*. -->
<!-- Backwards compatible new features should be based on *trunk-minor*. -->
<!-- Incompatible API changes should be based on *trunk-major*. -->

## Description

This PR adds a migration guide for moving MPCD scripts from HOOMD 2 to HOOMD 4.

This should be the last thing needed to finalize `mpcd-v4` for release! After this is merged, I can open a PR for `mpcd-v4` into `trunk-minor`.

## Motivation and context

Users will need help doing this.

## How has this been tested?

I read the documentation locally.

## Change log

N/A

## Checklist:

- [X] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.rst).
- [X] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [X] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
