### PR TITLE
Fix the link provied in the TriggeredOperation inherited docs.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,14 @@ Change Log
 5.x
 ---
 
+5.0.2 (not yet released)
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+* Correctly reference ``TriggeredOperation`` in inherited documentation
+  (`#1990 <https://github.com/glotzerlab/hoomd-blue/pull/1990>`__).
+
+*Fixed*
+
 5.0.1 (2025-01-20)
 ^^^^^^^^^^^^^^^^^^
 

--- a/hoomd/operation.py
+++ b/hoomd/operation.py
@@ -578,7 +578,7 @@ class TriggeredOperation(Operation):
     ----------
 
     **Members inherited from**
-    `Integrator <hoomd.md.Integrator>`:
+    `TriggeredOperation <hoomd.md.TriggeredOperation>`:
 
     .. py:attribute:: trigger
 

--- a/hoomd/operation.py
+++ b/hoomd/operation.py
@@ -578,7 +578,7 @@ class TriggeredOperation(Operation):
     ----------
 
     **Members inherited from**
-    `TriggeredOperation <hoomd.md.TriggeredOperation>`:
+    `TriggeredOperation <hoomd.operation.TriggeredOperation>`:
 
     .. py:attribute:: trigger
 


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should be based on *trunk-patch*. -->
<!-- Backwards compatible new features should be based on *trunk-minor*. -->
<!-- Incompatible API changes should be based on *trunk-major*. -->

## Description

<!-- Describe your changes in detail. -->
Fix the link provied in the TriggeredOperation inherited docs.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Do not misrepresent the inheritance chain for subclasses of `TriggeredOperation`.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
Will check the readthedocs build.

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
- [x] I have summarized these changes in `CHANGELOG.rst` following the established format.
