### PR TITLE
Export‑name validation and conflict resolution for FreeVolume

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,7 @@ Change Log
 
 * Use the provided alpha parameter in ``make_pppm_coulomb_forces``
   (`#2153 <https://github.com/glotzerlab/hoomd-blue/pull/2153>`__).
+* Add a unit test to verify that the export name of ``hoomd.hpmc.compute.FreeVolume``, and resolved the existing export name conflicts (`#2163 <https://github.com/glotzerlab/hoomd-blue/pull/2163>`__).
 
 5.4.0 (2025-09-26)
 ^^^^^^^^^^^^^^^^^^^^

--- a/hoomd/hpmc/module_convex_spheropolyhedron.cc
+++ b/hoomd/hpmc/module_convex_spheropolyhedron.cc
@@ -32,7 +32,7 @@ namespace detail
 void export_convex_spheropolyhedron(pybind11::module& m)
     {
     export_IntegratorHPMCMono<ShapeSpheropolyhedron>(m, "IntegratorHPMCMonoSpheropolyhedron");
-    export_ComputeFreeVolume<ShapeSpheropolyhedron>(m, "ComputeFreeVolumeSpheropolyhedron");
+    export_ComputeFreeVolume<ShapeSpheropolyhedron>(m, "ComputeFreeVolumeConvexSpheropolyhedron");
     export_ComputeSDF<ShapeSpheropolyhedron>(m, "ComputeSDFConvexSpheropolyhedron");
     export_UpdaterMuVT<ShapeSpheropolyhedron>(m, "UpdaterMuVTConvexSpheropolyhedron");
     export_UpdaterGCA<ShapeSpheropolyhedron>(m, "UpdaterGCAConvexSpheropolyhedron");
@@ -48,7 +48,7 @@ void export_convex_spheropolyhedron(pybind11::module& m)
 #ifdef ENABLE_HIP
 
     export_IntegratorHPMCMonoGPU<ShapeSpheropolyhedron>(m, "IntegratorHPMCMonoSpheropolyhedronGPU");
-    export_ComputeFreeVolumeGPU<ShapeSpheropolyhedron>(m, "ComputeFreeVolumeSpheropolyhedronGPU");
+    export_ComputeFreeVolumeGPU<ShapeSpheropolyhedron>(m, "ComputeFreeVolumeConvexSpheropolyhedronGPU");
     export_UpdaterGCAGPU<ShapeSpheropolyhedron>(m, "UpdaterGCAConvexSpheropolyhedronGPU");
 
 #endif

--- a/hoomd/hpmc/module_convex_spheropolyhedron.cc
+++ b/hoomd/hpmc/module_convex_spheropolyhedron.cc
@@ -48,7 +48,9 @@ void export_convex_spheropolyhedron(pybind11::module& m)
 #ifdef ENABLE_HIP
 
     export_IntegratorHPMCMonoGPU<ShapeSpheropolyhedron>(m, "IntegratorHPMCMonoSpheropolyhedronGPU");
-    export_ComputeFreeVolumeGPU<ShapeSpheropolyhedron>(m, "ComputeFreeVolumeConvexSpheropolyhedronGPU");
+    export_ComputeFreeVolumeGPU<ShapeSpheropolyhedron>(
+        m,
+        "ComputeFreeVolumeConvexSpheropolyhedronGPU");
     export_UpdaterGCAGPU<ShapeSpheropolyhedron>(m, "UpdaterGCAConvexSpheropolyhedronGPU");
 
 #endif

--- a/hoomd/hpmc/module_spheropolygon.cc
+++ b/hoomd/hpmc/module_spheropolygon.cc
@@ -29,7 +29,7 @@ namespace detail
 void export_spheropolygon(pybind11::module& m)
     {
     export_IntegratorHPMCMono<ShapeSpheropolygon>(m, "IntegratorHPMCMonoSpheropolygon");
-    export_ComputeFreeVolume<ShapeSpheropolygon>(m, "ComputeFreeVolumeSpheropolygon");
+    export_ComputeFreeVolume<ShapeSpheropolygon>(m, "ComputeFreeVolumeConvexSpheropolygon");
     export_ComputeSDF<ShapeSpheropolygon>(m, "ComputeSDFConvexSpheropolygon");
     export_UpdaterMuVT<ShapeSpheropolygon>(m, "UpdaterMuVTConvexSpheropolygon");
     export_UpdaterGCA<ShapeSpheropolygon>(m, "UpdaterGCAConvexSpheropolygon");
@@ -38,7 +38,7 @@ void export_spheropolygon(pybind11::module& m)
 
 #ifdef ENABLE_HIP
     export_IntegratorHPMCMonoGPU<ShapeSpheropolygon>(m, "IntegratorHPMCMonoSpheropolygonGPU");
-    export_ComputeFreeVolumeGPU<ShapeSpheropolygon>(m, "ComputeFreeVolumeSpheropolygonGPU");
+    export_ComputeFreeVolumeGPU<ShapeSpheropolygon>(m, "ComputeFreeVolumeConvexSpheropolygonGPU");
     export_UpdaterGCAGPU<ShapeSpheropolygon>(m, "UpdaterGCAConvexSpheropolygonGPU");
 #endif
     }

--- a/hoomd/hpmc/module_union_convex_polyhedron.cc
+++ b/hoomd/hpmc/module_union_convex_polyhedron.cc
@@ -34,7 +34,7 @@ void export_union_convex_polyhedron(pybind11::module& m)
         "IntegratorHPMCMonoConvexPolyhedronUnion");
     export_ComputeFreeVolume<ShapeUnion<ShapeSpheropolyhedron>>(
         m,
-        "ComputeFreeVolumeConvexPolyhedronUnion");
+        "ComputeFreeVolumeConvexSpheropolyhedronUnion");
     export_ComputeSDF<ShapeUnion<ShapeSpheropolyhedron>>(m,
                                                          "ComputeSDFConvexSpheropolyhedronUnion");
     export_UpdaterMuVT<ShapeUnion<ShapeSpheropolyhedron>>(m,
@@ -52,7 +52,7 @@ void export_union_convex_polyhedron(pybind11::module& m)
         "IntegratorHPMCMonoConvexPolyhedronUnionGPU");
     export_ComputeFreeVolumeGPU<ShapeUnion<ShapeSpheropolyhedron>>(
         m,
-        "ComputeFreeVolumeConvexPolyhedronUnionGPU");
+        "ComputeFreeVolumeConvexSpheropolyhedronUnionGPU");
     export_UpdaterGCAGPU<ShapeUnion<ShapeSpheropolyhedron>>(
         m,
         "UpdaterGCAConvexSpheropolyhedronUnionGPU");

--- a/hoomd/hpmc/pytest/test_compute_free_volume.py
+++ b/hoomd/hpmc/pytest/test_compute_free_volume.py
@@ -114,3 +114,37 @@ def test_2d_free_volume(simulation_factory):
     f = free_volume.free_volume
     if snapshot.communicator.rank == 0:
         assert f == pytest.approx(expected=100 * 100 - math.pi, rel=1e-3)
+
+
+def test_free_volume_export_name_matches_integrator(
+    simulation_factory, two_particle_snapshot_factory, valid_args
+):
+    integrator = valid_args[0]
+    args = valid_args[1]
+    n_dimensions = valid_args[2]
+
+    if isinstance(integrator, tuple):
+        inner_integrator = integrator[0]
+        integrator = integrator[1]
+        inner_mc = inner_integrator()
+        for i in range(len(args["shapes"])):
+            # This will fill in default values for the inner shape objects
+            inner_mc.shape["A"] = args["shapes"][i]
+            args["shapes"][i] = inner_mc.shape["A"].to_base()
+
+    mc = integrator()
+    mc.shape["A"] = args
+    sim = simulation_factory(two_particle_snapshot_factory(dimensions=n_dimensions))
+    assert sim.operations.integrator is None
+    sim.operations.add(mc)
+    sim.operations._schedule()
+
+    free_vol = hoomd.hpmc.compute.FreeVolume(test_particle_type="A", num_samples=10)
+    sim.operations.computes.append(free_vol)
+
+    try:
+        sim.run(1)
+    except AttributeError as e:
+        pytest.fail(
+            f"FreeVolume export class name mismatch for {integrator.__name__}: {e}"
+        )

--- a/hoomd/hpmc/pytest/test_compute_free_volume.py
+++ b/hoomd/hpmc/pytest/test_compute_free_volume.py
@@ -117,7 +117,7 @@ def test_2d_free_volume(simulation_factory):
 
 
 def test_free_volume_export_name_matches_integrator(
-    simulation_factory, two_particle_snapshot_factory, valid_args
+    device, simulation_factory, two_particle_snapshot_factory, valid_args
 ):
     integrator = valid_args[0]
     args = valid_args[1]

--- a/hoomd/hpmc/pytest/test_compute_free_volume.py
+++ b/hoomd/hpmc/pytest/test_compute_free_volume.py
@@ -132,7 +132,9 @@ def test_free_volume_export_name_matches_integrator(
             inner_mc.shape["A"] = args["shapes"][i]
             args["shapes"][i] = inner_mc.shape["A"].to_base()
 
-    if integrator == hoomd.hpmc.integrate.Sphinx and isinstance(device, hoomd.device.GPU):
+    if integrator == hoomd.hpmc.integrate.Sphinx and isinstance(
+        device, hoomd.device.GPU
+    ):
         pytest.skip("Sphinx does not build on the GPU by default.")
 
     mc = integrator()

--- a/hoomd/hpmc/pytest/test_compute_free_volume.py
+++ b/hoomd/hpmc/pytest/test_compute_free_volume.py
@@ -132,6 +132,9 @@ def test_free_volume_export_name_matches_integrator(
             inner_mc.shape["A"] = args["shapes"][i]
             args["shapes"][i] = inner_mc.shape["A"].to_base()
 
+    if integrator == hoomd.hpmc.integrate.Sphinx and isinstance(device, hoomd.device.GPU):
+        pytest.skip("Sphinx does not build on the GPU by default.")
+
     mc = integrator()
     mc.shape["A"] = args
     sim = simulation_factory(two_particle_snapshot_factory(dimensions=n_dimensions))

--- a/sphinx-doc/credits.rst
+++ b/sphinx-doc/credits.rst
@@ -89,6 +89,7 @@ The following people have contributed to HOOMD-blue:
 * Michael Howard, Auburn University
 * Michaela Bush, Auburn University
 * Mike Henry, Boise State University
+* Ming Zhu, Wuhan University
 * Nathan Horst
 * Nipuli Gunaratne, University of Michigan
 * Nicholas Cal Craven, Vanderbilt University


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should be based on *trunk-patch*. -->
<!-- Backwards compatible new features should be based on *trunk-minor*. -->
<!-- Incompatible API changes should be based on *trunk-major*. -->

## Description

<!-- Describe your changes in detail. -->
This PR adds a unit test checking that the export name of `FreeVolume` compute matches the integrator class name, and resolves an existing export‑name conflict for the `FreeVolume` class in the HPMC module.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
<!-- Replace ??? with the issue number that this pull request resolves. -->
Discussed in #2160
Resolves #2160

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
A variation on `test_shape_attached` that added `compute.FreeVolume` tests that all C++ export names are correct.

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
- [x] I have summarized these changes in `CHANGELOG.rst` following the established format.
