### PR TITLE
Allow dynamic loading of slurm_conf on Anvil.

### DIFF
--- a/hoomd/__init__.py
+++ b/hoomd/__init__.py
@@ -44,7 +44,8 @@ import signal
 
 # Work around /usr/lib64/slurm/auth_munge.so: undefined symbol: slurm_conf error on
 # Purdue Anvil.
-sys.setdlopenflags(os.RTLD_NOW | os.RTLD_GLOBAL)
+if os.environ.get('RCAC_CLUSTER') == 'anvil':
+    sys.setdlopenflags(os.RTLD_NOW | os.RTLD_GLOBAL)
 
 if ((pathlib.Path(__file__).parent / 'CMakeLists.txt').exists()
         and 'SPHINX' not in os.environ):

--- a/hoomd/__init__.py
+++ b/hoomd/__init__.py
@@ -42,8 +42,8 @@ import pathlib
 import os
 import signal
 
-# Work around /usr/lib64/slurm/auth_munge.so: undefined symbol: slurm_conf error on
-# Purdue Anvil.
+# Work around /usr/lib64/slurm/auth_munge.so: undefined symbol: slurm_conf
+# error on Purdue Anvil.
 if os.environ.get('RCAC_CLUSTER') == 'anvil':
     sys.setdlopenflags(os.RTLD_NOW | os.RTLD_GLOBAL)
 

--- a/hoomd/__init__.py
+++ b/hoomd/__init__.py
@@ -42,6 +42,10 @@ import pathlib
 import os
 import signal
 
+# Work around /usr/lib64/slurm/auth_munge.so: undefined symbol: slurm_conf error on
+# Purdue Anvil.
+sys.setdlopenflags(os.RTLD_NOW | os.RTLD_GLOBAL)
+
 if ((pathlib.Path(__file__).parent / 'CMakeLists.txt').exists()
         and 'SPHINX' not in os.environ):
     print("It appears that hoomd is being imported from the source directory:")


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should be based on *trunk-patch*. -->
<!-- Backwards compatible new features should be based on *trunk-minor*. -->
<!-- Incompatible API changes should be based on *trunk-major*. -->

## Description

<!-- Describe your changes in detail. -->
Set the `RTLD_NOW` and `RTLD_GLOBAL` ldopen flags.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
After a recent update on Purdue Anvil, HOOMD-blue fails to import with the error `/usr/lib64/slurm/auth_munge.so: undefined symbol: slurm_conf`.

From what I can tell, this is due to compile-time options for SLURM on Anvil which are outside our control:
* https://github.com/NVIDIA/deepops/issues/720#issuecomment-869053811
* https://github.com/NVIDIA/deepops/pull/1021

Setting [`RTLD_GLOBAL` may cause segfaults](https://stackoverflow.com/questions/20849755/python-shared-libraries-rtld-global-segfault), so I limit this setting to only Anvil. Should users report problems on Anvil, we can investigate other options.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
I executed `hoomd-benchmarks` on Anvil.

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
Fixed:

* Prevent ``/usr/lib64/slurm/auth_munge.so: undefined symbol: slurm_conf`` error on Purdue Anvil
  (`#1850 <https://github.com/glotzerlab/hoomd-blue/pull/1850>`__).
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
