### PR TITLE
Fix compile errors on recent clang versions

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -258,6 +258,11 @@ jobs:
       if: ${{ contains(inputs.config, 'cuda') }}
       run: nvidia-smi
 
+    - name: Check for devices
+      if: ${{ contains(inputs.config, 'cuda') }}
+      run: >
+        python3 -c "import hoomd; print('available:', hoomd.device.GPU.get_available_devices()); print('unavailable:', hoomd.device.GPU.get_unavailable_device_reasons());"
+
     ### Python unit tests
     - name: Run pytest (serial)
       run: python3 -m pytest --pyargs hoomd -x -v -ra --durations=0 --durations-min=0.1


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should be based on *trunk-patch*. -->
<!-- Backwards compatible new features should be based on *trunk-minor*. -->
<!-- Incompatible API changes should be based on *trunk-major*. -->

## Description

<!-- Describe your changes in detail. -->
Also patch nano-signal-slot to work with the latest version of clang.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Fix compile errors with the latest version of clang (on macOS)

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
HOOMD-blue now compiles and passes tests on a fully updated mac.

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
- [x] I have summarized these changes in `CHANGELOG.rst` following the established format.
