### PR TITLE
Fix maybe uninitialized warning in PairModulator

### DIFF
--- a/hoomd/md/PairModulator.h
+++ b/hoomd/md/PairModulator.h
@@ -144,7 +144,8 @@ template<typename PairEvaluator, typename DirectionalEnvelope> class PairModulat
                          const Scalar4& _q_j,
                          const Scalar _rcutsq,
                          const param_type& _params)
-        : dr(_dr), rsq(dot(_dr, _dr)), rcutsq(_rcutsq), q_i(_q_i), q_j(_q_j), params(_params)
+        : dr(_dr), rsq(dot(_dr, _dr)), rcutsq(_rcutsq), q_i(_q_i), q_j(_q_j), params(_params),
+          shape_i(nullptr), shape_j(nullptr), m_charge_i(0), m_charge_j(0)
         {
         }
 


### PR DESCRIPTION
## Description

My compiler raised some warnings about variables maybe being used uninitialized in `PairModulator`. This should silence those by initializing all member variables in the constructor.

## Motivation and context

Code should compile without warning.

## How has this been tested?

The compiler warnings went away.

## Checklist:

- [X] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.rst).
- [X] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [X] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
- [ ] I have summarized these changes in `CHANGELOG.rst` following the established format.
