### PR TITLE
Support rocm6.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,12 +13,18 @@ Change Log
   (`#1970 <https://github.com/glotzerlab/hoomd-blue/pull/1970>`__).
 * ``mpcd.update.ReverseNonequilibriumShearFlow``
   (`#1983 <https://github.com/glotzerlab/hoomd-blue/pull/1983>`__).
+* Support rocm 6
+  (`#2002 <https://github.com/glotzerlab/hoomd-blue/pull/2002>`__).
 
 *Fixed*
 
 * Correctly reference ``TriggeredOperation`` in inherited documentation
   (`#1990 <https://github.com/glotzerlab/hoomd-blue/pull/1990>`__).
 
+*Removed*
+
+* Support for rocm5
+  (`#2002 <https://github.com/glotzerlab/hoomd-blue/pull/2002>`__).
 
 5.0.1 (2025-01-20)
 ^^^^^^^^^^^^^^^^^^

--- a/CMake/hoomd/FindCUDALibs.cmake
+++ b/CMake/hoomd/FindCUDALibs.cmake
@@ -110,7 +110,6 @@ if (HIP_PLATFORM STREQUAL "amd")
     include_directories("${hipfft_INCLUDE_DIR}")
     include_directories("${hipfft_INCLUDE_DIR}/hipfft")
     message("Found hipfft includes: ${hipfft_INCLUDE_DIR}")
-    ##set(CMAKE_CXX_FLAGS )"${hipfft_INCLUDE_DIR}"
 endif()
 
 if (HIP_PLATFORM STREQUAL "nvcc")

--- a/CMake/hoomd/FindCUDALibs.cmake
+++ b/CMake/hoomd/FindCUDALibs.cmake
@@ -105,8 +105,12 @@ else()
     add_library(CUDA::cusparse UNKNOWN IMPORTED)
 endif()
 
-if (HIP_PLATFORM STREQUAL "hip-clang")
-    find_package(hipfft)
+if (HIP_PLATFORM STREQUAL "amd")
+    find_package(hipfft REQUIRED)
+    include_directories("${hipfft_INCLUDE_DIR}")
+    include_directories("${hipfft_INCLUDE_DIR}/hipfft")
+    message("Found hipfft includes: ${hipfft_INCLUDE_DIR}")
+    ##set(CMAKE_CXX_FLAGS )"${hipfft_INCLUDE_DIR}"
 endif()
 
 if (HIP_PLATFORM STREQUAL "nvcc")

--- a/CMake/hoomd/HOOMDCUDASetup.cmake
+++ b/CMake/hoomd/HOOMDCUDASetup.cmake
@@ -54,7 +54,8 @@ if (ENABLE_HIP)
     elseif(HIP_PLATFORM STREQUAL "amd")
         set(_cuda_min_arch 35)
 
-        # ignore warnings about unused results
+        # ignore warnings about unused results and set HIP_PLATFORM_HCC (which was previously
+        # set by rocm < 6.0.0)
         set(CMAKE_HIP_FLAGS "${CMAKE_CUDA_FLAGS} -Wno-unused-result -D__HIP_PLATFORM_HCC__")
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D__HIP_PLATFORM_HCC__")
     endif()

--- a/CMake/hoomd/HOOMDCUDASetup.cmake
+++ b/CMake/hoomd/HOOMDCUDASetup.cmake
@@ -51,11 +51,12 @@ if (ENABLE_HIP)
             set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -gencode=arch=compute_${_cuda_max_arch},code=compute_${_cuda_max_arch}")
         endif()
 
-    elseif(HIP_PLATFORM STREQUAL "hip-clang")
+    elseif(HIP_PLATFORM STREQUAL "amd")
         set(_cuda_min_arch 35)
 
         # ignore warnings about unused results
-        set(CMAKE_HIP_FLAGS "${CMAKE_CUDA_FLAGS} -Wno-unused-result")
+        set(CMAKE_HIP_FLAGS "${CMAKE_CUDA_FLAGS} -Wno-unused-result -D__HIP_PLATFORM_HCC__")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D__HIP_PLATFORM_HCC__")
     endif()
 endif (ENABLE_HIP)
 

--- a/CMake/hoomd/HOOMDHIPSetup.cmake
+++ b/CMake/hoomd/HOOMDHIPSetup.cmake
@@ -7,8 +7,8 @@ if(ENABLE_HIP)
         SET(HOOMD_DEVICE_LANGUAGE HIP)
 
         # setup nvcc to build for all CUDA architectures. Allow user to modify the list if desired
-        set(CMAKE_HIP_ARCHITECTURES gfx900 gfx906 gfx908 gfx90a CACHE STRING "List of AMD GPU to compile HIP code for. Separate with semicolons.")
-        set(HIP_PLATFORM hip-clang)
+        set(CMAKE_HIP_ARCHITECTURES gfx900 gfx906 gfx908 gfx90a gfx940 gfx941 gfx942 CACHE STRING "List of AMD GPU to compile HIP code for. Separate with semicolons.")
+        set(HIP_PLATFORM amd)
     elseif (HOOMD_GPU_PLATFORM STREQUAL "CUDA")
         # here we go if hipcc is not available, fall back on internal HIP->CUDA headers
         ENABLE_LANGUAGE(CUDA)
@@ -48,8 +48,8 @@ if(ENABLE_HIP)
     # branch upon HCC or NVCC target
     if(${HIP_PLATFORM} STREQUAL "nvcc")
         set_property(TARGET hip::host APPEND PROPERTY INTERFACE_COMPILE_DEFINITIONS __HIP_PLATFORM_NVCC__)
-    elseif(${HIP_PLATFORM} STREQUAL "hip-clang")
-        set_property(TARGET hip::host APPEND PROPERTY INTERFACE_COMPILE_DEFINITIONS __HIP_PLATFORM_AMD__)
+    elseif(${HIP_PLATFORM} STREQUAL "amd")
+        set_property(TARGET hip::host APPEND PROPERTY INTERFACE_COMPILE_DEFINITIONS __HIP_PLATFORM_AMD__ __HIP_PLATFORM_HCC__)
     endif()
 
     find_package(CUDALibs REQUIRED)

--- a/hoomd/CMakeLists.txt
+++ b/hoomd/CMakeLists.txt
@@ -265,7 +265,7 @@ target_compile_definitions(_hoomd PUBLIC HOOMD_LONGREAL_SIZE=${HOOMD_LONGREAL_SI
 
 # Libraries and compile definitions for CUDA enabled builds
 if (ENABLE_HIP)
-    if (HIP_PLATFORM STREQUAL "hip-clang")
+    if (HIP_PLATFORM STREQUAL "amd")
         target_link_libraries(_hoomd PUBLIC hip::hipfft)
     elseif(HIP_PLATFORM STREQUAL "nvcc")
         target_link_libraries(_hoomd PUBLIC CUDA::cudart CUDA::cufft)

--- a/hoomd/HOOMDMath.h
+++ b/hoomd/HOOMDMath.h
@@ -732,15 +732,15 @@ HOSTDEVICE inline hoomd::Scalar3& operator+=(hoomd::Scalar3& a, const hoomd::Sca
 
 //! Vector multiplication (component-wise)
 HOSTDEVICE inline hoomd::Scalar3 operator*(const hoomd::Scalar3& a, const hoomd::Scalar3& b)
-{
+    {
     return hoomd::make_scalar3(a.x * b.x, a.y * b.y, a.z * b.z);
-}
+    }
 
 //! Vector division (component-wise)
 HOSTDEVICE inline hoomd::Scalar3 operator/(const hoomd::Scalar3& a, const hoomd::Scalar3& b)
-{
+    {
     return hoomd::make_scalar3(a.x / b.x, a.y / b.y, a.z / b.z);
-}
+    }
 
 #endif
 
@@ -758,8 +758,6 @@ HOSTDEVICE inline hoomd::Scalar3& operator-=(hoomd::Scalar3& a, const hoomd::Sca
     return a;
     }
 
-
-
 //! Vector multiplication
 HOSTDEVICE inline hoomd::Scalar3& operator*=(hoomd::Scalar3& a, const hoomd::Scalar3& b)
     {
@@ -768,7 +766,6 @@ HOSTDEVICE inline hoomd::Scalar3& operator*=(hoomd::Scalar3& a, const hoomd::Sca
     a.z *= b.z;
     return a;
     }
-
 
 //! Scalar - vector multiplication
 HOSTDEVICE inline hoomd::Scalar3 operator*(const hoomd::Scalar& a, const hoomd::Scalar3& b)

--- a/hoomd/HOOMDMath.h
+++ b/hoomd/HOOMDMath.h
@@ -237,6 +237,8 @@ inline HOSTDEVICE float rsqrt(float x)
     return ::rsqrtf(x);
 #elif defined(__HIP_PLATFORM_HCC__)
     return ::__frsqrt_rn(x);
+#elif defined(__HIP_PLATFORM_AMD__)
+    return ::__frsqrt_rn(x);
 #endif
 #else
     return 1.0f / ::sqrtf(x);
@@ -727,6 +729,19 @@ HOSTDEVICE inline hoomd::Scalar3& operator+=(hoomd::Scalar3& a, const hoomd::Sca
     a.z += b.z;
     return a;
     }
+
+//! Vector multiplication (component-wise)
+HOSTDEVICE inline hoomd::Scalar3 operator*(const hoomd::Scalar3& a, const hoomd::Scalar3& b)
+{
+    return hoomd::make_scalar3(a.x * b.x, a.y * b.y, a.z * b.z);
+}
+
+//! Vector division (component-wise)
+HOSTDEVICE inline hoomd::Scalar3 operator/(const hoomd::Scalar3& a, const hoomd::Scalar3& b)
+{
+    return hoomd::make_scalar3(a.x / b.x, a.y / b.y, a.z / b.z);
+}
+
 #endif
 
 //! Vector subtraction
@@ -743,11 +758,7 @@ HOSTDEVICE inline hoomd::Scalar3& operator-=(hoomd::Scalar3& a, const hoomd::Sca
     return a;
     }
 
-//! Vector multiplication (component-wise)
-HOSTDEVICE inline hoomd::Scalar3 operator*(const hoomd::Scalar3& a, const hoomd::Scalar3& b)
-    {
-    return hoomd::make_scalar3(a.x * b.x, a.y * b.y, a.z * b.z);
-    }
+
 
 //! Vector multiplication
 HOSTDEVICE inline hoomd::Scalar3& operator*=(hoomd::Scalar3& a, const hoomd::Scalar3& b)
@@ -758,11 +769,7 @@ HOSTDEVICE inline hoomd::Scalar3& operator*=(hoomd::Scalar3& a, const hoomd::Sca
     return a;
     }
 
-//! Vector division (component-wise)
-HOSTDEVICE inline hoomd::Scalar3 operator/(const hoomd::Scalar3& a, const hoomd::Scalar3& b)
-    {
-    return hoomd::make_scalar3(a.x / b.x, a.y / b.y, a.z / b.z);
-    }
+
 //! Scalar - vector multiplication
 HOSTDEVICE inline hoomd::Scalar3 operator*(const hoomd::Scalar& a, const hoomd::Scalar3& b)
     {

--- a/hoomd/extern/CMakeLists.txt
+++ b/hoomd/extern/CMakeLists.txt
@@ -13,7 +13,7 @@ add_library(hipper INTERFACE)
 add_library(HOOMD::hipper ALIAS hipper)
 target_include_directories(hipper INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/hipper/include>
                                             $<INSTALL_INTERFACE:${PYTHON_SITE_INSTALL_DIR}/include/hoomd/extern/hipper/include>)
-if (HIP_PLATFORM STREQUAL "hcc" OR HIP_PLATFORM STREQUAL "hip-clang")
+if (HIP_PLATFORM STREQUAL "hcc" OR HIP_PLATFORM STREQUAL "amd")
     target_compile_definitions(hipper INTERFACE HIPPER_HIP)
 elseif(HIP_PLATFORM STREQUAL "nvcc")
     target_compile_definitions(hipper INTERFACE HIPPER_CUDA)


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should be based on *trunk-patch*. -->
<!-- Backwards compatible new features should be based on *trunk-minor*. -->
<!-- Incompatible API changes should be based on *trunk-major*. -->

## Description

<!-- Describe your changes in detail. -->
Support rocm6. Remove support for rocm5.

These commits were authored by @MartinGirard and contributed via a patch file instead of a direct pull request from a fork: #1998

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Allow HOOMD-blue to be compiled for the newest generation of AMD GPUs.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
HOOMD-blue builds and passes tests on Frontier with the rocm 6.3 module loaded.

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
- [x] I have summarized these changes in `CHANGELOG.rst` following the established format.
