### PR TITLE
Dynamical bonding check3

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,7 +21,7 @@ Next release
 
 * Table writer no longer errors on ``NaN`` scalar values (#2189).
 
-* Fixed vertex neighbor check in dynamical bonding code (#2202). 
+* Fixed vertex neighbor check in dynamical bonding code (#2202).
 
 6.0.0 (2025-11-21)
 ^^^^^^^^^^^^^^^^^^^^

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,8 @@ Next release
 
 * Table writer no longer errors on ``NaN`` scalar values (#2189).
 
+* Fixed vertex neighbor check in dynamical bonding code (#2202). 
+
 6.0.0 (2025-11-21)
 ^^^^^^^^^^^^^^^^^^^^
 

--- a/hoomd/md/MeshDynamicBondUpdater.cc
+++ b/hoomd/md/MeshDynamicBondUpdater.cc
@@ -260,7 +260,7 @@ void MeshDynamicBondUpdater::update(uint64_t timestep)
 
             unsigned int counter = 4;
 
-	    bool check_tic = true;
+            bool check_tic = true;
 
             for (unsigned int j = 0; j < 2 && check_tic; ++j)
                 {
@@ -292,30 +292,30 @@ void MeshDynamicBondUpdater::update(uint64_t timestep)
                     if (tic == tr_idx[j])
                         tic = h_neigh_bonds.data[b_idx[2 * j + k]].y;
 
-		    for(unsigned int kk = 2; kk < counter - 2 && check_tic; kk++)
-		    	{
-			if( tic == tr_idx[kk])
-				check_tic = false;
-			}
+                    for (unsigned int kk = 2; kk < counter - 2 && check_tic; kk++)
+                        {
+                        if (tic == tr_idx[kk])
+                            check_tic = false;
+                        }
 
-		    if(check_tic)
-			{
-			    unsigned int zaehler = 1;
-			    unsigned int nv_idx = h_triangles.data[tic].tag[0];
-			    while (nv_idx == v_idx[k] || nv_idx == v_idx[2 + j])
-				{
-				nv_idx = h_triangles.data[tic].tag[zaehler];
-				zaehler++;
-				}
-			    v_idx[counter] = nv_idx;
-			    tr_idx[counter - 2] = tic;
-			    counter++;
-			}
+                    if (check_tic)
+                        {
+                        unsigned int zaehler = 1;
+                        unsigned int nv_idx = h_triangles.data[tic].tag[0];
+                        while (nv_idx == v_idx[k] || nv_idx == v_idx[2 + j])
+                            {
+                            nv_idx = h_triangles.data[tic].tag[zaehler];
+                            zaehler++;
+                            }
+                        v_idx[counter] = nv_idx;
+                        tr_idx[counter - 2] = tic;
+                        counter++;
+                        }
                     }
                 }
 
-	    if(!check_tic)
-		    continue;
+            if (!check_tic)
+                continue;
 
             if (have_to_check_surrounding)
                 {

--- a/hoomd/md/MeshDynamicBondUpdater.cc
+++ b/hoomd/md/MeshDynamicBondUpdater.cc
@@ -260,7 +260,9 @@ void MeshDynamicBondUpdater::update(uint64_t timestep)
 
             unsigned int counter = 4;
 
-            for (unsigned int j = 0; j < 2; ++j)
+	    bool check_tic = true;
+
+            for (unsigned int j = 0; j < 2 && check_tic; ++j)
                 {
                 unsigned int bic = h_neigh_triags.data[tr_idx[j]].x;
                 unsigned int bic2 = h_neigh_triags.data[tr_idx[j]].y;
@@ -284,23 +286,36 @@ void MeshDynamicBondUpdater::update(uint64_t timestep)
                     b_idx[2 * j + 1] = bic;
                     b_idx[2 * j] = bic2;
                     }
-                for (unsigned int k = 0; k < 2; ++k)
+                for (unsigned int k = 0; k < 2 && check_tic; ++k)
                     {
                     unsigned int tic = h_neigh_bonds.data[b_idx[2 * j + k]].x;
                     if (tic == tr_idx[j])
                         tic = h_neigh_bonds.data[b_idx[2 * j + k]].y;
-                    unsigned int zaehler = 1;
-                    unsigned int nv_idx = h_triangles.data[tic].tag[0];
-                    while (nv_idx == v_idx[k] || nv_idx == v_idx[2 + j])
-                        {
-                        nv_idx = h_triangles.data[tic].tag[zaehler];
-                        zaehler++;
-                        }
-                    v_idx[counter] = nv_idx;
-                    tr_idx[counter - 2] = tic;
-                    counter++;
+
+		    for(unsigned int kk = 2; kk < counter - 2 && check_tic; kk++)
+		    	{
+			if( tic == tr_idx[kk])
+				check_tic = false;
+			}
+
+		    if(check_tic)
+			{
+			    unsigned int zaehler = 1;
+			    unsigned int nv_idx = h_triangles.data[tic].tag[0];
+			    while (nv_idx == v_idx[k] || nv_idx == v_idx[2 + j])
+				{
+				nv_idx = h_triangles.data[tic].tag[zaehler];
+				zaehler++;
+				}
+			    v_idx[counter] = nv_idx;
+			    tr_idx[counter - 2] = tic;
+			    counter++;
+			}
                     }
                 }
+
+	    if(!check_tic)
+		    continue;
 
             if (have_to_check_surrounding)
                 {


### PR DESCRIPTION
## Description

The new check fixes a bug of possible duplicated bonds and dangling vertices in the dynamical bonding code. The code now checks at every flip attempt whether both vertices have more than 3 neighbors. 

## Motivation and context

The new code fixes the bug and avoids crashes when using the Helfrich potential

## How has this been tested?

Stress tested at various meshes, and all tests still work properly.

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
- [x] I have summarized these changes in `CHANGELOG.rst` following the established format.
