### PR TITLE
Provide full CUDA errors for device scan messages.

### DIFF
--- a/hoomd/ExecutionConfiguration.cc
+++ b/hoomd/ExecutionConfiguration.cc
@@ -417,12 +417,12 @@ void ExecutionConfiguration::scanGPUs()
     if (error != hipSuccess)
         {
         std::string message = "Failed to get GPU device count: ";
-        #ifdef __HIP_PLATFORM_NVCC__
-                cudaError_t cuda_error = cudaPeekAtLastError();
-                message += string(cudaGetErrorString(cuda_error));
-        #else
-                message += string(hipGetErrorString(error));
-        #endif
+#ifdef __HIP_PLATFORM_NVCC__
+        cudaError_t cuda_error = cudaPeekAtLastError();
+        message += string(cudaGetErrorString(cuda_error));
+#else
+        message += string(hipGetErrorString(error));
+#endif
         s_gpu_scan_messages.push_back(message);
         return;
         }
@@ -442,12 +442,12 @@ void ExecutionConfiguration::scanGPUs()
         if (error != hipSuccess)
             {
             std::string message = "Failed to get device properties: ";
-            #ifdef __HIP_PLATFORM_NVCC__
-                    cudaError_t cuda_error = cudaPeekAtLastError();
-                    message += string(cudaGetErrorString(cuda_error));
-            #else
-                    message += string(hipGetErrorString(error));
-            #endif
+#ifdef __HIP_PLATFORM_NVCC__
+            cudaError_t cuda_error = cudaPeekAtLastError();
+            message += string(cudaGetErrorString(cuda_error));
+#else
+            message += string(hipGetErrorString(error));
+#endif
             s_gpu_scan_messages.push_back(message);
             continue;
             }

--- a/hoomd/ExecutionConfiguration.cc
+++ b/hoomd/ExecutionConfiguration.cc
@@ -416,8 +416,14 @@ void ExecutionConfiguration::scanGPUs()
     hipError_t error = hipGetDeviceCount(&dev_count);
     if (error != hipSuccess)
         {
-        s_gpu_scan_messages.push_back("Failed to get GPU device count: "
-                                      + string(hipGetErrorString(error)));
+        std::string message = "Failed to get GPU device count: ";
+        #ifdef __HIP_PLATFORM_NVCC__
+                cudaError_t cuda_error = cudaPeekAtLastError();
+                message += string(cudaGetErrorString(cuda_error));
+        #else
+                message += string(hipGetErrorString(error));
+        #endif
+        s_gpu_scan_messages.push_back(message);
         return;
         }
 
@@ -435,8 +441,14 @@ void ExecutionConfiguration::scanGPUs()
 
         if (error != hipSuccess)
             {
-            s_gpu_scan_messages.push_back("Failed to get device properties: "
-                                          + string(hipGetErrorString(error)));
+            std::string message = "Failed to get device properties: ";
+            #ifdef __HIP_PLATFORM_NVCC__
+                    cudaError_t cuda_error = cudaPeekAtLastError();
+                    message += string(cudaGetErrorString(cuda_error));
+            #else
+                    message += string(hipGetErrorString(error));
+            #endif
+            s_gpu_scan_messages.push_back(message);
             continue;
             }
 


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should be based on *trunk-patch*. -->
<!-- Backwards compatible new features should be based on *trunk-minor*. -->
<!-- Incompatible API changes should be based on *trunk-major*. -->

## Description

<!-- Describe your changes in detail. -->
Provide full CUDA errors for device scan messages.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
HIP errors state "Unknown error" for almost every CUDA error. This does not help users.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
CI checks.

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
Changed:

* Provide the full CUDA error message when scanning devices
  (`#1803 <https://github.com/glotzerlab/hoomd-blue/pull/1803>`__).

```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
