### PR TITLE
Remove the warnings about integrating orientation.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,15 @@ Change Log
 5.x
 ---
 
+5.1.1 (not yet released)
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+*Fixed*
+
+* Prevent warnings about forces that provide torques (or not)
+  (`#2015 <https://github.com/glotzerlab/hoomd-blue/pull/2015>`__).
+
+
 5.1.0 (2025-02-20)
 ^^^^^^^^^^^^^^^^^^
 

--- a/hoomd/ForceCompute.h
+++ b/hoomd/ForceCompute.h
@@ -166,13 +166,6 @@ class PYBIND11_EXPORT ForceCompute : public Compute
         }
 #endif
 
-    //! Returns true if this ForceCompute requires anisotropic integration
-    virtual bool isAnisotropic()
-        {
-        // by default, only translational degrees of freedom are integrated
-        return false;
-        }
-
     bool getLocalBuffersWriteable() const
         {
         return m_buffers_writeable;

--- a/hoomd/Integrator.cc
+++ b/hoomd/Integrator.cc
@@ -854,23 +854,6 @@ void Integrator::computeCallback(uint64_t timestep)
     }
 #endif
 
-bool Integrator::areForcesAnisotropic()
-    {
-    bool aniso = false;
-
-    for (const auto& force : m_forces)
-        {
-        aniso |= force->isAnisotropic();
-        }
-
-    for (const auto& constraint_force : m_constraint_forces)
-        {
-        aniso |= constraint_force->isAnisotropic();
-        }
-
-    return aniso;
-    }
-
 namespace detail
     {
 void export_Integrator(pybind11::module& m)

--- a/hoomd/Integrator.h
+++ b/hoomd/Integrator.h
@@ -207,9 +207,6 @@ class PYBIND11_EXPORT Integrator : public Updater
     /// The systems's communicator.
     std::shared_ptr<Communicator> m_comm;
 #endif
-
-    /// Check if any forces introduce anisotropic degrees of freedom
-    virtual bool areForcesAnisotropic();
     };
 
 namespace detail

--- a/hoomd/md/AnisoPotentialPair.h
+++ b/hoomd/md/AnisoPotentialPair.h
@@ -195,12 +195,6 @@ template<class aniso_evaluator> class AnisoPotentialPair : public ForceCompute
     virtual CommFlags getRequestedCommFlags(uint64_t timestep);
 #endif
 
-    //! Returns true because we compute the torque
-    virtual bool isAnisotropic()
-        {
-        return true;
-        }
-
     /// Start autotuning kernel launch parameters
     virtual void startAutotuning()
         {

--- a/hoomd/md/CustomForceCompute.h
+++ b/hoomd/md/CustomForceCompute.h
@@ -37,11 +37,6 @@ class PYBIND11_EXPORT CustomForceCompute : public ForceCompute
     //! Destructor
     ~CustomForceCompute();
 
-    bool isAnisotropic()
-        {
-        return m_aniso;
-        }
-
     protected:
     //! Actually compute the forces
     virtual void computeForces(uint64_t timestep);

--- a/hoomd/md/EvaluatorExternalElectricField.h
+++ b/hoomd/md/EvaluatorExternalElectricField.h
@@ -84,11 +84,6 @@ class EvaluatorExternalElectricField
         {
         }
 
-    DEVICE static bool isAnisotropic()
-        {
-        return false;
-        }
-
     //! ExternalElectricField needs charges
     DEVICE static bool needsCharge()
         {

--- a/hoomd/md/EvaluatorExternalMagneticField.h
+++ b/hoomd/md/EvaluatorExternalMagneticField.h
@@ -91,11 +91,6 @@ class EvaluatorExternalMagneticField
         {
         }
 
-    DEVICE static bool isAnisotropic()
-        {
-        return true;
-        }
-
     //! ExternalMagneticField needs charges
     DEVICE static bool needsCharge()
         {

--- a/hoomd/md/EvaluatorExternalPeriodic.h
+++ b/hoomd/md/EvaluatorExternalPeriodic.h
@@ -99,11 +99,6 @@ class EvaluatorExternalPeriodic
         {
         }
 
-    DEVICE static bool isAnisotropic()
-        {
-        return false;
-        }
-
     //! External Periodic doesn't need charges
     DEVICE static bool needsCharge()
         {

--- a/hoomd/md/EvaluatorWalls.h
+++ b/hoomd/md/EvaluatorWalls.h
@@ -143,11 +143,6 @@ template<class evaluator> class EvaluatorWalls
         {
         }
 
-    DEVICE static bool isAnisotropic()
-        {
-        return false;
-        }
-
     //! Charges not supported by walls evals
     DEVICE static bool needsCharge()
         {

--- a/hoomd/md/ForceComposite.h
+++ b/hoomd/md/ForceComposite.h
@@ -85,12 +85,6 @@ class PYBIND11_EXPORT ForceComposite : public MolecularForceCompute
                           std::vector<Scalar3>& pos,
                           std::vector<Scalar4>& orientation);
 
-    //! Returns true because we compute the torque on the central particle
-    virtual bool isAnisotropic()
-        {
-        return true;
-        }
-
 #ifdef ENABLE_MPI
     //! Get ghost particle fields requested by this pair potential
     virtual CommFlags getRequestedCommFlags(uint64_t timestep);

--- a/hoomd/md/IntegratorTwoStep.cc
+++ b/hoomd/md/IntegratorTwoStep.cc
@@ -226,18 +226,6 @@ const bool IntegratorTwoStep::getIntegrateRotationalDOF()
 void IntegratorTwoStep::prepRun(uint64_t timestep)
     {
     Integrator::prepRun(timestep);
-    if (m_integrate_rotational_dof && !areForcesAnisotropic())
-        {
-        m_exec_conf->msg->warning() << "Requested integration of orientations, but no forces"
-                                       " provide torques."
-                                    << endl;
-        }
-    if (!m_integrate_rotational_dof && areForcesAnisotropic())
-        {
-        m_exec_conf->msg->warning() << "Forces provide torques, but integrate_rotational_dof is"
-                                       " false."
-                                    << endl;
-        }
 
     for (auto& method : m_methods)
         method->setAnisotropic(m_integrate_rotational_dof);
@@ -370,17 +358,6 @@ CommFlags IntegratorTwoStep::determineFlags(uint64_t timestep)
     return flags;
     }
 #endif
-
-/// Check if any forces introduce anisotropic degrees of freedom
-bool IntegratorTwoStep::areForcesAnisotropic()
-    {
-    auto is_anisotropic = Integrator::areForcesAnisotropic();
-    if (m_rigid_bodies)
-        {
-        is_anisotropic |= m_rigid_bodies->isAnisotropic();
-        }
-    return is_anisotropic;
-    }
 
 void IntegratorTwoStep::validateGroups()
     {

--- a/hoomd/md/IntegratorTwoStep.h
+++ b/hoomd/md/IntegratorTwoStep.h
@@ -87,9 +87,6 @@ class PYBIND11_EXPORT IntegratorTwoStep : public Integrator
     virtual CommFlags determineFlags(uint64_t timestep);
 #endif
 
-    /// Check if any forces introduce anisotropic degrees of freedom
-    virtual bool areForcesAnisotropic();
-
     /// Updates the rigid body constituent particles
     virtual void updateRigidBodies(uint64_t timestep);
 

--- a/hoomd/md/PotentialExternal.h
+++ b/hoomd/md/PotentialExternal.h
@@ -43,8 +43,6 @@ template<class evaluator> class PotentialExternal : public ForceCompute
     typedef typename evaluator::param_type param_type;
     typedef typename evaluator::field_type field_type;
 
-    bool isAnisotropic();
-
     //! Sets parameters of the evaluator
     pybind11::object getParams(std::string type);
 
@@ -168,13 +166,6 @@ void PotentialExternal<evaluator>::validateType(unsigned int type, std::string a
         {
         throw std::runtime_error("Invalid type encountered when " + action);
         }
-    }
-
-//! Returns true if this ForceCompute requires anisotropic integration
-template<class evaluator> bool PotentialExternal<evaluator>::isAnisotropic()
-    {
-    // by default, only translational degrees of freedom are integrated
-    return evaluator::isAnisotropic();
     }
 
 //! Set the parameters for this potential


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should be based on *trunk-patch*. -->
<!-- Backwards compatible new features should be based on *trunk-minor*. -->
<!-- Incompatible API changes should be based on *trunk-major*. -->

## Description

<!-- Describe your changes in detail. -->
Remove warnings related to integrating rotational dof with (or without) torque providers.

## Motivation and context

This system was previously used to automatically select whether to integrate rotational degrees of freedom. Now that users always set `integrate_rotational_dof`, this system no longer serves a purpose and the warnings are often incorrect: #2000.

<!--- Why is this change required? What problem does it solve? -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
CI checks.

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
- [x] I have summarized these changes in `CHANGELOG.rst` following the established format.
