### PR TITLE
MPCD concentric cylinders geometry

### DIFF
--- a/hoomd/mpcd/CMakeLists.txt
+++ b/hoomd/mpcd/CMakeLists.txt
@@ -58,6 +58,7 @@ set(_forces
 
 set(_geometries
     ParallelPlateGeometry
+    ConcentricCylindersGeometry
     PlanarPoreGeometry
     SphereGeometry
     )

--- a/hoomd/mpcd/CMakeLists.txt
+++ b/hoomd/mpcd/CMakeLists.txt
@@ -57,8 +57,8 @@ set(_forces
     )
 
 set(_geometries
-    ParallelPlateGeometry
     ConcentricCylindersGeometry
+    ParallelPlateGeometry
     PlanarPoreGeometry
     SphereGeometry
     )

--- a/hoomd/mpcd/ConcentricCylindersGeometry.cc
+++ b/hoomd/mpcd/ConcentricCylindersGeometry.cc
@@ -20,9 +20,9 @@ void export_ConcentricCylindersGeometry(pybind11::module& m)
         m,
         ConcentricCylindersGeometry::getName().c_str())
         .def(pybind11::init<Scalar, Scalar, Scalar, bool>())
-        .def_property_readonly("R0", &ConcentricCylindersGeometry::getR0)
-        .def_property_readonly("R1", &ConcentricCylindersGeometry::getR1)
-        .def_property_readonly("speed", &ConcentricCylindersGeometry::getSpeed)
+        .def_property_readonly("inner_radius", &ConcentricCylindersGeometry::getR0)
+        .def_property_readonly("outer_radius", &ConcentricCylindersGeometry::getR1)
+        .def_property_readonly("angular_speed", &ConcentricCylindersGeometry::getAngularSpeed)
         .def_property_readonly("no_slip", &ConcentricCylindersGeometry::getNoSlip);
     }
     } // end namespace detail

--- a/hoomd/mpcd/ConcentricCylindersGeometry.cc
+++ b/hoomd/mpcd/ConcentricCylindersGeometry.cc
@@ -1,0 +1,30 @@
+// Copyright (c) 2009-2024 The Regents of the University of Michigan.
+// Part of HOOMD-blue, released under the BSD 3-Clause License.
+
+/*!
+ * \file mpcd/ConcentricCylindersGeometry.cc
+ * \brief Export function MPCD concentric cylinders geometry.
+ */
+
+#include "ConcentricCylindersGeometry.h"
+
+namespace hoomd
+    {
+namespace mpcd
+    {
+namespace detail
+    {
+void export_ConcentricCylindersGeometry(pybind11::module& m)
+    {
+    pybind11::class_<ConcentricCylindersGeometry, std::shared_ptr<ConcentricCylindersGeometry>>(
+        m,
+        ConcentricCylindersGeometry::getName().c_str())
+        .def(pybind11::init<Scalar, Scalar, Scalar, bool>())
+        .def_property_readonly("R0", &ConcentricCylindersGeometry::getR0)
+        .def_property_readonly("R1", &ConcentricCylindersGeometry::getR1)
+        .def_property_readonly("speed", &ConcentricCylindersGeometry::getSpeed)
+        .def_property_readonly("no_slip", &ConcentricCylindersGeometry::getNoSlip);
+    }
+    } // end namespace detail
+    } // end namespace mpcd
+    } // end namespace hoomd

--- a/hoomd/mpcd/ConcentricCylindersGeometry.cc
+++ b/hoomd/mpcd/ConcentricCylindersGeometry.cc
@@ -20,8 +20,8 @@ void export_ConcentricCylindersGeometry(pybind11::module& m)
         m,
         ConcentricCylindersGeometry::getName().c_str())
         .def(pybind11::init<Scalar, Scalar, Scalar, bool>())
-        .def_property_readonly("inner_radius", &ConcentricCylindersGeometry::getR0)
-        .def_property_readonly("outer_radius", &ConcentricCylindersGeometry::getR1)
+        .def_property_readonly("inner_radius", &ConcentricCylindersGeometry::getInnerRadius)
+        .def_property_readonly("outer_radius", &ConcentricCylindersGeometry::getOuterRadius)
         .def_property_readonly("angular_speed", &ConcentricCylindersGeometry::getAngularSpeed)
         .def_property_readonly("no_slip", &ConcentricCylindersGeometry::getNoSlip);
     }

--- a/hoomd/mpcd/ConcentricCylindersGeometry.h
+++ b/hoomd/mpcd/ConcentricCylindersGeometry.h
@@ -121,16 +121,19 @@ class __attribute__((visibility("default"))) ConcentricCylindersGeometry
         return (rsq > m_R1_sq || rsq < m_R0_sq);
         }
 
+    //! Add a contribution to random virtual particle velocity.
+    /*!
+     * \param vel Velocity of virtual particle
+     * \param pos Position of virtual particle
+     *
+     * Add velocity of rotating outer cylinder to \a vel for particles beyond the outer radius.
+     */
     HOSTDEVICE void addToVirtualParticleVelocity(Scalar3& vel, const Scalar3& pos) const
         {
         const Scalar rsq = pos.x * pos.x + pos.y * pos.y;
         if (rsq > m_R1_sq)
             {
-            // Find the closest point on the perimeter of the outer cylinder.
-            const Scalar pos_x = slow::sqrt(m_R1_sq / rsq) * pos.x;
-            const Scalar pos_y = slow::sqrt(m_R1_sq / rsq) * pos.y;
-
-            vel.x += m_w * -pos_y;
+            vel.x -= m_w * pos_y;
             vel.y += m_w * pos_x;
             }
         }

--- a/hoomd/mpcd/ConcentricCylindersGeometry.h
+++ b/hoomd/mpcd/ConcentricCylindersGeometry.h
@@ -133,8 +133,8 @@ class __attribute__((visibility("default"))) ConcentricCylindersGeometry
         const Scalar rsq = pos.x * pos.x + pos.y * pos.y;
         if (rsq > m_R1_sq)
             {
-            vel.x -= m_w * pos_y;
-            vel.y += m_w * pos_x;
+            vel.x -= m_w * pos.y;
+            vel.y += m_w * pos.x;
             }
         }
 

--- a/hoomd/mpcd/ConcentricCylindersGeometry.h
+++ b/hoomd/mpcd/ConcentricCylindersGeometry.h
@@ -1,0 +1,184 @@
+// Copyright (c) 2009-2024 The Regents of the University of Michigan.
+// Part of HOOMD-blue, released under the BSD 3-Clause License.
+
+/*!
+ * \file mpcd/ConcentricCylindersGeometry.h
+ * \brief Definition of the MPCD slit channel geometry
+ */
+
+#ifndef MPCD_CONCENTRIC_CYLINDERS_GEOMETRY_H_
+#define MPCD_CONCENTRIC_CYLINDERS_GEOMETRY_H_
+
+#include "hoomd/BoxDim.h"
+#include "hoomd/HOOMDMath.h"
+
+#ifdef __HIPCC__
+#define HOSTDEVICE __host__ __device__ inline
+#else
+#define HOSTDEVICE inline __attribute__((always_inline))
+#include <string>
+#endif // __HIPCC__
+
+namespace hoomd
+    {
+namespace mpcd
+    {
+//! Concentric cylinders geometry
+
+class __attribute__((visibility("default"))) ConcentricCylindersGeometry
+    {
+    public:
+    //! Constructor
+    /*!
+     * \param R0 Inner radius of the cylinder
+     * \param R1 Outer radius of the cylinder
+     * \param speed Speed of the outer cylinder
+     * \param no_slip Boundary condition at the wall (slip or no-slip)
+     */
+    HOSTDEVICE ConcentricCylindersGeometry(Scalar R0, Scalar R1, Scalar speed, bool no_slip)
+        : m_R0(R0), m_R02(R0 * R0), m_R1(R1), m_R12(R1 * R1), m_V(speed), m_no_slip(no_slip)
+        {
+        }
+
+    //! Detect collision between the particle and the boundary
+    /*!
+     * \param pos Proposed particle position
+     * \param vel Proposed particle velocity
+     * \param dt Integration time remaining
+     *
+     * \returns True if a collision occurred, and false otherwise
+     *
+     * \post The particle position \a pos is moved to the point of reflection, the velocity \a vel
+     * is updated according to the appropriate bounce back rule, and the integration time \a dt is
+     * decreased to the amount of time remaining.
+     */
+    HOSTDEVICE bool detectCollision(Scalar3& pos, Scalar3& vel, Scalar& dt) const
+        {
+        const Scalar r = pos.x * pos.x + pos.y * pos.y;
+        /*
+         * Check if particle is in bounds
+         */
+        const signed char sign = (char)((r > m_R12) - (r < m_R02));
+        // exit immediately if no collision is found or particle is not moving normal to the wall
+        // (since no new collision could have occurred if there is no normal motion)
+        if (sign == 0 || vel.x * vel.x + vel.y * vel.y == Scalar(0))
+            {
+            dt = Scalar(0);
+            return false;
+            }
+
+        /*
+         * Find the time remaining when the particle is collided with wall. This time is computed
+         * by backtracking the position, dot(pos, pos) = R^2.
+         */
+        const Scalar R = (sign == 1) ? R12 : R02;
+        const Scalar a = vel.x * vel.x + vel.y * vel.y;
+        const Scalar b = -Scalar(2) * (pos.x * vel.x + pos.y * vel.y);
+        const Scalar c = pos.x * pos.x + pos.y * pos.y - R * R;
+        dt = (-b + slow::sqrt(b * b - Scalar(4) * a * c)) / (Scalar(2) * a);
+
+        // backtrack the particle for dt to get to point of contact
+        pos -= vel * dt;
+
+        // update velocity according to boundary conditions
+        // no-slip requires reflection of the tangential components.
+        if (sign == 1)
+            {
+            // no-slip requires reflection of the tangential components.
+            if (m_no_slip)
+                {
+                vel.x = -vel.x + Scalar(2) * m_V * pos.x / R1;
+                vel.y = -vel.y + Scalar(2) * m_V * pos.y / R1;
+                vel.z = -vel.z;
+                }
+            // slip requires reflection of the normal components.
+            else
+                {
+                vel.x -= Scalar(2) * pos.x * pos.y * vel.x / (R * R);
+                vel.y -= Scalar(2) * pos.y * pos.y * vel.y / (R * R);
+                }
+            }
+
+        if (sign == -1)
+            {
+            if (m_no_slip)
+                {
+                vel = -vel;
+                }
+            else
+                {
+                vel.x -= Scalar(2) * pos.x * pos.y * vel.x / (R * R);
+                vel.y -= Scalar(2) * pos.y * pos.y * vel.y / (R * R);
+                }
+            }
+
+        return true;
+        }
+
+    //! Check if a particle is out of bounds
+    /*!
+     * \param pos Current particle position
+     * \returns True if particle is out of bounds, and false otherwise
+     */
+    HOSTDEVICE bool isOutside(const Scalar3& pos) const
+        {
+        const Scalar r = pos.x * pos.x + pos.y * pos.y return (r > m_R12 || r < m_R02);
+        }
+
+    //! Get inner radius of the cylinder
+    /*!
+     * \returns Inner radius of the cylinder
+     */
+    HOSTDEVICE Scalar getR0() const
+        {
+        return m_R0;
+        }
+
+    //! Get outer radius of the cylinder
+    /*!
+     * \returns Outer radius of the cylinder
+     */
+    HOSTDEVICE Scalar getR1() const
+        {
+        return m_R1;
+        }
+
+    //! Get the speed of the outer cylinder
+    /*!
+     * \returns Speed of the outer cylinder
+     */
+    HOSTDEVICE Scalar getSpeed() const
+        {
+        return m_V;
+        }
+
+    //! Get the wall boundary condition
+    /*!
+     * \returns Boundary condition at wall
+     */
+    HOSTDEVICE bool getNoSlip() const
+        {
+        return m_no_slip;
+        }
+
+#ifndef __HIPCC__
+    //! Get the unique name of this geometry
+    static std::string getName()
+        {
+        return std::string("ConcentricCylinders");
+        }
+#endif // __HIPCC__
+
+    private:
+    const Scalar m_R0;    //!< Inner radius of the cylinder
+    const Scalar m_R02;   //!< Square of inner radius
+    const Scalar m_R1;    //!< Outer radius of the cylinder
+    const Scalar m_R12;   //!< Velocity of the wall
+    const bool m_no_slip; //!< Boundary condition
+    };
+
+    } // end namespace mpcd
+    } // end namespace hoomd
+#undef HOSTDEVICE
+
+#endif // MPCD_CONCENTRIC_CYLINDERS_H_

--- a/hoomd/mpcd/ConcentricCylindersGeometry.h
+++ b/hoomd/mpcd/ConcentricCylindersGeometry.h
@@ -121,6 +121,20 @@ class __attribute__((visibility("default"))) ConcentricCylindersGeometry
         return (rsq > m_R1_sq || rsq < m_R0_sq);
         }
 
+    HOSTDEVICE void addToVirtualParticleVelocity(Scalar3& vel, const Scalar3& pos) const
+        {
+        const Scalar rsq = pos.x * pos.x + pos.y * pos.y;
+        if (rsq > m_R1_sq)
+            {
+            // Find the closest point on the perimeter of the outer cylinder.
+            const Scalar pos_x = slow::sqrt(m_R1_sq / rsq) * pos.x;
+            const Scalar pos_y = slow::sqrt(m_R1_sq / rsq) * pos.y;
+
+            vel.x += m_w * -pos_y;
+            vel.y += m_w * pos_x;
+            }
+        }
+
     //! Get inner radius of the cylinder
     /*!
      * \returns Inner radius of the cylinder

--- a/hoomd/mpcd/ConcentricCylindersGeometry.h
+++ b/hoomd/mpcd/ConcentricCylindersGeometry.h
@@ -74,7 +74,7 @@ class __attribute__((visibility("default"))) ConcentricCylindersGeometry
         const Scalar Rsq = (sign == 1) ? m_R0_sq : m_R1_sq;
         const Scalar b = -Scalar(2) * (pos.x * vel.x + pos.y * vel.y);
         const Scalar c = pos.x * pos.x + pos.y * pos.y - Rsq;
-        dt = (-b + sign * (slow::sqrt(b * b - Scalar(4) * vxy_sq * c))) / (Scalar(2) * vxy_sq);
+        dt = (-b + sign * slow::sqrt(b * b - Scalar(4) * vxy_sq * c)) / (Scalar(2) * vxy_sq);
 
         // backtrack the particle for dt to get to point of contact
         pos -= vel * dt;

--- a/hoomd/mpcd/CosineChannelGeometry.h
+++ b/hoomd/mpcd/CosineChannelGeometry.h
@@ -270,6 +270,13 @@ class __attribute__((visibility("default"))) CosineChannelGeometry
         return (a > m_H || a < -m_H);
         }
 
+    //! Add a contribution to random virtual particle velocity.
+    /*!
+     * \param vel Velocity of virtual particle
+     * \param pos Position of virtual particle
+     *
+     * No velocity contribution is needed as the wall is stationary.
+     */
     HOSTDEVICE void addToVirtualParticleVelocity(Scalar3& vel, const Scalar3& pos) const { }
 
     //! Get channel amplitude

--- a/hoomd/mpcd/CosineChannelGeometry.h
+++ b/hoomd/mpcd/CosineChannelGeometry.h
@@ -270,6 +270,8 @@ class __attribute__((visibility("default"))) CosineChannelGeometry
         return (a > m_H || a < -m_H);
         }
 
+    HOSTDEVICE void addToVirtualParticleVelocity(Scalar3& vel, const Scalar3& pos) const { }
+
     //! Get channel amplitude
     HOSTDEVICE Scalar getAmplitude() const
         {

--- a/hoomd/mpcd/CosineExpansionContractionGeometry.h
+++ b/hoomd/mpcd/CosineExpansionContractionGeometry.h
@@ -297,6 +297,13 @@ class __attribute__((visibility("default"))) CosineExpansionContractionGeometry
         return ((hi - m_H_wide) >= cell_size && (-m_H_wide - lo) >= cell_size);
         }
 
+    //! Add a contribution to random virtual particle velocity.
+    /*!
+     * \param vel Velocity of virtual particle
+     * \param pos Position of virtual particle
+     *
+     * No velocity contribution is needed as the wall is stationary.
+     */
     HOSTDEVICE void addToVirtualParticleVelocity(Scalar3& vel, const Scalar3& pos) const { }
 
     //! Get channel width at widest point

--- a/hoomd/mpcd/CosineExpansionContractionGeometry.h
+++ b/hoomd/mpcd/CosineExpansionContractionGeometry.h
@@ -297,6 +297,8 @@ class __attribute__((visibility("default"))) CosineExpansionContractionGeometry
         return ((hi - m_H_wide) >= cell_size && (-m_H_wide - lo) >= cell_size);
         }
 
+    HOSTDEVICE void addToVirtualParticleVelocity(Scalar3& vel, const Scalar3& pos) const { }
+
     //! Get channel width at widest point
     /*!
      * \returns Channel width at widest point

--- a/hoomd/mpcd/ParallelPlateGeometry.h
+++ b/hoomd/mpcd/ParallelPlateGeometry.h
@@ -134,6 +134,15 @@ class __attribute__((visibility("default"))) ParallelPlateGeometry
         return (pos.y > m_H || pos.y < -m_H);
         }
 
+    //! Add a contribution to random virtual particle velocity.
+    /*!
+     * \param vel Velocity of virtual particle
+     * \param pos Position of virtual particle
+     *
+     * Add velocity of moving parallel plates to \a vel for particles beyond the separation
+     * distance. The velocity is increased by \a m_V if beyond the upper plate, and decreased by \a
+     * m_V if beyond the lower plate.
+     */
     HOSTDEVICE void addToVirtualParticleVelocity(Scalar3& vel, const Scalar3& pos) const
         {
         if (pos.y > m_H)

--- a/hoomd/mpcd/ParallelPlateGeometry.h
+++ b/hoomd/mpcd/ParallelPlateGeometry.h
@@ -134,6 +134,18 @@ class __attribute__((visibility("default"))) ParallelPlateGeometry
         return (pos.y > m_H || pos.y < -m_H);
         }
 
+    HOSTDEVICE void addToVirtualParticleVelocity(Scalar3& vel, const Scalar3& pos) const
+        {
+        if (pos.y > m_H)
+            {
+            vel.x += m_V;
+            }
+        else if (pos.y < -m_H)
+            {
+            vel.x -= m_V;
+            }
+        }
+
     //! Get channel half width
     /*!
      * \returns Channel half width

--- a/hoomd/mpcd/PlanarPoreGeometry.h
+++ b/hoomd/mpcd/PlanarPoreGeometry.h
@@ -168,6 +168,13 @@ class __attribute__((visibility("default"))) PlanarPoreGeometry
         return ((pos.x > -m_L && pos.x < m_L) && (pos.y > m_H || pos.y < -m_H));
         }
 
+    //! Add a contribution to random virtual particle velocity.
+    /*!
+     * \param vel Velocity of virtual particle
+     * \param pos Position of virtual particle
+     *
+     * No velocity contribution is needed as the wall is stationary.
+     */
     HOSTDEVICE void addToVirtualParticleVelocity(Scalar3& vel, const Scalar3& pos) const { }
 
     //! Get pore half width

--- a/hoomd/mpcd/PlanarPoreGeometry.h
+++ b/hoomd/mpcd/PlanarPoreGeometry.h
@@ -168,6 +168,8 @@ class __attribute__((visibility("default"))) PlanarPoreGeometry
         return ((pos.x > -m_L && pos.x < m_L) && (pos.y > m_H || pos.y < -m_H));
         }
 
+    HOSTDEVICE void addToVirtualParticleVelocity(Scalar3& vel, const Scalar3& pos) const { }
+
     //! Get pore half width
     /*!
      * \returns Pore half width

--- a/hoomd/mpcd/RejectionVirtualParticleFiller.h
+++ b/hoomd/mpcd/RejectionVirtualParticleFiller.h
@@ -125,6 +125,7 @@ template<class Geometry> void RejectionVirtualParticleFiller<Geometry>::fill(uin
             Scalar3 vel;
             gen(vel.x, vel.y, rng);
             vel.z = gen(rng);
+            m_geom->addToVirtualParticleVelocity(vel, particle);
             h_tmp_vel.data[num_selected]
                 = make_scalar4(vel.x, vel.y, vel.z, __int_as_scalar(mpcd::detail::NO_CELL));
             ++num_selected;

--- a/hoomd/mpcd/RejectionVirtualParticleFillerGPU.cuh
+++ b/hoomd/mpcd/RejectionVirtualParticleFillerGPU.cuh
@@ -154,6 +154,7 @@ __global__ void draw_virtual_particles(Scalar4* d_tmp_pos,
     Scalar3 vel;
     gen(vel.x, vel.y, rng);
     vel.z = gen(rng);
+    geom.addToVirtualParticleVelocity(vel, pos);
     d_tmp_vel[idx] = make_scalar4(vel.x, vel.y, vel.z, __int_as_scalar(mpcd::detail::NO_CELL));
     }
 

--- a/hoomd/mpcd/SphereGeometry.h
+++ b/hoomd/mpcd/SphereGeometry.h
@@ -104,6 +104,8 @@ class __attribute__((visibility("default"))) SphereGeometry
         return dot(pos, pos) > m_R2;
         }
 
+    HOSTDEVICE void addToVirtualParticleVelocity(Scalar3& vel, const Scalar3& pos) const { }
+
     //! Get Sphere radius
     /*!
      * \returns confinement radius

--- a/hoomd/mpcd/SphereGeometry.h
+++ b/hoomd/mpcd/SphereGeometry.h
@@ -104,6 +104,13 @@ class __attribute__((visibility("default"))) SphereGeometry
         return dot(pos, pos) > m_R2;
         }
 
+    //! Add a contribution to random virtual particle velocity.
+    /*!
+     * \param vel Velocity of virtual particle
+     * \param pos Position of virtual particle
+     *
+     * No velocity contribution is needed as the wall is stationary.
+     */
     HOSTDEVICE void addToVirtualParticleVelocity(Scalar3& vel, const Scalar3& pos) const { }
 
     //! Get Sphere radius

--- a/hoomd/mpcd/geometry.py
+++ b/hoomd/mpcd/geometry.py
@@ -57,11 +57,11 @@ class Geometry(_HOOMDBaseObject):
 
 
 class ConcentricCylinders(Geometry):
-    r"""Concentric-cylinders channel.
+    r"""Concentric cylinders.
 
     Args:
-        inner_radius (float): Radius of inner cylinders.
-        outer_radius (float): Radius of outer cylinders
+        inner_radius (float): Radius of inner cylinder.
+        outer_radius (float): Radius of outer cylinder.
         angular_speed (float): Angular speed of the outer cylinder in the
             counterclockwise direction.
         no_slip (bool): If True, surfaces have no-slip boundary condition.
@@ -106,7 +106,7 @@ class ConcentricCylinders(Geometry):
 
         outer_radius (float): Radius of outer cylinder (*read only*).
 
-        angular_speed (float): Angular outer cylinder speed (*read only*).
+        angular_speed (float): Angular speed of outer cylinder (*read only*).
 
             `angular_speed` will have no effect if `no_slip` is False because
             the slip surface cannot generate shear stress.

--- a/hoomd/mpcd/geometry.py
+++ b/hoomd/mpcd/geometry.py
@@ -60,8 +60,8 @@ class ConcentricCylinders(Geometry):
     r"""Concentric-cylinders channel.
 
     Args:
-        R0 (float): Inner radius of the cylinders.
-        R1 (float): Outer radius of the cylinders
+        inner_radius (float): Radius of inner cylinders.
+        outer_radius (float): Radius of outer cylinders
         angular_speed (float): Angular speed of the outer cylinder in the
             counterclockwise direction.
         no_slip (bool): If True, surfaces have no-slip boundary condition.
@@ -77,7 +77,8 @@ class ConcentricCylinders(Geometry):
 
     .. code-block:: python
 
-        cylinders = hoomd.mpcd.geometry.ConcentricCylinders(R0=2.0, R1=5.0)
+        cylinders = hoomd.mpcd.geometry.ConcentricCylinders(inner_radius=2.0,
+          outer_radius=5.0)
         stream = hoomd.mpcd.stream.BounceBack(period=1, geometry=cylinders)
         simulation.operations.integrator.streaming_method = stream
 
@@ -86,7 +87,7 @@ class ConcentricCylinders(Geometry):
     .. code-block:: python
 
         cylinders = hoomd.mpcd.geometry.ConcentricCylinders(
-            R0=2.0, R1=5.0, no_slip=False)
+            inner_radius=2.0, outer_radius=5.0, no_slip=False)
         stream = hoomd.mpcd.stream.BounceBack(period=1, geometry=cylinders)
         simulation.operations.integrator.streaming_method = stream
 
@@ -95,33 +96,38 @@ class ConcentricCylinders(Geometry):
     .. code-block:: python
 
         cylinders = hoomd.mpcd.geometry.ConcentricCylinders(
-            R0=2.0, R1=5.0, angular_speed=1.0, no_slip=True)
+            inner_radius=2.0, outer_radius=5.0, angular_speed=1.0, no_slip=True)
         stream = hoomd.mpcd.stream.BounceBack(period=1, geometry=cylinders)
         simulation.operations.integrator.streaming_method = stream
 
     Attributes:
-        R0 (float): Inner radius of the cylinder (*read only*).
+        inner_radius (float): Radius of inner cylinder (*read only*).
 
-        R1 (float): Outer radius of the cylinder (*read only*).
+        outer_radius (float): Radius of outer cylinder (*read only*).
 
         angular_speed (float): Angular outer cylinder speed (*read only*).
 
-            `speed` will have no effect if `no_slip` is False because the slip
-            surface cannot generate shear stress.
+            `angular_speed` will have no effect if `no_slip` is False because
+            the slip surface cannot generate shear stress.
 
     """
 
-    def __init__(self, R0, R1, angular_speed=0.0, no_slip=True):
+    def __init__(self,
+                 inner_radius,
+                 outer_radius,
+                 angular_speed=0.0,
+                 no_slip=True):
         super().__init__(no_slip)
         param_dict = ParameterDict(
-            R0=float(R0),
-            R1=float(R1),
+            inner_radius=float(inner_radius),
+            outer_radius=float(outer_radius),
             angular_speed=float(angular_speed),
         )
         self._param_dict.update(param_dict)
 
     def _attach_hook(self):
-        self._cpp_obj = _mpcd.ConcentricCylinders(self.R0, self.R1,
+        self._cpp_obj = _mpcd.ConcentricCylinders(self.inner_radius,
+                                                  self.outer_radius,
                                                   self.angular_speed,
                                                   self.no_slip)
         super()._attach_hook()

--- a/hoomd/mpcd/geometry.py
+++ b/hoomd/mpcd/geometry.py
@@ -56,6 +56,77 @@ class Geometry(_HOOMDBaseObject):
         self._param_dict.update(param_dict)
 
 
+class ConcentricCylinders(Geometry):
+    r"""Concentric-cylinders channel.
+
+    Args:
+        R0 (float): Inner radius of the cylinders.
+        R1 (float): Outer radius of the cylinders
+        angular_speed (float): Angular speed of the outer cylinder in the
+            counterclockwise direction.
+        no_slip (bool): If True, surfaces have no-slip boundary condition.
+            Otherwise, they have the slip boundary condition.
+
+    `ConcentricCylinders` confines particles between two cylinders
+    centered around the origin. The inner cylinder are stationary, but the
+    outer cylinder may put into motion with 'angular_speed'.
+
+    .. rubric:: Examples:
+
+    Stationary concentric cylinders with no-slip boundary condition.
+
+    .. code-block:: python
+
+        cylinders = hoomd.mpcd.geometry.ConcentricCylinders(R0=2.0, R1=5.0)
+        stream = hoomd.mpcd.stream.BounceBack(period=1, geometry=cylinders)
+        simulation.operations.integrator.streaming_method = stream
+
+    Stationary concentric cylinders with slip boundary condition.
+
+    .. code-block:: python
+
+        cylinders = hoomd.mpcd.geometry.ConcentricCylinders(
+            R0=2.0, R1=5.0, no_slip=False)
+        stream = hoomd.mpcd.stream.BounceBack(period=1, geometry=cylinders)
+        simulation.operations.integrator.streaming_method = stream
+
+    Moving outer cylinder.
+
+    .. code-block:: python
+
+        cylinders = hoomd.mpcd.geometry.ConcentricCylinders(
+            R0=2.0, R1=5.0, angular_speed=1.0, no_slip=True)
+        stream = hoomd.mpcd.stream.BounceBack(period=1, geometry=cylinders)
+        simulation.operations.integrator.streaming_method = stream
+
+    Attributes:
+        R0 (float): Inner radius of the cylinder (*read only*).
+
+        R1 (float): Outer radius of the cylinder (*read only*).
+
+        angular_speed (float): Angular outer cylinder speed (*read only*).
+
+            `speed` will have no effect if `no_slip` is False because the slip
+            surface cannot generate shear stress.
+
+    """
+
+    def __init__(self, R0, R1, angular_speed=0.0, no_slip=True):
+        super().__init__(no_slip)
+        param_dict = ParameterDict(
+            R0=float(R0),
+            R1=float(R1),
+            angular_speed=float(angular_speed),
+        )
+        self._param_dict.update(param_dict)
+
+    def _attach_hook(self):
+        self._cpp_obj = _mpcd.ConcentricCylinders(self.R0, self.R1,
+                                                  self.angular_speed,
+                                                  self.no_slip)
+        super()._attach_hook()
+
+
 class ParallelPlates(Geometry):
     r"""Parallel-plate channel.
 

--- a/hoomd/mpcd/geometry.py
+++ b/hoomd/mpcd/geometry.py
@@ -68,8 +68,9 @@ class ConcentricCylinders(Geometry):
             Otherwise, they have the slip boundary condition.
 
     `ConcentricCylinders` confines particles between two cylinders
-    centered around the origin. The inner cylinder are stationary, but the
-    outer cylinder may put into motion with 'angular_speed'.
+    centered around the origin. The inner cylinder is stationary, but the
+    outer cylinder can rotate counterclockwise about the *z* axis with
+    constant `angular_speed`.
 
     .. rubric:: Examples:
 

--- a/hoomd/mpcd/module.cc
+++ b/hoomd/mpcd/module.cc
@@ -34,6 +34,7 @@ void export_ManualVirtualParticleFiller(pybind11::module&);
 void export_NoForce(pybind11::module&);
 void export_ParallelPlateGeometry(pybind11::module&);
 void export_ParallelPlateGeometryFiller(pybind11::module&);
+void export_ConcentricCylindersGeometry(pybind11::module&);
 void export_PlanarPoreGeometry(pybind11::module&);
 void export_PlanarPoreGeometryFiller(pybind11::module&);
 void export_Sorter(pybind11::module&);
@@ -73,6 +74,11 @@ void export_BounceBackStreamingMethodParallelPlateGeometryBlockForce(pybind11::m
 void export_BounceBackStreamingMethodParallelPlateGeometryConstantForce(pybind11::module&);
 void export_BounceBackStreamingMethodParallelPlateGeometryNoForce(pybind11::module&);
 void export_BounceBackStreamingMethodParallelPlateGeometrySineForce(pybind11::module&);
+// concentric cylinders
+void export_BounceBackStreamingMethodConcentricCylindersGeometryBlockForce(pybind11::module&);
+void export_BounceBackStreamingMethodConcentricCylindersGeometryConstantForce(pybind11::module&);
+void export_BounceBackStreamingMethodConcentricCylindersGeometryNoForce(pybind11::module&);
+void export_BounceBackStreamingMethodConcentricCylindersGeometrySineForce(pybind11::module&);
 // planar pore
 void export_BounceBackStreamingMethodPlanarPoreGeometryBlockForce(pybind11::module&);
 void export_BounceBackStreamingMethodPlanarPoreGeometryConstantForce(pybind11::module&);
@@ -89,6 +95,11 @@ void export_BounceBackStreamingMethodParallelPlateGeometryBlockForceGPU(pybind11
 void export_BounceBackStreamingMethodParallelPlateGeometryConstantForceGPU(pybind11::module&);
 void export_BounceBackStreamingMethodParallelPlateGeometryNoForceGPU(pybind11::module&);
 void export_BounceBackStreamingMethodParallelPlateGeometrySineForceGPU(pybind11::module&);
+// concentric cylinders
+void export_BounceBackStreamingMethodConcentricCylindersGeometryBlockForceGPU(pybind11::module&);
+void export_BounceBackStreamingMethodConcentricCylindersGeometryConstantForceGPU(pybind11::module&);
+void export_BounceBackStreamingMethodConcentricCylindersGeometryNoForceGPU(pybind11::module&);
+void export_BounceBackStreamingMethodConcentricCylindersGeometrySineForceGPU(pybind11::module&);
 // planar pore
 void export_BounceBackStreamingMethodPlanarPoreGeometryBlockForceGPU(pybind11::module&);
 void export_BounceBackStreamingMethodPlanarPoreGeometryConstantForceGPU(pybind11::module&);
@@ -102,10 +113,12 @@ void export_BounceBackStreamingMethodSphereGeometrySineForceGPU(pybind11::module
 #endif // ENABLE_HIP
 
 void export_BounceBackNVEParallelPlateGeometry(pybind11::module&);
+void export_BounceBackNVEConcentricCylindersGeometry(pybind11::module&);
 void export_BounceBackNVEPlanarPoreGeometry(pybind11::module&);
 void export_BounceBackNVESphereGeometry(pybind11::module&);
 #ifdef ENABLE_HIP
 void export_BounceBackNVEParallelPlateGeometryGPU(pybind11::module&);
+void export_BounceBackNVEConcentricCylindersGeometryGPU(pybind11::module&);
 void export_BounceBackNVEPlanarPoreGeometryGPU(pybind11::module&);
 void export_BounceBackNVESphereGeometryGPU(pybind11::module&);
 #endif // ENABLE_HIP
@@ -124,7 +137,11 @@ namespace gpu
 /*!
  * The kernel namespace contains the kernels that do the work of a kernel driver
  * in the gpu namespace. They are not part of the public interface for the MPCD component,
- * and are subject to change without notice.
+ * and are subject to change without notice.   // sphere
+    export_BounceBackStreamingMethodSphereGeometryBlockForce(m);
+    export_BounceBackStreamingMethodSphereGeometryConstantForce(m);
+    export_BounceBackStreamingMethodSphereGeometryNoForce(m);
+    export_BounceBackStreamingMethodSphereGeometrySineForce(m);
  */
 namespace kernel
     {
@@ -159,6 +176,7 @@ PYBIND11_MODULE(_mpcd, m)
     export_NoForce(m);
     export_ParallelPlateGeometry(m);
     export_ParallelPlateGeometryFiller(m);
+    export_ConcentricCylindersGeometry(m);
     export_PlanarPoreGeometry(m);
     export_PlanarPoreGeometryFiller(m);
     export_Sorter(m);
@@ -182,7 +200,11 @@ PYBIND11_MODULE(_mpcd, m)
 
     export_BulkStreamingMethodBlockForce(m);
     export_BulkStreamingMethodConstantForce(m);
-    export_BulkStreamingMethodNoForce(m);
+    export_BulkStreamingMethodNoForce(m); // sphere
+    export_BounceBackStreamingMethodSphereGeometryBlockForce(m);
+    export_BounceBackStreamingMethodSphereGeometryConstantForce(m);
+    export_BounceBackStreamingMethodSphereGeometryNoForce(m);
+    export_BounceBackStreamingMethodSphereGeometrySineForce(m);
     export_BulkStreamingMethodSineForce(m);
 #ifdef ENABLE_HIP
     export_BulkStreamingMethodBlockForceGPU(m);
@@ -196,6 +218,11 @@ PYBIND11_MODULE(_mpcd, m)
     export_BounceBackStreamingMethodParallelPlateGeometryConstantForce(m);
     export_BounceBackStreamingMethodParallelPlateGeometryNoForce(m);
     export_BounceBackStreamingMethodParallelPlateGeometrySineForce(m);
+    // concentric cylinders
+    export_BounceBackStreamingMethodConcentricCylindersGeometryBlockForce(m);
+    export_BounceBackStreamingMethodConcentricCylindersGeometryConstantForce(m);
+    export_BounceBackStreamingMethodConcentricCylindersGeometryNoForce(m);
+    export_BounceBackStreamingMethodConcentricCylindersGeometrySineForce(m);
     // planar pore
     export_BounceBackStreamingMethodPlanarPoreGeometryBlockForce(m);
     export_BounceBackStreamingMethodPlanarPoreGeometryConstantForce(m);
@@ -212,6 +239,11 @@ PYBIND11_MODULE(_mpcd, m)
     export_BounceBackStreamingMethodParallelPlateGeometryConstantForceGPU(m);
     export_BounceBackStreamingMethodParallelPlateGeometryNoForceGPU(m);
     export_BounceBackStreamingMethodParallelPlateGeometrySineForceGPU(m);
+    // concentric cylinders
+    export_BounceBackStreamingMethodConcentricCylindersGeometryBlockForceGPU(m);
+    export_BounceBackStreamingMethodConcentricCylindersGeometryConstantForceGPU(m);
+    export_BounceBackStreamingMethodConcentricCylindersGeometryNoForceGPU(m);
+    export_BounceBackStreamingMethodConcentricCylindersGeometrySineForceGPU(m);
     // planar pore
     export_BounceBackStreamingMethodPlanarPoreGeometryBlockForceGPU(m);
     export_BounceBackStreamingMethodPlanarPoreGeometryConstantForceGPU(m);
@@ -225,10 +257,12 @@ PYBIND11_MODULE(_mpcd, m)
 #endif // ENABLE_HIP
 
     export_BounceBackNVEParallelPlateGeometry(m);
+    export_BounceBackNVEConcentricCylindersGeometry(m);
     export_BounceBackNVEPlanarPoreGeometry(m);
     export_BounceBackNVESphereGeometry(m);
 #ifdef ENABLE_HIP
     export_BounceBackNVEParallelPlateGeometryGPU(m);
+    export_BounceBackNVEConcentricCylindersGeometryGPU(m);
     export_BounceBackNVEPlanarPoreGeometryGPU(m);
     export_BounceBackNVESphereGeometryGPU(m);
 #endif // ENABLE_HIP

--- a/hoomd/mpcd/module.cc
+++ b/hoomd/mpcd/module.cc
@@ -32,9 +32,10 @@ void export_ConstantForce(pybind11::module&);
 void export_Integrator(pybind11::module&);
 void export_ManualVirtualParticleFiller(pybind11::module&);
 void export_NoForce(pybind11::module&);
+void export_ConcentricCylindersGeometry(pybind11::module&);
+void export_ConcentricCylindersGeometryFiller(pybind11::module&);
 void export_ParallelPlateGeometry(pybind11::module&);
 void export_ParallelPlateGeometryFiller(pybind11::module&);
-void export_ConcentricCylindersGeometry(pybind11::module&);
 void export_PlanarPoreGeometry(pybind11::module&);
 void export_PlanarPoreGeometryFiller(pybind11::module&);
 void export_Sorter(pybind11::module&);
@@ -69,16 +70,16 @@ void export_BulkStreamingMethodNoForceGPU(pybind11::module&);
 void export_BulkStreamingMethodSineForceGPU(pybind11::module&);
 #endif // ENABLE_HIP
 
-// parallel plate
-void export_BounceBackStreamingMethodParallelPlateGeometryBlockForce(pybind11::module&);
-void export_BounceBackStreamingMethodParallelPlateGeometryConstantForce(pybind11::module&);
-void export_BounceBackStreamingMethodParallelPlateGeometryNoForce(pybind11::module&);
-void export_BounceBackStreamingMethodParallelPlateGeometrySineForce(pybind11::module&);
 // concentric cylinders
 void export_BounceBackStreamingMethodConcentricCylindersGeometryBlockForce(pybind11::module&);
 void export_BounceBackStreamingMethodConcentricCylindersGeometryConstantForce(pybind11::module&);
 void export_BounceBackStreamingMethodConcentricCylindersGeometryNoForce(pybind11::module&);
 void export_BounceBackStreamingMethodConcentricCylindersGeometrySineForce(pybind11::module&);
+// parallel plate
+void export_BounceBackStreamingMethodParallelPlateGeometryBlockForce(pybind11::module&);
+void export_BounceBackStreamingMethodParallelPlateGeometryConstantForce(pybind11::module&);
+void export_BounceBackStreamingMethodParallelPlateGeometryNoForce(pybind11::module&);
+void export_BounceBackStreamingMethodParallelPlateGeometrySineForce(pybind11::module&);
 // planar pore
 void export_BounceBackStreamingMethodPlanarPoreGeometryBlockForce(pybind11::module&);
 void export_BounceBackStreamingMethodPlanarPoreGeometryConstantForce(pybind11::module&);
@@ -90,16 +91,16 @@ void export_BounceBackStreamingMethodSphereGeometryConstantForce(pybind11::modul
 void export_BounceBackStreamingMethodSphereGeometryNoForce(pybind11::module&);
 void export_BounceBackStreamingMethodSphereGeometrySineForce(pybind11::module&);
 #ifdef ENABLE_HIP
-// parallel plate
-void export_BounceBackStreamingMethodParallelPlateGeometryBlockForceGPU(pybind11::module&);
-void export_BounceBackStreamingMethodParallelPlateGeometryConstantForceGPU(pybind11::module&);
-void export_BounceBackStreamingMethodParallelPlateGeometryNoForceGPU(pybind11::module&);
-void export_BounceBackStreamingMethodParallelPlateGeometrySineForceGPU(pybind11::module&);
 // concentric cylinders
 void export_BounceBackStreamingMethodConcentricCylindersGeometryBlockForceGPU(pybind11::module&);
 void export_BounceBackStreamingMethodConcentricCylindersGeometryConstantForceGPU(pybind11::module&);
 void export_BounceBackStreamingMethodConcentricCylindersGeometryNoForceGPU(pybind11::module&);
 void export_BounceBackStreamingMethodConcentricCylindersGeometrySineForceGPU(pybind11::module&);
+// parallel plate
+void export_BounceBackStreamingMethodParallelPlateGeometryBlockForceGPU(pybind11::module&);
+void export_BounceBackStreamingMethodParallelPlateGeometryConstantForceGPU(pybind11::module&);
+void export_BounceBackStreamingMethodParallelPlateGeometryNoForceGPU(pybind11::module&);
+void export_BounceBackStreamingMethodParallelPlateGeometrySineForceGPU(pybind11::module&);
 // planar pore
 void export_BounceBackStreamingMethodPlanarPoreGeometryBlockForceGPU(pybind11::module&);
 void export_BounceBackStreamingMethodPlanarPoreGeometryConstantForceGPU(pybind11::module&);
@@ -112,13 +113,13 @@ void export_BounceBackStreamingMethodSphereGeometryNoForceGPU(pybind11::module&)
 void export_BounceBackStreamingMethodSphereGeometrySineForceGPU(pybind11::module&);
 #endif // ENABLE_HIP
 
-void export_BounceBackNVEParallelPlateGeometry(pybind11::module&);
 void export_BounceBackNVEConcentricCylindersGeometry(pybind11::module&);
+void export_BounceBackNVEParallelPlateGeometry(pybind11::module&);
 void export_BounceBackNVEPlanarPoreGeometry(pybind11::module&);
 void export_BounceBackNVESphereGeometry(pybind11::module&);
 #ifdef ENABLE_HIP
-void export_BounceBackNVEParallelPlateGeometryGPU(pybind11::module&);
 void export_BounceBackNVEConcentricCylindersGeometryGPU(pybind11::module&);
+void export_BounceBackNVEParallelPlateGeometryGPU(pybind11::module&);
 void export_BounceBackNVEPlanarPoreGeometryGPU(pybind11::module&);
 void export_BounceBackNVESphereGeometryGPU(pybind11::module&);
 #endif // ENABLE_HIP
@@ -137,11 +138,7 @@ namespace gpu
 /*!
  * The kernel namespace contains the kernels that do the work of a kernel driver
  * in the gpu namespace. They are not part of the public interface for the MPCD component,
- * and are subject to change without notice.   // sphere
-    export_BounceBackStreamingMethodSphereGeometryBlockForce(m);
-    export_BounceBackStreamingMethodSphereGeometryConstantForce(m);
-    export_BounceBackStreamingMethodSphereGeometryNoForce(m);
-    export_BounceBackStreamingMethodSphereGeometrySineForce(m);
+ * and are subject to change without notice.
  */
 namespace kernel
     {
@@ -174,9 +171,11 @@ PYBIND11_MODULE(_mpcd, m)
     export_Integrator(m);
     export_ManualVirtualParticleFiller(m);
     export_NoForce(m);
+    export_ConcentricCylindersGeometry(m);
+    export_ConcentricCylindersGeometryFiller(m);
     export_ParallelPlateGeometry(m);
     export_ParallelPlateGeometryFiller(m);
-    export_ConcentricCylindersGeometry(m);
+    ;
     export_PlanarPoreGeometry(m);
     export_PlanarPoreGeometryFiller(m);
     export_Sorter(m);
@@ -200,11 +199,7 @@ PYBIND11_MODULE(_mpcd, m)
 
     export_BulkStreamingMethodBlockForce(m);
     export_BulkStreamingMethodConstantForce(m);
-    export_BulkStreamingMethodNoForce(m); // sphere
-    export_BounceBackStreamingMethodSphereGeometryBlockForce(m);
-    export_BounceBackStreamingMethodSphereGeometryConstantForce(m);
-    export_BounceBackStreamingMethodSphereGeometryNoForce(m);
-    export_BounceBackStreamingMethodSphereGeometrySineForce(m);
+    export_BulkStreamingMethodNoForce(m);
     export_BulkStreamingMethodSineForce(m);
 #ifdef ENABLE_HIP
     export_BulkStreamingMethodBlockForceGPU(m);
@@ -213,16 +208,16 @@ PYBIND11_MODULE(_mpcd, m)
     export_BulkStreamingMethodSineForceGPU(m);
 #endif // ENABLE_HIP
 
-    // parallel plate
-    export_BounceBackStreamingMethodParallelPlateGeometryBlockForce(m);
-    export_BounceBackStreamingMethodParallelPlateGeometryConstantForce(m);
-    export_BounceBackStreamingMethodParallelPlateGeometryNoForce(m);
-    export_BounceBackStreamingMethodParallelPlateGeometrySineForce(m);
     // concentric cylinders
     export_BounceBackStreamingMethodConcentricCylindersGeometryBlockForce(m);
     export_BounceBackStreamingMethodConcentricCylindersGeometryConstantForce(m);
     export_BounceBackStreamingMethodConcentricCylindersGeometryNoForce(m);
     export_BounceBackStreamingMethodConcentricCylindersGeometrySineForce(m);
+    // parallel plate
+    export_BounceBackStreamingMethodParallelPlateGeometryBlockForce(m);
+    export_BounceBackStreamingMethodParallelPlateGeometryConstantForce(m);
+    export_BounceBackStreamingMethodParallelPlateGeometryNoForce(m);
+    export_BounceBackStreamingMethodParallelPlateGeometrySineForce(m);
     // planar pore
     export_BounceBackStreamingMethodPlanarPoreGeometryBlockForce(m);
     export_BounceBackStreamingMethodPlanarPoreGeometryConstantForce(m);
@@ -234,16 +229,16 @@ PYBIND11_MODULE(_mpcd, m)
     export_BounceBackStreamingMethodSphereGeometryNoForce(m);
     export_BounceBackStreamingMethodSphereGeometrySineForce(m);
 #ifdef ENABLE_HIP
-    // parallel plate
-    export_BounceBackStreamingMethodParallelPlateGeometryBlockForceGPU(m);
-    export_BounceBackStreamingMethodParallelPlateGeometryConstantForceGPU(m);
-    export_BounceBackStreamingMethodParallelPlateGeometryNoForceGPU(m);
-    export_BounceBackStreamingMethodParallelPlateGeometrySineForceGPU(m);
     // concentric cylinders
     export_BounceBackStreamingMethodConcentricCylindersGeometryBlockForceGPU(m);
     export_BounceBackStreamingMethodConcentricCylindersGeometryConstantForceGPU(m);
     export_BounceBackStreamingMethodConcentricCylindersGeometryNoForceGPU(m);
     export_BounceBackStreamingMethodConcentricCylindersGeometrySineForceGPU(m);
+    // parallel plate
+    export_BounceBackStreamingMethodParallelPlateGeometryBlockForceGPU(m);
+    export_BounceBackStreamingMethodParallelPlateGeometryConstantForceGPU(m);
+    export_BounceBackStreamingMethodParallelPlateGeometryNoForceGPU(m);
+    export_BounceBackStreamingMethodParallelPlateGeometrySineForceGPU(m);
     // planar pore
     export_BounceBackStreamingMethodPlanarPoreGeometryBlockForceGPU(m);
     export_BounceBackStreamingMethodPlanarPoreGeometryConstantForceGPU(m);
@@ -256,13 +251,13 @@ PYBIND11_MODULE(_mpcd, m)
     export_BounceBackStreamingMethodSphereGeometrySineForceGPU(m);
 #endif // ENABLE_HIP
 
-    export_BounceBackNVEParallelPlateGeometry(m);
     export_BounceBackNVEConcentricCylindersGeometry(m);
+    export_BounceBackNVEParallelPlateGeometry(m);
     export_BounceBackNVEPlanarPoreGeometry(m);
     export_BounceBackNVESphereGeometry(m);
 #ifdef ENABLE_HIP
-    export_BounceBackNVEParallelPlateGeometryGPU(m);
     export_BounceBackNVEConcentricCylindersGeometryGPU(m);
+    export_BounceBackNVEParallelPlateGeometryGPU(m);
     export_BounceBackNVEPlanarPoreGeometryGPU(m);
     export_BounceBackNVESphereGeometryGPU(m);
 #endif // ENABLE_HIP

--- a/hoomd/mpcd/pytest/test_geometry.py
+++ b/hoomd/mpcd/pytest/test_geometry.py
@@ -19,7 +19,7 @@ def snap():
     return snap_
 
 
-class ConcentricCylinders:
+class TestConcentricCylinders:
 
     def test_default_init(self, simulation_factory, snap):
         geom = hoomd.mpcd.geometry.ConcentricCylinders(inner_radius=2.0,

--- a/hoomd/mpcd/pytest/test_geometry.py
+++ b/hoomd/mpcd/pytest/test_geometry.py
@@ -19,6 +19,48 @@ def snap():
     return snap_
 
 
+class ConcentricCylinders:
+
+    def test_default_init(self, simulation_factory, snap):
+        geom = hoomd.mpcd.geometry.ConcentricCylinders(R0=2.0, R1=4.0)
+        assert geom.R0 == 2.0
+        assert geom.R1 == 4.0
+        assert geom.angular_speed == 0.0
+        assert geom.no_slip
+
+        sim = simulation_factory(snap)
+        geom._attach(sim)
+        assert geom.R0 == 2.0
+        assert geom.R1 == 4.0
+        assert geom.angular_speed == 0.0
+        assert geom.no_slip
+
+    def test_nondefault_init(self, simulation_factory, snap):
+        geom = hoomd.mpcd.geometry.ConcentricCylinders(R0=2.0,
+                                                       R1=5.0,
+                                                       angular_speed=1.0,
+                                                       no_slip=False)
+        assert geom.R0 == 2.0
+        assert geom.R1 == 5.0
+        assert geom.angular_speed == 1.0
+        assert not geom.no_slip
+
+        sim = simulation_factory(snap)
+        geom._attach(sim)
+        assert geom.R0 == 2.0
+        assert geom.R1 == 5.0
+        assert geom.angular_speed == 1.0
+        assert not geom.no_slip
+
+    def test_pickling(self, simulation_factory, snap):
+        geom = hoomd.mpcd.geometry.ConcentricCylinders(R0=2.0, R1=4.0)
+        pickling_check(geom)
+
+        sim = simulation_factory(snap)
+        geom._attach(sim)
+        pickling_check(geom)
+
+
 class TestParallelPlates:
 
     def test_default_init(self, simulation_factory, snap):

--- a/hoomd/mpcd/pytest/test_geometry.py
+++ b/hoomd/mpcd/pytest/test_geometry.py
@@ -22,38 +22,40 @@ def snap():
 class ConcentricCylinders:
 
     def test_default_init(self, simulation_factory, snap):
-        geom = hoomd.mpcd.geometry.ConcentricCylinders(R0=2.0, R1=4.0)
-        assert geom.R0 == 2.0
-        assert geom.R1 == 4.0
+        geom = hoomd.mpcd.geometry.ConcentricCylinders(inner_radius=2.0,
+                                                       outer_radius=4.0)
+        assert geom.inner_radius == 2.0
+        assert geom.outer_radius == 4.0
         assert geom.angular_speed == 0.0
         assert geom.no_slip
 
         sim = simulation_factory(snap)
         geom._attach(sim)
-        assert geom.R0 == 2.0
-        assert geom.R1 == 4.0
+        assert geom.inner_radius == 2.0
+        assert geom.outer_radius == 4.0
         assert geom.angular_speed == 0.0
         assert geom.no_slip
 
     def test_nondefault_init(self, simulation_factory, snap):
-        geom = hoomd.mpcd.geometry.ConcentricCylinders(R0=2.0,
-                                                       R1=5.0,
+        geom = hoomd.mpcd.geometry.ConcentricCylinders(inner_radius=2.0,
+                                                       outer_radius=5.0,
                                                        angular_speed=1.0,
                                                        no_slip=False)
-        assert geom.R0 == 2.0
-        assert geom.R1 == 5.0
+        assert geom.inner_radius == 2.0
+        assert geom.outer_radius == 5.0
         assert geom.angular_speed == 1.0
         assert not geom.no_slip
 
         sim = simulation_factory(snap)
         geom._attach(sim)
-        assert geom.R0 == 2.0
-        assert geom.R1 == 5.0
+        assert geom.inner_radius == 2.0
+        assert geom.outer_radius == 5.0
         assert geom.angular_speed == 1.0
         assert not geom.no_slip
 
     def test_pickling(self, simulation_factory, snap):
-        geom = hoomd.mpcd.geometry.ConcentricCylinders(R0=2.0, R1=4.0)
+        geom = hoomd.mpcd.geometry.ConcentricCylinders(inner_radius=2.0,
+                                                       outer_radius=4.0)
         pickling_check(geom)
 
         sim = simulation_factory(snap)

--- a/hoomd/mpcd/pytest/test_stream.py
+++ b/hoomd/mpcd/pytest/test_stream.py
@@ -28,6 +28,16 @@ def snap():
             hoomd.mpcd.stream.BounceBack,
             {
                 "geometry":
+                    hoomd.mpcd.geometry.ConcentricCylinders(inner_radius=2.0,
+                                                            outer_radius=5.0,
+                                                            angular_speed=0.0,
+                                                            no_slip=True),
+            },
+        ),
+        (
+            hoomd.mpcd.stream.BounceBack,
+            {
+                "geometry":
                     hoomd.mpcd.geometry.CosineChannel(
                         amplitude=4.0, repeat_length=20.0, separation=2.0),
             },
@@ -67,8 +77,8 @@ def snap():
         ),
     ],
     ids=[
-        "Bulk", "CosineChannel", "CosineExpansionContraction", "ParallelPlates",
-        "PlanarPore", "Sphere"
+        "Bulk", "ConcentricCylinders", "CosineChannel",
+        "CosineExpansionContraction", "ParallelPlates", "PlanarPore", "Sphere"
     ],
 )
 class TestStreamingMethod:

--- a/hoomd/mpcd/pytest/test_stream.py
+++ b/hoomd/mpcd/pytest/test_stream.py
@@ -222,7 +222,7 @@ class TestConcentricCylinders:
         sim = simulation_factory(snap)
         sm = hoomd.mpcd.stream.BounceBack(
             period=1,
-            geometry=hoomd.mpcd.geometry.ConcentricCylinders(inner_radiuss=2.0,
+            geometry=hoomd.mpcd.geometry.ConcentricCylinders(inner_radius=2.0,
                                                              outer_radius=5.0))
         ig = hoomd.mpcd.Integrator(dt=0.1, streaming_method=sm)
         sim.operations.integrator = ig
@@ -232,7 +232,7 @@ class TestConcentricCylinders:
         snap = sim.state.get_snapshot()
         if snap.communicator.rank == 0:
             np.testing.assert_array_almost_equal(
-                snap.mpcd.position, [[-4.0, -3.1, 0.2], [-2.15, -0.15, 0.00]])
+                snap.mpcd.position, [[-4.0, -3.0, 0.1], [-2.15, -0.15, 0.00]])
             np.testing.assert_array_almost_equal(
                 snap.mpcd.velocity, [[-1.0, -1.0, 1.0], [1.0, 1.0, -1.0]])
 
@@ -285,7 +285,7 @@ class TestConcentricCylinders:
         if snap.communicator.rank == 0:
             np.testing.assert_array_almost_equal(
                 snap.mpcd.position,
-                [[-3.972, -3.028, 0.2], [-2.05, 0.05, -0.10]])
+                [[-3.972, -3.028, 0.2], [-2.05, -0.05, -0.10]])
             np.testing.assert_array_almost_equal(
                 snap.mpcd.velocity, [[0.28, -0.28, 1.0], [1.0, 1.0, -1.0]])
 
@@ -321,11 +321,9 @@ class TestConcentricCylinders:
         snap = sim.state.get_snapshot()
         if snap.communicator.rank == 0:
             np.testing.assert_array_almost_equal(
-                snap.mpcd.position,
-                [[-3.86666667, -2.925, 0.0], [-2.05, -0.05, -0.10]])
+                snap.mpcd.position, [[-3.60, -3.3, 0.0], [-2.05, -0.05, -0.10]])
             np.testing.assert_array_almost_equal(
-                snap.mpcd.velocity,
-                [[2.66666667, 1.5, -1.0], [-1.0, -1.0, 1.0]])
+                snap.mpcd.velocity, [[8.0, -6.0, -1.0], [-1.0, -1.0, 1.0]])
 
     def test_step_moving_wall_slip(self, simulation_factory, snap):
         """Test step with moving wall and slip condition."""
@@ -363,7 +361,8 @@ class TestConcentricCylinders:
         sim = simulation_factory(snap)
         sm = hoomd.mpcd.stream.BounceBack(
             period=1,
-            geometry=hoomd.mpcd.geometry.ConcentricCylinders(R0=R0, R1=R1))
+            geometry=hoomd.mpcd.geometry.ConcentricCylinders(inner_radius=R0,
+                                                             outer_radius=R1))
         ig = hoomd.mpcd.Integrator(dt=0.1, streaming_method=sm)
         sim.operations.integrator = ig
 

--- a/hoomd/mpcd/pytest/test_stream.py
+++ b/hoomd/mpcd/pytest/test_stream.py
@@ -200,7 +200,8 @@ class ConcentricCylinders:
         sim = simulation_factory(snap)
         sm = hoomd.mpcd.stream.BounceBack(
             period=1,
-            geometry=hoomd.mpcd.geometry.ConcentricCylinders(R0=2.0, R1=5.0))
+            geometry=hoomd.mpcd.geometry.ConcentricCylinders(inner_radiuss=2.0,
+                                                             outer_radius=5.0))
         ig = hoomd.mpcd.Integrator(dt=0.1, streaming_method=sm)
         sim.operations.integrator = ig
 
@@ -213,7 +214,7 @@ class ConcentricCylinders:
             np.testing.assert_array_almost_equal(
                 snap.mpcd.velocity, [[-1.0, -1.0, 1.0], [1.0, 1.0, -1.0]])
 
-        # take another step where one particle will now hit the outer wall
+        # take another step where first particle will now hit the outer wall
         sim.run(1)
         snap = sim.state.get_snapshot()
         if snap.communicator.rank == 0:
@@ -222,7 +223,7 @@ class ConcentricCylinders:
             np.testing.assert_array_almost_equal(
                 snap.mpcd.velocity, [[1.0, 1.0, -1.0], [1.0, 1.0, -1.0]])
 
-        # take another step, reflecting the second particle
+        # take another step where second particle will now hit the inner wall
         sim.run(1)
         snap = sim.state.get_snapshot()
         if snap.communicator.rank == 0:
@@ -240,8 +241,8 @@ class ConcentricCylinders:
         sim = simulation_factory(snap)
         sm = hoomd.mpcd.stream.BounceBack(
             period=1,
-            geometry=hoomd.mpcd.geometry.ConcentricCylinders(R0=2.0,
-                                                             R1=5.0,
+            geometry=hoomd.mpcd.geometry.ConcentricCylinders(inner_radius=2.0,
+                                                             outer_radius=5.0,
                                                              no_slip=False),
         )
         ig = hoomd.mpcd.Integrator(dt=0.1, streaming_method=sm)
@@ -256,7 +257,7 @@ class ConcentricCylinders:
             np.testing.assert_array_almost_equal(
                 snap.mpcd.velocity, [[-1.0, -1.0, 1.0], [1.0, 1.0, -1.0]])
 
-        # take another step where one particle will now hit the outer wall
+        # take another step where first particle will now hit the outer wall
         sim.run(1)
         snap = sim.state.get_snapshot()
         if snap.communicator.rank == 0:
@@ -266,7 +267,7 @@ class ConcentricCylinders:
             np.testing.assert_array_almost_equal(
                 snap.mpcd.velocity, [[0.28, -0.28, 1.0], [1.0, 1.0, -1.0]])
 
-        # take another step, reflecting perpendicular motion of second particle
+        # take another step where second partile will now hit the inner wall
         sim.run(1)
         snap = sim.state.get_snapshot()
         if snap.communicator.rank == 0:
@@ -285,8 +286,8 @@ class ConcentricCylinders:
         sim = simulation_factory(snap)
         sm = hoomd.mpcd.stream.BounceBack(
             period=1,
-            geometry=hoomd.mpcd.geometry.ConcentricCylinders(R0=2.0,
-                                                             R1=5.0,
+            geometry=hoomd.mpcd.geometry.ConcentricCylinders(inner_radius=2.0,
+                                                             outer_radius=5.0,
                                                              angular_speed=1,
                                                              no_slip=True),
         )
@@ -313,8 +314,8 @@ class ConcentricCylinders:
         sim = simulation_factory(snap)
         sm = hoomd.mpcd.stream.BounceBack(
             period=1,
-            geometry=hoomd.mpcd.geometry.ConcentricCylinders(R0=2.0,
-                                                             R1=5.0,
+            geometry=hoomd.mpcd.geometry.ConcentricCylinders(inner_radius=2.0,
+                                                             outer_radius=5.0,
                                                              angular_speed=1,
                                                              no_slip=False),
         )

--- a/sphinx-doc/credits.rst
+++ b/sphinx-doc/credits.rst
@@ -64,6 +64,7 @@ The following people have contributed to HOOMD-blue:
 * Jen Bradley, University of Michigan
 * Jenny Fothergill, Boise State University
 * Jens Glaser, Oak Ridge National Laboratory
+* Jinny Cha, Auburn University
 * Joseph Berleant, University of Michigan
 * Joseph Burkhart, University of Michigan
 * Joshua A. Anderson, University of Michigan

--- a/sphinx-doc/module-mpcd-geometry.rst
+++ b/sphinx-doc/module-mpcd-geometry.rst
@@ -11,8 +11,8 @@ mpcd.geometry
 .. autosummary::
     :nosignatures:
 
-    Geometry
     ConcentricCylinders
+    Geometry
     ParallelPlates
     PlanarPore
     Sphere
@@ -21,8 +21,8 @@ mpcd.geometry
 
 .. automodule:: hoomd.mpcd.geometry
     :synopsis: Geometries.
-    :members: Geometry,
-              ConcentricCylinders,
+    :members: ConcentricCylinders,
+              Geometry,
               ParallelPlates,
               PlanarPore,
               Sphere

--- a/sphinx-doc/module-mpcd-geometry.rst
+++ b/sphinx-doc/module-mpcd-geometry.rst
@@ -12,6 +12,7 @@ mpcd.geometry
     :nosignatures:
 
     Geometry
+    ConcentricCylinders
     ParallelPlates
     PlanarPore
     Sphere
@@ -21,6 +22,7 @@ mpcd.geometry
 .. automodule:: hoomd.mpcd.geometry
     :synopsis: Geometries.
     :members: Geometry,
+              ConcentricCylinders,
               ParallelPlates,
               PlanarPore,
               Sphere


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should be based on *trunk-patch*. -->
<!-- Backwards compatible new features should be based on *trunk-minor*. -->
<!-- Incompatible API changes should be based on *trunk-major*. -->

## Description

<!-- Describe your changes in detail. -->
This PR adds a new geometry: concentric cylinders. The particles are confined between two cylinders, where the outer cylinder can be rotated counterclockwise with respect to the inner cylinder.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
This type of geometry is helpful for simulating shear flow and is often used in CFD and experiments.

<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves #1882 

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
Python tests are added for `mpcd.geometry.ConcentricCylinders`.

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Change log

<!-- Propose a change log entry. -->
```
* `mpcd.geometry.ConcentricCylinders` for concentric cylinders
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
