### PR TITLE
Fix HPMC pair potential cpp class name in python to enable HPMC pair potentials from external components

### DIFF
--- a/hoomd/hpmc/pair/pair.py
+++ b/hoomd/hpmc/pair/pair.py
@@ -17,6 +17,7 @@
 """
 
 import hoomd
+from hoomd.hpmc import _hpmc
 
 
 class Pair(hoomd.operation._HOOMDBaseObject):
@@ -34,9 +35,11 @@ class Pair(hoomd.operation._HOOMDBaseObject):
         `Pair` should not be instantiated directly by users.
     """
 
+    _ext_module = _hpmc
+
     def _make_cpp_obj(self):
         cpp_sys_def = self._simulation.state._cpp_sys_def
-        cls = getattr(hoomd.hpmc._hpmc, self._cpp_class_name)
+        cls = getattr(self._ext_module, self._cpp_class_name)
         return cls(cpp_sys_def)
 
     def _attach_hook(self):


### PR DESCRIPTION
## Description

See title.

## Motivation and context

HOOMD-blue needs to support external components that provide HPMC pair potentials, especially with JIT on its way out.

## How has this been tested?

Tested locally. My component builds and runs as expected. 

## Change log

```

```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
