### PR TITLE
Thermalize floppy body particle momenta

### DIFF
--- a/hoomd/ParticleGroup.cc
+++ b/hoomd/ParticleGroup.cc
@@ -730,12 +730,12 @@ void ParticleGroup::thermalizeParticleMomenta(Scalar kT, uint64_t timestep)
                                                m_sysdef->getSeed()),
                                    hoomd::Counter(ptag));
 
-        // Generate a random velocity, excluding constituent particles
+        // Generate a random velocity, excluding constituent particles of rigid bodies
         Scalar mass = h_vel.data[j].w;
         Scalar sigma = slow::sqrt(kT / mass);
         hoomd::NormalDistribution<Scalar> normal(sigma);
-        // check if particles are constituent particles
-        if (h_tag.data[j] != h_body.data[j] && h_body.data[j] != NO_BODY)
+        // check if particles are constituent particles of a rigid body
+        if (h_tag.data[j] != h_body.data[j] && h_body.data[j] < MIN_FLOPPY)
             {
             h_vel.data[j].x = 0;
             h_vel.data[j].y = 0;
@@ -757,7 +757,7 @@ void ParticleGroup::thermalizeParticleMomenta(Scalar kT, uint64_t timestep)
         quat<Scalar> q(h_orientation.data[j]);
         vec3<Scalar> I(h_inertia.data[j]);
 
-        if (h_tag.data[j] == h_body.data[j] || h_body.data[j] == NO_BODY)
+        if (h_tag.data[j] == h_body.data[j] || h_body.data[j] >= MIN_FLOPPY)
             {
             if (I.x > 0)
                 p_vec.x = hoomd::NormalDistribution<Scalar>(slow::sqrt(kT * I.x))(rng);

--- a/hoomd/pytest/test_state.py
+++ b/hoomd/pytest/test_state.py
@@ -223,29 +223,41 @@ def test_thermalize_angular_momentum(simulation_factory,
         assert K > expected_K * 3 / 4 and K < expected_K * 4 / 3
 
 
-def test_zero_particle_velocity_angmom():
+def test_thermalize_body_particle_momenta(simulation_factory):
     snapshot = hoomd.Snapshot()
-    snapshot.configuration.box = (10, 10, 10, 0, 0, 0)
     if snapshot.communicator.rank == 0:
-        snapshot.particles.N = 4
+        snapshot.configuration.box = (10, 10, 10, 0, 0, 0)
+        snapshot.particles.N = 6
         snapshot.particles.types = ['A']
-        snapshot.particles.body[:] = [0, 0, 2, 2]
-        snapshot.particles.moment_inertia[:] = [[1, 1, 1]] * 4
+        snapshot.particles.body[:] = [0, 1, -2, 0, 1, -2]
+        snapshot.particles.moment_inertia[:] = [[1, 1, 1]
+                                                ] * snapshot.particles.N
 
-    sim = hoomd.Simulation(device=hoomd.device.CPU())
-    sim.create_state_from_snapshot(snapshot)
+    sim = simulation_factory(snapshot)
     sim.state.thermalize_particle_momenta(filter=hoomd.filter.All(), kT=1.0)
-    thermalized_snapshot = sim.state.get_snapshot()
 
+    snapshot = sim.state.get_snapshot()
     if snapshot.communicator.rank == 0:
-        numpy.testing.assert_allclose(
-            thermalized_snapshot.particles.velocity[1], [0, 0, 0])
-        numpy.testing.assert_allclose(
-            thermalized_snapshot.particles.velocity[3], [0, 0, 0])
-        numpy.testing.assert_allclose(thermalized_snapshot.particles.angmom[1],
-                                      [0, 0, 0, 0])
-        numpy.testing.assert_allclose(thermalized_snapshot.particles.angmom[3],
-                                      [0, 0, 0, 0])
+        v = snapshot.particles.velocity[:]
+        w = snapshot.particles.angmom[:]
+
+        # central particles get nonzero momenta
+        assert not numpy.allclose(v[0], [0, 0, 0])
+        assert not numpy.allclose(v[1], [0, 0, 0])
+        assert not numpy.allclose(w[0], [0, 0, 0, 0])
+        assert not numpy.allclose(w[1], [0, 0, 0, 0])
+
+        # constituent particles get zero momenta
+        assert numpy.allclose(v[3], [0, 0, 0])
+        assert numpy.allclose(v[4], [0, 0, 0])
+        assert numpy.allclose(w[3], [0, 0, 0, 0])
+        assert numpy.allclose(w[4], [0, 0, 0, 0])
+
+        # floppy particles get nonzero momenta
+        assert not numpy.allclose(v[2], [0, 0, 0])
+        assert not numpy.allclose(v[5], [0, 0, 0])
+        assert not numpy.allclose(w[2], [0, 0, 0, 0])
+        assert not numpy.allclose(w[5], [0, 0, 0, 0])
 
 
 def test_replicate(simulation_factory, lattice_snapshot_factory):


### PR DESCRIPTION
## Description

Particles in floppy bodies did not get their momenta thermalized, although they are independent degrees of freedom. This PR fixes that.

## Motivation and context

This is a fix to an undocumented feature, see discussion in #1885.

## How has this been tested?

I updated the unit tests for `thermalize_particle_momenta` involving body particles to include floppy bodies.

## Change log

```
* Thermalize momenta of particles with floppy body tags.
```

## Checklist:

- [X] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.rst).
- [X] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [X] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
