### PR TITLE
Fix hpmc potential energy calculation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,6 +23,9 @@ Change Log
   (`#1944 <https://github.com/glotzerlab/hoomd-blue/pull/1944>`__).
 * Read after write hazard in the GPU implementation of ``hoomd.md.mesh.conservation.Volume``
   (`#1953 <https://github.com/glotzerlab/hoomd-blue/pull/1953>`__).
+* ``hoomd.hpmc.pair.Pair.energy`` now computes the correct energy when there are multiple pair
+  potentials with different ``r_cut`` values
+  (`#1955 <https://github.com/glotzerlab/hoomd-blue/pull/1955>`__).
 
 *Added*
 

--- a/hoomd/hpmc/IntegratorHPMCMono.h
+++ b/hoomd/hpmc/IntegratorHPMCMono.h
@@ -1147,8 +1147,9 @@ double IntegratorHPMCMono<Shape>::computePairEnergy(uint64_t timestep,
                                 LongReal r_squared = dot(r_ij, r_ij);
                                 if (selected_pair)
                                     {
-                                    if (r_squared < selected_pair->getRCutSquaredTotal(typ_i, typ_j))
-                                    {
+                                    if (r_squared
+                                        < selected_pair->getRCutSquaredTotal(typ_i, typ_j))
+                                        {
                                         energy += selected_pair->energy(r_squared,
                                                                         r_ij,
                                                                         typ_i,
@@ -1157,7 +1158,7 @@ double IntegratorHPMCMono<Shape>::computePairEnergy(uint64_t timestep,
                                                                         typ_j,
                                                                         orientation_j,
                                                                         h_charge.data[j]);
-                                    }
+                                        }
                                     }
                                 else
                                     {

--- a/hoomd/hpmc/IntegratorHPMCMono.h
+++ b/hoomd/hpmc/IntegratorHPMCMono.h
@@ -1145,17 +1145,19 @@ double IntegratorHPMCMono<Shape>::computePairEnergy(uint64_t timestep,
                             if (h_tag.data[i] <= h_tag.data[j])
                                 {
                                 LongReal r_squared = dot(r_ij, r_ij);
-                                if (selected_pair
-                                    && r_squared < selected_pair->getRCutSquaredTotal(typ_i, typ_j))
+                                if (selected_pair)
                                     {
-                                    energy += selected_pair->energy(r_squared,
-                                                                    r_ij,
-                                                                    typ_i,
-                                                                    orientation_i,
-                                                                    h_charge.data[i],
-                                                                    typ_j,
-                                                                    orientation_j,
-                                                                    h_charge.data[j]);
+                                    if (r_squared < selected_pair->getRCutSquaredTotal(typ_i, typ_j))
+                                    {
+                                        energy += selected_pair->energy(r_squared,
+                                                                        r_ij,
+                                                                        typ_i,
+                                                                        orientation_i,
+                                                                        h_charge.data[i],
+                                                                        typ_j,
+                                                                        orientation_j,
+                                                                        h_charge.data[j]);
+                                    }
                                     }
                                 else
                                     {

--- a/hoomd/hpmc/pytest/test_pair_lennard_jones.py
+++ b/hoomd/hpmc/pytest/test_pair_lennard_jones.py
@@ -205,6 +205,13 @@ def test_multiple_pair_potentials(mc_simulation_factory):
     assert simulation.operations.integrator.pair_energy == pytest.approx(
         expected=-3.0, rel=1e-5)
 
+    # check that individual energies are computed correctly with varying r_cut
+    lennard_jones_2.params[('A', 'A')] = dict(epsilon=2.0, sigma=1.0, r_cut=0)
+    assert simulation.operations.integrator.pair_energy == pytest.approx(
+        expected=-1.0, rel=1e-5)
+    assert lennard_jones_1.energy == pytest.approx(expected=-1.0, rel=1e-5)
+    assert lennard_jones_2.energy == pytest.approx(expected=0.0, abs=1e-5)
+
 
 def test_logging():
     hoomd.conftest.logging_check(


### PR DESCRIPTION
Fix for calculating potential energy correctly when there are multiple potentials in `mc.pair_potentials` with different `r_cut`