### PR TITLE
Fix typos

### DIFF
--- a/hoomd/hpmc/update.py
+++ b/hoomd/hpmc/update.py
@@ -454,7 +454,7 @@ class MuVT(Updater):
 
     @log(category='sequence', requires_run=True)
     def insert_moves(self):
-        """tuple[int, int]: Count of the accepted and rejected paricle \
+        """tuple[int, int]: Count of the accepted and rejected particle \
         insertion moves.
 
         None when not attached
@@ -464,8 +464,8 @@ class MuVT(Updater):
 
     @log(category='sequence', requires_run=True)
     def remove_moves(self):
-        """tuple[int, int]: Count of the accepted and rejected paricle removal \
-        moves.
+        """tuple[int, int]: Count of the accepted and rejected particle \
+        removal moves.
 
         None when not attached
         """
@@ -474,7 +474,7 @@ class MuVT(Updater):
 
     @log(category='sequence', requires_run=True)
     def exchange_moves(self):
-        """tuple[int, int]: Count of the accepted and rejected paricle \
+        """tuple[int, int]: Count of the accepted and rejected particle \
         exchange moves.
 
         None when not attached
@@ -484,7 +484,7 @@ class MuVT(Updater):
 
     @log(category='sequence', requires_run=True)
     def volume_moves(self):
-        """tuple[int, int]: Count of the accepted and rejected paricle volume \
+        """tuple[int, int]: Count of the accepted and rejected particle volume \
         moves.
 
         None when not attached

--- a/hoomd/md/IntegrationMethodTwoStep.h
+++ b/hoomd/md/IntegrationMethodTwoStep.h
@@ -114,7 +114,7 @@ class PYBIND11_EXPORT IntegrationMethodTwoStep : public Autotuned
      */
     virtual void integrateStepTwo(uint64_t timestep) { }
 
-    //! Calculates force which keeps paricles on manifold in RATTLE integrators
+    //! Calculates force which keeps particles on manifold in RATTLE integrators
     /*! \param timestep Current time step
      */
     virtual void includeRATTLEForce(uint64_t timestep) { }


### PR DESCRIPTION
## Description

Several minor typos (spelling "particle" as "paricle") have been identified and fixed.

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
