### PR TITLE
fix missing MD headers

### DIFF
--- a/hoomd/md/CMakeLists.txt
+++ b/hoomd/md/CMakeLists.txt
@@ -89,8 +89,10 @@ set(_md_headers ActiveForceComputeGPU.h
                 ComputeThermoTypes.h
                 ComputeThermoHMATypes.h
                 ConstantForceComputeGPU.h
+                ConstantForceComputeGPU.cuh
                 ConstantForceCompute.h
                 CosineSqAngleForceComputeGPU.h
+                CosineSqAngleForceGPU.cuh
                 CosineSqAngleForceCompute.h
                 CustomForceCompute.h
                 EvaluatorBondFENE.h
@@ -99,7 +101,7 @@ set(_md_headers ActiveForceComputeGPU.h
                 EvaluatorSpecialPairLJ.h
                 EvaluatorSpecialPairCoulomb.h
                 EvaluatorExternalElectricField.h
-            		EvaluatorExternalMagneticField.h
+                EvaluatorExternalMagneticField.h
                 EvaluatorExternalPeriodic.h
                 EvaluatorPairALJ.h
                 EvaluatorPairBuckingham.h
@@ -131,20 +133,27 @@ set(_md_headers ActiveForceComputeGPU.h
                 EvaluatorTersoff.h
                 EvaluatorWalls.h
                 FIREEnergyMinimizerGPU.h
+                FIREEnergyMinimizerGPU.cuh
                 FIREEnergyMinimizer.h
                 ForceCompositeGPU.h
+                ForceCompositeGPU.cuh
                 ForceComposite.h
                 ForceDistanceConstraintGPU.h
+                ForceDistanceConstraintGPU.cuh
                 ForceDistanceConstraint.h
                 PatchEnvelope.h
                 HarmonicAngleForceComputeGPU.h
                 HarmonicAngleForceCompute.h
+                HarmonicAngleForceGPU.cuh
                 HarmonicDihedralForceComputeGPU.h
                 HarmonicDihedralForceCompute.h
+                HarmonicDihedralForceGPU.cuh
                 HarmonicImproperForceComputeGPU.h
                 HarmonicImproperForceCompute.h
-            		HelfrichMeshForceComputeGPU.h
-            		HelfrichMeshForceCompute.h
+                HarmonicImproperForceGPU.cuh
+                HelfrichMeshForceComputeGPU.h
+                HelfrichMeshForceComputeGPU.cuh
+                HelfrichMeshForceCompute.h
                 IntegrationMethodTwoStep.h
                 IntegratorTwoStep.h
                 ManifoldZCylinder.h
@@ -159,15 +168,20 @@ set(_md_headers ActiveForceComputeGPU.h
                 MuellerPlatheFlowEnum.h
                 MuellerPlatheFlow.h
                 MuellerPlatheFlowGPU.h
+                MuellerPlatheFlowGPU.cuh
                 NeighborListBinned.h
                 NeighborListGPUBinned.h
                 NeighborListGPU.h
+                NeighborListGPU.cuh
                 NeighborListGPUStencil.h
+                NeighborListGPUStencil.cuh
                 NeighborListGPUTree.h
+                NeighborListGPUTree.cuh
                 NeighborList.h
                 NeighborListStencil.h
                 NeighborListTree.h
                 OPLSDihedralForceComputeGPU.h
+                OPLSDihedralForceGPU.cuh
                 OPLSDihedralForceCompute.h
                 PairModulator.h
                 PotentialBondGPU.h
@@ -191,10 +205,13 @@ set(_md_headers ActiveForceComputeGPU.h
                 PeriodicImproper.h
                 PeriodicImproperForceCompute.h
                 PeriodicImproperForceComputeGPU.h
+                PeriodicImproperForceGPU.cuh
                 PPPMForceComputeGPU.h
+                PPPMForceComputeGPU.cuh
                 PPPMForceCompute.h
                 TableAngleForceComputeGPU.h
                 TableAngleForceCompute.h
+                TableAngleForceGPU.cuh
                 TableDihedralForceComputeGPU.h
                 TableDihedralForceCompute.h
                 TriangleAreaConservationMeshParameters.h
@@ -208,6 +225,7 @@ set(_md_headers ActiveForceComputeGPU.h
                 TwoStepRATTLEBD.h
                 TwoStepLangevinBase.h
                 TwoStepLangevinGPU.h
+                TwoStepLangevinGPU.cuh
                 TwoStepRATTLELangevinGPU.h
                 TwoStepRATTLELangevinGPU.cuh
                 TwoStepLangevin.h
@@ -217,12 +235,16 @@ set(_md_headers ActiveForceComputeGPU.h
                 TwoStepRATTLENVE.h
                 TwoStepConstantVolume.h
                 TwoStepConstantVolumeGPU.h
+                TwoStepConstantVolumeGPU.cuh
                 TwoStepConstantPressure.h
+                TwoStepConstantPressureGPU.h
+                TwoStepConstantPressureGPU.cuh
                 AlchemostatTwoStep.h
                 TwoStepNVTAlchemy.h
-		            VolumeConservationMeshParameters.h
-		            VolumeConservationMeshForceCompute.h
-            		VolumeConservationMeshForceComputeGPU.h
+                VolumeConservationMeshParameters.h
+                VolumeConservationMeshForceCompute.h
+                VolumeConservationMeshForceComputeGPU.h
+                VolumeConservationMeshForceComputeGPU.cuh
                 AlchemostatTwoStep.h
                 WallData.h
                 ZeroMomentumUpdater.h


### PR DESCRIPTION

## Description

Added missing cuh headers in CMake file so they are available to components­. 

## Motivation and context

In some cases, it is efficient to invoke hoomd gpu kernels directly in components, and they have to be available to the compiler. 

## How has this been tested?

The header files are not compiled, and no tests should be required here. 

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
- [x] I have summarized these changes in `CHANGELOG.rst` following the established format.
