### PR TITLE
Render math with katex

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -12,6 +12,7 @@ build:
   os: ubuntu-24.04
   tools:
     python: "3.13"
+    nodejs: "23"
 
 submodules:
   include: all

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,11 @@ Change Log
 * Set constituent particle velocities for rigid bodies
   (`#2024 <https://github.com/glotzerlab/hoomd-blue/pull/2024>`__).
 
+*Changed*
+
+* Use KaTeX to render math equations in the documentation
+  (`#2053 <https://github.com/glotzerlab/hoomd-blue/pull/2053>`__).
+
 *Fixed*
 
 * The documentation builds without warnings in Python 3.13 environments

--- a/hoomd/box.py
+++ b/hoomd/box.py
@@ -101,18 +101,23 @@ class Box:
     :math:`\\alpha`, :math:`\\beta` and :math:`\\gamma` are as follows:
 
     .. math::
-        \\cos\\gamma &= \\cos(\\angle\\vec a_1, \\vec a_2) &=&
+
+        \\begin{split}
+        \\cos\\gamma &= \\cos(\\angle\\vec a_1, \\vec a_2) =
             \\frac{xy}{\\sqrt{1+xy^2}}\\\\
-        \\cos\\beta &= \\cos(\\angle\\vec a_1, \\vec a_3) &=&
+        \\cos\\beta &= \\cos(\\angle\\vec a_1, \\vec a_3) =
             \\frac{xz}{\\sqrt{1+xz^2+yz^2}}\\\\
-        \\cos\\alpha &= \\cos(\\angle\\vec a_2, \\vec a_3) &=&
+        \\cos\\alpha &= \\cos(\\angle\\vec a_2, \\vec a_3) =
             \\frac{xy \\cdot xz + yz}{\\sqrt{1+xy^2} \\sqrt{1+xz^2+yz^2}}
+        \\end{split}
 
     Given an arbitrarily oriented lattice with box vectors :math:`\\vec v_1,
     \\vec v_2, \\vec v_3`, the parameters for the rotated box can be found as
     follows:
 
     .. math::
+
+        \\begin{split}
         L_x &= v_1\\\\
         a_{2x} &= \\frac{\\vec v_1 \\cdot \\vec v_2}{v_1}\\\\
         L_y &= \\sqrt{v_2^2 - a_{2x}^2}\\\\
@@ -122,6 +127,7 @@ class Box:
         a_{3x} &= \\frac{\\vec v_1 \\cdot \\vec v_3}{v_1}\\\\
         xz &= \\frac{a_{3x}}{L_z}\\\\
         yz &= \\frac{\\vec v_2 \\cdot \\vec v_3 - a_{2x}a_{3x}}{L_y L_z}
+        \\end{split}
 
     .. rubric:: Box images
 
@@ -227,7 +233,7 @@ class Box:
            The created box will be rotated with respect to the lattice basis. As
            a consequence the output of `to_matrix` will not be the same as the
            input provided to this function. This function also returns a
-           rotation matrix comensurate with this transformation. Using this
+           rotation matrix commensurate with this transformation. Using this
            rotation matrix users can rotate the original points into the new box
            by applying the rotation to the points.
 

--- a/hoomd/hpmc/compute.py
+++ b/hoomd/hpmc/compute.py
@@ -191,6 +191,7 @@ class SDF(Compute):
 
     .. math::
 
+        \begin{split}
         x_{ij}(\vec{A}) = \min \{ & x \in \mathbb{R}_{> 0} : \\
            & \mathrm{overlap}\left(
                 S_i(\mathbf{q}_i),
@@ -206,6 +207,7 @@ class SDF(Compute):
                                  \mathbf{q}_i,
                                  \mathbf{q}_j) \\
             \} &
+        \end{split}
 
     where :math:`\mathrm{overlap}` is the shape overlap function defined in
     `hoomd.hpmc.integrate`, :math:`S_i` is the shape of particle :math:`i`, and
@@ -214,6 +216,7 @@ class SDF(Compute):
 
     .. math::
 
+        \begin{split}
         x_{ij}(\vec{A}) = \max \{ & x \in \mathbb{R}_{< 0} : \\
            & \mathrm{overlap}\left(
                 S_i(\mathbf{q}_i),
@@ -229,6 +232,7 @@ class SDF(Compute):
                                  \mathbf{q}_i,
                                  \mathbf{q}_j) \\
             \} &
+        \end{split}
 
 
     For particle :math:`i`, `SDF` finds the the minimum (maximum for expansive

--- a/hoomd/hpmc/external/harmonic.py
+++ b/hoomd/hpmc/external/harmonic.py
@@ -39,6 +39,7 @@ class Harmonic(External):
 
     .. math::
 
+        \begin{split}
         U_{\mathrm{external},i} & = U_{\mathrm{translational},i} +
         U_{\mathrm{rotational},i} \\
         U_{\mathrm{translational},i} & = \frac{1}{2}
@@ -47,6 +48,7 @@ class Harmonic(External):
             k_{rotational} \cdot \min_j \left[
             (\mathbf{q}_i-\mathbf{q}_{0,i} \cdot
              \mathbf{q}_{\mathrm{symmetry},j})^2 \right]
+        \end{split}
 
 
     where :math:`k_{translational}` and :math:`k_{rotational}` correspond to the

--- a/hoomd/hpmc/integrate.py
+++ b/hoomd/hpmc/integrate.py
@@ -128,6 +128,7 @@ interactions between pairs of particles in multiple box images:
 
 .. math::
 
+    \begin{split}
     U_{\mathrm{pair}} = &
             \sum_{i=0}^{N_\mathrm{particles}-1}
             \sum_{j=i+1}^{N_\mathrm{particles}-1}
@@ -140,6 +141,7 @@ interactions between pairs of particles in multiple box images:
             U_{\mathrm{pair},ij}(\vec{r}_j - (\vec{r}_i + \vec{A}),
                                  \mathbf{q}_i,
                                  \mathbf{q}_j)
+    \end{split}
 
 where :math:`\vec{A} = h\vec{a}_1 + k\vec{a}_2 + l\vec{a}_3` is a vector that
 translates by periodic box images and the set of box images includes all image
@@ -217,6 +219,7 @@ The complete hard shape interaction energy for a given configuration is:
 
 .. math::
 
+    \begin{split}
     U_\mathrm{shape} = \quad & \infty
             \cdot
             \sum_{i=0}^{N_\mathrm{particles}-1}
@@ -237,6 +240,7 @@ The complete hard shape interaction energy for a given configuration is:
             S_j(\mathbf{q}_j, \vec{r}_j - (\vec{r}_i + \vec{A}))
             \right) \ne \emptyset
             \right]
+    \end{split}
 
 where the square brackets denote the Iverson bracket.
 

--- a/hoomd/hpmc/update.py
+++ b/hoomd/hpmc/update.py
@@ -60,6 +60,7 @@ class BoxMC(Updater):
 
       .. math::
 
+          \begin{split}
           V^t &= V + u \\
           L_x^t &= \left( \frac{Lx}{Ly} \frac{Lx}{Lz} V^t \right)^{1/3} \\
           L_y^t &= L_x^t \frac{Ly}{Lx} \\
@@ -67,6 +68,7 @@ class BoxMC(Updater):
           xy^t &= xy \\
           xz^t &= xz \\
           yz^t &= yz \\
+          \end{split}
 
       where :math:`u` is a random value uniformly distributed in the interval
       :math:`[-\delta_\mathrm{volume}, \delta_\mathrm{volume}]`.
@@ -75,10 +77,12 @@ class BoxMC(Updater):
 
       .. math::
 
+          \begin{split}
           V^t &= V + u \\
           L_x^t &= \left( \frac{Lx}{Ly} V^t \right)^{1/2} \\
           L_y^t &= L_x^t \frac{Ly}{Lx} \\
           xy^t &= xy \\
+          \end{split}
 
     * `volume` (``mode='ln'``): Change the volume (or area in 2D) of the
       simulation box while maining fixed aspect ratios :math:`Lx/Ly`,
@@ -86,6 +90,7 @@ class BoxMC(Updater):
 
       .. math::
 
+          \begin{split}
           V^t &= V e^u \\
           L_x^t &= \left( \frac{Lx}{Ly} \frac{Lx}{Lz} V^t \right)^{1/3} \\
           L_y^t &= L_x^t \frac{Ly}{Lx} \\
@@ -93,6 +98,7 @@ class BoxMC(Updater):
           xy^t &= xy \\
           xz^t &= xz \\
           yz^t &= yz \\
+          \end{split}
 
       where :math:`u` is a random value uniformly distributed in the interval
       :math:`[-\delta_\mathrm{volume}, \delta_\mathrm{volume}]`.
@@ -101,15 +107,19 @@ class BoxMC(Updater):
 
       .. math::
 
+          \begin{split}
           V^t &= V e^u \\
           L_x^t &= \left( \frac{Lx}{Ly} V^t \right)^{1/2} \\
           L_y^t &= L_x^t \frac{Ly}{Lx} \\
           xy^t &= xy \\
+          \end{split}
+
     * `aspect`: Change the aspect ratio of the simulation box while maintaining
       a fixed volume. In 3D:
 
       .. math::
 
+          \begin{split}
           L_k^t & = \begin{cases} L_k(1 + a) & u < 0.5 \\
                                 L_k \frac{1}{1+a}  & u \ge 0.5
                   \end{cases} \\
@@ -117,6 +127,7 @@ class BoxMC(Updater):
           xy^t &= xy \\
           xz^t &= xz \\
           yz^t &= yz \\
+          \end{split}
 
       where :math:`u` is a random value uniformly distributed in the interval
       :math:`[0, 1]`, :math:`a` is a random value uniformly distributed in the
@@ -127,11 +138,14 @@ class BoxMC(Updater):
 
       .. math::
 
+          \begin{split}
           L_k^t & = \begin{cases} L_k(1 + a) & u < 0.5 \\
                                 L_k \frac{1}{1+a}  & u \ge 0.5
                     \end{cases} \\
           L_{m \ne k}^t & = L_m \frac{L_k}{L_k^t} \\
           xy^t &= xy \\
+          \end{split}
+
     * `length`: Change the box lengths:
 
       .. math::
@@ -820,6 +834,7 @@ class QuickCompress(Updater):
 
     .. math::
 
+          \begin{split}
           L_x' &= \begin{cases}
           \max( L_x \cdot s, L_{\mathrm{target},x} )
           & L_{\mathrm{target},x} < L_x \\
@@ -856,11 +871,13 @@ class QuickCompress(Updater):
           \max( yz + (1-s) \cdot yz_\mathrm{target}, yz_\mathrm{target} )
           & yz_\mathrm{target} \ge yz
           \end{cases} \\
+          \end{split}
 
     and in 2D:
 
     .. math::
 
+          \begin{split}
           L_x' &= \begin{cases}
           \max( L_x \cdot s, L_{\mathrm{target},x} )
           & L_{\mathrm{target},x} < L_x \\
@@ -882,6 +899,7 @@ class QuickCompress(Updater):
           \end{cases} \\
           xz' &= xz \\
           yz' &= yz \\
+          \end{split}
 
     where the current simulation box is :math:`(L_x, L_y, L_z, xy, xz, yz)`,
     the target is :math:`(L_{\mathrm{target},x}, L_{\mathrm{target},y},

--- a/hoomd/md/constrain.py
+++ b/hoomd/md/constrain.py
@@ -148,9 +148,11 @@ class Rigid(Constraint):
 
     .. math::
 
+        \begin{split}
         \vec{r}_c &= \vec{r}_b
                     + \mathbf{q}_b \vec{r}_{c,\mathrm{body}} \mathbf{q}_b^* \\
         \mathbf{q}_c &= \mathbf{q}_b \mathbf{q}_{c,\mathrm{body}}
+        \end{split}
 
     where :math:`\vec{r}_c` and :math:`\mathbf{q}_c` are the position and
     orientation of a constituent particle in the simulation box,
@@ -197,11 +199,13 @@ class Rigid(Constraint):
 
     .. math::
 
+        \begin{split}
         \vec{F}_b' &= \vec{F}_b + \sum_c \vec{F}_c \\
         \vec{U}_b' &= U_b + \sum_c U_c \\
         \vec{\tau}_b' &= \vec{\tau}_b + \sum_c \vec{\tau}_c +
             (\mathbf{q}_b \vec{r}_{c,\mathrm{body}} \mathbf{q}_b^*)
             \times \vec{F}_c
+        \end{split}
 
     `Rigid` also computes the corrected virial accounting for the effective
     constraint force (see `Glaser 2020

--- a/hoomd/md/force.py
+++ b/hoomd/md/force.py
@@ -35,8 +35,10 @@ class Force(Compute):
 
     .. math::
 
+        \begin{split}
         U & = U_\mathrm{additional} + \sum_{i=0}^{N_\mathrm{particles}-1} U_i \\
         W & = W_\mathrm{additional} + \sum_{i=0}^{N_\mathrm{particles}-1} W_i
+        \end{split}
 
     `Force` represents virial tensors as six element arrays listing the
     components of the tensor in this order:

--- a/hoomd/md/integrate.py
+++ b/hoomd/md/integrate.py
@@ -172,20 +172,24 @@ class Integrator(_DynamicIntegrator):
 
     .. math::
 
+        \begin{split}
         \vec{F}_{\mathrm{net},i} &= \sum_{f \in \mathrm{forces}} \vec{F}_i^f \\
         \vec{\tau}_{\mathrm{net},i} &=
         \sum_{f \in \mathrm{forces}} \vec{\tau}_i^f \\
         U_{\mathrm{net},i} &= \sum_{f \in \mathrm{forces}} U_i^f \\
         W_{\mathrm{net},i} &= \sum_{f \in \mathrm{forces}} W_i^f \\
+        \end{split}
 
     `Integrator` also computes the net additional energy and virial
 
     .. math::
 
+        \begin{split}
         U_{\mathrm{net},\mathrm{additional}} &= \sum_{f \in \mathrm{forces}}
         U_\mathrm{additional}^f \\
         W_{\mathrm{net},\mathrm{additional}} &= \sum_{f \in \mathrm{forces}}
         W_\mathrm{additional}^f \\
+        \end{split}
 
     See `md.force.Force` for definitions of these terms. Constraints are a
     special type of force used to enforce specific constraints on the system

--- a/hoomd/md/long_range/pppm.py
+++ b/hoomd/md/long_range/pppm.py
@@ -29,7 +29,7 @@ def make_pppm_coulomb_forces(nlist, resolution, order, r_cut, alpha=0):
 
     .. math::
 
-        U_\\mathrm{coulomb} = \\frac{1}{2} \\sum_\\vec{n} \\sum_{i=0}^{N-1}
+        U_\\mathrm{coulomb} = \\frac{1}{2} \\sum_{\\vec{n}} \\sum_{i=0}^{N-1}
           \\sum_{j=0}^{N-1} u_\\mathrm{coulomb}(\\vec{r}_j - \\vec{r}_i +
           n_1 \\cdot \\vec{a}_1 + n_2 \\cdot \\vec{a}_2 +
           n_3 \\cdot \\vec{a}_3, q_i, q_j)

--- a/hoomd/md/methods/methods.py
+++ b/hoomd/md/methods/methods.py
@@ -329,12 +329,12 @@ class ConstantPressure(Thermostatted):
 
     .. math::
 
+        \begin{split}
         \frac{d^2 L}{dt^2} &= V W^{-1} (S - S_{ext})
-            - \gamma \frac{dL}{dt} + R(t)
-
-        \langle R \rangle &= 0
-
+            - \gamma \frac{dL}{dt} + R(t) \\
+        \langle R \rangle &= 0 \\
         \langle |R|^2 \rangle &= 2 \gamma kT \delta t W^{-1}
+        \end{split}
 
     Where :math:`\gamma` is the friction on the barostat piston, which damps
     unphysical volume oscillations at the cost of non-deterministic integration,
@@ -764,12 +764,12 @@ class Langevin(Method):
 
     .. math::
 
+        \begin{split}
         m \frac{d\vec{v}}{dt} &= \vec{F}_\mathrm{C} - \gamma \cdot \vec{v} +
-        \vec{F}_\mathrm{R}
-
-        \langle \vec{F}_\mathrm{R} \rangle &= 0
-
+        \vec{F}_\mathrm{R} \\
+        \langle \vec{F}_\mathrm{R} \rangle &= 0 \\
         \langle |\vec{F}_\mathrm{R}|^2 \rangle &= 2 d kT \gamma / \delta t
+        \end{split}
 
     where :math:`\vec{F}_\mathrm{C}` is the force on the particle from all
     potentials and constraint forces, :math:`\gamma` is the drag coefficient,
@@ -783,13 +783,13 @@ class Langevin(Method):
 
     .. math::
 
+        \begin{split}
         I \frac{d\vec{\omega}}{dt} &= \vec{\tau}_\mathrm{C} - \gamma_r \cdot
-        \vec{\omega} + \vec{\tau}_\mathrm{R}
-
-        \langle \vec{\tau}_\mathrm{R} \rangle &= 0,
-
+        \vec{\omega} + \vec{\tau}_\mathrm{R} \\
+        \langle \vec{\tau}_\mathrm{R} \rangle &= 0, \\
         \langle \tau_\mathrm{R}^i \cdot \tau_\mathrm{R}^i \rangle &=
         2 k T \gamma_r^i / \delta t,
+        \end{split}
 
     where :math:`\vec{\tau}_\mathrm{C} = \vec{\tau}_\mathrm{net}`,
     :math:`\gamma_r^i` is the i-th component of the rotational drag coefficient
@@ -970,16 +970,13 @@ class Brownian(Method):
 
     .. math::
 
-        \frac{d\vec{r}}{dt} &= \frac{\vec{F}_\mathrm{C} +
-        \vec{F}_\mathrm{R}}{\gamma},
-
-        \langle \vec{F}_\mathrm{R} \rangle &= 0,
-
-        \langle |\vec{F}_\mathrm{R}|^2 \rangle &= 2 d k T \gamma / \delta t,
-
-        \langle \vec{v}(t) \rangle &= 0,
-
-        \langle |\vec{v}(t)|^2 \rangle &= d k T / m,
+        \begin{split}
+        \frac{d\vec{r}}{dt} &= \frac{\vec{F}_\mathrm{C} + \vec{F}_\mathrm{R}}{\gamma}, \\
+        \langle \vec{F}_\mathrm{R} \rangle &= 0, \\
+        \langle |\vec{F}_\mathrm{R}|^2 \rangle &= 2 d k T \gamma / \delta t, \\
+        \langle \vec{v}(t) \rangle &= 0, \\
+        \langle |\vec{v}(t)|^2 \rangle &= d k T / m, \\
+        \end{split}
 
     where :math:`\vec{F}_\mathrm{C} = \vec{F}_\mathrm{net}` is the net force on
     the particle from all forces (`hoomd.md.Integrator.forces`) and constraints
@@ -994,17 +991,15 @@ class Brownian(Method):
 
     .. math::
 
+        \begin{split}
         \frac{d\mathbf{q}}{dt} &= \frac{\vec{\tau}_\mathrm{C} +
-        \vec{\tau}_\mathrm{R}}{\gamma_r},
-
-        \langle \vec{\tau}_\mathrm{R} \rangle &= 0,
-
+        \vec{\tau}_\mathrm{R}}{\gamma_r}, \\
+        \langle \vec{\tau}_\mathrm{R} \rangle &= 0, \\
         \langle \tau_\mathrm{R}^i \cdot \tau_\mathrm{R}^i \rangle &=
-        2 k T \gamma_r^i / \delta t,
-
-        \langle \vec{L}(t) \rangle &= 0,
-
-        \langle L^i(t) \cdot L^i(t) \rangle &= k T \cdot I^i,
+        2 k T \gamma_r^i / \delta t, \\
+        \langle \vec{L}(t) \rangle &= 0, \\
+        \langle L^i(t) \cdot L^i(t) \rangle &= k T \cdot I^i, \\
+        \end{split}
 
     where :math:`\vec{\tau}_\mathrm{C} = \vec{\tau}_\mathrm{net}`,
     :math:`\gamma_r^i` is the i-th component of the rotational drag coefficient
@@ -1174,13 +1169,12 @@ class OverdampedViscous(Method):
 
     .. math::
 
-        \frac{d\vec{r}}{dt} &= \vec{v}
-
-        \vec{v(t)} &= \frac{\vec{F}_\mathrm{C}}{\gamma}
-
-        \frac{d\mathbf{q}}{dt} &= \vec{\tau}
-
+        \begin{split}
+        \frac{d\vec{r}}{dt} &= \vec{v} \\
+        \vec{v(t)} &= \frac{\vec{F}_\mathrm{C}}{\gamma} \\
+        \frac{d\mathbf{q}}{dt} &= \vec{\tau} \\
         \tau^i &= \frac{\tau_\mathrm{C}^i}{\gamma_r^i}
+        \end{split}
 
     where :math:`\vec{F}_\mathrm{C} = \vec{F}_\mathrm{net}` is the net force on
     the particle from all forces (`hoomd.md.Integrator.forces`) and constraints

--- a/hoomd/md/methods/methods.py
+++ b/hoomd/md/methods/methods.py
@@ -971,7 +971,8 @@ class Brownian(Method):
     .. math::
 
         \begin{split}
-        \frac{d\vec{r}}{dt} &= \frac{\vec{F}_\mathrm{C} + \vec{F}_\mathrm{R}}{\gamma}, \\
+        \frac{d\vec{r}}{dt} &= \frac{\vec{F}_\mathrm{C}
+        + \vec{F}_\mathrm{R}}{\gamma}, \\
         \langle \vec{F}_\mathrm{R} \rangle &= 0, \\
         \langle |\vec{F}_\mathrm{R}|^2 \rangle &= 2 d k T \gamma / \delta t, \\
         \langle \vec{v}(t) \rangle &= 0, \\

--- a/hoomd/md/minimize/fire.py
+++ b/hoomd/md/minimize/fire.py
@@ -97,10 +97,14 @@ class FIRE(_DynamicIntegrator):
 
     .. math::
 
-        \\frac{\\sum |F|}{N*\\sqrt{N_{dof}}} < \\mathrm{\\text{force_tol}}
-        \\;\\;, \\;\\ \\Delta \\frac{\\sum|E|}{N} <
-        \\mathrm{\\text{energy_tol}} \\;\\;, and \\;\\ \\frac{\\sum|L|}{N} <
-        \\mathrm{\\text{angmom_tol}}
+        \\frac{\\sum |F|}{N\\sqrt{N_{dof}}} \\le \\mathrm{force\\_tol}
+
+    .. math::
+
+        \\Delta \\frac{\\sum|E|}{N} \\le \\mathrm{energy\\_tol}
+
+    .. math::
+        \\frac{\\sum|L|}{N} \\le \\mathrm{angmom\\_tol}
 
     where :math:`N_{\\mathrm{dof}}` is the number of degrees of freedom the
     minimization is acting over. Any of the criterion can be effectively

--- a/hoomd/md/pair/aniso.py
+++ b/hoomd/md/pair/aniso.py
@@ -71,21 +71,20 @@ class Dipole(AnisotropicPair):
 
     .. math::
 
-        U &= U_{dd} + U_{de} + U_{ee}
-
+        \begin{split}
+        U &= U_{dd} + U_{de} + U_{ee} \\
         U_{dd} &= A e^{-\kappa r}
             \left(\frac{\vec{\mu_i}\cdot\vec{\mu_j}}{r^3}
                   - 3\frac{(\vec{\mu_i}\cdot \vec{r_{ji}})
                            (\vec{\mu_j}\cdot \vec{r_{ji}})}
                           {r^5}
-            \right)
-
+            \right) \\
         U_{de} &= A e^{-\kappa r}
             \left(\frac{(\vec{\mu_j}\cdot \vec{r_{ji}})q_i}{r^3}
                 - \frac{(\vec{\mu_i}\cdot \vec{r_{ji}})q_j}{r^3}
-            \right)
-
+            \right) \\
         U_{ee} &= A e^{-\kappa r} \frac{q_i q_j}{r}
+        \end{split} \\
 
     Note:
        All units are documented electronic dipole moments. However, `Dipole`
@@ -175,15 +174,15 @@ class GayBerne(AnisotropicPair):
 
     .. math::
 
+        \begin{split}
         \zeta &= \left(\frac{r-\sigma+\sigma_{\mathrm{min}}}
-                           {\sigma_{\mathrm{min}}}\right),
-
+                           {\sigma_{\mathrm{min}}}\right), \\
         \sigma^{-2} &= \frac{1}{2} \hat{\vec{r}}
-            \cdot \vec{H^{-1}} \cdot \hat{\vec{r}},
-
+            \cdot \vec{H^{-1}} \cdot \hat{\vec{r}}, \\
         \vec{H} &= 2 \ell_\perp^2 \vec{1}
             + (\ell_\parallel^2 - \ell_\perp^2)
               (\vec{e_i} \otimes \vec{e_i} + \vec{e_j} \otimes \vec{e_j}),
+        \end{split}
 
     and :math:`\sigma_{\mathrm{min}} = 2 \min(\ell_\perp, \ell_\parallel)`.
     The parallel direction is aligned with *z* axis in the particle's
@@ -280,12 +279,13 @@ class ALJ(AnisotropicPair):
 
     .. math::
 
-        &U_0(r) = 4 \varepsilon \left[ \left( \frac{\sigma}{r} \right)^{12} -
-        \left( \frac{\sigma}{r} \right)^{6} \right]
-
-        &U_c(r_c) = 4 \varepsilon_c(\varepsilon) \left[ \left(
+        \begin{split}
+        U_0(r) &= 4 \varepsilon \left[ \left( \frac{\sigma}{r} \right)^{12} -
+        \left( \frac{\sigma}{r} \right)^{6} \right] \\
+        U_c(r_c) &= 4 \varepsilon_c(\varepsilon) \left[ \left(
         \frac{\sigma_c}{r_c} \right)^{12} - \left( \frac{\sigma_c}{r_c}
         \right)^{6} \right]
+        \end{split}
 
     where :math:`\varepsilon` (`epsilon <params>`) affects strength of both the
     central and contact interactions, :math:`\varepsilon_c` is an energy
@@ -298,11 +298,11 @@ class ALJ(AnisotropicPair):
 
     .. math::
 
-        \sigma_c &= \frac{1}{2} \left[\sigma_{ci} + \sigma_{cj} \right]
-
-        \sigma_{ci} &= \beta_i \cdot \sigma_i
-
+        \begin{split}
+        \sigma_c &= \frac{1}{2} \left[\sigma_{ci} + \sigma_{cj} \right] \\
+        \sigma_{ci} &= \beta_i \cdot \sigma_i \\
         \sigma_{cj} &= \beta_j \cdot \sigma_j
+        \end{split}
 
     The total potential energy is therefore the sum of two interactions, a
     central Lennard-Jones potential and a radially-shifted Lennard-Jones
@@ -371,43 +371,51 @@ class ALJ(AnisotropicPair):
 
       .. math::
 
+        \begin{split}
         r_{\mathrm{cut},ij} = \max \bigg( & \frac{\lambda_{min}}{2}
         (\sigma_i + \sigma_j), \\
         & R_i + R_j + R_{\mathrm{rounding},i} +
         R_{\mathrm{rounding},j} + \frac{\lambda_{min}}{2}
         (\beta_i \cdot \sigma_i + \beta_j \cdot \sigma_j) \bigg)
+        \end{split}
 
     * For alpha=1:
 
       .. math::
 
+            \begin{split}
             r_{\mathrm{cut},ij} =
             \max \bigg( & \frac{\lambda_{cut}^{attractive}}{2}
             (\sigma_i + \sigma_j),  \\
             & R_i + R_j  + R_{\mathrm{rounding},i} +
             R_{\mathrm{rounding},j}+ \frac{\lambda_{min}}{2}
             (\beta_i \cdot \sigma_i + \beta_j \cdot \sigma_j) \bigg)
+            \end{split}
 
     * For alpha=2:
 
       .. math::
 
+            \begin{split}
             r_{\mathrm{cut},ij} = \max \bigg( & \frac{\lambda_{min}}{2}
             (\sigma_i + \sigma_j)),  \\
             & R_i + R_j + R_{\mathrm{rounding},i} +
             R_{\mathrm{rounding},j} + \frac{\lambda_{cut}^{attractive}}{2}
             (\beta_i \cdot \sigma_i + \beta_j \cdot \sigma_j) \bigg)
+            \end{split}
 
     * For alpha=3:
 
       .. math::
 
+            \begin{split}
             r_{\mathrm{cut},ij} =
             \max \bigg( & \frac{\lambda_{cut}^{attractive}}{2}
             (\sigma_i + \sigma_j),  \\
             & R_i + R_j + R_{\mathrm{rounding},i} +
             R_{\mathrm{rounding},j} + \frac{\lambda_{cut}^{attractive}}{2}
             (\beta_i \cdot \sigma_i + \beta_j \cdot \sigma_j) \bigg)
+            \end{split}
 
     Warning:
         Changing dimension in a simulation will invalidate this force and will
@@ -640,12 +648,12 @@ class Patchy(AnisotropicPair):
     :math:`\alpha` and patch steepness :math:`\omega`:
 
     .. math::
-        \begin{align}
+        \begin{split}
         f(\theta, \alpha, \omega) &= \frac{\big(1+e^{-\omega (\cos{\theta} -
         \cos{\alpha}) }\big)^{-1} - f_{min}}{f_{max} - f_{min}}\\
         f_{max} &= \big( 1 + e^{-\omega (1 - \cos{\alpha}) } \big)^{-1} \\
         f_{min} &= \big( 1 + e^{-\omega (-1 - \cos{\alpha}) } \big)^{-1} \\
-        \end{align}
+        \end{split}
 
     .. image:: /patchy-pair.svg
          :align: center

--- a/hoomd/md/pair/pair.py
+++ b/hoomd/md/pair/pair.py
@@ -795,6 +795,8 @@ class DPD(Pair):
     where
 
     .. math::
+
+        \begin{split}
         F_{\mathrm{C}}(r) &= A \cdot  w(r_{ij}), \\
         F_{\mathrm{R, ij}}(r_{ij}) &= - \theta_{ij}\sqrt{3}
         \sqrt{\frac{2k_b\gamma T}{\Delta t}}\cdot w(r_{ij}),  \\
@@ -806,6 +808,7 @@ class DPD(Pair):
         & r < r_{\mathrm{cut}} \\
         0 & r \ge r_{\mathrm{cut}} \\
         \end{cases},
+        \end{split}
 
 
     :math:`\hat r_{ij}` is a normalized vector from particle i to
@@ -957,6 +960,8 @@ class DPDLJ(Pair):
     on every particle in the simulation state with:
 
     .. math::
+
+        \begin{split}
         F &= F_{\mathrm{C}}(r) + F_{\mathrm{R,ij}}(r_{ij}) +
             F_{\mathrm{D,ij}}(v_{ij}), \\
         F_{\mathrm{C}}(r) &= \partial U / \partial r, \\
@@ -973,6 +978,7 @@ class DPDLJ(Pair):
         & r < r_{\mathrm{cut}} \\
         0 & r \ge r_{\mathrm{cut}} \\
         \end{cases},
+        \end{split}
 
     :math:`\hat r_{ij}` is a normalized vector from particle i to
     particle j, :math:`v_{ij} = v_i - v_j`, and :math:`\theta_{ij}` is a
@@ -1529,12 +1535,14 @@ class DLVO(Pair):
     on every particle in the simulation state with:
 
     .. math::
+        \begin{split}
         V_{\mathrm{DLVO}}(r) = &- \frac{A}{6} \left[
             \frac{2a_1a_2}{r^2 - (a_1+a_2)^2} +
             \frac{2a_1a_2}{r^2 - (a_1-a_2)^2} \\
             + \log \left(
             \frac{r^2 - (a_1+a_2)^2}{r^2 - (a_1-a_2)^2} \right) \right] \\
             & + \frac{a_1 a_2}{a_1+a_2} Z e^{-\kappa(r - (a_1+a_2))}
+        \end{split}
 
     where :math:`a_1` is the radius of first particle in the pair, :math:`a_2`
     is the radius of second particle in the pair, :math:`A` is the Hamaker
@@ -1804,8 +1812,10 @@ class Fourier(Pair):
 
     .. math::
 
+        \begin{split}
         a_1 &= \sum_{n=2}^4 (-1)^n a_n \\
         b_1 &= \sum_{n=2}^4 n (-1)^n b_n \\
+        \end{split}
 
     enforce :math:`U(r_\mathrm{cut}) = 0`.
 

--- a/hoomd/mpcd/stream.py
+++ b/hoomd/mpcd/stream.py
@@ -9,12 +9,12 @@ a time :math:`\Delta t`:
 
 .. math::
 
-    \mathbf{v}(t + \Delta t/2) &= \mathbf{v}(t) + (\mathbf{f}/m)(\Delta t / 2)
-
-    \mathbf{r}(t+\Delta t) &= \mathbf{r}(t) + \mathbf{v}(t+\Delta t/2) \Delta t
-
+    \begin{split}
+    \mathbf{v}(t + \Delta t/2) &= \mathbf{v}(t) + (\mathbf{f}/m)(\Delta t / 2) \\
+    \mathbf{r}(t+\Delta t) &= \mathbf{r}(t) + \mathbf{v}(t+\Delta t/2) \Delta t \\
     \mathbf{v}(t + \Delta t) &= \mathbf{v}(t + \Delta t/2) +
     (\mathbf{f}/m)(\Delta t / 2)
+    \end{split}
 
 where **r** and **v** are the particle position and velocity, respectively, and
 **f** is the external force acting on the particles of mass *m*. For a list of

--- a/hoomd/tune/attr_tuner.py
+++ b/hoomd/tune/attr_tuner.py
@@ -162,16 +162,18 @@ class ManualTuneDefinition(_TuneDefinition):
     can return a y of ``None`` to indicate this. `hoomd.tune.SolverStep`
     objects will handle this automatically. Since we check for ``None``
     internally in `hoomd.tune.SolverStep` objects, a `ManualTuneDefinition`
-    object's ``y`` property should be consistant when called multiple times
+    object's ``y`` property should be consistent when called multiple times
     within a timestep.
 
     When setting ``x`` the value is clamped between the given domain via,
 
     .. math::
 
+        \\begin{split}
         x &= x_{max}, \\text{ if } x_n > x_{max},\\\\
         x &= x_{min}, \\text{ if } x_n < x_{min},\\\\
         x &= x_n, \\text{ otherwise}
+        \\end{split}
 
     Args:
         get_y (``callable``): A callable that gets the current value for y.

--- a/hoomd/variant/box.py
+++ b/hoomd/variant/box.py
@@ -207,10 +207,12 @@ class InverseVolumeRamp(_hoomd.VectorVariantBoxInverseVolumeRamp, BoxVariant):
 
     .. math::
 
+        \\begin{split}
         V(t) &= \\begin{cases} V_0 & t < t_{\\mathrm{start}} \\\\ \\left(
         \\lambda V_f^{-1} + (1 - \\lambda) V_0^{-1} \\right)^{-1} &
         t_{\\mathrm{start}} \\leq t < t_{\\mathrm{start}} + t_{\\mathrm{ramp}}
         \\\\ V_f & t \\geq t_{\\mathrm{start}} + t_{\\mathrm{ramp}} \\end{cases}
+        \\end{split}
 
     where :math:`\\lambda = \\frac{t - t_{\\mathrm{start}}}{t_{\\mathrm{ramp}} -
     t_{\\mathrm{start}}}`.

--- a/sphinx-doc/conf.py
+++ b/sphinx-doc/conf.py
@@ -7,6 +7,7 @@ import sys
 import os
 import sphinx
 import datetime
+from importlib.util import find_spec
 
 from sphinx.domains.python import PythonDomain
 
@@ -30,9 +31,13 @@ extensions = [
     "sphinx.ext.autosummary",
     "sphinx.ext.napoleon",
     "sphinx.ext.intersphinx",
-    "sphinx.ext.mathjax",
     "sphinx.ext.todo",
 ]
+
+if find_spec("sphinxcontrib.katex") is not None:
+    extensions.append("sphinxcontrib.katex")
+else:
+    extensions.append("sphinx.ext.mathjax")
 
 if os.getenv("READTHEDOCS"):
     extensions.append("sphinx_copybutton")

--- a/sphinx-doc/conf.py
+++ b/sphinx-doc/conf.py
@@ -45,6 +45,8 @@ if os.getenv("READTHEDOCS"):
     extensions.append("sphinxcontrib.googleanalytics")
     googleanalytics_id = "G-ZR0DNZD21E"
 
+    katex_prerender = True
+
 napoleon_include_special_with_doc = True
 
 notfound_context = {

--- a/sphinx-doc/requirements.in
+++ b/sphinx-doc/requirements.in
@@ -7,5 +7,6 @@ sphinx==8.1.3
 furo==2024.8.6
 tornado==6.4.2
 sphinxcontrib-googleanalytics==0.4
+sphinxcontrib-katex==0.9.10
 sphinx-copybutton==0.5.2
 sphinx-notfound-page==1.1.0

--- a/sphinx-doc/requirements.txt
+++ b/sphinx-doc/requirements.txt
@@ -143,6 +143,7 @@ sphinx==8.1.3
     #   sphinx-copybutton
     #   sphinx-notfound-page
     #   sphinxcontrib-googleanalytics
+    #   sphinxcontrib-katex
 sphinx-basic-ng==1.0.0b2
     # via furo
 sphinx-copybutton==0.5.2
@@ -159,6 +160,8 @@ sphinxcontrib-htmlhelp==2.1.0
     # via sphinx
 sphinxcontrib-jsmath==1.0.1
     # via sphinx
+sphinxcontrib-katex==0.9.10
+    # via -r requirements.in
 sphinxcontrib-qthelp==2.0.0
     # via sphinx
 sphinxcontrib-serializinghtml==2.0.0


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should be based on *trunk-patch*. -->
<!-- Backwards compatible new features should be based on *trunk-minor*. -->
<!-- Incompatible API changes should be based on *trunk-major*. -->

## Description

<!-- Describe your changes in detail. -->
When available, use katex to render math in the documentation.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Compared to mathjax, KaTeX does not reflow the page when it renders math, formatting is closer to true LaTeX, and pages load faster.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->
I have checked that the math on every page of the documentation renders. I made adjustments where needed so that equations render properly. The main differences are that:
* Sphinx's builtin mathjax assumes a `split` environment while katex does not.
* Sphinx's builtin mathjax also automatically converts
  ```
  equation 1
  
  equation 2
  
  equation 3
  ```
  to
  ```
  equation 1 \\
  equation 2 \\
  equation 3
  ```
  where katex does not.

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
- [x] I have summarized these changes in `CHANGELOG.rst` following the established format.
