### PR TITLE
Speeding up mesh construction

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,9 +7,6 @@ Change Log
 5.3.1 (not yet released)
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-5.3.0 (2025-06-26)
-^^^^^^^^^^^^^^^^^^
-
 *Fixed*
 
 * Ensure that GPU devices have full unified memory capabilities
@@ -18,6 +15,11 @@ Change Log
   (`#2089 <https://github.com/glotzerlab/hoomd-blue/pull/2089>`__).
 * Install cuh headers
   (`#2091 <https://github.com/glotzerlab/hoomd-blue/pull/2091>`__).
+* Reduce the time needed to generate mesh bonds
+  (`#2097 <https://github.com/glotzerlab/hoomd-blue/pull/2097>`__).
+
+5.3.0 (2025-06-26)
+^^^^^^^^^^^^^^^^^^
 
 *Added*
 

--- a/hoomd/MeshGroupData.cc
+++ b/hoomd/MeshGroupData.cc
@@ -125,7 +125,7 @@ void MeshGroupData<group_size, Group, name, snap>::initializeFromTriangleSnapsho
 
     if (group_size == 4)
         {
-	unsigned int bond_idx = 0;
+        unsigned int bond_idx = 0;
         for (unsigned group_idx = 0; group_idx < snapshot.groups.size(); group_idx++)
             {
             std::vector<unsigned int> triag_tag(3);
@@ -150,7 +150,7 @@ void MeshGroupData<group_size, Group, name, snap>::initializeFromTriangleSnapsho
             bonds[2].tag[2] = triag_tag[1];
             bonds[2].tag[3] = triag_tag[1];
 
-	for (unsigned int j = 0; j < bonds.size(); ++j)
+            for (unsigned int j = 0; j < bonds.size(); ++j)
                 {
                 if (bonds[j].tag[0] > bonds[j].tag[1])
                     {
@@ -170,11 +170,11 @@ void MeshGroupData<group_size, Group, name, snap>::initializeFromTriangleSnapsho
                     if (bonds[j].tag[0] == all_helper[i].tag[0]
                         && bonds[j].tag[1] == all_helper[i].tag[1])
                         {
-			unsigned int find_idx = all_helper[i].tag[2];
-			all_groups[find_idx].tag[3] = bonds[j].tag[2];
+                        unsigned int find_idx = all_helper[i].tag[2];
+                        all_groups[find_idx].tag[3] = bonds[j].tag[2];
 
-			all_helper.erase(all_helper.begin() + i);
-			i -= 1;
+                        all_helper.erase(all_helper.begin() + i);
+                        i -= 1;
                         bonds.erase(bonds.begin() + j);
                         break;
                         }
@@ -184,9 +184,9 @@ void MeshGroupData<group_size, Group, name, snap>::initializeFromTriangleSnapsho
                 {
                 all_groups.push_back(bonds[i]);
                 all_helper.push_back(bonds[i]);
-		long unsigned int all_helper_size = all_helper.size()-1;
-		all_helper[all_helper_size].tag[2] = bond_idx;
-		bond_idx++;
+                long unsigned int all_helper_size = all_helper.size() - 1;
+                all_helper[all_helper_size].tag[2] = bond_idx;
+                bond_idx++;
 
                 all_types.push_back(snapshot.type_id[group_idx]);
                 }

--- a/hoomd/MeshGroupData.cc
+++ b/hoomd/MeshGroupData.cc
@@ -125,8 +125,10 @@ void MeshGroupData<group_size, Group, name, snap>::initializeFromTriangleSnapsho
 
     if (group_size == 4)
         {
+	unsigned int bond_idx = 0;
         for (unsigned group_idx = 0; group_idx < snapshot.groups.size(); group_idx++)
             {
+            std::cout << group_idx << " " << snapshot.groups.size() << std::endl;
             std::vector<unsigned int> triag_tag(3);
             std::vector<typename BondedGroupData<group_size, Group, name, true>::members_t> bonds(
                 3);
@@ -149,7 +151,7 @@ void MeshGroupData<group_size, Group, name, snap>::initializeFromTriangleSnapsho
             bonds[2].tag[2] = triag_tag[1];
             bonds[2].tag[3] = triag_tag[1];
 
-            for (unsigned int j = 0; j < bonds.size(); ++j)
+	for (unsigned int j = 0; j < bonds.size(); ++j)
                 {
                 if (bonds[j].tag[0] > bonds[j].tag[1])
                     {
@@ -169,8 +171,11 @@ void MeshGroupData<group_size, Group, name, snap>::initializeFromTriangleSnapsho
                     if (bonds[j].tag[0] == all_helper[i].tag[0]
                         && bonds[j].tag[1] == all_helper[i].tag[1])
                         {
-                        // all_helper[i].tag[3] = group_idx;
-                        all_helper[i].tag[3] = bonds[j].tag[2];
+			unsigned int find_idx = all_helper[i].tag[2];
+			all_groups[find_idx].tag[3] = bonds[j].tag[2];
+
+			all_helper.erase(all_helper.begin() + i);
+			i -= 1;
                         bonds.erase(bonds.begin() + j);
                         break;
                         }
@@ -178,11 +183,15 @@ void MeshGroupData<group_size, Group, name, snap>::initializeFromTriangleSnapsho
                 }
             for (unsigned int i = 0; i < bonds.size(); ++i)
                 {
+                all_groups.push_back(bonds[i]);
                 all_helper.push_back(bonds[i]);
+		long unsigned int all_helper_size = all_helper.size()-1;
+		all_helper[all_helper_size].tag[2] = bond_idx;
+		bond_idx++;
+
                 all_types.push_back(snapshot.type_id[group_idx]);
                 }
             }
-        all_groups = all_helper;
         }
     else // this part will be important later for dynamical bonding
         {

--- a/hoomd/MeshGroupData.cc
+++ b/hoomd/MeshGroupData.cc
@@ -128,7 +128,6 @@ void MeshGroupData<group_size, Group, name, snap>::initializeFromTriangleSnapsho
 	unsigned int bond_idx = 0;
         for (unsigned group_idx = 0; group_idx < snapshot.groups.size(); group_idx++)
             {
-            std::cout << group_idx << " " << snapshot.groups.size() << std::endl;
             std::vector<unsigned int> triag_tag(3);
             std::vector<typename BondedGroupData<group_size, Group, name, true>::members_t> bonds(
                 3);


### PR DESCRIPTION
## Description

I figured out a way to significantly speed up the generation of the meshbond list. This speeds up large systems in particular.

## How has this been tested?

Tests still pass and mesh construction is now 100x faster

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
- [x] I have summarized these changes in `CHANGELOG.rst` following the established format.
