### PR TITLE
Remove restriction that prevents logging spherocylinder shape

### DIFF
--- a/hoomd/hpmc/ShapeSpheropolyhedron.h
+++ b/hoomd/hpmc/ShapeSpheropolyhedron.h
@@ -189,10 +189,6 @@ template<> inline std::string getShapeSpec(const ShapeSpheropolyhedron& spoly)
         {
         shapedef << "{\"type\": \"Sphere\", " << "\"diameter\": " << verts.diameter << "}";
         }
-    else if (nverts == 2)
-        {
-        throw std::runtime_error("Shape definition not supported for 2-vertex spheropolyhedra");
-        }
     else
         {
         shapedef << "{\"type\": \"ConvexPolyhedron\", \"rounding_radius\": " << verts.sweep_radius


### PR DESCRIPTION
## Description

While the integrators allow for sphereopolyhedra with two vertices (spherocylinders), an internal assertion in `ShapeSpheropolyhedron.h::getShapeSpec` prevented these shapes from being logged. This restriction has now been removed.

## How has this been tested?

Existing tests have not been modified.

## Change log

<!-- Propose a change log entry. -->
```
- Spheropolyhedra with two vertices can now be saved as a valid `gsd_shape_spec`
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
