### PR TITLE
Fix scale tuner

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,8 @@ Next release
 * Use the provided alpha parameter in ``make_pppm_coulomb_forces``
   (`#2153 <https://github.com/glotzerlab/hoomd-blue/pull/2153>`__).
 * Add a unit test to verify that the export name of ``hoomd.hpmc.compute.FreeVolume``, and resolved the existing export name conflicts (`#2163 <https://github.com/glotzerlab/hoomd-blue/pull/2163>`__).
+* Scale move sizes correctly when the acceptance rate is 0
+  (`#2174 <https://github.com/glotzerlab/hoomd-blue/pull/2174>`__).
 
 5.4.0 (2025-09-26)
 ^^^^^^^^^^^^^^^^^^^^

--- a/hoomd/hpmc/pytest/test_boxmc_move_tuner.py
+++ b/hoomd/hpmc/pytest/test_boxmc_move_tuner.py
@@ -291,3 +291,24 @@ class TestMoveSize:
     def test_pickling(self, boxmc_with_tuner, simulation):
         _, move_size_tuner = boxmc_with_tuner
         operation_pickling_check(move_size_tuner, simulation)
+
+
+@pytest.mark.cpu
+@pytest.mark.serial
+def test_zero_acceptance(simulation):
+    boxmc = hpmc.update.BoxMC(1, P=1.0)
+    boxmc.volume = {"weight": 1.0, "delta": 0.5, "mode": "standard"}
+    move_size_tuner = BoxMCMoveSize.scale_solver(10, boxmc, ["volume"], 0.5)
+
+    # Place overlapping particles to force all box moves to be rejected.
+    snapshot = simulation.state.get_snapshot()
+    snapshot.particles.position[0] = (0, 0, 0)
+    snapshot.particles.position[1] = (0, 0, 0)
+    simulation.state.set_snapshot(snapshot)
+
+    simulation.operations.tuners.append(move_size_tuner)
+    simulation.operations += boxmc
+    simulation.run(11)
+    tunable = move_size_tuner._tunables[0]
+    assert tunable.y == 0
+    assert boxmc.volume["delta"] < 0.5

--- a/hoomd/tune/solve.py
+++ b/hoomd/tune/solve.py
@@ -152,9 +152,9 @@ class ScaleSolver(RootSolver):
         else:
             # y was zero. Try a value an order of magnitude smaller
             if self.correlation == "positive":
-                scale = 0.1
-            else:
                 scale = 1.1
+            else:
+                scale = 0.9
 
         if scale > self.max_scale:
             scale = self.max_scale


### PR DESCRIPTION
<!-- Please confirm that your work is based on the correct branch. -->
<!-- Bug fixes should be based on *trunk-patch*. -->
<!-- Backwards compatible new features should be based on *trunk-minor*. -->
<!-- Incompatible API changes should be based on *trunk-major*. -->

## Description

<!-- Describe your changes in detail. -->
Scale move sizes the correct direction when the acceptance rate is 0.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
The tuner currently makes moves *larger* when the acceptance is 0. Thus, the tuner will never converge.

## How has this been tested?

A new unit test checks the behavior of the tuner with 0 acceptance.
<!--- Please describe in detail how you tested your changes. -->

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk-minor/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
- [x] I have summarized these changes in `CHANGELOG.rst` following the established format.
