### PR TITLE
Fix NaN error in table writing

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,7 +19,7 @@ Next release
 
 *Fixed*
 
-* Table writer no longer errors on `NaN` scalar values.
+* Table writer no longer errors on ``NaN`` scalar values.
 
 6.0.0 (2025-11-21)
 ^^^^^^^^^^^^^^^^^^^^

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,8 @@ Next release
 
 *Fixed*
 
+* Table writer no longer errors on `NaN` scalar values.
+
 6.0.0 (2025-11-21)
 ^^^^^^^^^^^^^^^^^^^^
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,7 +19,7 @@ Next release
 
 *Fixed*
 
-* Table writer no longer errors on ``NaN`` scalar values.
+* Table writer no longer errors on ``NaN`` scalar values (#2189).
 
 6.0.0 (2025-11-21)
 ^^^^^^^^^^^^^^^^^^^^

--- a/hoomd/pytest/test_table.py
+++ b/hoomd/pytest/test_table.py
@@ -240,6 +240,7 @@ def test_invalid_permutations(device, combination):
     for category in combination - {"string", "scalar"}:
         assert category in str(ve.value)
 
+
 def test_nan_is_ok():
     # Ensure that NaN value doesn't cause table writer to error
     sim = hoomd.util.make_example_simulation()

--- a/hoomd/pytest/test_table.py
+++ b/hoomd/pytest/test_table.py
@@ -239,3 +239,23 @@ def test_invalid_permutations(device, combination):
     # Now ensure category formatting operates correctly
     for category in combination - {"string", "scalar"}:
         assert category in str(ve.value)
+
+def test_nan_is_ok():
+    # Ensure that NaN value doesn't cause table writer to error
+    sim = hoomd.util.make_example_simulation()
+
+    logger = hoomd.logging.Logger(categories=["scalar"])
+    logger[("test", "nan")] = (lambda: float("NaN"), "scalar")
+
+    output = StringIO("")
+
+    table_writer = hoomd.write.Table(
+        trigger=1, 
+        logger=logger,
+        output=output,
+        delimiter=","
+    )
+
+    sim.operations.writers.append(table_writer)
+
+    sim.run(1)

--- a/hoomd/pytest/test_table.py
+++ b/hoomd/pytest/test_table.py
@@ -250,10 +250,7 @@ def test_nan_is_ok():
     output = StringIO("")
 
     table_writer = hoomd.write.Table(
-        trigger=1, 
-        logger=logger,
-        output=output,
-        delimiter=","
+        trigger=1,  logger=logger, output=output, delimiter=","
     )
 
     sim.operations.writers.append(table_writer)

--- a/hoomd/pytest/test_table.py
+++ b/hoomd/pytest/test_table.py
@@ -250,7 +250,7 @@ def test_nan_is_ok():
     output = StringIO("")
 
     table_writer = hoomd.write.Table(
-        trigger=1,  logger=logger, output=output, delimiter=","
+        trigger=1, logger=logger, output=output, delimiter=","
     )
 
     sim.operations.writers.append(table_writer)

--- a/hoomd/write/table.py
+++ b/hoomd/write/table.py
@@ -11,7 +11,7 @@
 from abc import ABCMeta, abstractmethod
 import copy
 from numbers import Integral
-from math import log10
+from math import log10, isnan
 from sys import stdout
 import inspect
 
@@ -126,6 +126,8 @@ class _Formatter:
             # already attempt to print out as many decimal points as possible so
             # we only need to determine the minimum size to from the decimal
             # point including the decimal point.
+            if isnan(value):
+                return "NaN"
             min_len_repr = self._digits_from_decimal(value) + 1
             # Use scientific formatting
             if not min_len_repr < 6 or min_len_repr > column_width:


### PR DESCRIPTION
## Description

Currently, NaN values cause the `hoomd.write.Table` to error when writing to output. The error happens in `write.table._Formatter.format_num()` because the formatter determines a minimum representation of the number by first converting it to `int`, which is not allowed for NaN. Here's a MWE:

```python
sim = hoomd.util.make_example_simulation()

logger = hoomd.logging.Logger(categories=["scalar"])
logger[("test", "nan")] = (lambda: float("NaN"), "scalar")

output = StringIO("")

table_writer = hoomd.write.Table(
    trigger=1, 
    logger=logger,
    output=output,
    delimiter=","
)

sim.operations.writers.append(table_writer)

sim.run(1)
```
which produces the following output:
```
  File "/home/joseph/micromamba/envs/gg/lib/python3.14/site-packages/hoomd/write/table.py", line 102, in __call__
    return self.format_num(value, column_width)
           ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^
  File "/home/joseph/micromamba/envs/gg/lib/python3.14/site-packages/hoomd/write/table.py", line 130, in format_num
    min_len_repr = self._digits_from_decimal(value) + 1
                   ~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^
  File "/home/joseph/micromamba/envs/gg/lib/python3.14/site-packages/hoomd/write/table.py", line 110, in _digits_from_decimal
    digits = int(log10(abs(num)))
ValueError: cannot convert float NaN to integer
```

I have fixed this issue by adding an is-NaN check in `write.table._Formatter.format_num()`, which automatically returns the string `"NaN"` as the minimum representation.

## Motivation and context

While NaN values are almost never desired, they shouldn't cause the table writer to fail. I encountered this issue when writing code to probe the potential energy field around an ALJ particle, which is poorly defined when probing within the particle itself.

## How has this been tested?

I added a small unit test to cover this edge case.

No revisions to the documentation are needed.

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
- [x] I have summarized these changes in `CHANGELOG.rst` following the established format.