### PR TITLE
Fix unnecessary modulo operations in Index1D.h

### DIFF
--- a/hoomd/Index1D.h
+++ b/hoomd/Index1D.h
@@ -79,7 +79,7 @@ struct Index2D
         uint2 t;
 
         t.y = idx / m_w;
-        t.x = idx % m_w;
+        t.x = idx - t.y * m_w;
         return t;
         }
 
@@ -153,7 +153,7 @@ struct Index3D
         uint3 t;
 
         t.z = idx / (m_h * m_w);
-        t.y = (idx % (m_h * m_w)) / m_w;
+        t.y = (idx - (t.z * m_h * m_w)) / m_w;
         t.x = idx - t.z * m_h * m_w - t.y * m_w;
         return t;
         }

--- a/sphinx-doc/credits.rst
+++ b/sphinx-doc/credits.rst
@@ -130,3 +130,4 @@ The following people have contributed to HOOMD-blue:
 * Nathan Barrett, Pritzker School of Molecular Engineering
 * Domagoj Fijan, University of Michigan
 * Cristina Butu, Columbia University
+* Haochen Yan, Lanzhou University


### PR DESCRIPTION

<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should be based on *trunk-patch*. -->
<!-- Backwards compatible new features should be based on *trunk-minor*. -->
<!-- Incompatible API changes should be based on *trunk-major*. -->

## Description

This PR replaces unnecessary modulo operations with multiplication and subtraction.

## Motivation and context

I was browsing through the project code and realised that this was a change that would improve performance.

## How has this been tested?

Local compilation passes fine.

## Change log

```
* Fix unnecessary modulo operations in Index1D.h
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
