### PR TITLE
Enhancement/md pair gaussian value check

### DIFF
--- a/hoomd/md/pair/pair.py
+++ b/hoomd/md/pair/pair.py
@@ -310,8 +310,8 @@ class ExpandedGaussian(Pair):
 
         * ``epsilon`` (`float`, **required**) - energy parameter
           :math:`\varepsilon` :math:`[\mathrm{energy}]`
-        * ``sigma`` (`float` > 0, **required**) - particle size
-          :math:`\sigma` :math:`[\mathrm{length}]`
+        * ``sigma`` (`float`, **required**) - particle size
+          :math:`\sigma > 0` :math:`[\mathrm{length}]`
         * ``delta`` (`float`, **required**) - shift distance
           :math:`\delta` :math:`[\mathrm{length}]`
 

--- a/hoomd/md/pair/pair.py
+++ b/hoomd/md/pair/pair.py
@@ -257,7 +257,7 @@ class Gaussian(Pair):
 
         * ``epsilon`` (`float`, **required**) - energy parameter
           :math:`\varepsilon` :math:`[\mathrm{energy}]`
-        * ``sigma`` (`float` > 0, **required**) - particle size :math:`\sigma`
+        * ``sigma`` (`float`, **required**) - particle size :math:`\sigma > 0`
           :math:`[\mathrm{length}]`
 
         Type: `TypeParameter` [`tuple` [``particle_type``, ``particle_type``],

--- a/hoomd/md/pair/pair.py
+++ b/hoomd/md/pair/pair.py
@@ -1868,6 +1868,8 @@ class LJGauss(Pair):
         super().__init__(nlist, default_r_cut, default_r_on, mode)
         params = TypeParameter(
             'params', 'particle_types',
-            TypeParameterDict(epsilon=float, sigma=positive_real,
-                              r0=float, len_keys=2))
+            TypeParameterDict(epsilon=float, 
+                              sigma=positive_real,
+                              r0=float, 
+                              len_keys=2))
         self._add_typeparam(params)

--- a/hoomd/md/pair/pair.py
+++ b/hoomd/md/pair/pair.py
@@ -1868,6 +1868,6 @@ class LJGauss(Pair):
         super().__init__(nlist, default_r_cut, default_r_on, mode)
         params = TypeParameter(
             'params', 'particle_types',
-            TypeParameterDict(epsilon=float, sigma=positive_real, 
+            TypeParameterDict(epsilon=float, sigma=positive_real,
                               r0=float, len_keys=2))
         self._add_typeparam(params)

--- a/hoomd/md/pair/pair.py
+++ b/hoomd/md/pair/pair.py
@@ -1868,8 +1868,8 @@ class LJGauss(Pair):
         super().__init__(nlist, default_r_cut, default_r_on, mode)
         params = TypeParameter(
             'params', 'particle_types',
-            TypeParameterDict(epsilon=float, 
+            TypeParameterDict(epsilon=float,
                               sigma=positive_real,
-                              r0=float, 
+                              r0=float,
                               len_keys=2))
         self._add_typeparam(params)

--- a/hoomd/md/pair/pair.py
+++ b/hoomd/md/pair/pair.py
@@ -12,7 +12,7 @@ from hoomd.md import force
 from hoomd.data.parameterdicts import ParameterDict, TypeParameterDict
 from hoomd.data.typeparam import TypeParameter
 import numpy as np
-from hoomd.data.typeconverter import OnlyFrom, nonnegative_real
+from hoomd.data.typeconverter import OnlyFrom, nonnegative_real, positive_real
 
 
 class Pair(force.Force):
@@ -257,7 +257,7 @@ class Gaussian(Pair):
 
         * ``epsilon`` (`float`, **required**) - energy parameter
           :math:`\varepsilon` :math:`[\mathrm{energy}]`
-        * ``sigma`` (`float`, **required**) - particle size :math:`\sigma`
+        * ``sigma`` (`float` > 0, **required**) - particle size :math:`\sigma`
           :math:`[\mathrm{length}]`
 
         Type: `TypeParameter` [`tuple` [``particle_type``, ``particle_type``],
@@ -275,7 +275,7 @@ class Gaussian(Pair):
         super().__init__(nlist, default_r_cut, default_r_on, mode)
         params = TypeParameter(
             'params', 'particle_types',
-            TypeParameterDict(epsilon=float, sigma=float, len_keys=2))
+            TypeParameterDict(epsilon=float, sigma=positive_real, len_keys=2))
         self._add_typeparam(params)
 
 
@@ -310,7 +310,7 @@ class ExpandedGaussian(Pair):
 
         * ``epsilon`` (`float`, **required**) - energy parameter
           :math:`\varepsilon` :math:`[\mathrm{energy}]`
-        * ``sigma`` (`float`, **required**) - particle size
+        * ``sigma`` (`float` > 0, **required**) - particle size
           :math:`\sigma` :math:`[\mathrm{length}]`
         * ``delta`` (`float`, **required**) - shift distance
           :math:`\delta` :math:`[\mathrm{length}]`
@@ -331,7 +331,7 @@ class ExpandedGaussian(Pair):
         params = TypeParameter(
             'params', 'particle_types',
             TypeParameterDict(epsilon=float,
-                              sigma=float,
+                              sigma=positive_real,
                               delta=float,
                               len_keys=2))
         self._add_typeparam(params)
@@ -1843,7 +1843,7 @@ class LJGauss(Pair):
 
         * ``epsilon`` (`float`, **required**) -
           energy parameter :math:`\varepsilon` :math:`[\mathrm{energy}]`
-        * ``sigma`` (`float`, **required**) -
+        * ``sigma`` (`float` > 0, **required**) -
           Gaussian width :math:`\sigma` :math:`[\mathrm{length}]`
         * ``r0`` (`float`, **required**) -
           Gaussian center :math:`r_0` :math:`[\mathrm{length}]`
@@ -1868,5 +1868,6 @@ class LJGauss(Pair):
         super().__init__(nlist, default_r_cut, default_r_on, mode)
         params = TypeParameter(
             'params', 'particle_types',
-            TypeParameterDict(epsilon=float, sigma=float, r0=float, len_keys=2))
+            TypeParameterDict(epsilon=float, sigma=positive_real, 
+                              r0=float, len_keys=2))
         self._add_typeparam(params)

--- a/hoomd/md/pair/pair.py
+++ b/hoomd/md/pair/pair.py
@@ -1843,8 +1843,8 @@ class LJGauss(Pair):
 
         * ``epsilon`` (`float`, **required**) -
           energy parameter :math:`\varepsilon` :math:`[\mathrm{energy}]`
-        * ``sigma`` (`float` > 0, **required**) -
-          Gaussian width :math:`\sigma` :math:`[\mathrm{length}]`
+        * ``sigma`` (`float`, **required**) -
+          Gaussian width :math:`\sigma > 0` :math:`[\mathrm{length}]`
         * ``r0`` (`float`, **required**) -
           Gaussian center :math:`r_0` :math:`[\mathrm{length}]`
 

--- a/hoomd/md/pytest/test_potential.py
+++ b/hoomd/md/pytest/test_potential.py
@@ -182,6 +182,7 @@ def _invalid_params():
 
     gauss_valid_dict = {'sigma': 0.05, 'epsilon': 0.05}
     gauss_invalid_dicts = _make_invalid_param_dict(gauss_valid_dict)
+    gauss_invalid_dicts.append({'sigma': 0, 'epsilon': 0.05})
     invalid_params_list.extend(
         _make_invalid_params(gauss_invalid_dicts, md.pair.Gaussian, {}))
 
@@ -192,6 +193,8 @@ def _invalid_params():
     }
     expanded_gaussian_invalid_dicts = _make_invalid_param_dict(
         expanded_gaussian_valid_dict)
+    expanded_gaussian_invalid_dicts.append({'sigma': 0, 'epsilon': 0.05, 
+                                            'delta': 0.1})
     invalid_params_list.extend(
         _make_invalid_params(expanded_gaussian_invalid_dicts,
                              md.pair.ExpandedGaussian, {}))
@@ -316,6 +319,7 @@ def _invalid_params():
 
     ljgauss_valid_dict = {'r0': 1.8, 'epsilon': 2.0, 'sigma': 0.02}
     ljgauss_invalid_dicts = _make_invalid_param_dict(ljgauss_valid_dict)
+    ljgauss_invalid_dicts.append({'r0': 1.8, 'epsilon': 0, 'sigma': 0.02})
     invalid_params_list.extend(
         _make_invalid_params(ljgauss_invalid_dicts, hoomd.md.pair.LJGauss, {}))
     table_valid_dict = {

--- a/hoomd/md/pytest/test_potential.py
+++ b/hoomd/md/pytest/test_potential.py
@@ -193,7 +193,7 @@ def _invalid_params():
     }
     expanded_gaussian_invalid_dicts = _make_invalid_param_dict(
         expanded_gaussian_valid_dict)
-    expanded_gaussian_invalid_dicts.append({'sigma': 0, 'epsilon': 0.05, 
+    expanded_gaussian_invalid_dicts.append({'sigma': 0, 'epsilon': 0.05,
                                             'delta': 0.1})
     invalid_params_list.extend(
         _make_invalid_params(expanded_gaussian_invalid_dicts,

--- a/hoomd/md/pytest/test_potential.py
+++ b/hoomd/md/pytest/test_potential.py
@@ -319,7 +319,7 @@ def _invalid_params():
 
     ljgauss_valid_dict = {'r0': 1.8, 'epsilon': 2.0, 'sigma': 0.02}
     ljgauss_invalid_dicts = _make_invalid_param_dict(ljgauss_valid_dict)
-    ljgauss_invalid_dicts.append({'r0': 1.8, 'epsilon': 0, 'sigma': 0.02})
+    ljgauss_invalid_dicts.append({'r0': 1.8, 'epsilon': 0.2, 'sigma': 0})
     invalid_params_list.extend(
         _make_invalid_params(ljgauss_invalid_dicts, hoomd.md.pair.LJGauss, {}))
     table_valid_dict = {

--- a/hoomd/md/pytest/test_potential.py
+++ b/hoomd/md/pytest/test_potential.py
@@ -193,8 +193,11 @@ def _invalid_params():
     }
     expanded_gaussian_invalid_dicts = _make_invalid_param_dict(
         expanded_gaussian_valid_dict)
-    expanded_gaussian_invalid_dicts.append({'sigma': 0, 'epsilon': 0.05,
-                                            'delta': 0.1})
+    expanded_gaussian_invalid_dicts.append({
+        'sigma': 0,
+        'epsilon': 0.05,
+        'delta': 0.1
+    })
     invalid_params_list.extend(
         _make_invalid_params(expanded_gaussian_invalid_dicts,
                              md.pair.ExpandedGaussian, {}))

--- a/sphinx-doc/credits.rst
+++ b/sphinx-doc/credits.rst
@@ -65,6 +65,7 @@ The following people have contributed to HOOMD-blue:
 * Jenny Fothergill, Boise State University
 * Jens Glaser, Oak Ridge National Laboratory
 * Joseph Berleant, University of Michigan
+* Joseph Burkhart, University of Michigan
 * Joshua A. Anderson, University of Michigan
 * Kelly Wang, University of Michigan
 * Kevin Daly, Princeton University


### PR DESCRIPTION
## Description

I have modified the `TypeParameterDict` for `md.pair.Gaussian`, `md.pair.ExpandedGaussian`, and `md.pair.LJGaussian` so that `sigma` must be a positive real number. Correspondingly, I have updated docstrings and pytests to reflect the new requirement.

## Motivation and context

This change ensures that users cannot accidentally or mistakenly set `sigma` equal to 0 for any of the Gaussian-type pair potentials, since doing so would cause divide-by-zero errors during simulation execution.

Resolves #1806

## How has this been tested?

I have added new invalid parameter dictionaries to the constructor function `_invalid_params()` in `hoomd/md/pytest/test_potential.py`.

I have built the documentation using Sphinx and confirmed that the changes I made to the docstrings display properly.

## Change log

```
Added a positive-number check to parameters for Gaussian-type pair potentials.
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
