### PR TITLE
Restrict `mpcd.collide.CellList` cell size

### DIFF
--- a/hoomd/mpcd/collide.py
+++ b/hoomd/mpcd/collide.py
@@ -29,12 +29,10 @@ class CellList(Compute):
     """Collision cell list.
 
     Args:
-        cell_size (float): Size of a collision cell.
         shift (bool): When True, randomly shift underlying collision cells.
 
-    The MPCD `CellList` bins particles into cubic cells of edge length
-    `cell_size`. Currently, the simulation box must be orthorhombic, and its
-    edges must be a multiple of `cell_size`.
+    The MPCD `CellList` bins particles into cubic cells of edge length 1.0.
+    The simulation box must be orthorhombic, and its edges must be an integer.
 
     When the total mean-free path of the MPCD particles is small, the cells
     should be randomly shifted in order to ensure Galilean invariance of the
@@ -52,14 +50,6 @@ class CellList(Compute):
         cell_list = simulation.operations.integrator.cell_list
 
     Attributes:
-        cell_size (float): Edge length of a collision cell.
-
-            .. rubric:: Example:
-
-            .. code-block:: python
-
-                cell_list.cell_size = 1.0
-
         shift (bool): When True, randomly shift underlying collision cells.
 
             .. rubric:: Example:
@@ -70,13 +60,10 @@ class CellList(Compute):
 
     """
 
-    def __init__(self, cell_size, shift=True):
+    def __init__(self, shift=True):
         super().__init__()
 
-        param_dict = ParameterDict(
-            cell_size=float(cell_size),
-            shift=bool(shift),
-        )
+        param_dict = ParameterDict(shift=bool(shift),)
         self._param_dict.update(param_dict)
 
     def _attach_hook(self):
@@ -88,8 +75,7 @@ class CellList(Compute):
         else:
             cpp_class = _mpcd.CellList
 
-        self._cpp_obj = cpp_class(sim.state._cpp_sys_def, self.cell_size,
-                                  self.shift)
+        self._cpp_obj = cpp_class(sim.state._cpp_sys_def, 1.0, self.shift)
 
         super()._attach_hook()
 

--- a/hoomd/mpcd/integrate.py
+++ b/hoomd/mpcd/integrate.py
@@ -184,7 +184,7 @@ class Integrator(_MDIntegrator):
             half_step_hook,
         )
 
-        self._cell_list = CellList(cell_size=1.0, shift=True)
+        self._cell_list = CellList()
 
         virtual_particle_fillers = ([] if virtual_particle_fillers is None else
                                     virtual_particle_fillers)
@@ -211,9 +211,8 @@ class Integrator(_MDIntegrator):
     def cell_list(self):
         """hoomd.mpcd.collide.CellList: Collision cell list.
 
-        A `CellList` is automatically created with each `Integrator`
-        using typical defaults of cell size 1 and random grid shifting enabled.
-        You can change this parameter configuration if desired.
+        A `CellList` is automatically created with each `Integrator` using the
+        default settings.
 
         """
         return self._cell_list

--- a/sphinx-doc/migrating.rst
+++ b/sphinx-doc/migrating.rst
@@ -125,7 +125,7 @@ common changes that you may need to make to your HOOMD 2 scripts are:
     * - Create snapshots using ``mpcd.data``
       - Use `hoomd.Snapshot.mpcd`
     * - Specify cell size using ``mpcd.data``
-      - Set through `hoomd.mpcd.Integrator.cell_list`
+      - The cell size is fixed at 1.0.
     * - Initialize MPCD particles with ``mpcd.init.read_snapshot``
       - Use `hoomd.Simulation.create_state_from_snapshot`
     * - Initialize MPCD particles randomly with ``mpcd.init.make_random``


### PR DESCRIPTION
## Description

We are actively working to relax the requirement that the MPCD cells be cubic (#773). Allowing the user to specify, change, or access the scalar `cell_size` is problematic. To avoid introducing API breaking changes after MPCD is rereleased, I would prefer to specify the cell size is fixed at 1.0, which is the standard choice for most MPCD models anyway. We will then extend the `CellList` API to allow specifying the number of cells along each lattice vector in future, which will allow the cell size to change.

## Motivation and context

This will help smoothen the release of MPCD.

## How has this been tested?

Existing tests pass.

## Change log

No change needed.

## Checklist:

- [X] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.rst).
- [X] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [X] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
