### PR TITLE
Fix mpcd particle positions

### DIFF
--- a/hoomd/mpcd/pytest/test_collide.py
+++ b/hoomd/mpcd/pytest/test_collide.py
@@ -225,7 +225,7 @@ class TestCollisionMethod:
             initial_snap.particles.velocity[:] = [velo_rigid]
             initial_snap.particles.angmom[:] = [angmom_rigid]
 
-            # place the mpcd particles on top of constituents
+            # place the mpcd particles on top of constituents, accounting for PBCs
             positions = np.add(def_rigid["positions"], pos_rigid)
             positions[positions < -11 * 0.5] = positions[positions < -11 * 0.5] + 11
             positions[positions > 11 * 0.5] = positions[positions > 11 * 0.5] - 11

--- a/hoomd/mpcd/pytest/test_collide.py
+++ b/hoomd/mpcd/pytest/test_collide.py
@@ -139,7 +139,7 @@ class TestCollisionMethod:
         "angmom_rigid", [[0, 0, 0, 0], [0, 2, 3, 4]], ids=["Nonrotating", "Rotating"]
     )
     @pytest.mark.parametrize(
-        "pos_rigid", [[0, 0, 0], [10, 10, 10]], ids=["center", "edge"]
+        "pos_rigid", [[0, 0, 0], [5, 5, 5]], ids=["center", "edge"]
     )
     @pytest.mark.parametrize(
         "def_rigid,properties_rigid",
@@ -216,7 +216,7 @@ class TestCollisionMethod:
 
         # create simulation
         initial_snap = one_particle_snapshot_factory(
-            particle_types=["A", "B"], position=pos_rigid, L=21
+            particle_types=["A", "B"], position=pos_rigid, L=11
         )
         total_mass = properties_rigid["mass"][0]
         if initial_snap.communicator.rank == 0:
@@ -226,9 +226,12 @@ class TestCollisionMethod:
             initial_snap.particles.angmom[:] = [angmom_rigid]
 
             # place the mpcd particles on top of constituents
+            positions = np.add(def_rigid["positions"], pos_rigid)
+            positions[positions < -11 * 0.5] = positions[positions < -11 * 0.5] + 11
+            positions[positions > 11 * 0.5] = positions[positions > 11 * 0.5] - 11
             initial_snap.mpcd.N = N_mpcd
             initial_snap.mpcd.types = ["C"]
-            initial_snap.mpcd.position[:] = def_rigid["positions"]
+            initial_snap.mpcd.position[:] = positions
             initial_snap.mpcd.velocity[:] = velo_mpcd
 
         sim = simulation_factory(initial_snap)
@@ -338,7 +341,7 @@ class TestCollisionMethod:
         # create simulation
         total_mass = properties_rigid["mass"][0]
         initial_snap = two_particle_snapshot_factory(
-            particle_types=["A", "B", "C", "D"], L=21
+            particle_types=["A", "B", "C", "D"], L=11
         )
         if initial_snap.communicator.rank == 0:
             # put a free particle that doesn't participate in collision on top of

--- a/hoomd/mpcd/pytest/test_collide.py
+++ b/hoomd/mpcd/pytest/test_collide.py
@@ -208,6 +208,7 @@ class TestCollisionMethod:
     ):
         if "kT" not in init_args:
             init_args["kT"] = 1.0
+        L = 11  # length of box
 
         N_mpcd = len(def_rigid["constituent_types"])
         rng = np.random.default_rng(seed=42)
@@ -216,7 +217,7 @@ class TestCollisionMethod:
 
         # create simulation
         initial_snap = one_particle_snapshot_factory(
-            particle_types=["A", "B"], position=pos_rigid, L=11
+            particle_types=["A", "B"], position=pos_rigid, L=L
         )
         total_mass = properties_rigid["mass"][0]
         if initial_snap.communicator.rank == 0:
@@ -227,8 +228,8 @@ class TestCollisionMethod:
 
             # place the mpcd particles on top of constituents, accounting for PBCs
             positions = np.add(def_rigid["positions"], pos_rigid)
-            positions[positions < -11 * 0.5] = positions[positions < -11 * 0.5] + 11
-            positions[positions > 11 * 0.5] = positions[positions > 11 * 0.5] - 11
+            positions[positions < -L * 0.5] = positions[positions < -L * 0.5] + L
+            positions[positions > L * 0.5] = positions[positions > L * 0.5] - L
             initial_snap.mpcd.N = N_mpcd
             initial_snap.mpcd.types = ["C"]
             initial_snap.mpcd.position[:] = positions


### PR DESCRIPTION
## Description

Fix bug in mpcd pytest with rigid bodies in which the mpcd particles are not placed in the same cell as the constituent particles.

## Motivation and context

The mpcd pytests that check momentum conservation when colliding with rigid body constituent particles require that mpcd particles be placed in the same location as the constituent particles to ensure a collision occurs. When testing periodic boundaries by placing the rigid body in a corner of the simulation box, the mpcd particles were not placed in the right location.

## How has this been tested?

The positions in the test have been checked manually to ensure they are now in the right place.

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
- [ ] I have summarized these changes in `CHANGELOG.rst` following the established format.