### PR TITLE
Fix segfault when attaching nlists with meshes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,8 @@ Change Log
 
 * Ensure that GPU devices have full unified memory capabilities
   (`#2099 <https://github.com/glotzerlab/hoomd-blue/pull/2099>`__).
+* Fix segfault when attaching nlists with meshes
+  (`#2089 <https://github.com/glotzerlab/hoomd-blue/pull/2089>`__).
 
 *Added*
 

--- a/hoomd/md/nlist.py
+++ b/hoomd/md/nlist.py
@@ -391,6 +391,18 @@ class NeighborList(Compute):
         return self._cpp_obj.getLocalPairList(self._simulation.timestep)
 
     @property
+    def mesh(self):
+        """Mesh data structure used to compute the meshbond exclusions."""
+        return self._mesh
+
+    @mesh.setter
+    def mesh(self, value):
+        if self._attached:
+            raise RuntimeError("mesh cannot be set after calling Simulation.run().")
+        mesh = OnlyTypes(Mesh, allow_none=True)(value)
+        self._mesh = mesh
+
+    @property
     def pair_list(self):
         """(*N_pairs*, 2) `numpy.ndarray` of `numpy.uint32`: Global pair list.
 

--- a/hoomd/md/nlist.py
+++ b/hoomd/md/nlist.py
@@ -226,17 +226,17 @@ class NeighborList(Compute):
             buffer=float(buffer),
             rebuild_check_delay=int(rebuild_check_delay),
             check_dist=bool(check_dist),
+            mesh=validate_mesh
         )
         params["exclusions"] = exclusions
+        params["mesh"] = mesh
         self._param_dict.update(params)
-
-        self._mesh = validate_mesh(mesh)
 
         self._in_context_manager = False
 
     def _attach_hook(self):
-        if self._mesh is not None:
-            if self._mesh._attached and self._simulation != self._mesh._simulation:
+        if self.mesh is not None:
+            if self.mesh._attached and self._simulation != self.mesh._simulation:
                 warnings.warn(
                     f"{self} object is creating a new equivalent mesh structure."
                     f" This is happending since the neighbor list is moving to" 
@@ -244,12 +244,12 @@ class NeighborList(Compute):
                     f" a new mesh.",
                     RuntimeWarning,
                 )
-            self._mesh._attach(self._simulation)
-            self._cpp_obj.addMesh(self._mesh._cpp_obj)
+            self.mesh._attach(self._simulation)
+            self._cpp_obj.addMesh(self.mesh._cpp_obj)
 
     def _detach_hook(self):
-        if self._mesh is not None:
-            self._mesh._detach_hook()
+        if self.mesh is not None:
+            self.mesh._detach_hook()
 
     @property
     def cpu_local_nlist_arrays(self):
@@ -391,18 +391,6 @@ class NeighborList(Compute):
         if not self._attached:
             raise hoomd.error.DataAccessError("local_pair_list")
         return self._cpp_obj.getLocalPairList(self._simulation.timestep)
-
-    @property
-    def mesh(self):
-        """Mesh data structure used to compute the meshbond exclusions."""
-        return self._mesh
-
-    @mesh.setter
-    def mesh(self, value):
-        if self._attached:
-            raise RuntimeError("mesh cannot be set after calling Simulation.run().")
-        mesh = OnlyTypes(Mesh, allow_none=True)(value)
-        self._mesh = mesh
 
     @property
     def pair_list(self):

--- a/hoomd/md/nlist.py
+++ b/hoomd/md/nlist.py
@@ -239,7 +239,7 @@ class NeighborList(Compute):
             if self._mesh._attached and self._simulation != self._mesh._simulation:
                 warnings.warn(
                     f"{self} object is creating a new equivalent mesh structure."
-                    f" This is happending since the neighbor list is moving to" 
+                    f" This is happending since the neighbor list is moving to"
                     f" a new simulation. To suppress the warning explicitly set"
                     f" a new mesh.",
                     RuntimeWarning,

--- a/hoomd/md/nlist.py
+++ b/hoomd/md/nlist.py
@@ -235,6 +235,14 @@ class NeighborList(Compute):
 
     def _attach_hook(self):
         if self._mesh is not None:
+            if self._mesh._attached and self._simulation != self._mesh._simulation:
+                warnings.warn(
+                    f"{self} object is creating a new equivalent mesh structure."
+                    f" This is happending since the force is moving to a new "
+                    f"simulation. To suppress the warning explicitly set new mesh.",
+                    RuntimeWarning,
+                )
+            self._mesh._attach(self._simulation)
             self._cpp_obj.addMesh(self._mesh._cpp_obj)
 
     def _detach_hook(self):

--- a/hoomd/md/nlist.py
+++ b/hoomd/md/nlist.py
@@ -226,7 +226,7 @@ class NeighborList(Compute):
             buffer=float(buffer),
             rebuild_check_delay=int(rebuild_check_delay),
             check_dist=bool(check_dist),
-            mesh=validate_mesh
+            mesh=validate_mesh,
         )
         params["exclusions"] = exclusions
         params["mesh"] = mesh

--- a/hoomd/md/nlist.py
+++ b/hoomd/md/nlist.py
@@ -82,6 +82,7 @@ from hoomd.data.typeconverter import OnlyFrom, OnlyTypes, nonnegative_real
 from hoomd.logging import log
 from hoomd.mesh import Mesh
 from hoomd.operation import Compute
+import warnings
 import inspect
 
 
@@ -238,8 +239,9 @@ class NeighborList(Compute):
             if self._mesh._attached and self._simulation != self._mesh._simulation:
                 warnings.warn(
                     f"{self} object is creating a new equivalent mesh structure."
-                    f" This is happending since the force is moving to a new "
-                    f"simulation. To suppress the warning explicitly set new mesh.",
+                    f" This is happending since the neighbor list is moving to" 
+                    f" a new simulation. To suppress the warning explicitly set"
+                    f" a new mesh.",
                     RuntimeWarning,
                 )
             self._mesh._attach(self._simulation)

--- a/hoomd/md/pytest/test_nlist.py
+++ b/hoomd/md/pytest/test_nlist.py
@@ -146,7 +146,7 @@ def test_mesh_simulation(nlist_params, simulation_factory, lattice_snapshot_fact
     sim.run(0)
 
     mesh1 = hoomd.mesh.Mesh()
-    with pytest.raises(RuntimeError):
+    with pytest.raises(hoomd.error.MutabilityError):
         nlist.mesh = mesh1
     assert nlist.mesh == mesh
 

--- a/hoomd/md/pytest/test_nlist.py
+++ b/hoomd/md/pytest/test_nlist.py
@@ -63,6 +63,7 @@ def test_common_params(nlist_params):
         "exclusions": ("bond",),
         "rebuild_check_delay": 1,
         "check_dist": True,
+        "mesh": None,
     }
     _assert_nlist_params(nlist, default_params_dict)
     new_params_dict = {
@@ -83,6 +84,7 @@ def test_common_params(nlist_params):
         ),
         "rebuild_check_delay": np.random.randint(8),
         "check_dist": False,
+        "mesh": hoomd.mesh.Mesh(),
     }
     for param in new_params_dict.keys():
         setattr(nlist, param, new_params_dict[param])
@@ -126,6 +128,27 @@ def test_simple_simulation(nlist_params, simulation_factory, lattice_snapshot_fa
     nlist.rebuild_check_delay = 1
     autotuned_kernel_parameter_check(instance=nlist, activate=lambda: sim.run(1))
 
+def test_mesh_simulation(nlist_params, simulation_factory, lattice_snapshot_factory):
+    nlist_cls, required_args = nlist_params
+    mesh = hoomd.mesh.Mesh()
+    nlist = nlist_cls(**required_args, buffer=0.4,mesh=mesh)
+    lj = hoomd.md.pair.LJ(nlist, default_r_cut=1.1)
+    lj.params[("A", "A")] = dict(epsilon=1, sigma=1)
+    lj.params[("A", "B")] = dict(epsilon=1, sigma=1)
+    lj.params[("B", "B")] = dict(epsilon=1, sigma=1)
+    integrator = hoomd.md.Integrator(0.005)
+    integrator.forces.append(lj)
+    integrator.methods.append(hoomd.md.methods.Langevin(hoomd.filter.All(), kT=1))
+
+    sim = simulation_factory(lattice_snapshot_factory(n=10))
+    sim.operations.integrator = integrator
+    sim.run(0)
+
+    mesh1 = hoomd.mesh.Mesh()
+    with pytest.raises(RuntimeError):
+        nlist.mesh = mesh1
+    assert nlist.mesh == mesh
+    
 
 def test_auto_detach_simulation(simulation_factory, two_particle_snapshot_factory):
     nlist = Cell(buffer=0.4)

--- a/hoomd/md/pytest/test_nlist.py
+++ b/hoomd/md/pytest/test_nlist.py
@@ -128,10 +128,11 @@ def test_simple_simulation(nlist_params, simulation_factory, lattice_snapshot_fa
     nlist.rebuild_check_delay = 1
     autotuned_kernel_parameter_check(instance=nlist, activate=lambda: sim.run(1))
 
+
 def test_mesh_simulation(nlist_params, simulation_factory, lattice_snapshot_factory):
     nlist_cls, required_args = nlist_params
     mesh = hoomd.mesh.Mesh()
-    nlist = nlist_cls(**required_args, buffer=0.4,mesh=mesh)
+    nlist = nlist_cls(**required_args, buffer=0.4, mesh=mesh)
     lj = hoomd.md.pair.LJ(nlist, default_r_cut=1.1)
     lj.params[("A", "A")] = dict(epsilon=1, sigma=1)
     lj.params[("A", "B")] = dict(epsilon=1, sigma=1)
@@ -148,7 +149,7 @@ def test_mesh_simulation(nlist_params, simulation_factory, lattice_snapshot_fact
     with pytest.raises(RuntimeError):
         nlist.mesh = mesh1
     assert nlist.mesh == mesh
-    
+
 
 def test_auto_detach_simulation(simulation_factory, two_particle_snapshot_factory):
     nlist = Cell(buffer=0.4)


### PR DESCRIPTION
Fix segfault when attaching nlists with meshes

<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should be based on *trunk-patch*. -->
<!-- Backwards compatible new features should be based on *trunk-minor*. -->
<!-- Incompatible API changes should be based on *trunk-major*. -->

## Description

Simulations segfaulted when attaching pair potentials with neighbor lists containing a mesh for exclusions to the integrator before the mesh forces were applied. 

The code now initializes the mesh through the cell lists as well. 

## How has this been tested?

I added a pytest

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
- [x] I have summarized these changes in `CHANGELOG.rst` following the established format.
