### PR TITLE
Fix mistake in formulas for variant.box.Interpolate

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,11 @@ Change Log
 5.x
 ---
 
+*Changed*
+* The formulas in the docs for `variant.box.Interpolate` are now consistent
+  (`#2060 <https://github.com/glotzerlab/hoomd-blue/pull/2060>`__).
+
+
 5.2.0 (2025-05-06)
 ^^^^^^^^^^^^^^^^^^
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,8 +5,7 @@ Change Log
 ---
 
 *Changed*
-* The formulas in the docs for `variant.box.Interpolate` are now consistent
-  (`#2060 <https://github.com/glotzerlab/hoomd-blue/pull/2060>`__).
+* The formulas in the docs for `variant.box.Interpolate` are now consistent (`#2060 <https://github.com/glotzerlab/hoomd-blue/pull/2060>`__).
 
 
 5.2.0 (2025-05-06)

--- a/hoomd/variant/box.py
+++ b/hoomd/variant/box.py
@@ -120,12 +120,12 @@ class Interpolate(_hoomd.VectorVariantBoxInterpolate, BoxVariant):
     .. math::
 
         \\begin{align*}
-        L_{x}' &= \\lambda L_{2x} + (1 - \\lambda) L_{1x} \\\\
-        L_{y}' &= \\lambda L_{2y} + (1 - \\lambda) L_{1y} \\\\
-        L_{z}' &= \\lambda L_{2z} + (1 - \\lambda) L_{1z} \\\\
-        xy' &= \\lambda xy_{2} + (1 - \\lambda) xy_{1} \\\\
-        xz' &= \\lambda xz_{2} + (1 - \\lambda) xz_{1} \\\\
-        yz' &= \\lambda yz_{2} + (1 - \\lambda) yz_{1} \\\\
+        L_{x}' &= \\lambda L_{fx} + (1 - \\lambda) L_{ix} \\\\
+        L_{y}' &= \\lambda L_{fy} + (1 - \\lambda) L_{iy} \\\\
+        L_{z}' &= \\lambda L_{fz} + (1 - \\lambda) L_{iz} \\\\
+        xy' &= \\lambda xy_{f} + (1 - \\lambda) xy_{i} \\\\
+        xz' &= \\lambda xz_{f} + (1 - \\lambda) xz_{i} \\\\
+        yz' &= \\lambda yz_{f} + (1 - \\lambda) yz_{i} \\\\
         \\end{align*}
 
     Where ``initial_box`` is :math:`(L_{ix}, L_{iy}, L_{iz}, xy_i, xz_i, yz_i)`,


### PR DESCRIPTION
## Description
Minor documentation fix for the Interpolate box variant. The formula used `2` and `1`, but the "where" statement used `f` and `i`.

## Motivation and context

Makes the docs clearer.

## How has this been tested?

Only documentation was affected, so no tests are needed.

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
- [x] I have summarized these changes in `CHANGELOG.rst` following the established format.
