### PR TITLE
Enable dumping only part of the buffer for burst writer.

### DIFF
--- a/hoomd/GSDDequeWriter.cc
+++ b/hoomd/GSDDequeWriter.cc
@@ -42,7 +42,7 @@ GSDDequeWriter::GSDDequeWriter(std::shared_ptr<SystemDefinition> sysdef,
         else
             {
             analyze(timestep);
-            dump(0, 0, true);
+            dump(0, -1, true);
             }
         }
     }
@@ -69,6 +69,10 @@ void GSDDequeWriter::dump(long int start, long int end, bool empty_buffer)
     if (start < 0 || start >= buffer_length)
         {
         throw std::runtime_error("Burst.dump's start index is out of range.");
+        }
+    if (end < 0)
+        {
+        end = buffer_length;
         }
     for (auto i = end - 1; i >= start; --i)
         {

--- a/hoomd/GSDDequeWriter.cc
+++ b/hoomd/GSDDequeWriter.cc
@@ -42,7 +42,7 @@ GSDDequeWriter::GSDDequeWriter(std::shared_ptr<SystemDefinition> sysdef,
         else
             {
             analyze(timestep);
-            dump();
+            dump(0, 0, true);
             }
         }
     }

--- a/hoomd/GSDDequeWriter.cc
+++ b/hoomd/GSDDequeWriter.cc
@@ -66,8 +66,7 @@ void GSDDequeWriter::dump(uint64_t start, uint64_t end, bool empty_buffer)
         {
         end = buffer_length;
         }
-    if end
-        > buffer_length
+    if (end > buffer_length)
             {
             throw std::runtime_error("End index is out of range.");
             }

--- a/hoomd/GSDDequeWriter.cc
+++ b/hoomd/GSDDequeWriter.cc
@@ -74,7 +74,7 @@ void GSDDequeWriter::dump(uint64_t start, uint64_t end, bool empty_buffer)
         {
         throw std::runtime_error("Burst.dump's start index is out of range.");
         }
-    for (auto i  {static_cast<long int>(end - 1)}; i >= static_cast<long int>(start); --i)
+    for (auto i {static_cast<long int>(end - 1)}; i >= static_cast<long int>(start); --i)
         {
         write(m_frame_queue[i], m_log_queue[i]);
         }

--- a/hoomd/GSDDequeWriter.cc
+++ b/hoomd/GSDDequeWriter.cc
@@ -59,13 +59,9 @@ void GSDDequeWriter::analyze(uint64_t timestep)
         }
     }
 
-void GSDDequeWriter::dump(uint64_t start, uint64_t end, bool empty_buffer)
+void GSDDequeWriter::dump(long int start, long int end, bool empty_buffer)
     {
-    auto buffer_length = static_cast<uint64_t>(m_frame_queue.size());
-    if (end == 0)
-        {
-        end = buffer_length;
-        }
+    auto buffer_length = static_cast<long int>(m_frame_queue.size());
     if (end > buffer_length)
         {
         throw std::runtime_error("Burst.dump's end index is out of range.");
@@ -74,7 +70,7 @@ void GSDDequeWriter::dump(uint64_t start, uint64_t end, bool empty_buffer)
         {
         throw std::runtime_error("Burst.dump's start index is out of range.");
         }
-    for (auto i {static_cast<long int>(end - 1)}; i >= static_cast<long int>(start); --i)
+    for (auto i = end - 1; i >= start; --i)
         {
         write(m_frame_queue[i], m_log_queue[i]);
         }

--- a/hoomd/GSDDequeWriter.cc
+++ b/hoomd/GSDDequeWriter.cc
@@ -74,7 +74,7 @@ void GSDDequeWriter::dump(uint64_t start, uint64_t end, bool empty_buffer)
         {
         throw std::runtime_error("Burst.dump's start index is out of range.");
         }
-    for (auto i = end - 1; i >= start; --i)
+    for (auto i  {static_cast<long int>(end - 1)}; i >= static_cast<long int>(start); --i)
         {
         write(m_frame_queue[i], m_log_queue[i]);
         }

--- a/hoomd/GSDDequeWriter.cc
+++ b/hoomd/GSDDequeWriter.cc
@@ -59,7 +59,7 @@ void GSDDequeWriter::analyze(uint64_t timestep)
         }
     }
 
-void GSDDequeWriter::dump(long int start, long int end, bool empty_buffer)
+void GSDDequeWriter::dump(long int start, long int end, bool clear_entire_buffer)
     {
     auto buffer_length = static_cast<long int>(m_frame_queue.size());
     if (end > buffer_length)
@@ -85,10 +85,14 @@ void GSDDequeWriter::dump(long int start, long int end, bool empty_buffer)
         {
         write(m_frame_queue[i], m_log_queue[i]);
         }
-    if (empty_buffer)
+    if (clear_entire_buffer)
         {
         m_frame_queue.clear();
         m_log_queue.clear();
+        } else
+        {
+        m_frame_queue.erase(m_frame_queue.begin() + start, m_frame_queue.begin() + end);
+        m_log_queue.erase(m_log_queue.begin() + start, m_log_queue.begin() + end);
         }
     }
 

--- a/hoomd/GSDDequeWriter.cc
+++ b/hoomd/GSDDequeWriter.cc
@@ -70,18 +70,18 @@ void GSDDequeWriter::dump(long int start, long int end, bool clear_entire_buffer
         {
         throw std::runtime_error("Burst.dump's start index is out of range.");
         }
+    long int iterator_start, iterator_end;
     if (end < 0)
         {
-        end = buffer_length - start;
-        start = 0;
+        iterator_end = buffer_length - start;
+        iterator_start = 0;
         }
     else
         {
-        auto temp_end = end;
-        end = buffer_length - start;
-        start = buffer_length - temp_end;
+        iterator_end = buffer_length - start;
+        iterator_start = buffer_length - end;
         }
-    for (auto i = end - 1; i >= start; --i)
+    for (auto i = iterator_end - 1; i >= iterator_start; --i)
         {
         write(m_frame_queue[i], m_log_queue[i]);
         }
@@ -89,10 +89,11 @@ void GSDDequeWriter::dump(long int start, long int end, bool clear_entire_buffer
         {
         m_frame_queue.clear();
         m_log_queue.clear();
-        } else
+        }
+    else
         {
-        m_frame_queue.erase(m_frame_queue.begin() + start, m_frame_queue.begin() + end);
-        m_log_queue.erase(m_log_queue.begin() + start, m_log_queue.begin() + end);
+        m_frame_queue.erase(m_frame_queue.begin() + iterator_start, m_frame_queue.end());
+        m_log_queue.erase(m_log_queue.begin() + iterator_start, m_log_queue.end());
         }
     }
 

--- a/hoomd/GSDDequeWriter.cc
+++ b/hoomd/GSDDequeWriter.cc
@@ -68,11 +68,11 @@ void GSDDequeWriter::dump(uint64_t start, uint64_t end, bool empty_buffer)
         }
     if (end > buffer_length)
         {
-        throw std::runtime_error("End index is out of range.");
+        throw std::runtime_error("Burst.dump's end index is out of range.");
         }
     if (start < 0 || start >= buffer_length)
         {
-        throw std::runtime_error("Start index is out of range.");
+        throw std::runtime_error("Burst.dump's start index is out of range.");
         }
     for (auto i = end - 1; i >= start; --i)
         {

--- a/hoomd/GSDDequeWriter.cc
+++ b/hoomd/GSDDequeWriter.cc
@@ -59,14 +59,30 @@ void GSDDequeWriter::analyze(uint64_t timestep)
         }
     }
 
-void GSDDequeWriter::dump()
+void GSDDequeWriter::dump(uint64_t start, uint64_t end, bool empty_buffer)
     {
-    for (auto i {static_cast<long int>(m_frame_queue.size()) - 1}; i >= 0; --i)
+    auto buffer_length = static_cast<long int>(m_frame_queue.size());
+    if (end == 0)
+        {
+        end = buffer_length;
+        }
+    if end > buffer_length
+        {
+        throw std::runtime_error("End index is out of range.");
+        }
+    if (start < 0 || start >= buffer_length)
+        {
+        throw std::runtime_error("Start index is out of range.");
+        }
+    for (auto i= end - 1; i >= start; --i)
         {
         write(m_frame_queue[i], m_log_queue[i]);
         }
-    m_frame_queue.clear();
-    m_log_queue.clear();
+    if (empty_buffer)
+        {
+        m_frame_queue.clear();
+        m_log_queue.clear();
+        }
     }
 
 int GSDDequeWriter::getMaxQueueSize() const

--- a/hoomd/GSDDequeWriter.cc
+++ b/hoomd/GSDDequeWriter.cc
@@ -47,7 +47,7 @@ GSDDequeWriter::GSDDequeWriter(std::shared_ptr<SystemDefinition> sysdef,
             dump(0, -1);
             }
         }
-    m_clear_whole_buffer_after_dump = clear_whole_buffer_after_dump;
+    setClearWholeBufferAfterDump(clear_whole_buffer_after_dump);
     }
 
 void GSDDequeWriter::analyze(uint64_t timestep)
@@ -124,6 +124,16 @@ void GSDDequeWriter::setMaxQueueSize(int new_max_size)
         }
     }
 
+bool GSDDequeWriter::getClearWholeBufferAfterDump() const
+    {
+    return m_clear_whole_buffer_after_dump;
+    }
+
+void GSDDequeWriter::setClearWholeBufferAfterDump(bool clear_whole_buffer_after_dump)
+    {
+    m_clear_whole_buffer_after_dump = clear_whole_buffer_after_dump;
+    }
+
 namespace detail
     {
 void export_GSDDequeWriter(pybind11::module& m)
@@ -144,6 +154,9 @@ void export_GSDDequeWriter(pybind11::module& m)
         .def_property("max_burst_size",
                       &GSDDequeWriter::getMaxQueueSize,
                       &GSDDequeWriter::setMaxQueueSize)
+        .def_property("clear_whole_buffer_after_dump",
+                      &GSDDequeWriter::getClearWholeBufferAfterDump,
+                      &GSDDequeWriter::setClearWholeBufferAfterDump)
         .def("__len__", &GSDDequeWriter::getCurrentQueueSize)
         .def("dump", &GSDDequeWriter::dump);
     }

--- a/hoomd/GSDDequeWriter.cc
+++ b/hoomd/GSDDequeWriter.cc
@@ -67,9 +67,9 @@ void GSDDequeWriter::dump(uint64_t start, uint64_t end, bool empty_buffer)
         end = buffer_length;
         }
     if (end > buffer_length)
-            {
-            throw std::runtime_error("End index is out of range.");
-            }
+        {
+        throw std::runtime_error("End index is out of range.");
+        }
     if (start < 0 || start >= buffer_length)
         {
         throw std::runtime_error("Start index is out of range.");

--- a/hoomd/GSDDequeWriter.cc
+++ b/hoomd/GSDDequeWriter.cc
@@ -72,7 +72,14 @@ void GSDDequeWriter::dump(long int start, long int end, bool empty_buffer)
         }
     if (end < 0)
         {
-        end = buffer_length;
+        end = buffer_length - start;
+        start = 0;
+        }
+    else
+        {
+        auto temp_end = end;
+        end = buffer_length - start;
+        start = buffer_length - temp_end;
         }
     for (auto i = end - 1; i >= start; --i)
         {

--- a/hoomd/GSDDequeWriter.cc
+++ b/hoomd/GSDDequeWriter.cc
@@ -66,15 +66,16 @@ void GSDDequeWriter::dump(uint64_t start, uint64_t end, bool empty_buffer)
         {
         end = buffer_length;
         }
-    if end > buffer_length
-        {
-        throw std::runtime_error("End index is out of range.");
-        }
+    if end
+        > buffer_length
+            {
+            throw std::runtime_error("End index is out of range.");
+            }
     if (start < 0 || start >= buffer_length)
         {
         throw std::runtime_error("Start index is out of range.");
         }
-    for (auto i= end - 1; i >= start; --i)
+    for (auto i = end - 1; i >= start; --i)
         {
         write(m_frame_queue[i], m_log_queue[i]);
         }

--- a/hoomd/GSDDequeWriter.cc
+++ b/hoomd/GSDDequeWriter.cc
@@ -66,7 +66,7 @@ void GSDDequeWriter::dump(long int start, long int end, bool empty_buffer)
         {
         throw std::runtime_error("Burst.dump's end index is out of range.");
         }
-    if (start < 0 || start >= buffer_length)
+    if (start < 0 || start > buffer_length)
         {
         throw std::runtime_error("Burst.dump's start index is out of range.");
         }

--- a/hoomd/GSDDequeWriter.cc
+++ b/hoomd/GSDDequeWriter.cc
@@ -61,7 +61,7 @@ void GSDDequeWriter::analyze(uint64_t timestep)
 
 void GSDDequeWriter::dump(uint64_t start, uint64_t end, bool empty_buffer)
     {
-    auto buffer_length = static_cast<long int>(m_frame_queue.size());
+    auto buffer_length = static_cast<uint64_t>(m_frame_queue.size());
     if (end == 0)
         {
         end = buffer_length;

--- a/hoomd/GSDDequeWriter.h
+++ b/hoomd/GSDDequeWriter.h
@@ -31,7 +31,7 @@ class PYBIND11_EXPORT GSDDequeWriter : public GSDDumpWriter
 
     void analyze(uint64_t timestep) override;
 
-    void dump();
+    void dump(uint64_t start, unit64_t end, bool empty_buffer);
 
     int getMaxQueueSize() const;
     void setMaxQueueSize(int new_max_size);

--- a/hoomd/GSDDequeWriter.h
+++ b/hoomd/GSDDequeWriter.h
@@ -31,7 +31,7 @@ class PYBIND11_EXPORT GSDDequeWriter : public GSDDumpWriter
 
     void analyze(uint64_t timestep) override;
 
-    void dump(uint64_t start, unit64_t end, bool empty_buffer);
+    void dump(uint64_t start, uint64_t end, bool empty_buffer);
 
     int getMaxQueueSize() const;
     void setMaxQueueSize(int new_max_size);

--- a/hoomd/GSDDequeWriter.h
+++ b/hoomd/GSDDequeWriter.h
@@ -26,12 +26,13 @@ class PYBIND11_EXPORT GSDDequeWriter : public GSDDumpWriter
                    int queue_size,
                    std::string mode,
                    bool write_on_init,
+                   bool clear_whole_buffer_after_dump,
                    uint64_t timestep);
     ~GSDDequeWriter() = default;
 
     void analyze(uint64_t timestep) override;
 
-    void dump(long int start, long int end, bool clear_entire_buffer);
+    void dump(long int start, long int end);
 
     int getMaxQueueSize() const;
     void setMaxQueueSize(int new_max_size);
@@ -40,6 +41,7 @@ class PYBIND11_EXPORT GSDDequeWriter : public GSDDumpWriter
 
     protected:
     int m_queue_size;
+    bool m_clear_whole_buffer_after_dump;
     std::deque<GSDDumpWriter::GSDFrame> m_frame_queue;
     std::deque<pybind11::dict> m_log_queue;
     };

--- a/hoomd/GSDDequeWriter.h
+++ b/hoomd/GSDDequeWriter.h
@@ -36,6 +36,8 @@ class PYBIND11_EXPORT GSDDequeWriter : public GSDDumpWriter
 
     int getMaxQueueSize() const;
     void setMaxQueueSize(int new_max_size);
+    bool getClearWholeBufferAfterDump() const;
+    void setClearWholeBufferAfterDump(bool clear_whole_buffer_after_dump);
 
     size_t getCurrentQueueSize() const;
 

--- a/hoomd/GSDDequeWriter.h
+++ b/hoomd/GSDDequeWriter.h
@@ -31,7 +31,7 @@ class PYBIND11_EXPORT GSDDequeWriter : public GSDDumpWriter
 
     void analyze(uint64_t timestep) override;
 
-    void dump(long int start, long int end, bool empty_buffer);
+    void dump(long int start, long int end, bool clear_entire_buffer);
 
     int getMaxQueueSize() const;
     void setMaxQueueSize(int new_max_size);

--- a/hoomd/GSDDequeWriter.h
+++ b/hoomd/GSDDequeWriter.h
@@ -31,7 +31,7 @@ class PYBIND11_EXPORT GSDDequeWriter : public GSDDumpWriter
 
     void analyze(uint64_t timestep) override;
 
-    void dump(uint64_t start, uint64_t end, bool empty_buffer);
+    void dump(long int start, long int end, bool empty_buffer);
 
     int getMaxQueueSize() const;
     void setMaxQueueSize(int new_max_size);

--- a/hoomd/md/pytest/test_burst_writer.py
+++ b/hoomd/md/pytest/test_burst_writer.py
@@ -183,12 +183,14 @@ def test_burst_dump_with_clear_buffer(sim, tmp_path, clear_entire_buffer):
     start_frame = 1
     end_frame = 3
     burst_trigger = hoomd.trigger.Periodic(period=2, phase=1)
-    burst_writer = hoomd.write.Burst(trigger=burst_trigger,
-                                     filename=filename,
-                                     mode='wb',
-                                     dynamic=['property', 'momentum'],
-                                     max_burst_size=4,
-                                     write_at_start=True)
+    burst_writer = hoomd.write.Burst(
+        trigger=burst_trigger,
+        filename=filename,
+        mode='wb',
+        dynamic=['property', 'momentum'],
+        max_burst_size=4,
+        write_at_start=True,
+        clear_whole_buffer_after_dump=clear_entire_buffer)
     sim.operations.writers.append(burst_writer)
     sim.run(12)
     burst_writer.flush()
@@ -198,7 +200,7 @@ def test_burst_dump_with_clear_buffer(sim, tmp_path, clear_entire_buffer):
             # First frame is always written
             assert len(traj) == 1
 
-    burst_writer.dump(start_frame, end_frame, clear_entire_buffer)
+    burst_writer.dump(start_frame, end_frame)
     burst_writer.flush()
     dumped_frames = [0, 7, 9]
     if sim.device.communicator.rank == 0:
@@ -296,12 +298,14 @@ def test_write_burst_log(sim, tmp_path):
 def test_burst_dump_empty_buffer(sim, tmp_path, clear_entire_buffer):
     filename = tmp_path / "temporary_test_file.gsd"
     burst_trigger = hoomd.trigger.Periodic(period=2, phase=1)
-    burst_writer = hoomd.write.Burst(trigger=burst_trigger,
-                                     filename=filename,
-                                     mode='wb',
-                                     dynamic=['property', 'momentum'],
-                                     max_burst_size=3,
-                                     write_at_start=True)
+    burst_writer = hoomd.write.Burst(
+        trigger=burst_trigger,
+        filename=filename,
+        mode='wb',
+        dynamic=['property', 'momentum'],
+        max_burst_size=3,
+        write_at_start=True,
+        clear_whole_buffer_after_dump=clear_entire_buffer)
     sim.operations.writers.append(burst_writer)
     sim.run(8)
     burst_writer.flush()
@@ -311,7 +315,7 @@ def test_burst_dump_empty_buffer(sim, tmp_path, clear_entire_buffer):
             # First frame is always written
             assert len(traj) == 1
 
-    burst_writer.dump(1, 2, clear_entire_buffer=clear_entire_buffer)
+    burst_writer.dump(1, 2)
     burst_writer.flush()
     if sim.device.communicator.rank == 0:
         with gsd.hoomd.open(name=filename, mode='r') as traj:

--- a/hoomd/md/pytest/test_burst_writer.py
+++ b/hoomd/md/pytest/test_burst_writer.py
@@ -145,8 +145,8 @@ def test_len(sim, tmp_path):
     assert len(burst_writer) == 0
 
 
-@pytest.mark.parametrize("start, end", [(0,-1), (0, 0), (0, 1), (0, 2), (1, 1),
-                                        (2, 2), (1,2), (1,-1), (2,-1) ])
+@pytest.mark.parametrize("start, end", [(0, -1), (0, 0), (0, 1), (0, 2), (1, 1),
+                                        (2, 2), (1, 2), (1, -1), (2, -1)])
 def test_burst_dump(sim, tmp_path, start, end):
     filename = tmp_path / "temporary_test_file.gsd"
 
@@ -174,7 +174,7 @@ def test_burst_dump(sim, tmp_path, start, end):
             end = len(dumped_frames)
         with gsd.hoomd.open(name=filename, mode='r') as traj:
             assert [frame.configuration.step for frame in traj
-                    ] == [0]+dumped_frames[start:end]
+                    ] == [0] + dumped_frames[start:end]
 
 
 def test_burst_max_size(sim, tmp_path):

--- a/hoomd/md/pytest/test_burst_writer.py
+++ b/hoomd/md/pytest/test_burst_writer.py
@@ -280,4 +280,4 @@ def test_burst_dump_empty_buffer(sim, tmp_path, empty_buffer):
     burst_writer.flush()
     if sim.device.communicator.rank == 0:
         with gsd.hoomd.open(name=filename, mode='r') as traj:
-            assert len(traj) == 6 if empty_buffer else 8
+            assert len(traj) == (6 if empty_buffer else 8)

--- a/hoomd/md/pytest/test_burst_writer.py
+++ b/hoomd/md/pytest/test_burst_writer.py
@@ -145,7 +145,9 @@ def test_len(sim, tmp_path):
     assert len(burst_writer) == 0
 
 
-def test_burst_dump(sim, tmp_path):
+@pytest.mark.parametrize("start, end", [(0, 0), (0, 1), (0, 2), (0, 3), (1, 2),
+                                        (1, 3), (2, 3)])
+def test_burst_dump(sim, tmp_path, start, end):
     filename = tmp_path / "temporary_test_file.gsd"
 
     burst_trigger = hoomd.trigger.Periodic(period=2, phase=1)
@@ -164,11 +166,15 @@ def test_burst_dump(sim, tmp_path):
             # First frame is always written
             assert len(traj) == 1
 
-    burst_writer.dump()
+    burst_writer.dump(start=start, end=end)
     burst_writer.flush()
+    full_solution = [0, 1, 2, 3]
     if sim.device.communicator.rank == 0:
+        if end == 0:
+            end = len(full_solution)
         with gsd.hoomd.open(name=filename, mode='r') as traj:
-            assert [frame.configuration.step for frame in traj] == [0, 3, 5, 7]
+            assert [frame.configuration.step for frame in traj
+                    ] == full_solution[start:end]
 
 
 def test_burst_max_size(sim, tmp_path):
@@ -242,3 +248,36 @@ def test_write_burst_log(sim, tmp_path):
         with gsd.hoomd.open(name=filename, mode='r') as traj:
             for frame, sim_ke in zip(traj[1:], kinetic_energies):
                 assert frame.log[key] == sim_ke
+
+
+@pytest.mark.parametrize("empty_buffer", [True, False])
+def test_burst_dump_empty_buffer(sim, tmp_path, empty_buffer):
+    filename = tmp_path / "temporary_test_file.gsd"
+    burst_trigger = hoomd.trigger.Periodic(period=2, phase=1)
+    burst_writer = hoomd.write.Burst(trigger=burst_trigger,
+                                     filename=filename,
+                                     mode='wb',
+                                     dynamic=['property', 'momentum'],
+                                     max_burst_size=3,
+                                     write_at_start=True)
+    sim.operations.writers.append(burst_writer)
+    sim.run(8)
+    burst_writer.flush()
+    if sim.device.communicator.rank == 0:
+        assert Path(filename).exists()
+        with gsd.hoomd.open(filename, "r") as traj:
+            # First frame is always written
+            assert len(traj) == 1
+
+    burst_writer.dump(empty_buffer=empty_buffer)
+    burst_writer.flush()
+    if sim.device.communicator.rank == 0:
+        with gsd.hoomd.open(name=filename, mode='r') as traj:
+            assert len(traj) == 4
+
+    sim.run(4)
+    burst_writer.dump()
+    burst_writer.flush()
+    if sim.device.communicator.rank == 0:
+        with gsd.hoomd.open(name=filename, mode='r') as traj:
+            assert len(traj) == 6 if empty_buffer else 8

--- a/hoomd/md/pytest/test_burst_writer.py
+++ b/hoomd/md/pytest/test_burst_writer.py
@@ -145,8 +145,8 @@ def test_len(sim, tmp_path):
     assert len(burst_writer) == 0
 
 
-@pytest.mark.parametrize("start, end", [(0, 0), (0, 1), (0, 2), (0, 3), (1, 2),
-                                        (1, 3), (2, 3)])
+@pytest.mark.parametrize("start, end", [(0,-1), (0, 0), (0, 1), (0, 2), (1, 1),
+                                        (2, 2), (1,2), (1,-1), (2,-1) ])
 def test_burst_dump(sim, tmp_path, start, end):
     filename = tmp_path / "temporary_test_file.gsd"
 
@@ -168,13 +168,13 @@ def test_burst_dump(sim, tmp_path, start, end):
 
     burst_writer.dump(start=start, end=end)
     burst_writer.flush()
-    full_solution = [0, 1, 2, 3]
+    dumped_frames = [3, 5, 7]
     if sim.device.communicator.rank == 0:
-        if end == 0:
-            end = len(full_solution)
+        if end == -1:
+            end = len(dumped_frames)
         with gsd.hoomd.open(name=filename, mode='r') as traj:
             assert [frame.configuration.step for frame in traj
-                    ] == full_solution[start:end]
+                    ] == [0]+dumped_frames[start:end]
 
 
 def test_burst_max_size(sim, tmp_path):

--- a/hoomd/write/gsd_burst.py
+++ b/hoomd/write/gsd_burst.py
@@ -114,7 +114,7 @@ class Burst(GSD):
                                               self.mode, self.write_at_start,
                                               sim.timestep)
 
-    def dump(self, start=0, end=-1, empty_buffer=True):
+    def dump(self, start=0, end=-1, clear_entire_buffer=True):
         """Write stored frames in range to the file and empties the buffer.
 
         This method alllows for custom writing of frames at user specified
@@ -124,8 +124,9 @@ class Burst(GSD):
             start (int): The first frame to write. Defaults to 0.
             end (int): The last frame to write, must be positive integer.
                 Defaults to -1 (last frame).
-            empty_buffer (bool): When ``True`` the buffer is emptied after
-                writing. Defaults to ``True``.
+            clear_entire_buffer (bool): When ``True`` the buffer is emptied after
+            writing. If ``False`` only frames in the buffer until end frame will be
+            deleted. Defaults to ``True``.
 
         .. rubric:: Example:
 
@@ -134,7 +135,7 @@ class Burst(GSD):
             burst.dump()
         """
         if self._attached:
-            self._cpp_obj.dump(start, end, empty_buffer)
+            self._cpp_obj.dump(start, end, clear_entire_buffer)
 
     def __len__(self):
         """Get the current length of the internal frame buffer.

--- a/hoomd/write/gsd_burst.py
+++ b/hoomd/write/gsd_burst.py
@@ -124,9 +124,9 @@ class Burst(GSD):
             start (int): The first frame to write. Defaults to 0.
             end (int): The last frame to write, must be positive integer.
                 Defaults to -1 (last frame).
-            clear_entire_buffer (bool): When ``True`` the buffer is emptied after
-            writing. If ``False`` only frames in the buffer until end frame will be
-            deleted. Defaults to ``True``.
+            clear_entire_buffer (bool): When ``True`` the buffer is emptied
+            after writing. If ``False`` only frames in the buffer until end
+            frame will be deleted. Defaults to ``True``.
 
         .. rubric:: Example:
 

--- a/hoomd/write/gsd_burst.py
+++ b/hoomd/write/gsd_burst.py
@@ -40,8 +40,9 @@ class Burst(GSD):
             has 0 frames: write one frame with the current state of the system
             when `hoomd.Simulation.run` is called. Defaults to ``False``.
         clear_whole_buffer_after_dump (bool): When ``True`` the buffer is
-            emptied after calling `dump` each time. When ``False``, `dump` removes
-            frames from the buffer unil the ``end`` index. Defaults to ``True``.
+            emptied after calling `dump` each time. When ``False``, `dump`
+            removes frames from the buffer unil the ``end`` index. Defaults
+            to ``True``.
 
     Warning:
         `Burst` errors when attempting to create a file or writing to one with
@@ -85,8 +86,8 @@ class Burst(GSD):
                 write_at_start = burst.write_at_start
 
         clear_whole_buffer_after_dump (bool): When ``True`` the buffer is
-            emptied after calling `dump` each time. When ``False``, `dump` removes
-            frames from the buffer unil the ``end`` index.
+            emptied after calling `dump` each time. When ``False``, `dump`
+            removes frames from the buffer unil the ``end`` index.
 
             .. rubric:: Example:
 

--- a/hoomd/write/gsd_burst.py
+++ b/hoomd/write/gsd_burst.py
@@ -114,11 +114,18 @@ class Burst(GSD):
                                               self.mode, self.write_at_start,
                                               sim.timestep)
 
-    def dump(self):
-        """Write all currently stored frames to the file and empties the buffer.
+    def dump(self, start=0, end=0, empty_buffer=True):
+        """Write stored frames in range to the file and empties the buffer.
 
         This method alllows for custom writing of frames at user specified
         conditions.
+
+        Args:
+            start (int): The first frame to write. Defaults to 0.
+            end (int): The last frame to write, must be positive integer.
+                Defaults to 0 (last frame).
+            empty_buffer (bool): When ``True`` the buffer is emptied after
+                writing. Defaults to ``True``.
 
         .. rubric:: Example:
 
@@ -127,7 +134,7 @@ class Burst(GSD):
             burst.dump()
         """
         if self._attached:
-            self._cpp_obj.dump()
+            self._cpp_obj.dump(start, end, empty_buffer)
 
     def __len__(self):
         """Get the current length of the internal frame buffer.

--- a/hoomd/write/gsd_burst.py
+++ b/hoomd/write/gsd_burst.py
@@ -80,6 +80,16 @@ class Burst(GSD):
             .. code-block:: python
 
                 write_at_start = burst.write_at_start
+
+        clear_whole_buffer_after_dump (bool): When ``True`` the buffer is
+        emptied after calling `dump` each time. If ``False`` only frames in the
+        buffer until the end frame will be deleted. Defaults to ``True``.
+
+            .. rubric:: Example:
+
+            .. code-block:: python
+
+                    burst.clear_buffer_after_dump = False
     """
 
     def __init__(self,
@@ -90,7 +100,8 @@ class Burst(GSD):
                  dynamic=None,
                  logger=None,
                  max_burst_size=-1,
-                 write_at_start=False):
+                 write_at_start=False,
+                 clear_whole_buffer_after_dump=True):
         super().__init__(trigger=trigger,
                          filename=filename,
                          filter=filter,
@@ -102,19 +113,19 @@ class Burst(GSD):
             ParameterDict(max_burst_size=int, write_at_start=bool))
         self._param_dict.update({
             "max_burst_size": max_burst_size,
-            "write_at_start": write_at_start
+            "write_at_start": write_at_start,
+            "clear_whole_buffer_after_dump": clear_whole_buffer_after_dump
         })
 
     def _attach_hook(self):
         sim = self._simulation
-        self._cpp_obj = _hoomd.GSDDequeWriter(sim.state._cpp_sys_def,
-                                              self.trigger, self.filename,
-                                              sim.state._get_group(self.filter),
-                                              self.logger, self.max_burst_size,
-                                              self.mode, self.write_at_start,
-                                              sim.timestep)
+        self._cpp_obj = _hoomd.GSDDequeWriter(
+            sim.state._cpp_sys_def, self.trigger, self.filename,
+            sim.state._get_group(self.filter), self.logger, self.max_burst_size,
+            self.mode, self.write_at_start, self.clear_whole_buffer_after_dump,
+            sim.timestep)
 
-    def dump(self, start=0, end=-1, clear_entire_buffer=True):
+    def dump(self, start=0, end=-1):
         """Write stored frames in range to the file and empties the buffer.
 
         This method alllows for custom writing of frames at user specified
@@ -124,9 +135,6 @@ class Burst(GSD):
             start (int): The first frame to write. Defaults to 0.
             end (int): The last frame to write.
                 Defaults to -1 (last frame).
-            clear_entire_buffer (bool): When ``True`` the buffer is emptied
-            after writing. If ``False`` only frames in the buffer until end
-            frame will be deleted. Defaults to ``True``.
 
         .. rubric:: Example:
 
@@ -135,7 +143,7 @@ class Burst(GSD):
             burst.dump()
         """
         if self._attached:
-            self._cpp_obj.dump(start, end, clear_entire_buffer)
+            self._cpp_obj.dump(start, end)
 
     def __len__(self):
         """Get the current length of the internal frame buffer.

--- a/hoomd/write/gsd_burst.py
+++ b/hoomd/write/gsd_burst.py
@@ -122,7 +122,7 @@ class Burst(GSD):
 
         Args:
             start (int): The first frame to write. Defaults to 0.
-            end (int): The last frame to write, must be positive integer.
+            end (int): The last frame to write.
                 Defaults to -1 (last frame).
             clear_entire_buffer (bool): When ``True`` the buffer is emptied
             after writing. If ``False`` only frames in the buffer until end

--- a/hoomd/write/gsd_burst.py
+++ b/hoomd/write/gsd_burst.py
@@ -39,6 +39,9 @@ class Burst(GSD):
         write_at_start (bool): When ``True`` **and** the file does not exist or
             has 0 frames: write one frame with the current state of the system
             when `hoomd.Simulation.run` is called. Defaults to ``False``.
+        clear_whole_buffer_after_dump (bool): When ``True`` the buffer is
+            emptied after calling `dump` each time. When ``False``, `dump` removes
+            frames from the buffer unil the ``end`` index. Defaults to ``True``.
 
     Warning:
         `Burst` errors when attempting to create a file or writing to one with
@@ -82,8 +85,8 @@ class Burst(GSD):
                 write_at_start = burst.write_at_start
 
         clear_whole_buffer_after_dump (bool): When ``True`` the buffer is
-        emptied after calling `dump` each time. If ``False`` only frames in the
-        buffer until the end frame will be deleted. Defaults to ``True``.
+            emptied after calling `dump` each time. When ``False``, `dump` removes
+            frames from the buffer unil the ``end`` index.
 
             .. rubric:: Example:
 

--- a/hoomd/write/gsd_burst.py
+++ b/hoomd/write/gsd_burst.py
@@ -114,7 +114,7 @@ class Burst(GSD):
                                               self.mode, self.write_at_start,
                                               sim.timestep)
 
-    def dump(self, start=0, end=0, empty_buffer=True):
+    def dump(self, start=0, end=-1, empty_buffer=True):
         """Write stored frames in range to the file and empties the buffer.
 
         This method alllows for custom writing of frames at user specified
@@ -123,7 +123,7 @@ class Burst(GSD):
         Args:
             start (int): The first frame to write. Defaults to 0.
             end (int): The last frame to write, must be positive integer.
-                Defaults to 0 (last frame).
+                Defaults to -1 (last frame).
             empty_buffer (bool): When ``True`` the buffer is emptied after
                 writing. Defaults to ``True``.
 


### PR DESCRIPTION
## Description
Adds 3 options to dump function of burst writer: start, stop and clear buffer. Start and stop determine which subset of frames will be dumped, while clear buffer flag clears the buffer  or not. Default options should give same results as the current implementation.

## Motivation and context
This would be very useful to have for interactivity with dupin where often we just want to dump a  subset of the deque buffer of dump writer.

## How has this been tested?
Tests testing new functionality have been added.

## Change log

```
Changed:

* Add option to dump a subset of frames in burst writer
  (`#1870 <https://github.com/glotzerlab/hoomd-blue/pull/1870>`__)
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
