### PR TITLE
Fix typo in tune and boxmc tune docs

### DIFF
--- a/hoomd/hpmc/nec/tune.py
+++ b/hoomd/hpmc/nec/tune.py
@@ -272,7 +272,7 @@ class ChainTime(_InternalCustomTuner):
 
         Note:
             Increasing ``gamma`` towards 1 does not necessarily speed up
-            convergence and can slow it done. In addition, large values of
+            convergence and can slow it down. In addition, large values of
             ``gamma`` can make the solver unstable especially when tuning
             frequently.
         """

--- a/hoomd/hpmc/nec/tune.py
+++ b/hoomd/hpmc/nec/tune.py
@@ -273,7 +273,7 @@ class ChainTime(_InternalCustomTuner):
         Note:
             Increasing ``gamma`` towards 1 does not necessarily speed up
             convergence and can slow it down. In addition, large values of
-            ``gamma`` can make the solver unstable especially when tuning
+            ``gamma`` can make the solver unstable, especially when tuning
             frequently.
         """
         solver = SecantSolver(gamma, tol)

--- a/hoomd/hpmc/tune/boxmc_move_size.py
+++ b/hoomd/hpmc/tune/boxmc_move_size.py
@@ -318,7 +318,7 @@ class BoxMCMoveSize(_InternalCustomTuner):
         Note:
             Increasing ``gamma`` towards 1 does not necessarily speed up
             convergence and can slow it down. In addition, large values of
-            ``gamma`` can make the solver unstable especially when tuning
+            ``gamma`` can make the solver unstable, especially when tuning
             frequently.
         """
         solver = SecantSolver(gamma, tol)

--- a/hoomd/hpmc/tune/boxmc_move_size.py
+++ b/hoomd/hpmc/tune/boxmc_move_size.py
@@ -317,7 +317,7 @@ class BoxMCMoveSize(_InternalCustomTuner):
 
         Note:
             Increasing ``gamma`` towards 1 does not necessarily speed up
-            convergence and can slow it done. In addition, large values of
+            convergence and can slow it down. In addition, large values of
             ``gamma`` can make the solver unstable especially when tuning
             frequently.
         """


### PR DESCRIPTION
## Description

Fixed a typo present in the docs for boxmc-tune and tune. No code was changed.


## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
