### PR TITLE
Fix katex errors when building the docs.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,8 @@ Change Log
 
 * Display vector math symbol correctly in the documentation
   (`#2109 <https://github.com/glotzerlab/hoomd-blue/pull/2109>`__).
+* Display equations correctly in the documentation
+  (`#2118 <https://github.com/glotzerlab/hoomd-blue/pull/2118>`__).
 
 5.3.1 (2025-07-18)
 ^^^^^^^^^^^^^^^^^^

--- a/hoomd/hpmc/update.py
+++ b/hoomd/hpmc/update.py
@@ -171,7 +171,7 @@ class BoxMC(Updater):
           \left( xy^t = xy,
                 \enspace xz,
                 \enspace yz + s_{yz} \right) & \frac{2}{3} \le u \le 1 \\
-          \end{cases} \\
+          \end{cases}
 
       where :math:`u` is a random value uniformly distributed in the interval
       :math:`[0, 1]` and :math:`s_k` is a random value uniformly distributed in
@@ -870,7 +870,7 @@ class QuickCompress(Updater):
           & yz_\mathrm{target} < yz \\
           \max( yz + (1-s) \cdot yz_\mathrm{target}, yz_\mathrm{target} )
           & yz_\mathrm{target} \ge yz
-          \end{cases} \\
+          \end{cases}
           \end{split}
 
     and in 2D:

--- a/hoomd/md/compute.py
+++ b/hoomd/md/compute.py
@@ -89,6 +89,7 @@ class ThermodynamicQuantities(Compute):
 
         .. math::
 
+            \\begin{align*}
             W_\\mathrm{isotropic} = & \\left(
             W_{\\mathrm{net},\\mathrm{additional}}^{xx}
             + W_{\\mathrm{net},\\mathrm{additional}}^{yy}
@@ -98,6 +99,7 @@ class ThermodynamicQuantities(Compute):
             + W_\\mathrm{{net},i}^{yy}
             + W_\\mathrm{{net},i}^{zz}
             \\right)
+            \\end{align*}
 
         where the net virial terms are computed by `hoomd.md.Integrator`
         over all of the forces in `hoomd.md.Integrator.forces` and

--- a/hoomd/md/force.py
+++ b/hoomd/md/force.py
@@ -411,8 +411,11 @@ class Active(Force):
 
     .. math::
 
-        \vec{F}_i = \mathbf{q}_i \vec{f}_i \mathbf{q}_i^* \\
-        \vec{\tau}_i = \mathbf{q}_i \vec{u}_i \mathbf{q}_i^*,
+        \vec{F}_i = \mathbf{q}_i \vec{f}_i \mathbf{q}_i^*
+
+    .. math::
+
+        \vec{\tau}_i = \mathbf{q}_i \vec{u}_i \mathbf{q}_i^*
 
     where :math:`\vec{f}_i` is the active force in the local particle
     coordinate system (set by type `active_force`) and :math:`\vec{u}_i`

--- a/hoomd/md/force.py
+++ b/hoomd/md/force.py
@@ -433,13 +433,12 @@ class Active(Force):
     Examples::
 
         all = hoomd.filter.All()
-        active = hoomd.md.force.Active(
-            filter=hoomd.filter.All()
-            )
-        active.active_force['A','B'] = (1,0,0)
-        active.active_torque['A','B'] = (0,0,0)
+        active = hoomd.md.force.Active(filter=hoomd.filter.All())
+        active.active_force["A", "B"] = (1, 0, 0)
+        active.active_torque["A", "B"] = (0, 0, 0)
         rotational_diffusion_updater = active.create_diffusion_updater(
-            trigger=10)
+            trigger=10
+        )
         sim.operations += rotational_diffusion_updater
 
     Note:

--- a/hoomd/md/pair/aniso.py
+++ b/hoomd/md/pair/aniso.py
@@ -84,7 +84,7 @@ class Dipole(AnisotropicPair):
                 - \frac{(\vec{\mu_i}\cdot \vec{r_{ji}})q_j}{r^3}
             \right) \\
         U_{ee} &= A e^{-\kappa r} \frac{q_i q_j}{r}
-        \end{split} \\
+        \end{split}
 
     Note:
        All units are documented electronic dipole moments. However, `Dipole`

--- a/hoomd/md/pair/pair.py
+++ b/hoomd/md/pair/pair.py
@@ -1137,7 +1137,7 @@ class Moliere(Pair):
 
     .. math::
         U(r) = \frac{Z_i Z_j e^2}{4 \pi \epsilon_0 r_{ij}} \left[ 0.35 \exp
-          \left( -0.3 \frac{r_{ij}}{a_F} \right) + \\
+          \left( -0.3 \frac{r_{ij}}{a_F} \right) +
           0.55 \exp \left( -1.2 \frac{r_{ij}}{a_F} \right) + 0.10 \exp
           \left( -6.0 \frac{r_{ij}}{a_F} \right) \right]
 
@@ -1220,9 +1220,9 @@ class ZBL(Pair):
     .. math::
         U(r) =
           \frac{Z_i Z_j e^2}{4 \pi \epsilon_0 r_{ij}} \left[ 0.1818
-          \exp \left( -3.2 \frac{r_{ij}}{a_F} \right) \right. \\
-          + 0.5099 \exp \left( -0.9423 \frac{r_{ij}}{a_F} \right) \\
-          + 0.2802 \exp \left( -0.4029 \frac{r_{ij}}{a_F} \right) \\
+          \exp \left( -3.2 \frac{r_{ij}}{a_F} \right) \right.
+          + 0.5099 \exp \left( -0.9423 \frac{r_{ij}}{a_F} \right)
+          + 0.2802 \exp \left( -0.4029 \frac{r_{ij}}{a_F} \right)
           + \left. 0.02817 \exp \left( -0.2016 \frac{r_{ij}}{a_F} \right)
           \right]
 
@@ -1536,14 +1536,12 @@ class DLVO(Pair):
     on every particle in the simulation state with:
 
     .. math::
-        \begin{split}
-        V_{\mathrm{DLVO}}(r) = &- \frac{A}{6} \left[
+        V_{\mathrm{DLVO}}(r) = - \frac{A}{6} \left[
             \frac{2a_1a_2}{r^2 - (a_1+a_2)^2} +
-            \frac{2a_1a_2}{r^2 - (a_1-a_2)^2} \\
+            \frac{2a_1a_2}{r^2 - (a_1-a_2)^2}
             + \log \left(
-            \frac{r^2 - (a_1+a_2)^2}{r^2 - (a_1-a_2)^2} \right) \right] \\
-            & + \frac{a_1 a_2}{a_1+a_2} Z e^{-\kappa(r - (a_1+a_2))}
-        \end{split}
+            \frac{r^2 - (a_1+a_2)^2}{r^2 - (a_1-a_2)^2} \right) \right]
+            + \frac{a_1 a_2}{a_1+a_2} Z e^{-\kappa(r - (a_1+a_2))}
 
     where :math:`a_1` is the radius of first particle in the pair, :math:`a_2`
     is the radius of second particle in the pair, :math:`A` is the Hamaker
@@ -2195,8 +2193,8 @@ class Zetterling(Pair):
     state:
 
     .. math::
-        U(r) = A \\frac{\\exp{(\\alpha r)\\cos{(2 k_F r)}}}{r^3}
-              + B \\left( \\frac{\\sigma}{r} \\right)^n
+        U(r) = A \frac{\exp{(\alpha r)\cos{(2 k_F r)}}}{r^3}
+              + B \left( \frac{\sigma}{r} \right)^n
 
     The potential was introduced in `F. H. M. Zetterling, M. Dzugutov, and S. Lidin
     2001`_.

--- a/hoomd/md/pair/pair.py
+++ b/hoomd/md/pair/pair.py
@@ -1156,15 +1156,15 @@ class Moliere(Pair):
     Example::
 
         nl = nlist.Cell()
-        moliere = pair.Moliere(default_r_cut = 3.0, nlist=nl)
+        moliere = pair.Moliere(default_r_cut=3.0, nlist=nl)
 
         Zi = 54
         Zj = 7
         e = 1
         a0 = 1
-        aF = 0.8853 * a0 / (np.sqrt(Zi) + np.sqrt(Zj))**(2/3)
+        aF = 0.8853 * a0 / (np.sqrt(Zi) + np.sqrt(Zj)) ** (2 / 3)
 
-        moliere.params[('A', 'B')] = dict(qi=Zi*e, qj=Zj*e, aF=aF)
+        moliere.params[("A", "B")] = dict(qi=Zi * e, qj=Zj * e, aF=aF)
 
     {inherited}
 
@@ -1246,9 +1246,9 @@ class ZBL(Pair):
         Zj = 7
         e = 1
         a0 = 1
-        aF = 0.8853 * a0 / (Zi**(0.23) + Zj**(0.23))
+        aF = 0.8853 * a0 / (Zi ** (0.23) + Zj ** (0.23))
 
-        zbl.params[('A', 'B')] = dict(qi=Zi*e, qj=Zj*e, aF=aF)
+        zbl.params[("A", "B")] = dict(qi=Zi * e, qj=Zj * e, aF=aF)
 
     {inherited}
 
@@ -1557,9 +1557,9 @@ class DLVO(Pair):
 
         nl = hoomd.md.nlist.Cell()
         dlvo = hoomd.md.pair.DLVO(nlist=nl)
-        dlvo.params[('A', 'A')] = dict(A=1.0, kappa=1.0, Z=2, a1=1, a2=1)
-        dlvo.params[('A', 'B')] = dict(A=2.0, kappa=0.5, Z=3, a1=1, a2=3)
-        dlvo.params[('B', 'B')] = dict(A=2.0, kappa=0.5, Z=3, a1=3, a2=3)
+        dlvo.params[("A", "A")] = dict(A=1.0, kappa=1.0, Z=2, a1=1, a2=1)
+        dlvo.params[("A", "B")] = dict(A=2.0, kappa=0.5, Z=3, a1=1, a2=3)
+        dlvo.params[("B", "B")] = dict(A=2.0, kappa=0.5, Z=3, a1=3, a2=3)
 
     {inherited}
 

--- a/hoomd/md/pytest/test_aniso_pair.py
+++ b/hoomd/md/pytest/test_aniso_pair.py
@@ -472,11 +472,11 @@ def test_aniso_force_computes(make_two_particle_simulation, aniso_forces_and_ene
 
     .. math::
 
-        r_1 = (0, 0, 0.1) \ r_2 = (0, 0, 0.85) \\
-        \theta_1 = (1, 0, 0, 0) \ \theta_2 = (0.86615809, 0.4997701, 0, 0) \\
-        \\
-        r_1 = (0, 0, 0.1) \ r_2 = (0, 0, 1.6) \\
-        \theta_1 = (1, 0, 0, 0) \ \theta_2 = (0.70738827, 0, 0, 0.70682518) \\
+        r_1 = (0, 0, 0.1) \ r_2 = (0, 0, 0.85)
+        \theta_1 = (1, 0, 0, 0) \ \theta_2 = (0.86615809, 0.4997701, 0, 0)
+
+        r_1 = (0, 0, 0.1) \ r_2 = (0, 0, 1.6)
+        \theta_1 = (1, 0, 0, 0) \ \theta_2 = (0.70738827, 0, 0, 0.70682518)
 
     """
     pot = aniso_forces_and_energies.pair_potential(

--- a/sphinx-doc/conf.py
+++ b/sphinx-doc/conf.py
@@ -42,7 +42,7 @@ else:
 if os.getenv("READTHEDOCS"):
     extensions.append("sphinx_copybutton")
     extensions.append("notfound.extension")
-    extensions.append("sphinxcontrib.googleanalytics")
+    # extensions.append("sphinxcontrib.googleanalytics")
     googleanalytics_id = "G-ZR0DNZD21E"
 
     katex_prerender = True

--- a/sphinx-doc/units.rst
+++ b/sphinx-doc/units.rst
@@ -67,10 +67,10 @@ Example base and derived units for common MD unit systems.
      - atomic mass unit
      - atomic mass unit
    * - :math:`[\mathrm{area}]`
-     - :math:`\mathrm{Å}^2`
+     - :math:`\text{\AA}^2`
      - :math:`\mathrm{nm}^2`
    * - :math:`[\mathrm{volume}]`
-     - :math:`\mathrm{Å}^3`
+     - :math:`\text{\AA}^3`
      - :math:`\mathrm{nm}^3`
    * - :math:`[\mathrm{time}]`
      - `48.8882129 fs <https://www.wolframalpha.com/input/?i=angstrom+*+amu%5E%281%2F2%29+*+%28kcal%2FAvogadro+number%29%5E%28%E2%88%921%2F2%29>`__


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should be based on *trunk-patch*. -->
<!-- Backwards compatible new features should be based on *trunk-minor*. -->
<!-- Incompatible API changes should be based on *trunk-major*. -->

## Description

<!-- Describe your changes in detail. -->
Fix katex errors when building the docs.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Make all equations in the docs readable and remove distracting error messages from documentation builds.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
```
$ READTHEDOCS=1 sphinx-build -anWTEv --keep-going -b html --jobs 1 sphinx-doc/ html
```

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
- [x] I have summarized these changes in `CHANGELOG.rst` following the established format.
