### PR TITLE
Fix reference to Langevin piston paper

### DIFF
--- a/hoomd/md/methods/methods.py
+++ b/hoomd/md/methods/methods.py
@@ -279,7 +279,7 @@ class ConstantPressure(Thermostatted):
     See Also:
         * `G. J. Martyna, D. J. Tobias, M. L. Klein  1994
           <http://dx.doi.org/10.1063/1.467468>`__
-        * `S. E. Feller, Y. Zhang, R. W. Pastor 1995
+        * `S. E. Feller, Y. Zhang, R. W. Pastor, B. R. Brooks 1995
           <https://doi.org/10.1063/1.470648>`_
         * `M. E. Tuckerman et. al. 2006
           <http://dx.doi.org/10.1088/0305-4470/39/19/S18>`__


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should be based on *trunk-patch*. -->
<!-- Backwards compatible new features should be based on *trunk-minor*. -->
<!-- Incompatible API changes should be based on *trunk-major*. -->

## Description

Add the last author of the Langevin piston paper to the link text.

## Motivation and context

Proper citations = good.

## How has this been tested?

Link shows added author's name in docs.

## Change log

<!-- Propose a change log entry. -->
```
Fixed:

* Correct citation to Langevin piston paper
  (`#1849 <https://github.com/glotzerlab/hoomd-blue/pull/1849>`__).
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
