### PR TITLE
Small docfix: fix namespace error in example in md.force.Custom docstring

### DIFF
--- a/hoomd/md/force.py
+++ b/hoomd/md/force.py
@@ -241,9 +241,11 @@ class Custom(Force):
       See the documentation in `hoomd.State` for more information on the local
       snapshot API.
 
-    Examples::
+    .. rubric:: Examples:
 
-        class MyCustomForce(hoomd.force.Custom):
+    .. code-block:: python
+
+        class MyCustomForce(hoomd.md.force.Custom):
             def __init__(self):
                 super().__init__(aniso=True)
 
@@ -263,9 +265,9 @@ class Custom(Force):
         Pass ``aniso=True`` to the `md.force.Custom` constructor if your custom
         force produces non-zero torques on particles.
 
-    Examples::
+    .. code-block:: python
 
-        class MyCustomForce(hoomd.force.Custom):
+        class MyCustomForce(hoomd.md.force.Custom):
             def __init__(self):
                 super().__init__()
 


### PR DESCRIPTION
## Description

Fixes a namespace error in the examples in the docstring of `md.force.Custom`

## Motivation and context

Working examples are better than non-working examples in the documentation.

## How has this been tested?

Added `sybil` to the docstring and now it passes the unit tests.


## Change log

<!-- Propose a change log entry. -->
```

```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
