### PR TITLE
Automatically flush GSD trajectories

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,22 @@ Change Log
 
 * The Zetterling pair potential: ``hoomd.hpmc.pair.Zetterling``
   (`#2057 <https://github.com/glotzerlab/hoomd-blue/pull/2057>`__).
+* ``hoomd.write.GSD`` now automatically flushes on frame writes 10 seconds
+  or longer since the previous flush. Configure this time with
+  ``auto_flush_period``. The flush does not occur on a timer -- it is only
+  called after a normally scheduled frame write
+  (`#2085 <https://github.com/glotzerlab/hoomd-blue/pull/2085>`__).
+
+*Changed*
+
+* The ``GSD`` write buffer size now defaults to 1 MiB. Files will thus
+  grow in size more continuiously (the previous default was 64 MiB).
+  File size changes are subject to additional buffering by the OS
+  and may or may not be predictable.
+  At the same time, new frames will no longer be available for reading
+  until after the file is flushed (which occurs on write after 10 seconds
+  by default) or closed
+  (`#2085 <https://github.com/glotzerlab/hoomd-blue/pull/2085>`__).
 
 *Fixed*
 

--- a/hoomd/GSDDumpWriter.cc
+++ b/hoomd/GSDDumpWriter.cc
@@ -220,6 +220,8 @@ void GSDDumpWriter::setDynamic(pybind11::object dynamic)
 
 void GSDDumpWriter::flush()
     {
+    m_last_flush_time = m_exec_conf->getMPIConfig()->getWalltime();
+
     if (m_exec_conf->isRoot())
         {
         m_exec_conf->msg->notice(5) << "GSD: flush gsd file " << m_fname << endl;
@@ -247,6 +249,16 @@ uint64_t GSDDumpWriter::getMaximumWriteBufferSize()
         {
         return 0;
         }
+    }
+
+void GSDDumpWriter::setAutoFlushPeriod(double period)
+    {
+    m_auto_flush_period = period;
+    }
+
+double GSDDumpWriter::getAutoFlushPeriod()
+    {
+    return m_auto_flush_period;
     }
 
 //! Initializes the output file for writing
@@ -365,6 +377,11 @@ void GSDDumpWriter::analyze(uint64_t timestep)
     populateLocalFrame(m_local_frame, timestep);
     auto log_data = getLogData();
     write(m_local_frame, log_data);
+
+    if (m_exec_conf->getMPIConfig()->getWalltime() + m_auto_flush_period > m_last_flush_time)
+        {
+        flush();
+        }
     }
 
 void GSDDumpWriter::write(GSDDumpWriter::GSDFrame& frame, pybind11::dict log_data)
@@ -1547,7 +1564,10 @@ void export_GSDDumpWriter(pybind11::module& m)
         .def("flush", &GSDDumpWriter::flush)
         .def_property("maximum_write_buffer_size",
                       &GSDDumpWriter::getMaximumWriteBufferSize,
-                      &GSDDumpWriter::setMaximumWriteBufferSize);
+                      &GSDDumpWriter::setMaximumWriteBufferSize)
+        .def_property("auto_flush_period",
+                      &GSDDumpWriter::getAutoFlushPeriod,
+                      &GSDDumpWriter::setAutoFlushPeriod);
     }
 
     } // end namespace detail

--- a/hoomd/GSDDumpWriter.cc
+++ b/hoomd/GSDDumpWriter.cc
@@ -378,8 +378,9 @@ void GSDDumpWriter::analyze(uint64_t timestep)
     auto log_data = getLogData();
     write(m_local_frame, log_data);
 
-    if (m_exec_conf->getMPIConfig()->getWalltime() + m_auto_flush_period > m_last_flush_time)
+    if (m_exec_conf->getMPIConfig()->getWalltime() > m_last_flush_time + m_auto_flush_period)
         {
+        m_exec_conf->msg->notice(5) << "GSD: auto flush at step " << timestep << endl;
         flush();
         }
     }

--- a/hoomd/GSDDumpWriter.cc
+++ b/hoomd/GSDDumpWriter.cc
@@ -234,10 +234,6 @@ void GSDDumpWriter::setMaximumWriteBufferSize(uint64_t size)
         {
         int retval = gsd_set_maximum_write_buffer_size(&m_handle, size);
         GSDUtils::checkError(retval, m_fname);
-
-        // Scale the index buffer entires to write with the write buffer.
-        retval = gsd_set_index_entries_to_buffer(&m_handle, size / 256);
-        GSDUtils::checkError(retval, m_fname);
         }
     }
 

--- a/hoomd/GSDDumpWriter.h
+++ b/hoomd/GSDDumpWriter.h
@@ -5,7 +5,6 @@
 
 #include "Analyzer.h"
 #include "ParticleGroup.h"
-#include "SharedSignal.h"
 
 #include "hoomd/extern/gsd.h"
 #include <memory>

--- a/hoomd/GSDDumpWriter.h
+++ b/hoomd/GSDDumpWriter.h
@@ -127,6 +127,12 @@ class PYBIND11_EXPORT GSDDumpWriter : public Analyzer
     /// Get the maximum write buffer size (in bytes)
     uint64_t getMaximumWriteBufferSize();
 
+    /// Set the automatic flush period (in seconds)
+    void setAutoFlushPeriod(double period);
+
+    /// Get the automatic flush period (in seconds)
+    double getAutoFlushPeriod();
+
     protected:
     gsd_handle m_handle; //!< Handle to the file
 
@@ -252,6 +258,12 @@ class PYBIND11_EXPORT GSDDumpWriter : public Analyzer
 
     /// Working array to sort local particles by tag
     std::vector<unsigned int> m_index;
+
+    /// Time of last flush.
+    double m_last_flush_time = 0.0;
+
+    /// Time (in seconds) between automatic calls to flush.
+    double m_auto_flush_period = 10;
 
     //! Write a type mapping out to the file
     void writeTypeMapping(std::string chunk, std::vector<std::string> type_mapping);

--- a/hoomd/extern/gsd.c
+++ b/hoomd/extern/gsd.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2023 The Regents of the University of Michigan
+// Copyright (c) 2016-2025 The Regents of the University of Michigan
 // Part of GSD, released under the BSD 2-Clause License.
 
 #include <sys/stat.h>
@@ -28,6 +28,7 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <stddef.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 
@@ -64,16 +65,10 @@ enum
     GSD_INITIAL_WRITE_BUFFER_SIZE = 1024
     };
 
-/// Default maximum size of write buffer
+/// Default maximum size of write buffer (in bytes)
 enum
     {
-    GSD_DEFAULT_MAXIMUM_WRITE_BUFFER_SIZE = 64 * 1024 * 1024
-    };
-
-/// Default number of index entries to buffer
-enum
-    {
-    GSD_DEFAULT_INDEX_ENTRIES_TO_BUFFER = 256 * 1024
+    GSD_DEFAULT_MAXIMUM_WRITE_BUFFER_BYTES = 1024 * 1024
     };
 
 /// Size of hash map
@@ -85,20 +80,29 @@ enum
 /// Current GSD file specification
 enum
     {
-    GSD_CURRENT_FILE_VERSION = 2
+    GSD_CURRENT_FILE_VERSION_MAJOR = 2
+    };
+
+enum
+    {
+    GSD_CURRENT_FILE_VERSION_MINOR = 1
     };
 
 // define windows wrapper functions
 #ifdef _WIN32
 #define lseek _lseeki64
 #define ftruncate _chsize
-#define fsync _commit
 typedef int64_t ssize_t;
 
 int S_IRUSR = _S_IREAD;
 int S_IWUSR = _S_IWRITE;
 int S_IRGRP = _S_IREAD;
 int S_IWGRP = _S_IWRITE;
+
+int gsd_fsync(int fd)
+    {
+    return _commit(fd);
+    }
 
 inline ssize_t pread(int fd, void* buf, size_t count, int64_t offset)
     {
@@ -126,6 +130,16 @@ inline ssize_t pwrite(int fd, const void* buf, size_t count, int64_t offset)
     return result;
     }
 
+#elif defined(__APPLE__)
+int gsd_fsync(int fd)
+    {
+    return fcntl(fd, F_FULLFSYNC);
+    }
+#else
+int gsd_fsync(int fd)
+    {
+    return fsync(fd);
+    }
 #endif
 
 /** Zero memory
@@ -163,12 +177,15 @@ inline static ssize_t gsd_io_pwrite_retry(int fd, const void* buf, size_t count,
 #if defined(_WIN32) || defined(__APPLE__)
         // win32 and apple raise an error for writes greater than INT_MAX
         if (to_write > INT_MAX / 2)
+            {
             to_write = INT_MAX / 2;
+            }
 #endif
 
         errno = 0;
         ssize_t bytes_written
             = pwrite(fd, ptr + total_bytes_written, to_write, offset + total_bytes_written);
+
         if (bytes_written == -1 || (bytes_written == 0 && errno != 0))
             {
             return GSD_ERROR_IO;
@@ -205,7 +222,9 @@ inline static ssize_t gsd_io_pread_retry(int fd, void* buf, size_t count, int64_
 #if defined(_WIN32) || defined(__APPLE__)
         // win32 and apple raise errors for reads greater than INT_MAX
         if (to_read > INT_MAX / 2)
+            {
             to_read = INT_MAX / 2;
+            }
 #endif
 
         errno = 0;
@@ -511,6 +530,7 @@ inline static int gsd_byte_buffer_append(struct gsd_byte_buffer* buf, const char
             }
 
         char* old_data = buf->data;
+        // NOLINTNEXTLINE(bugprone-suspicious-realloc-usage): realloc is used correctly
         buf->data = realloc(buf->data, sizeof(char) * new_reserved);
         if (buf->data == NULL)
             {
@@ -613,25 +633,23 @@ inline static int gsd_index_buffer_map(struct gsd_index_buffer* buf, struct gsd_
 
 #if GSD_USE_MMAP
     // map the index in read only mode
-    size_t page_size = getpagesize();
     size_t index_size = sizeof(struct gsd_index_entry) * handle->header.index_allocated_entries;
-    size_t offset = (handle->header.index_location / page_size) * page_size;
     buf->mapped_data = mmap(NULL,
-                            index_size + (handle->header.index_location - offset),
+                            index_size + handle->header.index_location,
                             PROT_READ,
                             MAP_SHARED,
                             handle->fd,
-                            offset);
+                            0);
 
     if (buf->mapped_data == MAP_FAILED)
         {
         return GSD_ERROR_IO;
         }
 
-    buf->data = (struct gsd_index_entry*)(((char*)buf->mapped_data)
-                                          + (handle->header.index_location - offset));
+    buf->data
+        = (struct gsd_index_entry*)(((char*)buf->mapped_data) + handle->header.index_location);
 
-    buf->mapped_len = index_size + (handle->header.index_location - offset);
+    buf->mapped_len = index_size + handle->header.index_location;
     buf->reserved = handle->header.index_allocated_entries;
 #else
     // mmap not supported, read the data from the disk
@@ -758,6 +776,7 @@ inline static int gsd_index_buffer_add(struct gsd_index_buffer* buf, struct gsd_
         {
         // grow the array
         size_t new_reserved = buf->reserved * 2;
+        // NOLINTNEXTLINE(bugprone-suspicious-realloc-usage): realloc is used correctly
         buf->data = realloc(buf->data, sizeof(struct gsd_index_entry) * new_reserved);
         if (buf->data == NULL)
             {
@@ -964,18 +983,25 @@ inline static int gsd_expand_file_index(struct gsd_handle* handle, size_t size_r
         return retval;
         }
 
-    // allocate the copy buffer
-    uint64_t copy_buffer_size
-        = GSD_DEFAULT_INDEX_ENTRIES_TO_BUFFER * sizeof(struct gsd_index_entry);
+    int64_t new_index_location = lseek(handle->fd, 0, SEEK_END);
+    int64_t old_index_location = handle->header.index_location;
+
+    // fill the new index space with 0s
+    size_t new_index_bytes = size_new * sizeof(struct gsd_index_entry);
+    retval = ftruncate(handle->fd, new_index_location + new_index_bytes);
+    if (retval != 0)
+        {
+        return GSD_ERROR_IO;
+        }
+
+    // write the current index to the end of the file
+    uint64_t copy_buffer_size = GSD_DEFAULT_MAXIMUM_WRITE_BUFFER_BYTES;
     if (copy_buffer_size > size_old * sizeof(struct gsd_index_entry))
         {
         copy_buffer_size = size_old * sizeof(struct gsd_index_entry);
         }
     char* buf = malloc(copy_buffer_size);
 
-    // write the current index to the end of the file
-    int64_t new_index_location = lseek(handle->fd, 0, SEEK_END);
-    int64_t old_index_location = handle->header.index_location;
     size_t total_bytes_written = 0;
     size_t old_index_bytes = size_old * sizeof(struct gsd_index_entry);
     while (total_bytes_written < old_index_bytes)
@@ -1011,34 +1037,8 @@ inline static int gsd_expand_file_index(struct gsd_handle* handle, size_t size_r
         total_bytes_written += bytes_written;
         }
 
-    // fill the new index space with 0s
-    gsd_util_zero_memory(buf, copy_buffer_size);
-
-    size_t new_index_bytes = size_new * sizeof(struct gsd_index_entry);
-    while (total_bytes_written < new_index_bytes)
-        {
-        size_t bytes_to_copy = copy_buffer_size;
-        if (new_index_bytes - total_bytes_written < copy_buffer_size)
-            {
-            bytes_to_copy = new_index_bytes - total_bytes_written;
-            }
-
-        ssize_t bytes_written = gsd_io_pwrite_retry(handle->fd,
-                                                    buf,
-                                                    bytes_to_copy,
-                                                    new_index_location + total_bytes_written);
-
-        if (bytes_written == -1 || bytes_written != bytes_to_copy)
-            {
-            free(buf);
-            return GSD_ERROR_IO;
-            }
-
-        total_bytes_written += bytes_written;
-        }
-
     // sync the expanded index
-    retval = fsync(handle->fd);
+    retval = gsd_fsync(handle->fd);
     if (retval != 0)
         {
         free(buf);
@@ -1050,7 +1050,7 @@ inline static int gsd_expand_file_index(struct gsd_handle* handle, size_t size_r
 
     // update the header
     handle->header.index_location = new_index_location;
-    handle->file_size = handle->header.index_location + total_bytes_written;
+    handle->file_size = new_index_location + new_index_bytes;
     handle->header.index_allocated_entries = size_new;
 
     // write the new header out
@@ -1062,7 +1062,7 @@ inline static int gsd_expand_file_index(struct gsd_handle* handle, size_t size_r
         }
 
     // sync the updated header
-    retval = fsync(handle->fd);
+    retval = gsd_fsync(handle->fd);
     if (retval != 0)
         {
         return GSD_ERROR_IO;
@@ -1082,10 +1082,9 @@ inline static int gsd_expand_file_index(struct gsd_handle* handle, size_t size_r
     @brief Flush the write buffer.
 
     gsd_write_frame() writes small data chunks into the write buffer. It adds index entries for
-    these chunks to gsd_handle::buffer_index with locations offset from the start of the write
-    buffer. gsd_flush_write_buffer() writes the buffer to the end of the file, moves the index
-    entries to gsd_handle::frame_index and updates the location to reference the beginning of the
-    file.
+    these chunks to gsd_handle::buffer_index with locations offset from the current end of file.
+    gsd_flush_write_buffer() writes the buffer to the end of the file. The entries in the buffered
+    index have valid locations because nothing else writes past the end of the file.
 
     @param handle Handle to flush the write buffer.
     @returns GSD_SUCCESS on success or GSD_* error codes on error
@@ -1097,16 +1096,10 @@ inline static int gsd_flush_write_buffer(struct gsd_handle* handle)
         return GSD_ERROR_INVALID_ARGUMENT;
         }
 
-    if (handle->write_buffer.size == 0 && handle->buffer_index.size == 0)
+    if (handle->write_buffer.size == 0)
         {
         // nothing to do
         return GSD_SUCCESS;
-        }
-
-    if (handle->write_buffer.size > 0 && handle->buffer_index.size == 0)
-        {
-        // error: bytes in buffer, but no index for them
-        return GSD_ERROR_INVALID_ARGUMENT;
         }
 
     // write the buffer to the end of the file
@@ -1125,24 +1118,6 @@ inline static int gsd_flush_write_buffer(struct gsd_handle* handle)
 
     // reset write_buffer for new data
     handle->write_buffer.size = 0;
-
-    // Move buffer_index entries to frame_index.
-    size_t i;
-    for (i = 0; i < handle->buffer_index.size; i++)
-        {
-        struct gsd_index_entry* new_index;
-        int retval = gsd_index_buffer_add(&handle->frame_index, &new_index);
-        if (retval != GSD_SUCCESS)
-            {
-            return retval;
-            }
-
-        *new_index = handle->buffer_index.data[i];
-        new_index->location += offset;
-        }
-
-    // clear the buffer index for new entries
-    handle->buffer_index.size = 0;
 
     return GSD_SUCCESS;
     }
@@ -1214,7 +1189,7 @@ inline static int gsd_flush_name_buffer(struct gsd_handle* handle)
             }
 
         // sync the updated name list
-        retval = fsync(handle->fd);
+        retval = gsd_fsync(handle->fd);
         if (retval != 0)
             {
             return GSD_ERROR_IO;
@@ -1248,7 +1223,7 @@ inline static int gsd_flush_name_buffer(struct gsd_handle* handle)
         }
 
     // sync the updated name list or header
-    retval = fsync(handle->fd);
+    retval = gsd_fsync(handle->fd);
     if (retval != 0)
         {
         return GSD_ERROR_IO;
@@ -1377,7 +1352,8 @@ gsd_initialize_file(int fd, const char* application, const char* schema, uint32_
     gsd_util_zero_memory(&header, sizeof(header));
 
     header.magic = GSD_MAGIC_ID;
-    header.gsd_version = gsd_make_version(GSD_CURRENT_FILE_VERSION, 0);
+    header.gsd_version
+        = gsd_make_version(GSD_CURRENT_FILE_VERSION_MAJOR, GSD_CURRENT_FILE_VERSION_MINOR);
     strncpy(header.application, application, sizeof(header.application) - 1);
     header.application[sizeof(header.application) - 1] = 0;
     strncpy(header.schema, schema, sizeof(header.schema) - 1);
@@ -1420,7 +1396,7 @@ gsd_initialize_file(int fd, const char* application, const char* schema, uint32_
         }
 
     // sync file
-    retval = fsync(fd);
+    retval = gsd_fsync(fd);
     if (retval != 0)
         {
         return GSD_ERROR_IO;
@@ -1560,22 +1536,17 @@ inline static int gsd_initialize_handle(struct gsd_handle* handle)
     // determine the current frame counter
     if (handle->file_index.size == 0)
         {
-        handle->cur_frame = 0;
+        handle->file_frame = 0;
         }
     else
         {
-        handle->cur_frame = handle->file_index.data[handle->file_index.size - 1].frame + 1;
+        handle->file_frame = handle->file_index.data[handle->file_index.size - 1].frame + 1;
         }
+    handle->buffer_frame = handle->file_frame;
 
     // if this is a write mode, allocate the initial frame index and the name buffer
     if (handle->open_flags != GSD_OPEN_READONLY)
         {
-        retval = gsd_index_buffer_allocate(&handle->frame_index, GSD_INITIAL_FRAME_INDEX_SIZE);
-        if (retval != GSD_SUCCESS)
-            {
-            return retval;
-            }
-
         retval = gsd_index_buffer_allocate(&handle->buffer_index, GSD_INITIAL_FRAME_INDEX_SIZE);
         if (retval != GSD_SUCCESS)
             {
@@ -1597,8 +1568,25 @@ inline static int gsd_initialize_handle(struct gsd_handle* handle)
         }
 
     handle->pending_index_entries = 0;
-    handle->maximum_write_buffer_size = GSD_DEFAULT_MAXIMUM_WRITE_BUFFER_SIZE;
-    handle->index_entries_to_buffer = GSD_DEFAULT_INDEX_ENTRIES_TO_BUFFER;
+    handle->maximum_write_buffer_size = GSD_DEFAULT_MAXIMUM_WRITE_BUFFER_BYTES;
+
+    // Silently upgrade writable files from a previous matching major version to the latest
+    // minor version.
+    if ((handle->open_flags == GSD_OPEN_READWRITE || handle->open_flags == GSD_OPEN_APPEND)
+        && (handle->header.gsd_version
+            <= gsd_make_version(GSD_CURRENT_FILE_VERSION_MAJOR, GSD_CURRENT_FILE_VERSION_MINOR))
+        && (handle->header.gsd_version >> (sizeof(uint32_t) * 4) == GSD_CURRENT_FILE_VERSION_MAJOR))
+        {
+        handle->header.gsd_version
+            = gsd_make_version(GSD_CURRENT_FILE_VERSION_MAJOR, GSD_CURRENT_FILE_VERSION_MINOR);
+        size_t bytes_written
+            = gsd_io_pwrite_retry(handle->fd, &(handle->header), sizeof(struct gsd_header), 0);
+
+        if (bytes_written != sizeof(struct gsd_header))
+            {
+            return GSD_ERROR_IO;
+            }
+        }
 
     return GSD_SUCCESS;
     }
@@ -1773,15 +1761,6 @@ int gsd_truncate(struct gsd_handle* handle)
         return retval;
         }
 
-    if (handle->frame_index.reserved > 0)
-        {
-        retval = gsd_index_buffer_free(&handle->frame_index);
-        if (retval != GSD_SUCCESS)
-            {
-            return retval;
-            }
-        }
-
     if (handle->buffer_index.reserved > 0)
         {
         retval = gsd_index_buffer_free(&handle->buffer_index);
@@ -1840,15 +1819,6 @@ int gsd_close(struct gsd_handle* handle)
     if (retval != GSD_SUCCESS)
         {
         return retval;
-        }
-
-    if (handle->frame_index.reserved > 0)
-        {
-        retval = gsd_index_buffer_free(&handle->frame_index);
-        if (retval != GSD_SUCCESS)
-            {
-            return retval;
-            }
         }
 
     if (handle->buffer_index.reserved > 0)
@@ -1916,13 +1886,8 @@ int gsd_end_frame(struct gsd_handle* handle)
         return GSD_ERROR_FILE_MUST_BE_WRITABLE;
         }
 
-    handle->cur_frame++;
+    handle->buffer_frame++;
     handle->pending_index_entries = 0;
-
-    if (handle->frame_index.size > 0 || handle->buffer_index.size > handle->index_entries_to_buffer)
-        {
-        return gsd_flush(handle);
-        }
 
     return GSD_SUCCESS;
     }
@@ -1938,34 +1903,34 @@ int gsd_flush(struct gsd_handle* handle)
         return GSD_ERROR_FILE_MUST_BE_WRITABLE;
         }
 
-    // flush the namelist buffer
-    int retval = gsd_flush_name_buffer(handle);
+    // flush the write buffer first so that all locations in the buffer_index are maintained.
+    int retval = gsd_flush_write_buffer(handle);
     if (retval != GSD_SUCCESS)
         {
         return retval;
         }
 
-    // flush the write buffer
-    retval = gsd_flush_write_buffer(handle);
+    // flush the namelist buffer
+    retval = gsd_flush_name_buffer(handle);
     if (retval != GSD_SUCCESS)
         {
         return retval;
         }
 
     // sync the data before writing the index
-    retval = fsync(handle->fd);
+    retval = gsd_fsync(handle->fd);
     if (retval != 0)
         {
         return GSD_ERROR_IO;
         }
 
-    // Write the frame index to the file, excluding the index entries that are part of the current
+    // Write the buffer index to the file, excluding the index entries that are part of the current
     // frame.
-    if (handle->pending_index_entries > handle->frame_index.size)
+    if (handle->pending_index_entries > handle->buffer_index.size)
         {
         return GSD_ERROR_INVALID_ARGUMENT;
         }
-    uint64_t index_entries_to_write = handle->frame_index.size - handle->pending_index_entries;
+    uint64_t index_entries_to_write = handle->buffer_index.size - handle->pending_index_entries;
 
     if (index_entries_to_write > 0)
         {
@@ -1976,7 +1941,7 @@ int gsd_flush(struct gsd_handle* handle)
             }
 
         // sort the index before writing
-        retval = gsd_index_buffer_sort(&handle->frame_index);
+        retval = gsd_index_buffer_sort(&handle->buffer_index);
         if (retval != 0)
             {
             return retval;
@@ -1988,9 +1953,15 @@ int gsd_flush(struct gsd_handle* handle)
 
         size_t bytes_to_write = sizeof(struct gsd_index_entry) * index_entries_to_write;
         ssize_t bytes_written
-            = gsd_io_pwrite_retry(handle->fd, handle->frame_index.data, bytes_to_write, write_pos);
+            = gsd_io_pwrite_retry(handle->fd, handle->buffer_index.data, bytes_to_write, write_pos);
 
         if (bytes_written == -1 || bytes_written != bytes_to_write)
+            {
+            return GSD_ERROR_IO;
+            }
+
+        retval = gsd_fsync(handle->fd);
+        if (retval != 0)
             {
             return GSD_ERROR_IO;
             }
@@ -1998,7 +1969,7 @@ int gsd_flush(struct gsd_handle* handle)
 #if !GSD_USE_MMAP
         // add the entries to the file index
         memcpy(handle->file_index.data + handle->file_index.size,
-               handle->frame_index.data,
+               handle->buffer_index.data,
                sizeof(struct gsd_index_entry) * index_entries_to_write);
 #endif
 
@@ -2010,14 +1981,16 @@ int gsd_flush(struct gsd_handle* handle)
             {
             for (uint64_t i = 0; i < handle->pending_index_entries; i++)
                 {
-                handle->frame_index.data[i]
-                    = handle->frame_index
-                          .data[handle->frame_index.size - handle->pending_index_entries + i];
+                handle->buffer_index.data[i]
+                    = handle->buffer_index
+                          .data[handle->buffer_index.size - handle->pending_index_entries + i];
                 }
             }
 
-        handle->frame_index.size = handle->pending_index_entries;
+        handle->buffer_index.size = handle->pending_index_entries;
         }
+
+    handle->file_frame = handle->buffer_frame;
 
     return GSD_SUCCESS;
     }
@@ -2068,34 +2041,36 @@ int gsd_write_chunk(struct gsd_handle* handle,
     struct gsd_index_entry entry;
     // populate fields in the entry's data
     gsd_util_zero_memory(&entry, sizeof(struct gsd_index_entry));
-    entry.frame = handle->cur_frame;
+    entry.frame = handle->buffer_frame;
     entry.id = id;
     entry.type = (uint8_t)type;
     entry.N = N;
     entry.M = M;
+    entry.location = handle->file_size + handle->write_buffer.size;
     size_t size = N * M * gsd_sizeof_type(type);
 
-    // decide whether to write this chunk to the buffer or straight to disk
-    if (size < handle->maximum_write_buffer_size)
+    // flush the buffer if this entry won't fit
+    if (size > (handle->maximum_write_buffer_size - handle->write_buffer.size))
         {
-        // flush the buffer if this entry won't fit
-        if (size > (handle->maximum_write_buffer_size - handle->write_buffer.size))
-            {
-            gsd_flush_write_buffer(handle);
-            }
-
-        entry.location = handle->write_buffer.size;
-
-        // add an entry to the buffer index
-        struct gsd_index_entry* index_entry;
-
-        int retval = gsd_index_buffer_add(&handle->buffer_index, &index_entry);
+        int retval = gsd_flush_write_buffer(handle);
         if (retval != GSD_SUCCESS)
             {
             return retval;
             }
-        *index_entry = entry;
+        }
 
+    // add an entry to the buffer index
+    struct gsd_index_entry* index_entry;
+    int retval = gsd_index_buffer_add(&handle->buffer_index, &index_entry);
+    if (retval != GSD_SUCCESS)
+        {
+        return retval;
+        }
+    *index_entry = entry;
+
+    // decide whether to write this chunk to the buffer or straight to disk
+    if (size < handle->maximum_write_buffer_size)
+        {
         // add the data to the write buffer
         if (size > 0)
             {
@@ -2108,21 +2083,8 @@ int gsd_write_chunk(struct gsd_handle* handle,
         }
     else
         {
-        // add an entry to the frame index
-        struct gsd_index_entry* index_entry;
-
-        int retval = gsd_index_buffer_add(&handle->frame_index, &index_entry);
-        if (retval != GSD_SUCCESS)
-            {
-            return retval;
-            }
-        *index_entry = entry;
-
-        // find the location at the end of the file for the chunk
-        index_entry->location = handle->file_size;
-
         // write the data
-        ssize_t bytes_written = gsd_io_pwrite_retry(handle->fd, data, size, index_entry->location);
+        ssize_t bytes_written = gsd_io_pwrite_retry(handle->fd, data, size, entry.location);
         if (bytes_written == -1 || bytes_written != size)
             {
             return GSD_ERROR_IO;
@@ -2142,7 +2104,7 @@ uint64_t gsd_get_nframes(struct gsd_handle* handle)
         {
         return 0;
         }
-    return handle->cur_frame;
+    return handle->file_frame;
     }
 
 const struct gsd_index_entry*
@@ -2159,14 +2121,6 @@ gsd_find_chunk(struct gsd_handle* handle, uint64_t frame, const char* name)
     if (frame >= gsd_get_nframes(handle))
         {
         return NULL;
-        }
-    if (handle->open_flags != GSD_OPEN_READONLY)
-        {
-        int retval = gsd_flush(handle);
-        if (retval != GSD_SUCCESS)
-            {
-            return NULL;
-            }
         }
 
     // find the id for the given name
@@ -2258,14 +2212,6 @@ int gsd_read_chunk(struct gsd_handle* handle, void* data, const struct gsd_index
         {
         return GSD_ERROR_INVALID_ARGUMENT;
         }
-    if (handle->open_flags != GSD_OPEN_READONLY)
-        {
-        int retval = gsd_flush(handle);
-        if (retval != GSD_SUCCESS)
-            {
-            return retval;
-            }
-        }
 
     size_t size = chunk->N * chunk->M * gsd_sizeof_type((enum gsd_type)chunk->type);
     if (size == 0)
@@ -2335,6 +2281,10 @@ size_t gsd_sizeof_type(enum gsd_type type)
         {
         val = sizeof(double);
         }
+    else if (type == GSD_TYPE_CHARACTER)
+        {
+        val = sizeof(char);
+        }
     else
         {
         return 0;
@@ -2356,14 +2306,6 @@ gsd_find_matching_chunk_name(struct gsd_handle* handle, const char* match, const
     if (handle->file_names.n_names == 0)
         {
         return NULL;
-        }
-    if (handle->open_flags != GSD_OPEN_READONLY)
-        {
-        int retval = gsd_flush(handle);
-        if (retval != GSD_SUCCESS)
-            {
-            return NULL;
-            }
         }
 
     // return nothing found if the name buffer is corrupt
@@ -2433,7 +2375,7 @@ int gsd_upgrade(struct gsd_handle* handle)
         {
         return GSD_ERROR_INVALID_ARGUMENT;
         }
-    if (handle->frame_index.size > 0 || handle->frame_names.n_names > 0)
+    if (handle->buffer_index.size > 0 || handle->frame_names.n_names > 0)
         {
         return GSD_ERROR_INVALID_ARGUMENT;
         }
@@ -2481,7 +2423,7 @@ int gsd_upgrade(struct gsd_handle* handle)
                 }
 
             // sync the updated index
-            retval = fsync(handle->fd);
+            retval = gsd_fsync(handle->fd);
             if (retval != 0)
                 {
                 return GSD_ERROR_IO;
@@ -2539,7 +2481,7 @@ int gsd_upgrade(struct gsd_handle* handle)
             handle->file_names.data = new_name_buf;
 
             // sync the updated name list
-            retval = fsync(handle->fd);
+            retval = gsd_fsync(handle->fd);
             if (retval != 0)
                 {
                 gsd_byte_buffer_free(&new_name_buf);
@@ -2547,8 +2489,9 @@ int gsd_upgrade(struct gsd_handle* handle)
                 }
             }
 
-        // label the file as a v2.0 file
-        handle->header.gsd_version = gsd_make_version(GSD_CURRENT_FILE_VERSION, 0);
+        // GSD always writes files matching the current major and minor version.
+        handle->header.gsd_version
+            = gsd_make_version(GSD_CURRENT_FILE_VERSION_MAJOR, GSD_CURRENT_FILE_VERSION_MINOR);
 
         // write the new header out
         ssize_t bytes_written
@@ -2559,7 +2502,7 @@ int gsd_upgrade(struct gsd_handle* handle)
             }
 
         // sync the updated header
-        int retval = fsync(handle->fd);
+        int retval = gsd_fsync(handle->fd);
         if (retval != 0)
             {
             return GSD_ERROR_IO;
@@ -2599,27 +2542,6 @@ int gsd_set_maximum_write_buffer_size(struct gsd_handle* handle, uint64_t size)
         }
 
     handle->maximum_write_buffer_size = size;
-
-    return GSD_SUCCESS;
-    }
-
-uint64_t gsd_get_index_entries_to_buffer(struct gsd_handle* handle)
-    {
-    if (handle == NULL)
-        {
-        return 0;
-        }
-    return handle->index_entries_to_buffer;
-    }
-
-int gsd_set_index_entries_to_buffer(struct gsd_handle* handle, uint64_t number)
-    {
-    if (handle == NULL || number == 0)
-        {
-        return GSD_ERROR_INVALID_ARGUMENT;
-        }
-
-    handle->index_entries_to_buffer = number;
 
     return GSD_SUCCESS;
     }

--- a/hoomd/extern/gsd.h
+++ b/hoomd/extern/gsd.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2023 The Regents of the University of Michigan
+// Copyright (c) 2016-2025 The Regents of the University of Michigan
 // Part of GSD, released under the BSD 2-Clause License.
 
 #ifndef GSD_H
@@ -48,7 +48,10 @@ extern "C"
         GSD_TYPE_FLOAT,
 
         /// 64-bit floating point number.
-        GSD_TYPE_DOUBLE
+        GSD_TYPE_DOUBLE,
+
+        /// 8-bit character.
+        GSD_TYPE_CHARACTER
         };
 
     /// Flag for GSD file open options
@@ -288,9 +291,6 @@ extern "C"
         /// Mapped data chunk index
         struct gsd_index_buffer file_index;
 
-        /// Index entries to append to the current frame
-        struct gsd_index_buffer frame_index;
-
         /// Buffered index entries to append to the current frame
         struct gsd_index_buffer buffer_index;
 
@@ -303,8 +303,11 @@ extern "C"
         /// List of names added in the current frame
         struct gsd_name_buffer frame_names;
 
-        /// The index of the last frame in the file
-        uint64_t cur_frame;
+        /// The index of the last frame in the buffer
+        uint64_t buffer_frame;
+
+        /// The index of the last frame comitted to the file
+        uint64_t file_frame;
 
         /// Size of the file (in bytes)
         int64_t file_size;
@@ -320,9 +323,6 @@ extern "C"
 
         /// Maximum write buffer size (bytes).
         uint64_t maximum_write_buffer_size;
-
-        /// Number of index entries to buffer before flushing.
-        uint64_t index_entries_to_buffer;
         };
 
     /** Specify a version.
@@ -459,7 +459,10 @@ extern "C"
         @pre *handle* was opened by gsd_open().
 
         @post The current frame counter is increased by 1.
-        @post Flush the write buffer if it has overflowed. See gsd_flush().
+
+        @note Starting with GSD 4.0, gsd_end_frame() does NOT automatically flush buffered frames
+        to the filesystem. Callers must manually call gsd_flush() or gsd_close() to commit the
+        buffered frames to the filesystem.
 
         @return
           - GSD_SUCCESS (0) on success. Negative value on failure:
@@ -542,7 +545,8 @@ extern "C"
 
         @return A pointer to the found chunk, or NULL if not found.
 
-        @note gsd_find_chunk() calls gsd_flush() when the file is writable.
+        @note In read/write files gsd_find_chunk() can only find chunks that have been committed
+        to the file with gsd_flush().
     */
     const struct gsd_index_entry*
     gsd_find_chunk(struct gsd_handle* handle, uint64_t frame, const char* name);
@@ -565,7 +569,8 @@ extern "C"
           - GSD_ERROR_FILE_MUST_BE_READABLE: The file was opened in append mode.
           - GSD_ERROR_FILE_CORRUPT: The GSD file is corrupt.
 
-        @note gsd_read_chunk() calls gsd_flush() when the file is writable.
+        @note In read/write files gsd_read_chunk() can only read chunks that have been committed
+        to the file with gsd_flush().
     */
     int gsd_read_chunk(struct gsd_handle* handle, void* data, const struct gsd_index_entry* chunk);
 
@@ -603,7 +608,8 @@ extern "C"
         @return Pointer to a string, NULL if no more matching chunks are found found, or NULL if
         *prev* is invalid
 
-        @note  gsd_find_matching_chunk_name() calls gsd_flush() when the file is writable.
+        @note In read/write files gsd_find_matching_chunk_names() can only find names that have
+        been committed to the file with gsd_flush().
     */
     const char*
     gsd_find_matching_chunk_name(struct gsd_handle* handle, const char* match, const char* prev);
@@ -647,34 +653,6 @@ extern "C"
           - GSD_ERROR_INVALID_ARGUMENT: size == 0
     */
     int gsd_set_maximum_write_buffer_size(struct gsd_handle* handle, uint64_t size);
-
-    /** Get the number of index entries to buffer.
-
-        @param handle Handle to an open GSD file
-
-        @pre *handle* was opened by gsd_open().
-
-        @return The number of index entries to buffer, or 0 on error.
-    */
-    uint64_t gsd_get_index_entries_to_buffer(struct gsd_handle* handle);
-
-    /** Set the number of index entries to buffer.
-
-        @param handle Handle to an open GSD file
-        @param number Number of index entries to buffer before automatically flushing in
-        `gsd_end_frame()` (must be greater than 0).
-
-        @pre *handle* was opened by gsd_open().
-
-        @note GSD may allocate more than this number of entries in the buffer, as needed to store
-        all index entries for the already buffered frames and the current frame.
-
-        @return
-          - GSD_SUCCESS (0) on success. Negative value on failure:
-          - GSD_ERROR_INVALID_ARGUMENT: *handle* is NULL
-          - GSD_ERROR_INVALID_ARGUMENT: number == 0
-    */
-    int gsd_set_index_entries_to_buffer(struct gsd_handle* handle, uint64_t number);
 
 #ifdef __cplusplus
     }

--- a/hoomd/write/gsd.py
+++ b/hoomd/write/gsd.py
@@ -257,11 +257,11 @@ class GSD(Writer):
         maximum_write_buffer_size (int): Size (in bytes) to buffer in memory
            before writing to the file. Defaults to 1 MiB.
 
-            .. rubric:: Example:
+           .. rubric:: Example:
 
-            .. code-block:: python
+           .. code-block:: python
 
-                gsd.maximum_write_buffer_size = 16 * 1024**2
+               gsd.maximum_write_buffer_size = 16 * 1024**2
 
         auto_flush_period (float): Time (in seconds) to wait between automatic
             calls to `flush()`. Defaults to 10 seconds.
@@ -275,6 +275,61 @@ class GSD(Writer):
 
     __doc__ = inspect.cleandoc(__doc__).replace(
         "{inherited}", inspect.cleandoc(Writer._doc_inherited)
+    )
+
+    _doc_inherited = (
+        Writer._doc_inherited
+        + """
+    ----------
+
+    **Members inherited from** `GSD <hoomd.write.GSD>`:
+
+    .. py:attribute:: filename
+
+        File name to write (*read-only*).
+        `Read more... <hoomd.write.GSD.filename>`
+
+    .. py:attribute:: filter
+
+        Select the particles to write (*read-only*).
+        `Read more... <hoomd.write.GSD.filter>`
+
+    .. py:attribute:: mode
+
+        The file open mode (*read-only*).
+        `Read more... <hoomd.write.GSD.mode>`
+
+    .. py:attribute:: dynamic
+
+        Field names and/or field categores to save in all frames.
+        `Read more... <hoomd.write.GSD.dynamic>`
+
+    .. py:attribute:: write_diameter
+
+        When `False`, do not write ``particles/diameter``. Set to `True` to write
+        non-default particle diameters.
+        `Read more... <hoomd.write.GSD.write_diameter>`
+
+    .. py:attribute:: maximum_write_buffer_size
+
+        Size (in bytes) to buffer in memory before writing to the file.
+        `Read more... <hoomd.write.GSD.maximum_write_buffer_size>`
+
+    .. py:attribute:: auto_flush_period
+
+        Time (in seconds) to wait between automatic calls to `flush()`.
+        `Read more... <hoomd.write.GSD.auto_flush_period>`
+
+    .. py:property:: logger
+
+        Provide log quantities to write.
+        `Read more... <hoomd.write.GSD.logger>`
+
+    .. py:method:: flush
+
+        Flush the write buffer to the file.
+        `Read more... <hoomd.write.GSD.flush>`
+    """
     )
 
     def __init__(
@@ -408,7 +463,9 @@ class GSD(Writer):
 
         .. rubric:: Example:
 
-            .. code-block:: python
+        .. code-block:: python
+
+            gsd.flush()
         """
         if not self._attached:
             raise RuntimeError(

--- a/hoomd/write/gsd.py
+++ b/hoomd/write/gsd.py
@@ -262,6 +262,15 @@ class GSD(Writer):
             .. code-block:: python
 
                 gsd.maximum_write_buffer_size = 16 * 1024**2
+
+        auto_flush_period (float): Time (in seconds) to wait between automatic
+            calls to `flush()`. Defaults to 10 seconds.
+
+            .. rubric:: Example:
+
+            .. code-block:: python
+
+                gsd.auto_flush_period = 30
     """
 
     __doc__ = inspect.cleandoc(__doc__).replace(
@@ -314,6 +323,7 @@ class GSD(Writer):
                 dynamic=[dynamic_validation],
                 write_diameter=False,
                 maximum_write_buffer_size=1024 * 1024,
+                auto_flush_period=10,
                 _defaults=dict(filter=filter, dynamic=dynamic),
             )
         )
@@ -392,15 +402,13 @@ class GSD(Writer):
     def flush(self):
         """Flush the write buffer to the file.
 
-        Example::
+        See Also:
+            Users should rarely, if ever, need to call `flush()`. GSD automatically
+            calls `flush()` every `auto_flush_period` seconds.
 
-            gsd_writer.flush()
+        .. rubric:: Example:
 
-        Flush all write buffers::
-
-            for writer in simulation.operations.writers:
-                if hasattr(writer, "flush"):
-                    writer.flush()
+            .. code-block:: python
         """
         if not self._attached:
             raise RuntimeError(

--- a/hoomd/write/gsd.py
+++ b/hoomd/write/gsd.py
@@ -255,13 +255,13 @@ class GSD(Writer):
                 gsd.write_diameter = True
 
         maximum_write_buffer_size (int): Size (in bytes) to buffer in memory
-           before writing to the file.
+           before writing to the file. Defaults to 1 MiB.
 
             .. rubric:: Example:
 
             .. code-block:: python
 
-                gsd.maximum_write_buffer_size = 128 * 1024**2
+                gsd.maximum_write_buffer_size = 16 * 1024**2
     """
 
     __doc__ = inspect.cleandoc(__doc__).replace(
@@ -313,7 +313,7 @@ class GSD(Writer):
                 truncate=bool(truncate),
                 dynamic=[dynamic_validation],
                 write_diameter=False,
-                maximum_write_buffer_size=64 * 1024 * 1024,
+                maximum_write_buffer_size=1024 * 1024,
                 _defaults=dict(filter=filter, dynamic=dynamic),
             )
         )
@@ -487,7 +487,7 @@ class _GSDLogWriter:
                     # This places logged quantities that are
                     # per-{particle,bond,...} into the correct GSD namespace
                     # log/particles/{remaining namespace}. This preserves OVITO
-                    # intergration.
+                    # integration.
                     if type_category in self._per_categories:
                         log[
                             "/".join(


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should be based on *trunk-patch*. -->
<!-- Backwards compatible new features should be based on *trunk-minor*. -->
<!-- Incompatible API changes should be based on *trunk-major*. -->

## Description

<!-- Describe your changes in detail. -->
Automatically flush GSD trajectories every 10 seconds (configurable).
Also update to the latest GSD implementation which improves file write performance and data integrity.

TODO:
- [x] Consider updating the tutorials to close the gsd files rather than flushing manually. With the new system, users should never need to call `flush`.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
In a recent review of GSD, I discovered several issues that needed resolving. The only way to maintain a high level of performance was to change the way that buffers are flushed in GSD: https://github.com/glotzerlab/gsd/pull/429

At the same time, many users experience frustration at the fact that the content they expect in GSD files is not there. There are many examples of over-complicated systems to call `flush` and workaround this. Flushing every 10 seconds by default will give users the output they expect (file contents appears in a reasonable amount of time) and does not harm performance. No matter what the file I/O pattern is, from writing TB files as fast as possible to writing kB files over the course of hours - the time to flush is relatively fixed (up to ~4 ms on even the slowest file systems). Therefore, flushing every 10 seconds should not harm performance too much even in extreme examples, yet it is often enough that users may not even notice that the data is buffered.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
All unit test pass. I checked GSD file contents and number of frames while running a test script, and they both behaved as expected.

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
- [x] I have summarized these changes in `CHANGELOG.rst` following the established format.
