### PR TITLE
Ensure that partitions have different seeds in MuVT.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,8 @@ Change Log
 
 * Correct compile errors with ``-DENABLE_GPU=on -DHOOMD_GPU_PLATFORM=HIP``
   (`#1920 <https://github.com/glotzerlab/hoomd-blue/pull/1915>`__)
+* Ensure that users set unique seeds on all partitions when performing Gibbs ensemble simulations
+  (`#1925 <https://github.com/glotzerlab/hoomd-blue/pull/1925>`__)
 
 4.9.0 (2024-10-29)
 ^^^^^^^^^^^^^^^^^^

--- a/hoomd/RNGIdentifiers.h
+++ b/hoomd/RNGIdentifiers.h
@@ -34,7 +34,7 @@ struct RNGIdentifier
     static const uint8_t UpdaterClusters = 8;
     static const uint8_t UpdaterClustersPairwise = 9;
     static const uint8_t UpdaterExternalFieldWall = 10;
-    static const uint8_t UpdaterMuVT = 11;
+    static const uint8_t UpdaterMuVTGroup = 11;
     static const uint8_t UpdaterMuVTDepletants1 = 12;
     static const uint8_t UpdaterMuVTDepletants2 = 13;
     static const uint8_t UpdaterMuVTDepletants3 = 14;
@@ -42,8 +42,8 @@ struct RNGIdentifier
     static const uint8_t UpdaterMuVTDepletants5 = 16;
     static const uint8_t UpdaterMuVTDepletants6 = 17;
     static const uint8_t UpdaterMuVTPoisson = 18;
-    static const uint8_t UpdaterMuVTBox1 = 19;
-    static const uint8_t UpdaterMuVTBox2 = 20;
+    static const uint8_t UpdaterMuVTInsertRemove = 19;
+    static const uint8_t Unused1 = 20;
     static const uint8_t ActiveForceCompute = 21;
     static const uint8_t EvaluatorPairDPDThermo = 22;
     static const uint8_t IntegrationMethodTwoStep = 23;

--- a/hoomd/hpmc/UpdaterMuVT.h
+++ b/hoomd/hpmc/UpdaterMuVT.h
@@ -394,7 +394,8 @@ UpdaterMuVT<Shape>::UpdaterMuVT(std::shared_ptr<SystemDefinition> sysdef,
             }
 
         // synchronize move types across all ranks within each group
-        for (unsigned int group = 0; group < this->m_exec_conf->getNPartitions() / npartition; group++)
+        for (unsigned int group = 0; group < this->m_exec_conf->getNPartitions() / npartition;
+             group++)
             {
             uint16_t tmp = m_move_type_seed;
             MPI_Bcast(&tmp,


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should be based on *trunk-patch*. -->
<!-- Backwards compatible new features should be based on *trunk-minor*. -->
<!-- Incompatible API changes should be based on *trunk-major*. -->

## Description

<!-- Describe your changes in detail. -->
Ensure that users select different seeds for partitions in MuVT Gibbs groups. Use the seed from the root of the group for random numbers that must be the same across the group.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Prior to this change `MuVT` *required* that users choose the same seed for all partitions participating in the same Gibbs ensemble group. Doing so results in correlated local moves in the separate simulation boxes.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
I tested the fix locally. Setting identical seeds within the Gibbs groups causes the error. Setting different seeds no longer causes an `MPI_Recv` error.

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
- [x] I have summarized these changes in `CHANGELOG.rst` following the established format.
