### PR TITLE
Add error when ellipsoid axis is zero

### DIFF
--- a/hoomd/hpmc/ShapeEllipsoid.h
+++ b/hoomd/hpmc/ShapeEllipsoid.h
@@ -67,8 +67,7 @@ struct EllipsoidParams : ShapeParams
         y = v["b"].cast<ShortReal>();
         z = v["c"].cast<ShortReal>();
 
-        if (x <= ELLIPSOID_OVERLAP_PRECISION || y <= ELLIPSOID_OVERLAP_PRECISION
-            || z <= ELLIPSOID_OVERLAP_PRECISION)
+        if (x <= 0.0f || y <= 0.0f || z <= 0.0f)
             {
             throw std::domain_error("All semimajor axes must be nonzero!");
             }

--- a/hoomd/hpmc/ShapeEllipsoid.h
+++ b/hoomd/hpmc/ShapeEllipsoid.h
@@ -66,6 +66,12 @@ struct EllipsoidParams : ShapeParams
         x = v["a"].cast<ShortReal>();
         y = v["b"].cast<ShortReal>();
         z = v["c"].cast<ShortReal>();
+
+        if (x <= ELLIPSOID_OVERLAP_PRECISION || y <= ELLIPSOID_OVERLAP_PRECISION
+            || z <= ELLIPSOID_OVERLAP_PRECISION)
+            {
+            throw std::domain_error("All semimajor axes must be nonzero!");
+            }
         }
 
     /// Convert parameters to a python dictionary

--- a/hoomd/hpmc/ShapeFacetedEllipsoid.h
+++ b/hoomd/hpmc/ShapeFacetedEllipsoid.h
@@ -72,56 +72,57 @@ struct FacetedEllipsoidParams : ShapeParams
             }
         }
 
-        if (pybind11::len(offsets) != pybind11::len(normals))
-            throw std::runtime_error("Number of normals unequal number of offsets");
+    if (pybind11::len(offsets) != pybind11::len(normals))
+        throw std::runtime_error("Number of normals unequal number of offsets");
 
-        // extract the normals from the python list
-        for (unsigned int i = 0; i < len(normals); i++)
-            {
-            pybind11::list normals_i = normals[i];
-            if (len(normals_i) != 3)
-                throw std::runtime_error("Each normal must have 3 elements: found "
-                                         + pybind11::str(normals_i).cast<std::string>() + " in "
-                                         + pybind11::str(normals).cast<std::string>());
-            n[i] = vec3<ShortReal>(pybind11::cast<ShortReal>(normals_i[0]),
-                                   pybind11::cast<ShortReal>(normals_i[1]),
-                                   pybind11::cast<ShortReal>(normals_i[2]));
-            offset[i] = pybind11::cast<ShortReal>(offsets[i]);
-            }
-
-        // extract the vertices from the python list
-        pybind11::list vertices_list;
-        if (!vertices.is_none())
-            {
-            vertices_list = pybind11::list(vertices);
-            }
-        // when vertices is None, pass an empty list to PolyhedronVertices
-
-        pybind11::dict verts_dict;
-        verts_dict["vertices"] = vertices_list;
-        verts_dict["sweep_radius"] = 0;
-        verts_dict["ignore_statistics"] = ignore;
-        verts = PolyhedronVertices(verts_dict, managed);
-
-        // scale vertices onto the surface of the ellipsoid
-        for (unsigned int i = 0; i < verts.N; ++i)
-            {
-            verts.x[i] /= a;
-            verts.y[i] /= b;
-            verts.z[i] /= c;
-            }
-
-        // set the origin
-        origin = vec3<ShortReal>(pybind11::cast<ShortReal>(origin_tuple[0]),
-                                 pybind11::cast<ShortReal>(origin_tuple[1]),
-                                 pybind11::cast<ShortReal>(origin_tuple[2]));
-
-        // add the edge-sphere vertices
-        initializeVertices(managed);
+    // extract the normals from the python list
+    for (unsigned int i = 0; i < len(normals); i++)
+        {
+        pybind11::list normals_i = normals[i];
+        if (len(normals_i) != 3)
+            throw std::runtime_error("Each normal must have 3 elements: found "
+                                     + pybind11::str(normals_i).cast<std::string>() + " in "
+                                     + pybind11::str(normals).cast<std::string>());
+        n[i] = vec3<ShortReal>(pybind11::cast<ShortReal>(normals_i[0]),
+                               pybind11::cast<ShortReal>(normals_i[1]),
+                               pybind11::cast<ShortReal>(normals_i[2]));
+        offset[i] = pybind11::cast<ShortReal>(offsets[i]);
         }
 
+    // extract the vertices from the python list
+    pybind11::list vertices_list;
+    if (!vertices.is_none())
+        {
+        vertices_list = pybind11::list(vertices);
+        }
+    // when vertices is None, pass an empty list to PolyhedronVertices
+
+    pybind11::dict verts_dict;
+    verts_dict["vertices"] = vertices_list;
+    verts_dict["sweep_radius"] = 0;
+    verts_dict["ignore_statistics"] = ignore;
+    verts = PolyhedronVertices(verts_dict, managed);
+
+    // scale vertices onto the surface of the ellipsoid
+    for (unsigned int i = 0; i < verts.N; ++i)
+        {
+        verts.x[i] /= a;
+        verts.y[i] /= b;
+        verts.z[i] /= c;
+        }
+
+    // set the origin
+    origin = vec3<ShortReal>(pybind11::cast<ShortReal>(origin_tuple[0]),
+                             pybind11::cast<ShortReal>(origin_tuple[1]),
+                             pybind11::cast<ShortReal>(origin_tuple[2]));
+
+    // add the edge-sphere vertices
+    initializeVertices(managed);
+    }
+
     /// Convert parameters to a python dictionary
-    pybind11::dict asDict()
+    pybind11::dict
+    asDict()
         {
         pybind11::dict v;
         pybind11::list vertices = verts.asDict()["vertices"];
@@ -347,7 +348,8 @@ struct FacetedEllipsoidParams : ShapeParams
         additional_verts.set_memory_hint();
         }
 #endif
-    } __attribute__((aligned(32)));
+    }
+__attribute__((aligned(32)));
 
 /// Support function for ShapeFacetedEllipsoid
 class SupportFuncFacetedEllipsoid
@@ -656,7 +658,7 @@ test_overlap<ShapeFacetedEllipsoid, ShapeFacetedEllipsoid>(const vec3<Scalar>& r
     }
 
     } // end namespace hpmc
-    } // end namespace hoomd
+} // end namespace hoomd
 
 #undef DEVICE
 #undef HOSTDEVICE

--- a/hoomd/hpmc/ShapeFacetedEllipsoid.h
+++ b/hoomd/hpmc/ShapeFacetedEllipsoid.h
@@ -66,6 +66,12 @@ struct FacetedEllipsoidParams : ShapeParams
         pybind11::tuple origin_tuple = v["origin"];
         ignore = v["ignore_statistics"].cast<unsigned int>();
 
+        if (a <= 0.0f || b <= 0.0f || c <= 0.0f)
+            {
+            throw std::domain_error("All semimajor axes must be nonzero!");
+            }
+        }
+
         if (pybind11::len(offsets) != pybind11::len(normals))
             throw std::runtime_error("Number of normals unequal number of offsets");
 

--- a/hoomd/hpmc/ShapeFacetedEllipsoid.h
+++ b/hoomd/hpmc/ShapeFacetedEllipsoid.h
@@ -70,59 +70,57 @@ struct FacetedEllipsoidParams : ShapeParams
             {
             throw std::domain_error("All semimajor axes must be nonzero!");
             }
+
+        if (pybind11::len(offsets) != pybind11::len(normals))
+            throw std::runtime_error("Number of normals unequal number of offsets");
+
+        // extract the normals from the python list
+        for (unsigned int i = 0; i < len(normals); i++)
+            {
+            pybind11::list normals_i = normals[i];
+            if (len(normals_i) != 3)
+                throw std::runtime_error("Each normal must have 3 elements: found "
+                                         + pybind11::str(normals_i).cast<std::string>() + " in "
+                                         + pybind11::str(normals).cast<std::string>());
+            n[i] = vec3<ShortReal>(pybind11::cast<ShortReal>(normals_i[0]),
+                                   pybind11::cast<ShortReal>(normals_i[1]),
+                                   pybind11::cast<ShortReal>(normals_i[2]));
+            offset[i] = pybind11::cast<ShortReal>(offsets[i]);
+            }
+
+        // extract the vertices from the python list
+        pybind11::list vertices_list;
+        if (!vertices.is_none())
+            {
+            vertices_list = pybind11::list(vertices);
+            }
+        // when vertices is None, pass an empty list to PolyhedronVertices
+
+        pybind11::dict verts_dict;
+        verts_dict["vertices"] = vertices_list;
+        verts_dict["sweep_radius"] = 0;
+        verts_dict["ignore_statistics"] = ignore;
+        verts = PolyhedronVertices(verts_dict, managed);
+
+        // scale vertices onto the surface of the ellipsoid
+        for (unsigned int i = 0; i < verts.N; ++i)
+            {
+            verts.x[i] /= a;
+            verts.y[i] /= b;
+            verts.z[i] /= c;
+            }
+
+        // set the origin
+        origin = vec3<ShortReal>(pybind11::cast<ShortReal>(origin_tuple[0]),
+                                 pybind11::cast<ShortReal>(origin_tuple[1]),
+                                 pybind11::cast<ShortReal>(origin_tuple[2]));
+
+        // add the edge-sphere vertices
+        initializeVertices(managed);
         }
-
-    if (pybind11::len(offsets) != pybind11::len(normals))
-        throw std::runtime_error("Number of normals unequal number of offsets");
-
-    // extract the normals from the python list
-    for (unsigned int i = 0; i < len(normals); i++)
-        {
-        pybind11::list normals_i = normals[i];
-        if (len(normals_i) != 3)
-            throw std::runtime_error("Each normal must have 3 elements: found "
-                                     + pybind11::str(normals_i).cast<std::string>() + " in "
-                                     + pybind11::str(normals).cast<std::string>());
-        n[i] = vec3<ShortReal>(pybind11::cast<ShortReal>(normals_i[0]),
-                               pybind11::cast<ShortReal>(normals_i[1]),
-                               pybind11::cast<ShortReal>(normals_i[2]));
-        offset[i] = pybind11::cast<ShortReal>(offsets[i]);
-        }
-
-    // extract the vertices from the python list
-    pybind11::list vertices_list;
-    if (!vertices.is_none())
-        {
-        vertices_list = pybind11::list(vertices);
-        }
-    // when vertices is None, pass an empty list to PolyhedronVertices
-
-    pybind11::dict verts_dict;
-    verts_dict["vertices"] = vertices_list;
-    verts_dict["sweep_radius"] = 0;
-    verts_dict["ignore_statistics"] = ignore;
-    verts = PolyhedronVertices(verts_dict, managed);
-
-    // scale vertices onto the surface of the ellipsoid
-    for (unsigned int i = 0; i < verts.N; ++i)
-        {
-        verts.x[i] /= a;
-        verts.y[i] /= b;
-        verts.z[i] /= c;
-        }
-
-    // set the origin
-    origin = vec3<ShortReal>(pybind11::cast<ShortReal>(origin_tuple[0]),
-                             pybind11::cast<ShortReal>(origin_tuple[1]),
-                             pybind11::cast<ShortReal>(origin_tuple[2]));
-
-    // add the edge-sphere vertices
-    initializeVertices(managed);
-    }
 
     /// Convert parameters to a python dictionary
-    pybind11::dict
-    asDict()
+    pybind11::dict asDict()
         {
         pybind11::dict v;
         pybind11::list vertices = verts.asDict()["vertices"];
@@ -348,8 +346,7 @@ struct FacetedEllipsoidParams : ShapeParams
         additional_verts.set_memory_hint();
         }
 #endif
-    }
-__attribute__((aligned(32)));
+    } __attribute__((aligned(32)));
 
 /// Support function for ShapeFacetedEllipsoid
 class SupportFuncFacetedEllipsoid
@@ -658,7 +655,7 @@ test_overlap<ShapeFacetedEllipsoid, ShapeFacetedEllipsoid>(const vec3<Scalar>& r
     }
 
     } // end namespace hpmc
-} // end namespace hoomd
+    } // end namespace hoomd
 
 #undef DEVICE
 #undef HOSTDEVICE

--- a/hoomd/hpmc/pytest/test_shape.py
+++ b/hoomd/hpmc/pytest/test_shape.py
@@ -80,7 +80,7 @@ def test_invalid_shape_params(invalid_args):
         mc.shape["A"] = args
 
 
-@pytest.mark.parametrize("c", [0.0, 1e-8, -0.5])
+@pytest.mark.parametrize("c", [0.0, -0.5])
 def test_ellipsoid_semimajor_axis(c):
     cpp_shape = hoomd.hpmc._hpmc.EllipsoidParams
     args = {'a': 0.125, 'b': 0.375, 'c': c}

--- a/hoomd/hpmc/pytest/test_shape.py
+++ b/hoomd/hpmc/pytest/test_shape.py
@@ -85,7 +85,16 @@ def test_invalid_shape_params(invalid_args):
     [hoomd.hpmc._hpmc.EllipsoidParams, hoomd.hpmc._hpmc.FacetedEllipsoidParams])
 @pytest.mark.parametrize("c", [0.0, -0.5])
 def test_semimajor_axis_validity(cpp_shape, c):
-    args = {'a': 0.125, 'b': 0.375, 'c': c}
+    args = {
+        'a': 0.125,
+        'b': 0.375,
+        'c': c,
+        # These properties are only read for the FacetedEllipsoid
+        'normals': [],
+        'offsets': [],
+        'vertices': [],
+        'origin': []
+    }
     with pytest.raises(ValueError) as err:
         cpp_shape({"ignore_statistics": False} | args)
 

--- a/hoomd/hpmc/pytest/test_shape.py
+++ b/hoomd/hpmc/pytest/test_shape.py
@@ -80,9 +80,11 @@ def test_invalid_shape_params(invalid_args):
         mc.shape["A"] = args
 
 
+@pytest.mark.parametrize(
+    "cpp_shape",
+    [hoomd.hpmc._hpmc.EllipsoidParams, hoomd.hpmc._hpmc.FacetedEllipsoidParams])
 @pytest.mark.parametrize("c", [0.0, -0.5])
-def test_ellipsoid_semimajor_axis(c):
-    cpp_shape = hoomd.hpmc._hpmc.EllipsoidParams
+def test_semimajor_axis_validity(cpp_shape, c):
     args = {'a': 0.125, 'b': 0.375, 'c': c}
     with pytest.raises(ValueError) as err:
         cpp_shape({"ignore_statistics": False} | args)

--- a/hoomd/hpmc/pytest/test_shape.py
+++ b/hoomd/hpmc/pytest/test_shape.py
@@ -80,6 +80,16 @@ def test_invalid_shape_params(invalid_args):
         mc.shape["A"] = args
 
 
+@pytest.mark.parametrize("c", [0.0, 1e-8, -0.5])
+def test_ellipsoid_semimajor_axis(c):
+    cpp_shape = hoomd.hpmc._hpmc.EllipsoidParams
+    args = {'a': 0.125, 'b': 0.375, 'c': c}
+    with pytest.raises(ValueError) as err:
+        cpp_shape({"ignore_statistics": False} | args)
+
+    assert ("All semimajor axes must be nonzero!" in str(err))
+
+
 def test_shape_attached(simulation_factory, two_particle_snapshot_factory,
                         valid_args):
     integrator = valid_args[0]


### PR DESCRIPTION
## Description

A check was added to verify values are within the expected range. ~I set the minimum allowed value to `ELLIPSOID_OVERLAP_PRECISION` (1e-6), which may or may not be the correct choice. We could do FLT_EPSILON from <cfloat> as well, but that may not be consistent if `HOOMD_SHORTREAL_SIZE==64`.~ I am open to suggestions about the correct value to assign.

Errors occur then any semimajor axis is less than `0.0f`.

## Motivation and context

Overlap checks do not work for ellipsoids with any semimajor axis less than zero. This error (on the c++ level) prevents users from inadvertently encountering this issue.

Resolves #1762

## How has this been tested?

A new test has been added that attempts to set invalid parameters. This tests values at zero, slightly above zero, and well below it.

## Change log

<!-- Propose a change log entry. -->
```
- Provide an error message for invalid Ellipsoid shape params.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
