### PR TITLE
Fix ALJ shape checking

### DIFF
--- a/hoomd/md/pair/aniso.py
+++ b/hoomd/md/pair/aniso.py
@@ -431,7 +431,7 @@ class ALJ(AnisotropicPair):
         * ``vertices`` (`list` [`tuple` [`float`, `float`, `float`]],
           **required**) - The vertices of a convex polytope in 2 or 3
           dimensions. The third dimension in 2D is ignored.
-        * ``rounding_radii`` (`tuple` [`float`, `float`, `float`] or `float`) 
+        * ``rounding_radii`` (`tuple` [`float`, `float`, `float`] or `float`)
           - The semimajor axes of a rounding ellipsoid
           :math:`R_{\mathrm{rounding},i}`. If a single value is specified, the
           rounding ellipsoid is a sphere. Defaults to (0.0, 0.0, 0.0).

--- a/hoomd/md/pair/aniso.py
+++ b/hoomd/md/pair/aniso.py
@@ -431,8 +431,8 @@ class ALJ(AnisotropicPair):
         * ``vertices`` (`list` [`tuple` [`float`, `float`, `float`]],
           **required**) - The vertices of a convex polytope in 2 or 3
           dimensions. The third dimension in 2D is ignored.
-        * ``rounding_radii`` (`tuple` [`float`, `float`, `float`] or `float`,
-          **required**) - The semimajor axes of a rounding ellipsoid
+        * ``rounding_radii`` (`tuple` [`float`, `float`, `float`] or `float`) 
+          - The semimajor axes of a rounding ellipsoid
           :math:`R_{\mathrm{rounding},i}`. If a single value is specified, the
           rounding ellipsoid is a sphere. Defaults to (0.0, 0.0, 0.0).
         * ``faces`` (`list` [`list` [`int`]], **required**) - The faces of the

--- a/hoomd/md/pair/aniso.py
+++ b/hoomd/md/pair/aniso.py
@@ -534,7 +534,7 @@ class ALJ(AnisotropicPair):
                                   to_type_converter((float, float, float)),
                                   preprocess=self._to_three_tuple),
                               len_keys=1,
-                              _defaults={'rounding_radii', (0.0, 0.0, 0.0)}))
+                              _defaults={'rounding_radii': (0.0, 0.0, 0.0)}))
 
         self._extend_typeparam((params, shape))
 


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should be based on *trunk-patch*. -->
<!-- Backwards compatible new features should be based on *trunk-minor*. -->
<!-- Incompatible API changes should be based on *trunk-major*. -->

## Description

<!-- Describe your changes in detail. -->
Correctly set the default `rounding_radii` and document that it is not required.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Properly issue the error:
```
hoomd.error.IncompleteSpecificationError: For <class 'hoomd.md.pair.aniso.ALJ'> in TypeParameter shape for key B value for key vertices in index 0 in index 0 is required
```
instead of
```
ValueError: For <class 'hoomd.md.pair.aniso.ALJ'> in TypeParameter shape dictionary update sequence element #0 has length 3; 2 is required
```
when the user does not set the `shape` for a particle type.

<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves #1805

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
I tested with the the reproducer in #1805.

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
Fixed:

* Issue a proper error message when `ALJ.shape` is not set for all particle types
  (`#1808 <https://github.com/glotzerlab/hoomd-blue/pull/1808>`__).

```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
