### PR TITLE
Patch FIRE GPU minimizer to prevent conflicts

### DIFF
--- a/hoomd/md/FIREEnergyMinimizerGPU.cc
+++ b/hoomd/md/FIREEnergyMinimizerGPU.cc
@@ -206,11 +206,14 @@ void FIREEnergyMinimizerGPU::update(uint64_t timestep)
                 CHECK_CUDA_ERROR();
             }
 
-        ArrayHandle<Scalar> h_sum(m_sum3, access_location::host, access_mode::read);
-        Pt += h_sum.data[0];
-        vnorm += h_sum.data[1];
-        fnorm += h_sum.data[2];
-
+        // Ensure h_sum goes out of scope before anisotropic block
+        {
+            ArrayHandle<Scalar> h_sum(m_sum3, access_location::host, access_mode::read);
+            Pt += h_sum.data[0];
+            vnorm += h_sum.data[1];
+            fnorm += h_sum.data[2];
+        }
+            
         if ((*method)->getAnisotropic())
             {
 #ifdef ENABLE_MPI

--- a/hoomd/md/FIREEnergyMinimizerGPU.cc
+++ b/hoomd/md/FIREEnergyMinimizerGPU.cc
@@ -206,14 +206,14 @@ void FIREEnergyMinimizerGPU::update(uint64_t timestep)
                 CHECK_CUDA_ERROR();
             }
 
-        // Ensure h_sum goes out of scope before anisotropic block
-        {
+            // Ensure h_sum goes out of scope before anisotropic block
+            {
             ArrayHandle<Scalar> h_sum(m_sum3, access_location::host, access_mode::read);
             Pt += h_sum.data[0];
             vnorm += h_sum.data[1];
             fnorm += h_sum.data[2];
-        }
-            
+            }
+
         if ((*method)->getAnisotropic())
             {
 #ifdef ENABLE_MPI

--- a/sphinx-doc/credits.rst
+++ b/sphinx-doc/credits.rst
@@ -111,6 +111,7 @@ The following people have contributed to HOOMD-blue:
 * Sam Nola, University of Michigan
 * Simone Ciarella, Eindhoven University of Technology
 * Shannon Moran, University of Michigan
+* Shawn Douglas, University of California, San Francisco
 * Sophie YouJung Lee, University of Michigan
 * Stephen Thomas, Boise State University
 * Steve Barr, Princeton University


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should be based on *trunk-patch*. -->
<!-- Backwards compatible new features should be based on *trunk-minor*. -->
<!-- Incompatible API changes should be based on *trunk-major*. -->

## Description

The FIRE energy minimizer on GPU fails with a `Cannot acquire access to array in use` error when using rigid bodies with `integrate_rotational_dof=True`. 

The bug is caused by overlapping ArrayHandle scopes for the m_sum3 array in FIREEnergyMinimizerGPU.cc:

1. At line 209, a host-side ArrayHandle<Scalar> h_sum(m_sum3, ...) is created to read sum values
2. This handle remains in scope when entering the anisotropic block at line 214
3. Inside the anisotropic block at line 263, the code tries to create a device-side ArrayHandle for the same m_sum3 array
4. This causes a conflict as both handles try to access the same GPUArray, resulting in the error

Proposed Fix: Add a scope block around the host-side ArrayHandle to ensure it releases its lock before the anisotropic block executes.

## Motivation and context

Resolves #2080

## How has this been tested?

I've tested an equivalent change in my own local fork of this repo with the script I provided in Issue #2080. My fork has other custom modifications, so I copied only the relevant lines into this PR requested by @joaander. Due to time constraints, I have not tested this PR specifically, so I recommend testing it with your build system.

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
- [ ] I have summarized these changes in `CHANGELOG.rst` following the established format.
