### PR TITLE
Fix several issues with MPCD virtual particle filler on GPU

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,9 @@ Change Log
   (`#1925 <https://github.com/glotzerlab/hoomd-blue/pull/1925>`__)
 * Mesh potentials return only one volume or area when ``ignore_type == True``
   (`#1928 <https://github.com/glotzerlab/hoomd-blue/pull/1928>`__)
+* Ensure correct methods are used by ``hoomd.mpcd.fill.VirtualParticleFiller`` for certain
+  geometries, improving performance on the GPU in these cases
+  (`#1934 <https://github.com/glotzerlab/hoomd-blue/pull/1934>`__).
 
 *Added*
 

--- a/hoomd/mpcd/RejectionVirtualParticleFiller.h
+++ b/hoomd/mpcd/RejectionVirtualParticleFiller.h
@@ -162,10 +162,8 @@ template<class Geometry> void export_RejectionVirtualParticleFiller(pybind11::mo
     namespace py = pybind11;
     const std::string name = Geometry::getName() + "GeometryFiller";
     py::class_<mpcd::RejectionVirtualParticleFiller<Geometry>,
-               std::shared_ptr<mpcd::RejectionVirtualParticleFiller<Geometry>>>(
-        m,
-        name.c_str(),
-        py::base<mpcd::VirtualParticleFiller>())
+               mpcd::VirtualParticleFiller,
+               std::shared_ptr<mpcd::RejectionVirtualParticleFiller<Geometry>>>(m, name.c_str())
         .def(pybind11::init<std::shared_ptr<SystemDefinition>,
                             const std::string&,
                             Scalar,

--- a/hoomd/mpcd/RejectionVirtualParticleFillerGPU.cuh
+++ b/hoomd/mpcd/RejectionVirtualParticleFillerGPU.cuh
@@ -38,7 +38,7 @@ struct draw_virtual_particles_args_t
                                   const Scalar _vel_factor,
                                   const unsigned int _type,
                                   const unsigned int _N_virt_max,
-                                  const unsigned int _timestep,
+                                  const uint64_t _timestep,
                                   const unsigned int _seed,
                                   const unsigned int _filler_id,
                                   const unsigned int _block_size)
@@ -58,7 +58,7 @@ struct draw_virtual_particles_args_t
     const Scalar vel_factor;
     const unsigned int type;
     const unsigned int N_virt_max;
-    const unsigned int timestep;
+    const uint64_t timestep;
     const unsigned int seed;
     const unsigned int filler_id;
     const unsigned int block_size;
@@ -126,7 +126,7 @@ __global__ void draw_virtual_particles(Scalar4* d_tmp_pos,
                                        const Scalar vel_factor,
                                        const unsigned int type,
                                        const unsigned int N_virt_max,
-                                       const unsigned int timestep,
+                                       const uint64_t timestep,
                                        const unsigned int seed,
                                        const unsigned int filler_id,
                                        const unsigned int block_size,

--- a/hoomd/mpcd/RejectionVirtualParticleFillerGPU.h
+++ b/hoomd/mpcd/RejectionVirtualParticleFillerGPU.h
@@ -54,7 +54,7 @@ class PYBIND11_EXPORT RejectionVirtualParticleFillerGPU
 
     protected:
     //! Fill the volume outside the confinement
-    virtual void fill(unsigned int timestep);
+    virtual void fill(uint64_t timestep);
 
     private:
     GPUArray<bool> m_keep_particles; // Track whether particles are in/out of bounds for geometry
@@ -64,8 +64,7 @@ class PYBIND11_EXPORT RejectionVirtualParticleFillerGPU
     std::shared_ptr<Autotuner<1>> m_tuner2; //!< Autotuner for particle tagging
     };
 
-template<class Geometry>
-void RejectionVirtualParticleFillerGPU<Geometry>::fill(unsigned int timestep)
+template<class Geometry> void RejectionVirtualParticleFillerGPU<Geometry>::fill(uint64_t timestep)
     {
     // Number of particles that we need to draw (constant)
     const BoxDim& box = this->m_pdata->getBox();
@@ -182,10 +181,8 @@ template<class Geometry> void export_RejectionVirtualParticleFillerGPU(pybind11:
     namespace py = pybind11;
     const std::string name = Geometry::getName() + "GeometryFillerGPU";
     py::class_<mpcd::RejectionVirtualParticleFillerGPU<Geometry>,
-               std::shared_ptr<mpcd::RejectionVirtualParticleFillerGPU<Geometry>>>(
-        m,
-        name.c_str(),
-        py::base<mpcd::RejectionVirtualParticleFiller<Geometry>>())
+               mpcd::RejectionVirtualParticleFiller<Geometry>,
+               std::shared_ptr<mpcd::RejectionVirtualParticleFillerGPU<Geometry>>>(m, name.c_str())
         .def(pybind11::init<std::shared_ptr<SystemDefinition>,
                             const std::string&,
                             Scalar,

--- a/hoomd/mpcd/module.cc
+++ b/hoomd/mpcd/module.cc
@@ -28,6 +28,8 @@ void export_CollisionMethod(pybind11::module&);
 #ifdef ENABLE_MPI
 void export_Communicator(pybind11::module&);
 #endif // ENABLE_MPI
+void export_ConcentricCylindersGeometry(pybind11::module&);
+void export_ConcentricCylindersGeometryFiller(pybind11::module&);
 void export_ConstantForce(pybind11::module&);
 void export_CosineChannelGeometry(pybind11::module&);
 void export_CosineChannelGeometryFiller(pybind11::module&);
@@ -36,8 +38,6 @@ void export_CosineExpansionContractionGeometryFiller(pybind11::module&);
 void export_Integrator(pybind11::module&);
 void export_ManualVirtualParticleFiller(pybind11::module&);
 void export_NoForce(pybind11::module&);
-void export_ConcentricCylindersGeometry(pybind11::module&);
-void export_ConcentricCylindersGeometryFiller(pybind11::module&);
 void export_ParallelPlateGeometry(pybind11::module&);
 void export_ParallelPlateGeometryFiller(pybind11::module&);
 void export_PlanarPoreGeometry(pybind11::module&);
@@ -56,6 +56,7 @@ void export_CellThermoComputeGPU(pybind11::module&);
 #ifdef ENABLE_MPI
 void export_CommunicatorGPU(pybind11::module&);
 #endif // ENABLE_MPI
+void export_ConcentricCylindersGeometryFillerGPU(pybind11::module&);
 void export_CosineChannelGeometryFillerGPU(pybind11::module&);
 void export_CosineExpansionContractionGeometryFillerGPU(pybind11::module&);
 void export_ParallelPlateGeometryFillerGPU(pybind11::module&);
@@ -203,6 +204,8 @@ PYBIND11_MODULE(_mpcd, m)
 #ifdef ENABLE_MPI
     export_Communicator(m);
 #endif // ENABLE_MPI
+    export_ConcentricCylindersGeometry(m);
+    export_ConcentricCylindersGeometryFiller(m);
     export_ConstantForce(m);
     export_CosineChannelGeometry(m);
     export_CosineChannelGeometryFiller(m);
@@ -211,11 +214,8 @@ PYBIND11_MODULE(_mpcd, m)
     export_Integrator(m);
     export_ManualVirtualParticleFiller(m);
     export_NoForce(m);
-    export_ConcentricCylindersGeometry(m);
-    export_ConcentricCylindersGeometryFiller(m);
     export_ParallelPlateGeometry(m);
     export_ParallelPlateGeometryFiller(m);
-    ;
     export_PlanarPoreGeometry(m);
     export_PlanarPoreGeometryFiller(m);
     export_Sorter(m);
@@ -230,6 +230,7 @@ PYBIND11_MODULE(_mpcd, m)
 #ifdef ENABLE_MPI
     export_CommunicatorGPU(m);
 #endif // ENABLE_MPI
+    export_ConcentricCylindersGeometryFillerGPU(m);
     export_CosineChannelGeometryFillerGPU(m);
     export_CosineExpansionContractionGeometryFillerGPU(m);
     export_ParallelPlateGeometryFillerGPU(m);

--- a/hoomd/mpcd/pytest/test_fill.py
+++ b/hoomd/mpcd/pytest/test_fill.py
@@ -22,6 +22,10 @@ def snap():
 @pytest.mark.parametrize(
     "cls, init_args",
     [
+        (hoomd.mpcd.geometry.ConcentricCylinders, {
+            "inner_radius": 4.0,
+            "outer_radius": 8.0
+        }),
         (hoomd.mpcd.geometry.CosineChannel, {
             "amplitude": 4.0,
             "repeat_length": 20.0,
@@ -44,7 +48,7 @@ def snap():
         }),
     ],
     ids=[
-        "CosineChannel", "CosineExpansionContraction", "ParallelPlates",
+        "ConcentricCylinders","CosineChannel", "CosineExpansionContraction", "ParallelPlates",
         "PlanarPore", "Sphere"
     ],
 )

--- a/hoomd/mpcd/pytest/test_fill.py
+++ b/hoomd/mpcd/pytest/test_fill.py
@@ -48,8 +48,8 @@ def snap():
         }),
     ],
     ids=[
-        "ConcentricCylinders","CosineChannel", "CosineExpansionContraction", "ParallelPlates",
-        "PlanarPore", "Sphere"
+        "ConcentricCylinders", "CosineChannel", "CosineExpansionContraction",
+        "ParallelPlates", "PlanarPore", "Sphere"
     ],
 )
 class TestGeometryFiller:


### PR DESCRIPTION
## Description

This is a bugfix that resolves a few issues with the MPCD virtual particle filler:

* Export statements were missing for the concentric cylinder virtual particle filler on the GPU. This was not caught because the geometry was missing from the test list for the filler.
* An error was made translating the pybind11 code for the rejection virtual particle filler on the GPU. Due to the way the inheritance was implemented, the GPU class was constructed but the CPU fill method was invoked. This led to poor performance in GPU simulations that was not been previously noticed, probably because we tried with MD+MPCD simulations rather than pure MPCD (for which performance hits in MPCD are less significant).
* An error was made translating the timestep variable in the GPU code from a 32-bit int to a 64-bit int. This produced compiler warnings.

## Motivation and context

The correct code should be available and run, and HOOMD should compile without warning.

Fixes #1933

## How has this been tested?

Added geometry to unit tests in `mpcd/pytest/test_fill.py`, benchmarked performance on NCSA Delta GPU, and checked compiler output. 

## Checklist:

- [X] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.rst).
- [X] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [X] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
- [X] I have summarized these changes in `CHANGELOG.rst` following the established format.
