### PR TITLE
Improve the data access error message.

### DIFF
--- a/hoomd/error.py
+++ b/hoomd/error.py
@@ -28,8 +28,9 @@ class DataAccessError(RuntimeError):
 
     def __str__(self):
         """Returns the error message."""
-        return (f'The property {self.data_name} is unavailable until the '
-                'simulation runs for 0 or more steps.')
+        return (f'The property {self.data_name} is not available until the '
+                'operation is added to a simulation AND `simulation.run` '
+                'has been called.')
 
 
 class TypeConversionError(ValueError):


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should be based on *trunk-patch*. -->
<!-- Backwards compatible new features should be based on *trunk-minor*. -->
<!-- Incompatible API changes should be based on *trunk-major*. -->

## Description

<!-- Describe your changes in detail. -->
Clarify that operations must be added and simulation.run called in the data access error message.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Previously, the message only mentioned `simulation.run` which is necessary but not sufficient. This caused confusion for users.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
Tested with the MWE in #1818.

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
Changed:

* Clarify the `DataAccessError` message
  (`#1820 <https://github.com/glotzerlab/hoomd-blue/pull/1820>`__).

```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
