### PR TITLE
Correctly account for neighbors in HPMC when updaters move particles.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,9 @@ Change Log
   (`#2020 <https://github.com/glotzerlab/hoomd-blue/pull/2020>`__).
 * MD integrators no longer integrate the z degree of freedom in 2D simulation boxes
   (`#2021 <https://github.com/glotzerlab/hoomd-blue/pull/2021>`__).
+* HPMC integrators no longer miss pairwise interactions when updaters, such as
+  ``RemoveDrift`` move particles
+  (`#2022 <https://github.com/glotzerlab/hoomd-blue/pull/2022>`__).
 
 5.1.0 (2025-02-20)
 ^^^^^^^^^^^^^^^^^^

--- a/hoomd/hpmc/IntegratorHPMCMono.h
+++ b/hoomd/hpmc/IntegratorHPMCMono.h
@@ -250,15 +250,13 @@ template<class Shape> class IntegratorHPMCMono : public IntegratorHPMC
 #ifdef ENABLE_MPI
         if (m_sysdef->isDomainDecomposed())
             {
-            // this is kludgy but necessary since we are calling the communications methods directly
-            m_comm->setFlags(getCommFlags(0));
-
             if (migrate)
-                m_comm->migrateParticles();
-            else
-                m_pdata->removeAllGhostParticles();
+                {
+                m_comm->forceMigrate();
+                }
 
-            m_comm->exchangeGhosts();
+            // The timestep flag is not used in HPMC simulations, pass 0.
+            m_comm->communicate(0);
 
             m_aabb_tree_invalid = true;
             }

--- a/hoomd/hpmc/IntegratorHPMCMono.h
+++ b/hoomd/hpmc/IntegratorHPMCMono.h
@@ -440,7 +440,9 @@ template<class Shape> void IntegratorHPMCMono<Shape>::update(uint64_t timestep)
     m_update_order.resize(m_pdata->getN());
     m_update_order.shuffle(timestep, m_sysdef->getSeed(), m_exec_conf->getRank());
 
-    // update the AABB Tree
+    // update the AABB Tree. Assume that it is invalid as previously called Updaters may have
+    // moved particles.
+    m_aabb_tree_invalid = true;
     buildAABBTree();
     // limit m_d entries so that particles cannot possibly wander more than one box image in one
     // time step


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should be based on *trunk-patch*. -->
<!-- Backwards compatible new features should be based on *trunk-minor*. -->
<!-- Incompatible API changes should be based on *trunk-major*. -->

## Description

<!-- Describe your changes in detail. -->
Specifically fix an issue where using `RemoveDrift` would cause overlapping hard particles. More generally, ensure that `IntegratorHPMCMono` properly accounts for all potential neighbors after updaters move particles outside of the integrator's control.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
A user reported overlapping particles in a Frenkel-Ladd simulation that used `RemoveDrift`.

In serial: `IntegratorHPMCMono` moved particles and set the aabb invalid flag. If a logger then examined the number of overlaps, the AABB is rebuilt and the invalid flag cleared. An updater could then move particles and the following call to integrate would NOT rebuild the AABB tree - instead using the stale tree and therefore missing neighbors. 

In parallel: An updater might move a particle outside the local domain. `IntegratorHPMCMono` assumes that all particles are local. Any updater that moves particles needs to call `communicate` to ensure this and `RemoveDrift` did not do so.

## How has this been tested?

Cases that trigger this bug are extremely rare. I have tested these fixes with the minimal example script provided by the user. Short runs now behave correctly in serial and parallel. We will test this branch with full production runs before merging.

I will also run the hoomd-validation test suite before merging.

<!--- Please describe in detail how you tested your changes. -->

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
- [x] I have summarized these changes in `CHANGELOG.rst` following the established format.
