### PR TITLE
Fix "Failed to get a function signature" sphinx warnings.

### DIFF
--- a/hoomd/custom/custom_operation.py
+++ b/hoomd/custom/custom_operation.py
@@ -143,7 +143,6 @@ class _AbstractLoggableWithPassthrough(_AbstractLoggable):
         if isinstance(mthd, property):
 
             @property
-            @functools.wraps(mthd)
             def getter(self):
                 return getattr(self._action, name)
 
@@ -153,6 +152,7 @@ class _AbstractLoggableWithPassthrough(_AbstractLoggable):
                 def setter(self, new_value):
                     setattr(self._action, name, new_value)
 
+            getter.__doc__ = mthd.__doc__
             return getter
 
         @functools.wraps(mthd)


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should be based on *trunk-patch*. -->
<!-- Backwards compatible new features should be based on *trunk-minor*. -->
<!-- Incompatible API changes should be based on *trunk-major*. -->

## Description

<!-- Describe your changes in detail. -->
Prevent the "Failed to get a function signature" warning in Sphinx.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
This is causing the readthedocs builds to fail.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
Locally and CI checks.

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

Internal change, no log entry needed.

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
