### PR TITLE
Fix: Correct alpha parameter implementation in PPPM (line 137)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,14 @@ Change Log
 5.x
 ---
 
+6.0.0 (not released)
+^^^^^^^^^^^^^^^^^^^^
+
+*Fixed*
+
+* Use the provided alpha parameter in ``make_pppm_coulomb_forces``
+  (`#2153 <https://github.com/glotzerlab/hoomd-blue/pull/2153>`__).
+
 5.4.0 (2025-09-26)
 ^^^^^^^^^^^^^^^^^^^^
 

--- a/hoomd/md/long_range/pppm.py
+++ b/hoomd/md/long_range/pppm.py
@@ -134,7 +134,7 @@ def make_pppm_coulomb_forces(nlist, resolution, order, r_cut, alpha=0):
         resolution=resolution,
         order=order,
         r_cut=r_cut,
-        alpha=0,
+        alpha=alpha,
         pair_force=real_space_force,
     )
 

--- a/sphinx-doc/credits.rst
+++ b/sphinx-doc/credits.rst
@@ -134,3 +134,4 @@ The following people have contributed to HOOMD-blue:
 * Nathan Barrett, Pritzker School of Molecular Engineering
 * Domagoj Fijan, University of Michigan
 * Cristina Butu, Columbia University
+* Shuo-Lin Weng, Texas A&M University


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should be based on *trunk-patch*. -->
<!-- Backwards compatible new features should be based on *trunk-minor*. -->
<!-- Incompatible API changes should be based on *trunk-major*. -->

## Description

Fix the alpha parameter implementation in PPPM method (`hoomd/md/long_range/pppm.py`, line 137).

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

<!-- Replace ??? with the issue number that this pull request resolves. -->
Fixes an issue where the PPPM always behaved as if `alpha=0`, regardless of the value set in `hoomd.md.long_range.pppm.make_pppm_coulomb_forces()`. The update ensures that the specified `alpha` parameter is correctly passed and applied during PPPM force construction.

Resolves #2152

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

Using the same testing code as in #2152, setting `alpha` to non-zero values now produces distinct energy curves—confirming that the parameter is correctly applied.

## Checklist:

- [X] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.rst).
- [X] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [ ] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
- [x] I have summarized these changes in `CHANGELOG.rst` following the established format.
