### PR TITLE
Jared shi patch 1

### DIFF
--- a/hoomd/md/mesh/bending.py
+++ b/hoomd/md/mesh/bending.py
@@ -103,7 +103,7 @@ class Helfrich(MeshPotential):
     with the area of the dual cell of vertex i
     :math:`\sigma_i=(\sum_{j \in \mathrm{Neigh}(i)}\sigma_{ij})/4`, the
     length of the bond in the dual lattice  :math:`\sigma_{ij}=
-    r_{ij}(\text{cot}\theta_1+\text{cot}\theta_2)/2` and the angles
+    l_{ij}(\text{cot}\theta_1+\text{cot}\theta_2)/2` and the angles
     :math:`\theta_1` and :math:`\theta_2` opposite to the shared bond of
     vertex :math:`i` and :math:`j`.
 

--- a/sphinx-doc/credits.rst
+++ b/sphinx-doc/credits.rst
@@ -58,6 +58,7 @@ The following people have contributed to HOOMD-blue:
 * James Antonaglia, University of Michigan
 * James Proctor, University of Michigan
 * James W. Swan, Massachusetts Institute of Technology
+* Jared Shi, University of Michigan
 * Jen Bradley, University of Michigan
 * Jenny Fothergill, Boise State University
 * Jens Glaser, Oak Ridge National Laboratory


### PR DESCRIPTION
Rename the variable r_ij to l_ij to represent the distance between particles i and j.

## Description

<!-- Describe your changes in detail. -->

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
To prevent potential ambiguity by unifying the variables. Gompper's paper uses l_ij as the distance, while Agrawal's MeMC paper uses R_ij. 


<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves #???

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
- [ ] I have summarized these changes in `CHANGELOG.rst` following the established format.
