### PR TITLE
Fix vector symbol rendering in katex.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,14 @@ Change Log
 5.x
 ---
 
+5.3.2 (not yet released)
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+*Fixed*
+
+* Display vector math symbol correctly in the documentation
+  (`#2109 <https://github.com/glotzerlab/hoomd-blue/pull/2109>`__).
+
 5.3.1 (2025-07-18)
 ^^^^^^^^^^^^^^^^^^
 

--- a/sphinx-doc/_static/fix-katex.css
+++ b/sphinx-doc/_static/fix-katex.css
@@ -1,0 +1,6 @@
+.katex .overlay {
+  background-color: transparent;
+  opacity: 1;
+  position: static;
+  transition: all 0s ease 0s;
+}

--- a/sphinx-doc/conf.py
+++ b/sphinx-doc/conf.py
@@ -34,6 +34,10 @@ extensions = [
 
 if find_spec("sphinxcontrib.katex") is not None:
     extensions.append("sphinxcontrib.katex")
+
+    katex_options = r"""{
+        output: 'mathml',
+    }"""
 else:
     extensions.append("sphinx.ext.mathjax")
 

--- a/sphinx-doc/conf.py
+++ b/sphinx-doc/conf.py
@@ -35,7 +35,7 @@ extensions = [
 if find_spec("sphinxcontrib.katex") is not None:
     extensions.append("sphinxcontrib.katex")
 
-    html_css_files = ['fix-katex.css']
+    html_css_files = ["fix-katex.css"]
 else:
     extensions.append("sphinx.ext.mathjax")
 

--- a/sphinx-doc/conf.py
+++ b/sphinx-doc/conf.py
@@ -35,9 +35,7 @@ extensions = [
 if find_spec("sphinxcontrib.katex") is not None:
     extensions.append("sphinxcontrib.katex")
 
-    katex_options = r"""{
-        output: 'mathml',
-    }"""
+    html_css_files = ['fix-katex.css']
 else:
     extensions.append("sphinx.ext.mathjax")
 


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should be based on *trunk-patch*. -->
<!-- Backwards compatible new features should be based on *trunk-minor*. -->
<!-- Incompatible API changes should be based on *trunk-major*. -->

## Description

<!-- Describe your changes in detail. -->
Fix the `\vec{v}` symbols in the documentation.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
None of the vector symbols are rendering in the documentation. This appears to be a common issue related to css and themes: https://github.com/KaTeX/KaTeX/issues?q=is%3Aissue%20state%3Aclosed%20vec

The shortest way to work around this issue is to override the css `overlay` class applied to katex entries. This workaround is prone to breakage should furo later set any new css properties in overlay. https://github.com/KaTeX/KaTeX/issues/1456

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
* [x] Test in Firefox
* [x] Test in Safari
* [x] Test in Chrome

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
- [x] I have summarized these changes in `CHANGELOG.rst` following the established format.
