### PR TITLE
Fix read after write hazard in the GPU implementations of `ALJ`, `Dipole`, and `Patchy*` potentials.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,8 @@ Change Log
   (`#1934 <https://github.com/glotzerlab/hoomd-blue/pull/1934>`__).
 * Correctly apply ``HPMCIntegrator.external_potentials`` in ``hoomd.hpmc.update.MuVT``
   (`#1941 <https://github.com/glotzerlab/hoomd-blue/pull/1941>`__).
+* Fix arbitrary simulation crashes when running with ``hoomd.md.pair.aniso.ALJ``
+  (`#1944 <https://github.com/glotzerlab/hoomd-blue/pull/1944>`__).
 
 *Added*
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,7 +21,7 @@ Change Log
   (`#1934 <https://github.com/glotzerlab/hoomd-blue/pull/1934>`__).
 * Correctly apply ``HPMCIntegrator.external_potentials`` in ``hoomd.hpmc.update.MuVT``
   (`#1941 <https://github.com/glotzerlab/hoomd-blue/pull/1941>`__).
-* Fix arbitrary simulation crashes when running with ``hoomd.md.pair.aniso.ALJ``
+* Read after write hazard in the GPU implementation of ``Dipole`` and ``ALJ``
   (`#1944 <https://github.com/glotzerlab/hoomd-blue/pull/1944>`__).
 
 *Added*

--- a/hoomd/md/AnisoPotentialPairGPU.cuh
+++ b/hoomd/md/AnisoPotentialPairGPU.cuh
@@ -197,6 +197,7 @@ gpu_compute_pair_aniso_forces_kernel(Scalar4* d_force,
                 = ((int*)d_shape_params)[cur_offset + threadIdx.x];
             }
         }
+
     __syncthreads();
 
     // initialize extra shared mem
@@ -208,6 +209,8 @@ gpu_compute_pair_aniso_forces_kernel(Scalar4* d_force,
 
     for (unsigned int cur_type = 0; cur_type < ntypes; ++cur_type)
         s_shape_params[cur_type].load_shared(s_extra, available_bytes);
+
+    __syncthreads();
 
     // start by identifying which particle we are to handle
     unsigned int idx;

--- a/hoomd/md/ForceCompositeGPU.cc
+++ b/hoomd/md/ForceCompositeGPU.cc
@@ -198,7 +198,7 @@ void ForceCompositeGPU::computeForces(uint64_t timestep)
 
         if (nelem != 0)
             {
-            hipMemsetAsync(d_virial.data, 0, sizeof(Scalar) * nelem * m_virial_pitch);
+            hipMemsetAsync(d_virial.data, 0, sizeof(Scalar) * m_virial.getNumElements());
             }
 
         if (m_exec_conf->isCUDAErrorCheckingEnabled())


### PR DESCRIPTION
## Description

This PR removes a race condition on the shared memory in the anisotropic pair potential GPU kernel launcher by adding a call to `__syncthreads()` after the per-pair and per-type parameters are loaded.

## Motivation and context

Many users have reported arbitrary crashes when using `hoomd.pair.aniso.ALJ` on the GPU, often reported as a divide by zero floating point exception. It turns out that was only a symptom of the bug; running with the GPU error checking reported an illegal memory access instead of the floating point exception. The illegal access was triggered by the race condition that is fixed in this PR.

## How has this been tested?

`compute-sanitizer --tool racecheck` previously reported a race condition when running a simulation that uses `hoomd.md.pair.aniso.ALJ` and runs cleanly with this fix.


## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
- [x] I have summarized these changes in `CHANGELOG.rst` following the established format.
