### PR TITLE
Handle 2 and 3+ key sets consistently.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,16 @@ Change Log
 * Use the provided alpha parameter in ``make_pppm_coulomb_forces``
   (`#2153 <https://github.com/glotzerlab/hoomd-blue/pull/2153>`__).
 
+*Changed*
+
+* Setting two tuples of type parameters like this ``lj.r_cut[('A', 'B'), ('C', 'D')] = ...``
+  now sets the parameters A-B and C-D. This is consistent with the behavior when setting
+  more than two parameters. For example: ``lj.r_cut[('A', 'B'), ('C', 'D'), ('E', 'F')] = ...``
+  sets parameters for A-B, C-D, and E-F. In previous HOOMD-blue releases, the two-tuple
+  code path was different (it would set A-C, A-D, B-C, and B-D). Update your scripts
+  accordingly.
+  (`#2157 <https://github.com/glotzerlab/hoomd-blue/pull/2157>`__)
+
 5.4.0 (2025-09-26)
 ^^^^^^^^^^^^^^^^^^^^
 

--- a/hoomd/data/parameterdicts.py
+++ b/hoomd/data/parameterdicts.py
@@ -6,7 +6,7 @@
 from abc import abstractmethod
 from collections.abc import Mapping, MutableMapping
 from copy import copy
-from itertools import product, combinations_with_replacement
+from itertools import combinations_with_replacement
 
 import numpy as np
 
@@ -112,7 +112,7 @@ class _SmartTypeIndexer:
         if self.len_key == 1:
             return self.validate_and_split_len_one(key)
         else:
-            return self.validate_and_split_len(key)
+            return self.validate_and_split_len(key, key)
 
     def validate_and_split_len_one(self, key):
         """Validate single type keys.
@@ -130,28 +130,25 @@ class _SmartTypeIndexer:
         else:
             raise KeyError("The key {} is not valid.".format(key))
 
-    def validate_and_split_len(self, key):
+    def validate_and_split_len(self, key, parent):
         """Validate all key lengths greater than one, N.
 
-        Valid input is an arbitrarily deep series of iterables that culminate
-        in N length tuples, this includes an iterable depth of zero.  The N
-        length tuples can contain for each member either a type string or an
-        iterable of type strings.
+        Due to the way that __setitem__ behaves, inputs are either a tuple with
+        ``len_key`` strings OR an iterator over tuples of ``len_key`` strings.
         """
-        if isinstance(key, tuple) and len(key) == self.len_key:
-            if any([not _is_key_iterable(v) and not isinstance(v, str) for v in key]):
-                raise KeyError("The key {} is not valid.".format(key))
-            # convert str to single item list for proper enumeration using
-            # product
-            key_types_list = [[v] if isinstance(v, str) else v for v in key]
-            return list(product(*key_types_list))
+        if (
+            isinstance(key, tuple)
+            and len(key) == self.len_key
+            and all(isinstance(v, str) for v in key)
+        ):
+            return [key]
         elif _is_iterable(key):
             keys = []
             for k in key:
-                keys.extend(self.validate_and_split_len(k))
+                keys.extend(self.validate_and_split_len(k, key))
             return keys
         else:
-            raise KeyError("The key {} is not valid.".format(key))
+            raise KeyError("The key {} is not valid.".format(parent))
 
     @property
     def valid_types(self):

--- a/hoomd/data/typeparam.py
+++ b/hoomd/data/typeparam.py
@@ -90,7 +90,7 @@ class TypeParameter(MutableMapping):
 
         .. code-block:: python
 
-            langevin.gamma[["B", "C"]] = 3.0
+            langevin.gamma["B", "C", "D"] = 3.0
 
         Set type pair parameters with a tuple of names:
 
@@ -100,22 +100,14 @@ class TypeParameter(MutableMapping):
 
             lj.params[("A", "A")] = dict(epsilon=1.5, sigma=2.0)
 
-        Set parameters for multiple pairs (e.g. ('A', 'B') and ('A', 'C')):
+        Set parameters for multiple pairs (e.g. ('A', 'B'), ('C', 'D'),
+        and ('E', 'F')):
 
         .. skip: next if(not hoomd.version.md_built)
 
         .. code-block:: python
 
-            lj.params[("A", ["B", "C"])] = dict(epsilon=0, sigma=0)
-
-        Set parameters for multiple pairs (e.g. ('B', 'B'), ('B', 'C'), ('C',
-        'B'), and ('C', 'C')):
-
-        .. skip: next if(not hoomd.version.md_built)
-
-        .. code-block:: python
-
-            lj.params[(["B", "C"], ["B", "C"])] = dict(epsilon=1, sigma=1)
+            lj.params[("A", "B"), ("B", "C"), ("E", "F")] = dict(epsilon=0, sigma=0)
 
         Note:
             Setting the value for *(a,b)* automatically sets the symmetric

--- a/hoomd/pytest/test_type_parameter_dict.py
+++ b/hoomd/pytest/test_type_parameter_dict.py
@@ -129,16 +129,26 @@ class TestTypeParameterDict(BaseMappingTest):
             if len_keys == 1:
                 yield types, set(types)
                 return
-            yield (types[0], types[1:]), {(types[0], t) for t in types[1:]}
-            keys = [(types[-1], t) for t in types[:2]]
-            yield keys, set(tuple(sorted(k)) for k in keys)
-            if len(types) > 4:
-                mid_point = len(types) // 2
-                key_spec = (types[:mid_point], types[mid_point:])
-                keys = {
-                    (t1, t2) for t2 in types[mid_point:] for t1 in types[mid_point:]
-                }
-                yield key_spec, keys
+            for i in range(n):
+                for j in range(n):
+                    key = (types[i], types[j])
+                    sorted_key = list(key)
+                    sorted_key.sort()
+                    yield key, set((tuple(sorted_key),))
+
+            if n >= 2:
+                keys = ((types[0], types[0]), (types[1], types[1]))
+                yield keys, set(keys)
+                keys = ((types[0], types[1]), (types[1], types[1]))
+                yield keys, set(keys)
+
+            if n >= 3:
+                keys = (
+                    (types[0], types[0]),
+                    (types[1], types[1]),
+                    (types[2], types[2]),
+                )
+                yield keys, set(keys)
 
         return yield_key_pairs
 

--- a/sphinx-doc/deprecated.rst
+++ b/sphinx-doc/deprecated.rst
@@ -1,14 +1,14 @@
 Deprecated
 ==========
 
-Features deprecated in HOOMD 5.x may be removed in a future 5.0.0 release.
+Features deprecated in HOOMD 6.x may be removed in a future 7.0.0 release.
 
 HOOMD may issue `FutureWarning` messages to provide warnings for breaking changes in the next major
 release. Use Python's warnings module to silence warnings which may not be correctable until the
 next major release. Use this filter: ``ignore::FutureWarning:hoomd``. See Python's `warnings`
 documentation for more information on warning filters.
 
-5.x
+6.x
 ---
 
-No features have been deprecated in 5.x releases.
+No features have been deprecated in 6.x releases.

--- a/sphinx-doc/migrating.rst
+++ b/sphinx-doc/migrating.rst
@@ -1,6 +1,20 @@
 Migrating to the latest version
 ===============================
 
+Migrating to HOOMD-blue 6
+-------------------------
+
+Breaking changes to existing functionalities
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Check your scripts for anywhere you set type parameters with two tuples. For example:
+``lj.r_cut(('A', 'B'), ('C', 'D')) = ...``. In HOOMD-blue 5.x and prior versions, this
+would take the product and set the A-C, A-D, B-C, and B-D parameters. In HOOMD-blue
+6 and later, this will set the A-B and C-D parameters. Identify what parameters  you
+intend to set and adjust your script accordingly. Many users expect the new behavior
+because it is consistent with setting 3 (or more) tuples:
+``lj.r_cut(('A', 'B'), ('C', 'D'), ('E', 'F')) = ...`` sets parameters for A-B, C-D, and E-F.
+
 Migrating to HOOMD-blue 5
 -------------------------
 

--- a/sphinx-doc/migrating.rst
+++ b/sphinx-doc/migrating.rst
@@ -8,12 +8,12 @@ Breaking changes to existing functionalities
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Check your scripts for anywhere you set type parameters with two tuples. For example:
-``lj.r_cut(('A', 'B'), ('C', 'D')) = ...``. In HOOMD-blue 5.x and prior versions, this
+``lj.r_cut[('A', 'B'), ('C', 'D')] = ...``. In HOOMD-blue 5.x and prior versions, this
 would take the product and set the A-C, A-D, B-C, and B-D parameters. In HOOMD-blue
 6 and later, this will set the A-B and C-D parameters. Identify what parameters  you
 intend to set and adjust your script accordingly. Many users expect the new behavior
 because it is consistent with setting 3 (or more) tuples:
-``lj.r_cut(('A', 'B'), ('C', 'D'), ('E', 'F')) = ...`` sets parameters for A-B, C-D, and E-F.
+``lj.r_cut[('A', 'B'), ('C', 'D'), ('E', 'F')] = ...`` sets parameters for A-B, C-D, and E-F.
 
 Migrating to HOOMD-blue 5
 -------------------------


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should be based on *trunk-patch*. -->
<!-- Backwards compatible new features should be based on *trunk-minor*. -->
<!-- Incompatible API changes should be based on *trunk-major*. -->

## Description

<!-- Describe your changes in detail. -->
Handle 2 and 3+ key sets consistently when setting type parameters.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Discussed in #2156. 

<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves #2156

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
Altered unit tests verify expected behavior.

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
- [x] I have summarized these changes in `CHANGELOG.rst` following the established format.
