### PR TITLE
fix Brownian integrators when using anisotropic interactions and zeroing out elements of the moment of inertia tensor

### DIFF
--- a/hoomd/md/TwoStepBD.cc
+++ b/hoomd/md/TwoStepBD.cc
@@ -182,20 +182,20 @@ void TwoStepBD::integrateStepOne(uint64_t timestep)
                 bf_torque.z = NormalDistribution<Scalar>(sigma_r.z)(rng);
 
                 if (x_zero)
-		    {
+                    {
                     bf_torque.x = 0;
                     t.x = 0;
-		    }
+                    }
                 if (y_zero)
-		    {
+                    {
                     bf_torque.y = 0;
                     t.y = 0;
-		    }
+                    }
                 if (z_zero)
-		    {
+                    {
                     bf_torque.z = 0;
                     t.z = 0;
-		    }
+                    }
 
                 // use the damping by gamma_r and rotate back to lab frame
                 // Notes For the Future: take special care when have anisotropic gamma_r

--- a/hoomd/md/TwoStepBD.cc
+++ b/hoomd/md/TwoStepBD.cc
@@ -182,11 +182,20 @@ void TwoStepBD::integrateStepOne(uint64_t timestep)
                 bf_torque.z = NormalDistribution<Scalar>(sigma_r.z)(rng);
 
                 if (x_zero)
+		    {
                     bf_torque.x = 0;
+                    t.x = 0;
+		    }
                 if (y_zero)
+		    {
                     bf_torque.y = 0;
+                    t.y = 0;
+		    }
                 if (z_zero)
+		    {
                     bf_torque.z = 0;
+                    t.z = 0;
+		    }
 
                 // use the damping by gamma_r and rotate back to lab frame
                 // Notes For the Future: take special care when have anisotropic gamma_r

--- a/hoomd/md/TwoStepBDGPU.cu
+++ b/hoomd/md/TwoStepBDGPU.cu
@@ -233,11 +233,20 @@ __global__ void gpu_brownian_step_one_kernel(Scalar4* d_pos,
                 bf_torque.z = NormalDistribution<Scalar>(sigma_r.z)(rng);
 
                 if (x_zero)
+		    {
                     bf_torque.x = 0;
+                    t.x = 0;
+		    }
                 if (y_zero)
+		    {
                     bf_torque.y = 0;
+                    t.y = 0;
+		    }
                 if (z_zero)
+		    {
                     bf_torque.z = 0;
+                    t.z = 0;
+		    }
 
                 // use the damping by gamma_r and rotate back to lab frame
                 // For Future Updates: take special care when have anisotropic gamma_r

--- a/hoomd/md/TwoStepBDGPU.cu
+++ b/hoomd/md/TwoStepBDGPU.cu
@@ -233,20 +233,20 @@ __global__ void gpu_brownian_step_one_kernel(Scalar4* d_pos,
                 bf_torque.z = NormalDistribution<Scalar>(sigma_r.z)(rng);
 
                 if (x_zero)
-		    {
+                    {
                     bf_torque.x = 0;
                     t.x = 0;
-		    }
+                    }
                 if (y_zero)
-		    {
+                    {
                     bf_torque.y = 0;
                     t.y = 0;
-		    }
+                    }
                 if (z_zero)
-		    {
+                    {
                     bf_torque.z = 0;
                     t.z = 0;
-		    }
+                    }
 
                 // use the damping by gamma_r and rotate back to lab frame
                 // For Future Updates: take special care when have anisotropic gamma_r

--- a/hoomd/md/TwoStepRATTLEBD.h
+++ b/hoomd/md/TwoStepRATTLEBD.h
@@ -331,20 +331,20 @@ template<class Manifold> void TwoStepRATTLEBD<Manifold>::integrateStepOne(uint64
                 bf_torque.z = NormalDistribution<Scalar>(sigma_r.z)(rng);
 
                 if (x_zero)
-		    {
+                    {
                     bf_torque.x = 0;
                     t.x = 0;
-		    }
+                    }
                 if (y_zero)
-		    {
+                    {
                     bf_torque.y = 0;
                     t.y = 0;
-		    }
+                    }
                 if (z_zero)
-		    {
+                    {
                     bf_torque.z = 0;
                     t.z = 0;
-		    }
+                    }
 
                 // use the d_invamping by gamma_r and rotate back to lab frame
                 // Notes For the Future: take special care when have anisotropic gamma_r

--- a/hoomd/md/TwoStepRATTLEBD.h
+++ b/hoomd/md/TwoStepRATTLEBD.h
@@ -331,11 +331,20 @@ template<class Manifold> void TwoStepRATTLEBD<Manifold>::integrateStepOne(uint64
                 bf_torque.z = NormalDistribution<Scalar>(sigma_r.z)(rng);
 
                 if (x_zero)
+		    {
                     bf_torque.x = 0;
+                    t.x = 0;
+		    }
                 if (y_zero)
+		    {
                     bf_torque.y = 0;
+                    t.y = 0;
+		    }
                 if (z_zero)
+		    {
                     bf_torque.z = 0;
+                    t.z = 0;
+		    }
 
                 // use the d_invamping by gamma_r and rotate back to lab frame
                 // Notes For the Future: take special care when have anisotropic gamma_r

--- a/hoomd/md/TwoStepRATTLEBDGPU.cuh
+++ b/hoomd/md/TwoStepRATTLEBDGPU.cuh
@@ -291,20 +291,20 @@ __global__ void gpu_rattle_brownian_step_one_kernel(Scalar4* d_pos,
                 bf_torque.z = NormalDistribution<Scalar>(sigma_r.z)(rng);
 
                 if (x_zero)
-		    {
+                    {
                     bf_torque.x = 0;
                     t.x = 0;
-		    }
+                    }
                 if (y_zero)
-		    {
+                    {
                     bf_torque.y = 0;
                     t.y = 0;
-		    }
+                    }
                 if (z_zero)
-		    {
+                    {
                     bf_torque.z = 0;
                     t.z = 0;
-		    }
+                    }
 
                 // use the damping by gamma_r and rotate back to lab frame
                 // For Future Updates: take special care when have anisotropic gamma_r

--- a/hoomd/md/TwoStepRATTLEBDGPU.cuh
+++ b/hoomd/md/TwoStepRATTLEBDGPU.cuh
@@ -291,11 +291,20 @@ __global__ void gpu_rattle_brownian_step_one_kernel(Scalar4* d_pos,
                 bf_torque.z = NormalDistribution<Scalar>(sigma_r.z)(rng);
 
                 if (x_zero)
+		    {
                     bf_torque.x = 0;
+                    t.x = 0;
+		    }
                 if (y_zero)
+		    {
                     bf_torque.y = 0;
+                    t.y = 0;
+		    }
                 if (z_zero)
+		    {
                     bf_torque.z = 0;
+                    t.z = 0;
+		    }
 
                 // use the damping by gamma_r and rotate back to lab frame
                 // For Future Updates: take special care when have anisotropic gamma_r


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should be based on *trunk-patch*. -->
<!-- Backwards compatible new features should be based on *trunk-minor*. -->
<!-- Incompatible API changes should be based on *trunk-major*. -->

## Description

The Brownian integrators did not zero out the torques of an anisotropic pair potential when the moment of inertia has a 0 element. This PR fixes that bug in both the regular and rattle Brownian integrator.

## Motivation and context

Important for simulations of particles with fixed orientations

## How has this been tested?

I tested it on some of my simulations. 

## Change log

<!-- Propose a change log entry. -->
```
Fix Brownian integrators when using anisotropic interactions and zeroing out elements of the moment of inertia tensor
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
