### PR TITLE
Add _ext_module variable to base python classes

### DIFF
--- a/hoomd/md/constrain.py
+++ b/hoomd/md/constrain.py
@@ -37,6 +37,10 @@ class Constraint(Force):
         for `isinstance` or `issubclass` checks.
     """
 
+    # Module where the C++ class is defined. Reassign this when developing an
+    # external plugin.
+    _ext_module = _md
+
     def _attach_hook(self):
         """Create the c++ mirror class."""
         if isinstance(self._simulation.device, hoomd.device.CPU):

--- a/hoomd/md/constrain.py
+++ b/hoomd/md/constrain.py
@@ -44,9 +44,9 @@ class Constraint(Force):
     def _attach_hook(self):
         """Create the c++ mirror class."""
         if isinstance(self._simulation.device, hoomd.device.CPU):
-            cpp_cls = getattr(_md, self._cpp_class_name)
+            cpp_cls = getattr(self._ext_module, self._cpp_class_name)
         else:
-            cpp_cls = getattr(_md, self._cpp_class_name + "GPU")
+            cpp_cls = getattr(self._ext_module, self._cpp_class_name + "GPU")
 
         self._cpp_obj = cpp_cls(self._simulation.state._cpp_sys_def)
 

--- a/hoomd/md/external/field.py
+++ b/hoomd/md/external/field.py
@@ -33,9 +33,9 @@ class Field(force.Force):
 
     def _attach_hook(self):
         if isinstance(self._simulation.device, hoomd.device.CPU):
-            cls = getattr(_md, self._cpp_class_name)
+            cls = getattr(self._ext_module, self._cpp_class_name)
         else:
-            cls = getattr(_md, self._cpp_class_name + "GPU")
+            cls = getattr(self._ext_module, self._cpp_class_name + "GPU")
 
         self._cpp_obj = cls(self._simulation.state._cpp_sys_def)
 

--- a/hoomd/md/external/field.py
+++ b/hoomd/md/external/field.py
@@ -27,6 +27,10 @@ class Field(force.Force):
         for `isinstance` or `issubclass` checks.
     """
 
+    # Module where the C++ class is defined. Reassign this when developing an
+    # external plugin.
+    _ext_module = _md
+
     def _attach_hook(self):
         if isinstance(self._simulation.device, hoomd.device.CPU):
             cls = getattr(_md, self._cpp_class_name)

--- a/hoomd/md/external/wall.py
+++ b/hoomd/md/external/wall.py
@@ -180,6 +180,10 @@ class WallPotential(force.Force):
         potentials.
     """
 
+    # Module where the C++ class is defined. Reassign this when developing an
+    # external plugin.
+    _ext_module = _md
+
     def __init__(self, walls):
         self._walls = None
         self.walls = hoomd.wall._WallsMetaList(walls, _to_md_cpp_wall)

--- a/hoomd/md/external/wall.py
+++ b/hoomd/md/external/wall.py
@@ -190,9 +190,9 @@ class WallPotential(force.Force):
 
     def _attach_hook(self):
         if isinstance(self._simulation.device, hoomd.device.CPU):
-            cls = getattr(_md, self._cpp_class_name)
+            cls = getattr(self._ext_module, self._cpp_class_name)
         else:
-            cls = getattr(_md, self._cpp_class_name + "GPU")
+            cls = getattr(self._ext_module, self._cpp_class_name + "GPU")
         self._cpp_obj = cls(self._simulation.state._cpp_sys_def)
         self._walls._sync({
             hoomd.wall.Sphere:

--- a/hoomd/md/pair/aniso.py
+++ b/hoomd/md/pair/aniso.py
@@ -47,6 +47,10 @@ class AnisotropicPair(Pair):
         mode (`str`, optional) : the energy shifting mode, defaults to "none".
     """
 
+    # Module where the C++ class is defined. Reassign this when developing an
+    # external plugin.
+    _ext_module = _md
+
     _accepted_modes = ("none", "shift")
 
     def __init__(self, nlist, default_r_cut=None, mode="none"):

--- a/hoomd/md/pair/aniso.py
+++ b/hoomd/md/pair/aniso.py
@@ -47,10 +47,6 @@ class AnisotropicPair(Pair):
         mode (`str`, optional) : the energy shifting mode, defaults to "none".
     """
 
-    # Module where the C++ class is defined. Reassign this when developing an
-    # external plugin.
-    _ext_module = _md
-
     _accepted_modes = ("none", "shift")
 
     def __init__(self, nlist, default_r_cut=None, mode="none"):


### PR DESCRIPTION
## Description

Without the variable `_ext_module` some of the base python classes cannot be easily extended in external plugins, because it will not correctly find it, i.e when wanting to use or import "plugin_name.wall.PotentialName" it will instead look for "hoomd.wall.PotentialName". The simple inclusion of "_ext_module = _md" that can be overwritten by the plugin fixes this issue.

## Motivation and context

Needed for convenient development of external plugins. 
Resolves Issue #1852.

## How has this been tested?

This has been tested locally on the CPU. Because it only touches *.py files, no other tests are necessary. 

## Change log

<!-- Propose a change log entry. -->
```
Fix: External walls, external fields, and constrains can now be implemented via external plugins 
```

## Checklist:

- [X] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.rst).
- [X] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [X] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
