### PR TITLE
Silence the same sweep distance error.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,14 @@ Change Log
 5.x
 ---
 
+5.1.2 (not yet released)
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+*Fixed*
+
+* Remove the error message that NEC prints when one particle simultaneously collides with two
+  others (`#2029 <https://github.com/glotzerlab/hoomd-blue/pull/2029>`__).
+
 5.1.1 (2025-03-19)
 ^^^^^^^^^^^^^^^^^^
 

--- a/hoomd/hpmc/IntegratorHPMCMonoNEC.h
+++ b/hoomd/hpmc/IntegratorHPMCMonoNEC.h
@@ -398,7 +398,7 @@ template<class Shape> void IntegratorHPMCMonoNEC<Shape>::update(uint64_t timeste
                         {
                         this->m_exec_conf->msg->error()
                             << "The number of chain elements exceeded safe-guard limit of "
-                            << debug_max_chain << ".\n";
+                            << debug_max_chain << "." << std::endl;
                         this->m_exec_conf->msg->error()
                             << "Shorten chain_time if this message appears regularly." << std::endl;
                         break;
@@ -866,11 +866,11 @@ double IntegratorHPMCMonoNEC<Shape>::sweepDistance(vec3<Scalar>& direction,
                                             }
                                         }
 
-                                    if (newDist == sweepableDistance)
-                                        {
-                                        this->m_exec_conf->msg->error()
-                                            << "Two particles with the same distance\n";
-                                        }
+                                    // 3-way collisions (newDist == sweepableDistance) should be
+                                    // extremely rare, yet they somehow occur often with NEC.
+                                    // Ignore these cases and choose one colliding pair to resolve.
+                                    // NEC would sample the correct distribution even if all
+                                    // velocities were fixed.
                                     }
                                 }
                             }


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should be based on *trunk-patch*. -->
<!-- Backwards compatible new features should be based on *trunk-minor*. -->
<!-- Incompatible API changes should be based on *trunk-major*. -->

## Description

<!-- Describe your changes in detail. -->
Remove the error message that NEC prints when one particle simultaneously collides with two others.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
See #2028

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
The minimal working example in #2028.

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
- [x] I have summarized these changes in `CHANGELOG.rst` following the established format.
