### PR TITLE
Handle ghost forces consistently

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,8 @@ Change Log
   (`#2015 <https://github.com/glotzerlab/hoomd-blue/pull/2015>`__).
 * Compile without errors or warnings with CUDA 12.8
   (`#2019 <https://github.com/glotzerlab/hoomd-blue/pull/2019>`__).
+* `force.Active` applies torques correctly when the filter is not `All`
+  (`#2020 <https://github.com/glotzerlab/hoomd-blue/pull/2020>`__).
 
 5.1.0 (2025-02-20)
 ^^^^^^^^^^^^^^^^^^

--- a/hoomd/BondedGroupData.cc
+++ b/hoomd/BondedGroupData.cc
@@ -829,9 +829,7 @@ void BondedGroupData<group_size, Group, name, has_type_mapping>::rebuildGPUTable
 
             // now, update the actual table
             // zero the number of bonded groups counter (again)
-            memset(h_n_groups.data,
-                   0,
-                   sizeof(unsigned int) * (m_pdata->getN() + m_pdata->getNGhosts()));
+            m_gpu_n_groups.zeroFill();
 
             // loop through all group and add them to each column in the list
             for (unsigned int cur_group = 0; cur_group < ngroups_tot; cur_group++)

--- a/hoomd/CellList.cc
+++ b/hoomd/CellList.cc
@@ -425,7 +425,7 @@ void CellList::computeCellList()
     Index2D cli = m_cell_list_indexer;
 
     // clear the bin sizes to 0
-    memset(h_cell_size.data, 0, sizeof(unsigned int) * m_cell_indexer.getNumElements());
+    m_cell_size.zeroFill();
 
     Scalar3 ghost_width = getGhostWidth();
 

--- a/hoomd/CellListGPU.cc
+++ b/hoomd/CellListGPU.cc
@@ -69,10 +69,7 @@ void CellListGPU::computeCellList()
                                         access_mode::overwrite);
 
         // reset cell list contents
-        hipMemsetAsync(d_cell_size.data,
-                       0,
-                       sizeof(unsigned int) * m_cell_indexer.getNumElements(),
-                       0);
+        m_cell_size.zeroFill();
         if (m_exec_conf->isCUDAErrorCheckingEnabled())
             CHECK_CUDA_ERROR();
 

--- a/hoomd/CellListStencil.cc
+++ b/hoomd/CellListStencil.cc
@@ -78,7 +78,7 @@ void CellListStencil::compute(uint64_t timestep)
         ArrayHandle<unsigned int> h_n_stencil(m_n_stencil,
                                               access_location::host,
                                               access_mode::overwrite);
-        memset((void*)h_n_stencil.data, 0, sizeof(unsigned int) * m_pdata->getNTypes());
+        m_n_stencil.zeroFill();
         return;
         }
 

--- a/hoomd/ForceCompute.cc
+++ b/hoomd/ForceCompute.cc
@@ -44,9 +44,9 @@ ForceCompute::ForceCompute(std::shared_ptr<SystemDefinition> sysdef)
         ArrayHandle<Scalar4> h_force(m_force, access_location::host, access_mode::overwrite);
         ArrayHandle<Scalar4> h_torque(m_torque, access_location::host, access_mode::overwrite);
         ArrayHandle<Scalar> h_virial(m_virial, access_location::host, access_mode::overwrite);
-        memset(h_force.data, 0, sizeof(Scalar4) * m_force.getNumElements());
-        memset(h_torque.data, 0, sizeof(Scalar4) * m_torque.getNumElements());
-        memset(h_virial.data, 0, sizeof(Scalar) * m_virial.getNumElements());
+        m_force.zeroFill();
+        m_torque.zeroFill();
+        m_virial.zeroFill();
         }
 
     m_virial_pitch = m_virial.getPitch();
@@ -88,9 +88,9 @@ void ForceCompute::reallocate()
         ArrayHandle<Scalar4> h_force(m_force, access_location::host, access_mode::overwrite);
         ArrayHandle<Scalar4> h_torque(m_torque, access_location::host, access_mode::overwrite);
         ArrayHandle<Scalar> h_virial(m_virial, access_location::host, access_mode::overwrite);
-        memset(h_force.data, 0, sizeof(Scalar4) * m_force.getNumElements());
-        memset(h_torque.data, 0, sizeof(Scalar4) * m_torque.getNumElements());
-        memset(h_virial.data, 0, sizeof(Scalar) * m_virial.getNumElements());
+        m_force.zeroFill();
+        m_torque.zeroFill();
+        m_virial.zeroFill();
         }
 
     // the pitch of the virial array may have changed

--- a/hoomd/GPUArray.h
+++ b/hoomd/GPUArray.h
@@ -437,6 +437,9 @@ template<class T> class GPUArray
         return m_exec_conf;
         }
 
+    /// Fill the array with 0's
+    void zeroFill() const;
+
     protected:
     //! Clear memory starting from a given element
     /*! \param first The first element to clear
@@ -894,6 +897,29 @@ template<class T> void GPUArray<T>::allocate()
             = std::unique_ptr<T, hoomd::detail::device_deleter<T>>(reinterpret_cast<T*>(device_ptr),
                                                                    device_deleter);
         }
+#endif
+    }
+
+template<class T> void GPUArray<T>::zeroFill() const
+    {
+    if (!h_data.get())
+        return;
+
+#ifdef ENABLE_HIP
+
+    if (m_data_location == data_location::host || m_data_location == data_location::hostdevice)
+        {
+        memset((void*)h_data.get(), 0, sizeof(T) * m_num_elements);
+        }
+    if (m_data_location == data_location::device || m_data_location == data_location::hostdevice)
+        {
+        hipMemsetAsync(d_data.get(), 0, sizeof(T) * m_num_elements);
+        }
+
+#else
+
+    memset((void*)h_data.get(), 0, sizeof(T) * m_num_elements);
+
 #endif
     }
 

--- a/hoomd/Integrator.cc
+++ b/hoomd/Integrator.cc
@@ -184,9 +184,9 @@ void Integrator::computeNetForce(uint64_t timestep)
                                           access_mode::overwrite);
 
         // start by zeroing the net force and virial arrays
-        memset((void*)h_net_force.data, 0, sizeof(Scalar4) * net_force.getNumElements());
-        memset((void*)h_net_virial.data, 0, sizeof(Scalar) * net_virial.getNumElements());
-        memset((void*)h_net_torque.data, 0, sizeof(Scalar4) * net_torque.getNumElements());
+        net_force.zeroFill();
+        net_virial.zeroFill();
+        net_torque.zeroFill();
 
         for (unsigned int i = 0; i < 6; ++i)
             external_virial[i] = Scalar(0.0);
@@ -393,9 +393,9 @@ void Integrator::computeNetForceGPU(uint64_t timestep)
         if (m_forces.size() == 0)
             {
             // start by zeroing the net force and virial arrays
-            hipMemset(d_net_force.data, 0, sizeof(Scalar4) * net_force.getNumElements());
-            hipMemset(d_net_torque.data, 0, sizeof(Scalar4) * net_torque.getNumElements());
-            hipMemset(d_net_virial.data, 0, 6 * sizeof(Scalar) * net_virial_pitch);
+            net_force.zeroFill();
+            net_torque.zeroFill();
+            net_virial.zeroFill();
             if (m_exec_conf->isCUDAErrorCheckingEnabled())
                 CHECK_CUDA_ERROR();
             }

--- a/hoomd/ParticleData.cc
+++ b/hoomd/ParticleData.cc
@@ -386,9 +386,10 @@ void ParticleData::allocate(unsigned int N)
         ArrayHandle<Scalar> h_net_virial(m_net_virial,
                                          access_location::host,
                                          access_mode::overwrite);
-        memset(h_net_force.data, 0, sizeof(Scalar4) * m_net_force.getNumElements());
-        memset(h_net_torque.data, 0, sizeof(Scalar4) * m_net_torque.getNumElements());
-        memset(h_net_virial.data, 0, sizeof(Scalar) * m_net_virial.getNumElements());
+
+        m_net_force.zeroFill();
+        m_net_torque.zeroFill();
+        m_net_virial.zeroFill();
         }
 
     GPUArray<Scalar4> orientation(N, m_exec_conf);
@@ -482,9 +483,9 @@ void ParticleData::allocateAlternateArrays(unsigned int N)
         ArrayHandle<Scalar> h_net_virial_alt(m_net_virial_alt,
                                              access_location::host,
                                              access_mode::overwrite);
-        memset(h_net_force_alt.data, 0, sizeof(Scalar4) * m_net_force_alt.getNumElements());
-        memset(h_net_torque_alt.data, 0, sizeof(Scalar4) * m_net_torque_alt.getNumElements());
-        memset(h_net_virial_alt.data, 0, sizeof(Scalar) * m_net_virial_alt.getNumElements());
+        m_net_force_alt.zeroFill();
+        m_net_torque_alt.zeroFill();
+        m_net_virial_alt.zeroFill();
         }
     }
 
@@ -577,9 +578,10 @@ void ParticleData::reallocate(unsigned int max_n)
         ArrayHandle<Scalar> h_net_virial(m_net_virial,
                                          access_location::host,
                                          access_mode::readwrite);
-        memset(h_net_force.data, 0, sizeof(Scalar4) * m_net_force.getNumElements());
-        memset(h_net_torque.data, 0, sizeof(Scalar4) * m_net_torque.getNumElements());
-        memset(h_net_virial.data, 0, sizeof(Scalar) * m_net_virial.getNumElements());
+
+        m_net_force.zeroFill();
+        m_net_torque.zeroFill();
+        m_net_virial.zeroFill();
         }
 
     m_orientation.resize(max_n);
@@ -617,9 +619,10 @@ void ParticleData::reallocate(unsigned int max_n)
             ArrayHandle<Scalar> h_net_virial_alt(m_net_virial_alt,
                                                  access_location::host,
                                                  access_mode::overwrite);
-            memset(h_net_force_alt.data, 0, sizeof(Scalar4) * m_net_force_alt.getNumElements());
-            memset(h_net_torque_alt.data, 0, sizeof(Scalar4) * m_net_torque_alt.getNumElements());
-            memset(h_net_virial_alt.data, 0, sizeof(Scalar) * m_net_virial_alt.getNumElements());
+
+            m_net_force_alt.zeroFill();
+            m_net_torque_alt.zeroFill();
+            m_net_virial_alt.zeroFill();
             }
         }
 

--- a/hoomd/md/ActiveForceCompute.cc
+++ b/hoomd/md/ActiveForceCompute.cc
@@ -186,8 +186,8 @@ void ActiveForceCompute::setForces()
     assert(h_pos.data != NULL);
 
     // zero forces so we don't leave any forces set for indices that are no longer part of our group
-    memset(h_force.data, 0, sizeof(Scalar4) * m_force.getNumElements());
-    memset(h_torque.data, 0, sizeof(Scalar4) * m_force.getNumElements());
+    m_force.zeroFill();
+    m_torque.zeroFill();
 
     for (unsigned int i = 0; i < m_group->getNumMembers(); i++)
         {

--- a/hoomd/md/ActiveForceComputeGPU.cc
+++ b/hoomd/md/ActiveForceComputeGPU.cc
@@ -100,6 +100,9 @@ void ActiveForceComputeGPU::setForces()
     unsigned int group_size = m_group->getNumMembers();
     unsigned int N = m_pdata->getN();
 
+    m_force.zeroFill();
+    m_torque.zeroFill();
+
     // compute the forces on the GPU
     m_tuner_force->begin();
 

--- a/hoomd/md/ActiveForceComputeGPU.cu
+++ b/hoomd/md/ActiveForceComputeGPU.cu
@@ -152,7 +152,6 @@ hipError_t gpu_compute_active_force_set_forces(const unsigned int group_size,
     dim3 threads(block_size, 1, 1);
 
     // run the kernel
-    hipMemset(d_force, 0, sizeof(Scalar4) * N);
     hipLaunchKernelGGL((gpu_compute_active_force_set_forces_kernel),
                        dim3(grid),
                        dim3(threads),

--- a/hoomd/md/AlchemyData.h
+++ b/hoomd/md/AlchemyData.h
@@ -59,7 +59,7 @@ struct AlchemicalMDParticle : AlchemicalParticle
         ArrayHandle<Scalar> h_forces(m_alchemical_derivatives,
                                      access_location::host,
                                      access_mode::overwrite);
-        memset((void*)h_forces.data, 0, sizeof(Scalar) * m_alchemical_derivatives.getNumElements());
+        m_alchemical_derivatives.zeroFill();
         }
 
     void resizeForces(unsigned int N)

--- a/hoomd/md/AnisoPotentialPair.h
+++ b/hoomd/md/AnisoPotentialPair.h
@@ -455,9 +455,9 @@ void AnisoPotentialPair<aniso_evaluator>::computeForces(uint64_t timestep)
     ArrayHandle<Scalar> h_rcutsq(m_rcutsq, access_location::host, access_mode::read);
         {
         // need to start from a zero force, energy and virial
-        memset(&h_force.data[0], 0, sizeof(Scalar4) * m_pdata->getN());
-        memset(&h_torque.data[0], 0, sizeof(Scalar4) * m_pdata->getN());
-        memset(&h_virial.data[0], 0, sizeof(Scalar) * m_virial.getNumElements());
+        m_force.zeroFill();
+        m_torque.zeroFill();
+        m_virial.zeroFill();
 
         PDataFlags flags = this->m_pdata->getFlags();
         bool compute_virial = flags[pdata_flag::pressure_tensor];

--- a/hoomd/md/AnisoPotentialPair.h
+++ b/hoomd/md/AnisoPotentialPair.h
@@ -574,7 +574,7 @@ void AnisoPotentialPair<aniso_evaluator>::computeForces(uint64_t timestep)
 
                     // add the force to particle j if we are using the third law (MEM TRANSFER: 10
                     // scalars / FLOPS: 8)
-                    if (third_law)
+                    if (third_law && j < m_pdata->getN())
                         {
                         h_force.data[j].x -= force.x;
                         h_force.data[j].y -= force.y;

--- a/hoomd/md/AreaConservationMeshForceCompute.cc
+++ b/hoomd/md/AreaConservationMeshForceCompute.cc
@@ -123,8 +123,8 @@ void AreaConservationMeshForceCompute::computeForces(uint64_t timestep)
     assert(h_rtag.data);
     assert(h_triangles.data);
 
-    memset((void*)h_force.data, 0, sizeof(Scalar4) * m_force.getNumElements());
-    memset((void*)h_virial.data, 0, sizeof(Scalar) * m_virial.getNumElements());
+    m_force.zeroFill();
+    m_virial.zeroFill();
 
     const BoxDim& box = m_pdata->getGlobalBox();
 

--- a/hoomd/md/BendingRigidityMeshForceCompute.cc
+++ b/hoomd/md/BendingRigidityMeshForceCompute.cc
@@ -99,8 +99,8 @@ void BendingRigidityMeshForceCompute::computeForces(uint64_t timestep)
     assert(h_rtag.data);
     assert(h_bonds.data);
 
-    memset((void*)h_force.data, 0, sizeof(Scalar4) * m_force.getNumElements());
-    memset((void*)h_virial.data, 0, sizeof(Scalar) * m_virial.getNumElements());
+    m_force.zeroFill();
+    m_virial.zeroFill();
 
     const BoxDim& box = m_pdata->getGlobalBox();
 

--- a/hoomd/md/BondTablePotential.cc
+++ b/hoomd/md/BondTablePotential.cc
@@ -170,8 +170,8 @@ void BondTablePotential::computeForces(uint64_t timestep)
     assert(h_pos.data);
 
     // Zero data for force calculation.
-    memset((void*)h_force.data, 0, sizeof(Scalar4) * m_force.getNumElements());
-    memset((void*)h_virial.data, 0, sizeof(Scalar) * m_virial.getNumElements());
+    m_force.zeroFill();
+    m_virial.zeroFill();
 
     // get a local copy of the simulation box too
     const BoxDim& box = m_pdata->getGlobalBox();

--- a/hoomd/md/ConstantForceCompute.cc
+++ b/hoomd/md/ConstantForceCompute.cc
@@ -151,8 +151,8 @@ void ConstantForceCompute::setForces()
     assert(h_t_actVec.data != NULL);
 
     // zero forces so we don't leave any forces set for indices that are no longer part of our group
-    memset(h_force.data, 0, sizeof(Scalar4) * m_force.getNumElements());
-    memset(h_torque.data, 0, sizeof(Scalar4) * m_force.getNumElements());
+    m_force.zeroFill();
+    m_torque.zeroFill();
 
     for (unsigned int i = 0; i < m_group->getNumMembers(); i++)
         {

--- a/hoomd/md/ConstantForceComputeGPU.cc
+++ b/hoomd/md/ConstantForceComputeGPU.cc
@@ -64,6 +64,9 @@ void ConstantForceComputeGPU::setForces()
     unsigned int group_size = m_group->getNumMembers();
     unsigned int N = m_pdata->getN();
 
+    m_force.zeroFill();
+    m_torque.zeroFill();
+
     // compute the forces on the GPU
     m_tuner->begin();
 

--- a/hoomd/md/ConstantForceComputeGPU.cu
+++ b/hoomd/md/ConstantForceComputeGPU.cu
@@ -70,8 +70,6 @@ hipError_t gpu_compute_constant_force_set_forces(const unsigned int group_size,
     dim3 threads(block_size, 1, 1);
 
     // run the kernel
-    hipMemset(d_force, 0, sizeof(Scalar4) * N);
-    hipMemset(d_torque, 0, sizeof(Scalar4) * N);
     hipLaunchKernelGGL((gpu_compute_constant_force_set_forces_kernel),
                        dim3(grid),
                        dim3(threads),

--- a/hoomd/md/CosineSqAngleForceCompute.cc
+++ b/hoomd/md/CosineSqAngleForceCompute.cc
@@ -116,8 +116,8 @@ void CosineSqAngleForceCompute::computeForces(uint64_t timestep)
     assert(h_rtag.data);
 
     // Zero data for force calculation.
-    memset((void*)h_force.data, 0, sizeof(Scalar4) * m_force.getNumElements());
-    memset((void*)h_virial.data, 0, sizeof(Scalar) * m_virial.getNumElements());
+    m_force.zeroFill();
+    m_virial.zeroFill();
 
     // get a local copy of the simulation box too
     const BoxDim& box = m_pdata->getGlobalBox();

--- a/hoomd/md/CustomForceCompute.cc
+++ b/hoomd/md/CustomForceCompute.cc
@@ -41,18 +41,18 @@ void CustomForceCompute::computeForces(uint64_t timestep)
         // zero necessary arrays
         {
         ArrayHandle<Scalar4> h_force(m_force, access_location::host, access_mode::overwrite);
-        memset(h_force.data, 0, sizeof(Scalar4) * m_pdata->getN());
+        m_force.zeroFill();
         }
     if (m_aniso)
         {
         ArrayHandle<Scalar4> h_torque(m_torque, access_location::host, access_mode::overwrite);
-        memset(h_torque.data, 0, sizeof(Scalar4) * m_pdata->getN());
+        m_torque.zeroFill();
         }
 
     if (m_pdata->getFlags()[pdata_flag::pressure_tensor])
         {
         ArrayHandle<Scalar> h_virial(m_virial, access_location::host, access_mode::overwrite);
-        memset(h_virial.data, 0, sizeof(Scalar) * m_virial.getNumElements());
+        m_virial.zeroFill();
         }
     // execute python callback to update the forces, if present
     m_setForces(timestep);

--- a/hoomd/md/ForceComposite.cc
+++ b/hoomd/md/ForceComposite.cc
@@ -705,9 +705,9 @@ void ForceComposite::computeForces(uint64_t timestep)
     ArrayHandle<unsigned int> h_body_len(m_body_len, access_location::host, access_mode::read);
 
     // reset constraint forces and torques
-    memset(h_force.data, 0, sizeof(Scalar4) * m_pdata->getN());
-    memset(h_torque.data, 0, sizeof(Scalar4) * m_pdata->getN());
-    memset(h_virial.data, 0, sizeof(Scalar) * m_virial.getNumElements());
+    m_force.zeroFill();
+    m_torque.zeroFill();
+    m_virial.zeroFill();
 
     unsigned int n_particles_local = m_pdata->getN() + m_pdata->getNGhosts();
     size_t net_virial_pitch = m_pdata->getNetVirial().getPitch();

--- a/hoomd/md/ForceDistanceConstraint.cc
+++ b/hoomd/md/ForceDistanceConstraint.cc
@@ -171,7 +171,7 @@ void ForceDistanceConstraint::fillMatrixVector(uint64_t timestep)
     ArrayHandle<double> h_cvec(m_cvec, access_location::host, access_mode::overwrite);
 
     // clear matrix
-    memset(h_cmatrix.data, 0, sizeof(double) * m_cmatrix.size());
+    m_cmatrix.zeroFill();
 
     const BoxDim& box = m_pdata->getBox();
 
@@ -440,8 +440,8 @@ void ForceDistanceConstraint::computeConstraintForces(uint64_t timestep)
     unsigned int n_ptl = m_pdata->getN();
 
     // reset force array
-    memset(h_force.data, 0, sizeof(Scalar4) * n_ptl);
-    memset(h_virial.data, 0, sizeof(Scalar) * 6 * m_virial_pitch);
+    m_force.zeroFill();
+    m_virial.zeroFill();
 
     unsigned int n_constraint = m_cdata->getN() + m_cdata->getNGhosts();
 

--- a/hoomd/md/ForceDistanceConstraintGPU.cc
+++ b/hoomd/md/ForceDistanceConstraintGPU.cc
@@ -118,8 +118,8 @@ void ForceDistanceConstraintGPU::fillMatrixVector(uint64_t timestep)
         ArrayHandle<double> d_cvec(m_cvec, access_location::device, access_mode::overwrite);
 
         // reset matrix elements
-        hipMemset(d_cmatrix.data, 0, sizeof(double) * n_constraint * n_constraint);
-        hipMemset(d_cvec.data, 0, sizeof(double) * n_constraint);
+        m_cmatrix.zeroFill();
+        m_cvec.zeroFill();
         }
 
         {

--- a/hoomd/md/HarmonicAngleForceCompute.cc
+++ b/hoomd/md/HarmonicAngleForceCompute.cc
@@ -118,8 +118,8 @@ void HarmonicAngleForceCompute::computeForces(uint64_t timestep)
     assert(h_rtag.data);
 
     // Zero data for force calculation.
-    memset((void*)h_force.data, 0, sizeof(Scalar4) * m_force.getNumElements());
-    memset((void*)h_virial.data, 0, sizeof(Scalar) * m_virial.getNumElements());
+    m_force.zeroFill();
+    m_virial.zeroFill();
 
     // get a local copy of the simulation box too
     const BoxDim& box = m_pdata->getGlobalBox();

--- a/hoomd/md/HarmonicDihedralForceCompute.cc
+++ b/hoomd/md/HarmonicDihedralForceCompute.cc
@@ -124,8 +124,8 @@ void HarmonicDihedralForceCompute::computeForces(uint64_t timestep)
     ArrayHandle<Scalar> h_virial(m_virial, access_location::host, access_mode::overwrite);
 
     // Zero data for force calculation.
-    memset((void*)h_force.data, 0, sizeof(Scalar4) * m_force.getNumElements());
-    memset((void*)h_virial.data, 0, sizeof(Scalar) * m_virial.getNumElements());
+    m_force.zeroFill();
+    m_virial.zeroFill();
 
     // there are enough other checks on the input data: but it doesn't hurt to be safe
     assert(h_force.data);

--- a/hoomd/md/HarmonicImproperForceCompute.cc
+++ b/hoomd/md/HarmonicImproperForceCompute.cc
@@ -104,8 +104,8 @@ void HarmonicImproperForceCompute::computeForces(uint64_t timestep)
     assert(h_rtag.data);
 
     // Zero data for force calculation.
-    memset((void*)h_force.data, 0, sizeof(Scalar4) * m_force.getNumElements());
-    memset((void*)h_virial.data, 0, sizeof(Scalar) * m_virial.getNumElements());
+    m_force.zeroFill();
+    m_virial.zeroFill();
 
     // get a local copy of the simulation box too
     const BoxDim& box = m_pdata->getBox();

--- a/hoomd/md/HelfrichMeshForceCompute.cc
+++ b/hoomd/md/HelfrichMeshForceCompute.cc
@@ -120,8 +120,8 @@ void HelfrichMeshForceCompute::computeForces(uint64_t timestep)
     assert(h_sigma.data);
     assert(h_sigma_dash.data);
 
-    memset((void*)h_force.data, 0, sizeof(Scalar4) * m_force.getNumElements());
-    memset((void*)h_virial.data, 0, sizeof(Scalar) * m_virial.getNumElements());
+    m_force.zeroFill();
+    m_virial.zeroFill();
 
     const BoxDim& box = m_pdata->getGlobalBox();
 
@@ -402,8 +402,8 @@ void HelfrichMeshForceCompute::computeSigma()
     ArrayHandle<Scalar> h_sigma(m_sigma, access_location::host, access_mode::overwrite);
     ArrayHandle<Scalar3> h_sigma_dash(m_sigma_dash, access_location::host, access_mode::overwrite);
 
-    memset((void*)h_sigma.data, 0, sizeof(Scalar) * m_sigma.getNumElements());
-    memset((void*)h_sigma_dash.data, 0, sizeof(Scalar3) * m_sigma_dash.getNumElements());
+    m_sigma.zeroFill();
+    m_sigma_dash.zeroFill();
 
     const unsigned int size = (unsigned int)m_mesh_data->getMeshBondData()->getN();
     for (unsigned int i = 0; i < size; i++)

--- a/hoomd/md/MolecularForceCompute.cc
+++ b/hoomd/md/MolecularForceCompute.cc
@@ -317,9 +317,7 @@ void MolecularForceCompute::initMolecules()
     ArrayHandle<unsigned int> h_molecule_order(m_molecule_order,
                                                access_location::host,
                                                access_mode::overwrite);
-    memset(h_molecule_order.data,
-           0,
-           sizeof(unsigned int) * (m_pdata->getN() + m_pdata->getNGhosts()));
+    m_molecule_order.zeroFill();
 
     // resize reverse-lookup
     m_molecule_idx.resize(nptl_local);
@@ -333,7 +331,7 @@ void MolecularForceCompute::initMolecules()
                                              access_mode::overwrite);
 
     // reset reverse lookup
-    memset(h_molecule_idx.data, 0, sizeof(unsigned int) * nptl_local);
+    m_molecule_idx.zeroFill();
 
     unsigned int i_mol = 0;
     for (auto it_mol = local_molecules_sorted.begin(); it_mol != local_molecules_sorted.end();

--- a/hoomd/md/NeighborList.cc
+++ b/hoomd/md/NeighborList.cc
@@ -106,7 +106,7 @@ NeighborList::NeighborList(std::shared_ptr<SystemDefinition> sysdef, Scalar r_bu
         ArrayHandle<unsigned int> h_conditions(m_conditions,
                                                access_location::host,
                                                access_mode::overwrite);
-        memset(h_conditions.data, 0, sizeof(unsigned int) * m_pdata->getNTypes());
+        m_conditions.zeroFill();
         }
 
     // allocate m_last_pos
@@ -560,8 +560,8 @@ void NeighborList::resizeAndClearExclusions()
     ArrayHandle<unsigned int> h_n_ex_tag(m_n_ex_tag, access_location::host, access_mode::overwrite);
     ArrayHandle<unsigned int> h_n_ex_idx(m_n_ex_idx, access_location::host, access_mode::overwrite);
 
-    memset(h_n_ex_tag.data, 0, sizeof(unsigned int) * m_n_ex_tag.getNumElements());
-    memset(h_n_ex_idx.data, 0, sizeof(unsigned int) * m_n_ex_idx.getNumElements());
+    m_n_ex_tag.zeroFill();
+    m_n_ex_idx.zeroFill();
     m_exclusions_set = false;
 
     forceUpdate();
@@ -1533,7 +1533,7 @@ void NeighborList::resetConditions()
     ArrayHandle<unsigned int> h_conditions(m_conditions,
                                            access_location::host,
                                            access_mode::overwrite);
-    memset(h_conditions.data, 0, sizeof(unsigned int) * m_pdata->getNTypes());
+    m_conditions.zeroFill();
     }
 
 void NeighborList::growExclusionList()

--- a/hoomd/md/NeighborListGPUTree.cc
+++ b/hoomd/md/NeighborListGPUTree.cc
@@ -500,7 +500,7 @@ void NeighborListGPUTree::traverseTree()
     ArrayHandle<unsigned int> h_Nmax(m_Nmax, access_location::host, access_mode::read);
 
     // clear the neighbor counts
-    hipMemset(d_n_neigh.data, 0, sizeof(unsigned int) * m_pdata->getN());
+    m_n_neigh.zeroFill();
 
     const BoxDim& box = m_pdata->getBox();
 

--- a/hoomd/md/OPLSDihedralForceCompute.cc
+++ b/hoomd/md/OPLSDihedralForceCompute.cc
@@ -115,8 +115,8 @@ void OPLSDihedralForceCompute::computeForces(uint64_t timestep)
     ArrayHandle<Scalar4> h_params(m_params, access_location::host, access_mode::read);
 
     // Zero data for force calculation before computation
-    memset((void*)h_force.data, 0, sizeof(Scalar4) * m_force.getNumElements());
-    memset((void*)h_virial.data, 0, sizeof(Scalar) * m_virial.getNumElements());
+    m_force.zeroFill();
+    m_virial.zeroFill();
 
     // there are enough other checks on the input data, but it doesn't hurt to be safe
     assert(h_force.data);

--- a/hoomd/md/PPPMForceCompute.cc
+++ b/hoomd/md/PPPMForceCompute.cc
@@ -44,7 +44,7 @@ PPPMForceCompute::PPPMForceCompute(std::shared_ptr<SystemDefinition> sysdef,
     m_pdata->getBoxChangeSignal().connect<PPPMForceCompute, &PPPMForceCompute::setBoxChange>(this);
     // reset virial
     ArrayHandle<Scalar> h_virial(m_virial, access_location::host, access_mode::overwrite);
-    memset(h_virial.data, 0, sizeof(Scalar) * m_virial.getNumElements());
+    m_virial.zeroFill();
 
     m_mesh_points = make_uint3(0, 0, 0);
     m_global_dim = make_uint3(0, 0, 0);
@@ -605,8 +605,8 @@ void PPPMForceCompute::computeInfluenceFunction()
     ArrayHandle<Scalar3> h_k(m_k, access_location::host, access_mode::overwrite);
 
     // reset arrays
-    memset(h_inf_f.data, 0, sizeof(Scalar) * m_inf_f.getNumElements());
-    memset(h_k.data, 0, sizeof(Scalar3) * m_k.getNumElements());
+    m_inf_f.zeroFill();
+    m_k.zeroFill();
 
     const BoxDim& global_box = m_pdata->getGlobalBox();
 
@@ -786,7 +786,7 @@ void PPPMForceCompute::assignParticles()
     const BoxDim& box = m_pdata->getBox();
 
     // set mesh to zero
-    memset(h_mesh.data, 0, sizeof(kiss_fft_cpx) * m_mesh.getNumElements());
+    m_mesh.zeroFill();
 
     Scalar V_cell = box.getVolume() / (Scalar)(m_mesh_points.x * m_mesh_points.y * m_mesh_points.z);
 
@@ -1102,7 +1102,7 @@ void PPPMForceCompute::interpolateForces()
     ArrayHandle<Scalar4> h_force(m_force, access_location::host, access_mode::overwrite);
 
     // reset force for ALL particles
-    memset(h_force.data, 0, sizeof(Scalar4) * m_pdata->getN());
+    m_force.zeroFill();
 
     ArrayHandle<Scalar> h_rho_coeff(m_rho_coeff, access_location::host, access_mode::read);
 
@@ -1593,7 +1593,7 @@ void PPPMForceCompute::fixExclusions()
     ArrayHandle<Scalar> h_virial(m_virial, access_location::host, access_mode::readwrite);
 
     // reset virial (but not forces, we reset them above)
-    memset(h_virial.data, 0, sizeof(Scalar) * m_virial.getNumElements());
+    m_virial.zeroFill();
 
     size_t virial_pitch = m_virial.getPitch();
 

--- a/hoomd/md/PPPMForceComputeGPU.cc
+++ b/hoomd/md/PPPMForceComputeGPU.cc
@@ -720,7 +720,7 @@ void PPPMForceComputeGPU::fixExclusions()
     ArrayHandle<Scalar> d_charge(m_pdata->getCharges(), access_location::device, access_mode::read);
 
     // reset virial
-    hipMemset(d_virial.data, 0, sizeof(Scalar) * m_virial.getNumElements());
+    m_virial.zeroFill();
 
     Index2D nex = m_nlist->getExListIndexer();
 

--- a/hoomd/md/PeriodicImproperForceCompute.cc
+++ b/hoomd/md/PeriodicImproperForceCompute.cc
@@ -74,8 +74,8 @@ void PeriodicImproperForceCompute::computeForces(uint64_t timestep)
                                                    access_mode::read);
 
     // Zero data for force calculation.
-    memset((void*)h_force.data, 0, sizeof(Scalar4) * m_force.getNumElements());
-    memset((void*)h_virial.data, 0, sizeof(Scalar) * m_virial.getNumElements());
+    m_force.zeroFill();
+    m_virial.zeroFill();
 
     // there are enough other checks on the input data: but it doesn't hurt to be safe
     assert(h_force.data);

--- a/hoomd/md/PotentialBond.h
+++ b/hoomd/md/PotentialBond.h
@@ -186,8 +186,8 @@ void PotentialBond<evaluator, Bonds>::computeForces(uint64_t timestep)
     assert(h_charge.data);
 
     // Zero data for force calculation
-    memset((void*)h_force.data, 0, sizeof(Scalar4) * m_force.getNumElements());
-    memset((void*)h_virial.data, 0, sizeof(Scalar) * m_virial.getNumElements());
+    m_force.zeroFill();
+    m_virial.zeroFill();
 
     // we are using the minimum image of the global box here
     // to ensure that ghosts are always correctly wrapped (even if a bond exceeds half the domain

--- a/hoomd/md/PotentialExternal.h
+++ b/hoomd/md/PotentialExternal.h
@@ -116,9 +116,9 @@ template<class evaluator> void PotentialExternal<evaluator>::computeForces(uint6
     unsigned int nparticles = m_pdata->getN();
 
     // Zero data for force calculation.
-    memset((void*)h_force.data, 0, sizeof(Scalar4) * m_force.getNumElements());
-    memset((void*)h_torque.data, 0, sizeof(Scalar4) * m_torque.getNumElements());
-    memset((void*)h_virial.data, 0, sizeof(Scalar) * m_virial.getNumElements());
+    m_force.zeroFill();
+    m_torque.zeroFill();
+    m_virial.zeroFill();
 
     // there are enough other checks on the input data: but it doesn't hurt to be safe
     assert(h_force.data);

--- a/hoomd/md/PotentialPair.h
+++ b/hoomd/md/PotentialPair.h
@@ -596,8 +596,8 @@ template<class evaluator> void PotentialPair<evaluator>::computeForces(uint64_t 
         bool compute_virial = flags[pdata_flag::pressure_tensor];
 
         // need to start from a zero force, energy and virial
-        memset((void*)h_force.data, 0, sizeof(Scalar4) * m_force.getNumElements());
-        memset((void*)h_virial.data, 0, sizeof(Scalar) * m_virial.getNumElements());
+        m_force.zeroFill();
+        m_virial.zeroFill();
 
         // for each particle
         for (int i = 0; i < (int)m_pdata->getN(); i++)

--- a/hoomd/md/PotentialPairAlchemical.h
+++ b/hoomd/md/PotentialPairAlchemical.h
@@ -328,8 +328,8 @@ void PotentialPairAlchemical<evaluator, extra_pkg, alpha_particle_type>::compute
         bool compute_virial = flags[pdata_flag::pressure_tensor];
 
         // need to start from a zero force, energy and virial
-        memset((void*)h_force.data, 0, sizeof(Scalar4) * m_force.getNumElements());
-        memset((void*)h_virial.data, 0, sizeof(Scalar) * m_virial.getNumElements());
+        m_force.zeroFill();
+        m_virial.zeroFill();
 
         // for each particle
         for (int i = 0; i < (int)m_pdata->getN(); i++)

--- a/hoomd/md/PotentialPairDPDThermo.h
+++ b/hoomd/md/PotentialPairDPDThermo.h
@@ -138,8 +138,8 @@ template<class evaluator> void PotentialPairDPDThermo<evaluator>::computeForces(
     ArrayHandle<Scalar> h_rcutsq(this->m_rcutsq, access_location::host, access_mode::read);
 
     // need to start from a zero force, energy and virial
-    memset((void*)h_force.data, 0, sizeof(Scalar4) * this->m_force.getNumElements());
-    memset((void*)h_virial.data, 0, sizeof(Scalar) * this->m_virial.getNumElements());
+    this->m_force.zeroFill();
+    this->m_virial.zeroFill();
 
     uint16_t seed = this->m_sysdef->getSeed();
 

--- a/hoomd/md/PotentialPairDPDThermo.h
+++ b/hoomd/md/PotentialPairDPDThermo.h
@@ -243,7 +243,7 @@ template<class evaluator> void PotentialPairDPDThermo<evaluator>::computeForces(
 
                 // add the force to particle j if we are using the third law (MEM TRANSFER: 10
                 // scalars / FLOPS: 8)
-                if (third_law)
+                if (third_law && j < this->m_pdata->getN())
                     {
                     unsigned int mem_idx = j;
                     h_force.data[mem_idx].x -= dx.x * force_divr;

--- a/hoomd/md/PotentialSpecialPair.h
+++ b/hoomd/md/PotentialSpecialPair.h
@@ -200,8 +200,8 @@ template<class evaluator> void PotentialSpecialPair<evaluator>::computeForces(ui
     assert(h_charge.data);
 
     // Zero data for force calculation
-    memset((void*)h_force.data, 0, sizeof(Scalar4) * m_force.getNumElements());
-    memset((void*)h_virial.data, 0, sizeof(Scalar) * m_virial.getNumElements());
+    m_force.zeroFill();
+    m_virial.zeroFill();
 
     // we are using the minimum image of the global box here
     // to ensure that ghosts are always correctly wrapped (even if a bond exceeds half the domain

--- a/hoomd/md/PotentialTersoff.h
+++ b/hoomd/md/PotentialTersoff.h
@@ -319,8 +319,8 @@ template<class evaluator> void PotentialTersoff<evaluator>::computeForces(uint64
         ArrayHandle<param_type> h_params(m_params, access_location::host, access_mode::read);
 
         // need to start from a zero force, energy
-        memset(h_force.data, 0, sizeof(Scalar4) * (m_pdata->getN() + m_pdata->getNGhosts()));
-        memset(h_virial.data, 0, sizeof(Scalar) * 6 * m_virial_pitch);
+        m_force.zeroFill();
+        m_virial.zeroFill();
 
         // for each particle
         for (int i = 0; i < (int)m_pdata->getN(); i++)
@@ -582,8 +582,8 @@ template<class evaluator> void PotentialTersoff<evaluator>::computeForces(uint64
         ArrayHandle<param_type> h_params(m_params, access_location::host, access_mode::read);
 
         // need to start from a zero force, energy
-        memset(h_force.data, 0, sizeof(Scalar4) * (m_pdata->getN() + m_pdata->getNGhosts()));
-        memset(h_virial.data, 0, sizeof(Scalar) * 6 * m_virial_pitch);
+        m_force.zeroFill();
+        m_virial.zeroFill();
 
         unsigned int ntypes = m_pdata->getNTypes();
 

--- a/hoomd/md/TableAngleForceCompute.cc
+++ b/hoomd/md/TableAngleForceCompute.cc
@@ -152,8 +152,8 @@ void TableAngleForceCompute::computeForces(uint64_t timestep)
     size_t virial_pitch = m_virial.getPitch();
 
     // Zero data for force calculation.
-    memset((void*)h_force.data, 0, sizeof(Scalar4) * m_force.getNumElements());
-    memset((void*)h_virial.data, 0, sizeof(Scalar) * m_virial.getNumElements());
+    m_force.zeroFill();
+    m_virial.zeroFill();
 
     // get a local copy of the simulation box too
     const BoxDim& box = m_pdata->getBox();

--- a/hoomd/md/TableDihedralForceCompute.cc
+++ b/hoomd/md/TableDihedralForceCompute.cc
@@ -147,8 +147,8 @@ void TableDihedralForceCompute::computeForces(uint64_t timestep)
     size_t virial_pitch = m_virial.getPitch();
 
     // Zero data for force calculation.
-    memset((void*)h_force.data, 0, sizeof(Scalar4) * m_force.getNumElements());
-    memset((void*)h_virial.data, 0, sizeof(Scalar) * m_virial.getNumElements());
+    m_force.zeroFill();
+    m_virial.zeroFill();
 
     // get a local copy of the simulation box too
     const BoxDim& box = m_pdata->getBox();

--- a/hoomd/md/TriangleAreaConservationMeshForceCompute.cc
+++ b/hoomd/md/TriangleAreaConservationMeshForceCompute.cc
@@ -115,8 +115,8 @@ void TriangleAreaConservationMeshForceCompute::computeForces(uint64_t timestep)
     assert(h_triangles.data);
 
     // Zero data for force calculation.
-    memset((void*)h_force.data, 0, sizeof(Scalar4) * m_force.getNumElements());
-    memset((void*)h_virial.data, 0, sizeof(Scalar) * m_virial.getNumElements());
+    m_force.zeroFill();
+    m_virial.zeroFill();
 
     // get a local copy of the simulation box
     const BoxDim& box = m_pdata->getGlobalBox();

--- a/hoomd/md/VolumeConservationMeshForceCompute.cc
+++ b/hoomd/md/VolumeConservationMeshForceCompute.cc
@@ -122,8 +122,8 @@ void VolumeConservationMeshForceCompute::computeForces(uint64_t timestep)
     assert(h_rtag.data);
     assert(h_triangles.data);
 
-    memset((void*)h_force.data, 0, sizeof(Scalar4) * m_force.getNumElements());
-    memset((void*)h_virial.data, 0, sizeof(Scalar) * m_virial.getNumElements());
+    m_force.zeroFill();
+    m_virial.zeroFill();
 
     const BoxDim& box = m_pdata->getGlobalBox();
 

--- a/hoomd/mpcd/CellList.cc
+++ b/hoomd/mpcd/CellList.cc
@@ -357,7 +357,7 @@ void mpcd::CellList::buildCellList()
                                           access_mode::overwrite);
     ArrayHandle<unsigned int> h_cell_np(m_cell_np, access_location::host, access_mode::overwrite);
     // zero the cell counter
-    memset(h_cell_np.data, 0, sizeof(unsigned int) * m_cell_indexer.getNumElements());
+    m_cell_np.zeroFill();
 
     uint3 conditions = make_uint3(0, 0, 0);
 


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should be based on *trunk-patch*. -->
<!-- Backwards compatible new features should be based on *trunk-minor*. -->
<!-- Incompatible API changes should be based on *trunk-major*. -->

## Description

<!-- Describe your changes in detail. -->
* Implement and use `GPUArray::zeroFill` to ensure that arrays are properly cleared.
* Don't write -f forces to ghost j particles.
* Clear torques in the `force.Active` implementation on the GPU.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
While investigating a bug where `ALJ` computes forces that do not sum to 0, I found some inconsistencies in the ghost particle logic. I don't think these caused the bug (will test and see), but I still think they are worth changing for clarity and consistency.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
CI checks. Will also test with the ALJ reproducer.

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
- [x] I have summarized these changes in `CHANGELOG.rst` following the established format.
