### PR TITLE
Fix typo in list optimizer docs

### DIFF
--- a/hoomd/md/tune/nlist_buffer.py
+++ b/hoomd/md/tune/nlist_buffer.py
@@ -324,7 +324,7 @@ class NeighborListBuffer(hoomd.tune.custom_tuner._InternalCustomTuner):
             minimum_buffer (`float`, optional): The smallest buffer value to
                 allow (defaults to 0).
             n_bins (`int`, optional): The number of bins in the range to test
-                (defaults to 2).
+                (defaults to 5).
             n_rounds (`int`, optional): The number of rounds to perform the
                 optimization over (defaults to 1).
 


### PR DESCRIPTION
## Description

The docstring of the list grid optimizer did not match the default value set on the python level. This has been fixed.

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
