### PR TITLE
Default `BUILD_MPCD` off on the HIP platform.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,7 +104,13 @@ else ()
 option(BUILD_HPMC "Build the hpmc package" off)
 endif()
 option(BUILD_METAL "Build the metal package" on)
+
+if (ENABLE_GPU AND HOOMD_GPU_PLATFORM STREQUAL "HIP")
+message("Defaulting BUILD_MPCD=off due to HIP GPU platform.")
+option(BUILD_MPCD "Build the mpcd package" off)
+else()
 option(BUILD_MPCD "Build the mpcd package" ${BUILD_MD})
+endif()
 
 # Optionally use TBB for threading
 option(ENABLE_TBB "Enable support for Threading Building Blocks (TBB)" off)


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should be based on *trunk-patch*. -->
<!-- Backwards compatible new features should be based on *trunk-minor*. -->
<!-- Incompatible API changes should be based on *trunk-major*. -->

## Description

<!-- Describe your changes in detail. -->
Default `BUILD_MPCD` off on the HIP platform.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
MPCD fails to compile on the HIP platform.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
Fixed:

* Prevent compile errors with default settings except for ``-DENABLE_GPU=on -DHOOMD_GPU_PLATFORM=HIP``
  (`#1851 <https://github.com/glotzerlab/hoomd-blue/pull/1851>`__).

```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
