### PR TITLE
Fix code example in documentation.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,8 @@ Change Log
   (`#2060 <https://github.com/glotzerlab/hoomd-blue/pull/2060>`__).
 * Do not increment z image in 2D simulation boxes
   (`#2071 <https://github.com/glotzerlab/hoomd-blue/pull/2071>`__).
+* Code block example in `hoomd.md.pair.DPDConservative`
+  (`#2084 <https://github.com/glotzerlab/hoomd-blue/pull/2084>`__).
 
 5.2.0 (2025-05-06)
 ^^^^^^^^^^^^^^^^^^

--- a/hoomd/md/pair/pair.py
+++ b/hoomd/md/pair/pair.py
@@ -910,7 +910,8 @@ class DPDConservative(Pair):
         nl = nlist.Cell()
         dpdc = pair.DPDConservative(nlist=nl, default_r_cut=3.0)
         dpdc.params[("A", "A")] = dict(A=1.0)
-        dpdc.params[("A", "B")] = dict(A=2.0, r_cut=1.0)
+        dpdc.params[("A", "B")] = dict(A=2.0)
+        dpdc.r_cut[("A", "B")] = 1.0
         dpdc.params[(["A", "B"], ["C", "D"])] = dict(A=3.0)
 
     {inherited}


### PR DESCRIPTION
## Description

While trying to run some copy-and-pasted code from the DPD section of the documentation, I was getting an error related to an invalid parameter. This PR fixes the code block by setting `r_cut` afterward, rather than passing it into the parameters dict.
 
## How has this been tested?

The docs build locally.

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
- [x] I have summarized these changes in `CHANGELOG.rst` following the established format.
