### PR TITLE
Fix math typos in Bussi thermostat doc

### DIFF
--- a/hoomd/md/methods/thermostats.py
+++ b/hoomd/md/methods/thermostats.py
@@ -281,9 +281,9 @@ class Bussi(Thermostat):
     given characteristic time constant and :math:`\alpha` is given by:
 
     .. math::
-        \alpha = \sqrt{e^{\delta t / \tau}
-                 + (1 - e^{\delta t / \tau}) \frac{(2 g_{N-1} + n^2) kT}{2 K}
-                 + 2 n \sqrt{e^{\delta t / \tau} (1-e^{\delta t / \tau})
+        \alpha = \sqrt{e^{-\delta t / \tau}
+                 + (1 - e^{-\delta t / \tau}) \frac{(2 g_{N-1} + n^2) kT}{2 K}
+                 + 2 n \sqrt{e^{-\delta t / \tau} (1-e^{-\delta t / \tau})
                     \frac{kT}{2 K}}}
 
     where :math:`\delta t` is the step size and :math:`n` is a random value

--- a/sphinx-doc/credits.rst
+++ b/sphinx-doc/credits.rst
@@ -72,6 +72,7 @@ The following people have contributed to HOOMD-blue:
 * Khalid Ahmed, University of Michigan
 * Kody Takada, University of Michigan
 * Kristi Pepa, University of Michigan
+* Kumpei Shiraishi, University of Osaka
 * Kwabena Darko, University of Houston
 * Kwanghwi Je, University of Michigan
 * Kieran Nehil-Puleo, Vanderbilt University


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should be based on *trunk-patch*. -->
<!-- Backwards compatible new features should be based on *trunk-minor*. -->
<!-- Incompatible API changes should be based on *trunk-major*. -->

## Description

Minor math typos in the scaling factor of Bussi thermostat are fixed.
cf. Eq. (A7) in their paper https://doi.org/10.1063/1.2408420

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
- [ ] I have summarized these changes in `CHANGELOG.rst` following the established format.
