### PR TITLE
Always flush gsd writers on exit

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,7 @@ Next release
 *Fixed*
 
 * Divide by zero with MPCD if rigid body has constituent with zero mass (#2228)
+* Ensure that GSD files are always flushed on exit (#2236)
 
 6.1.0 (2026-02-07)
 ^^^^^^^^^^^^^^^^^^^^

--- a/hoomd/__init__.py
+++ b/hoomd/__init__.py
@@ -99,7 +99,6 @@ _default_excepthook = sys.excepthook
 
 def _hoomd_sys_excepthook(type, value, traceback):
     """Override Python's excepthook to abort MPI runs."""
-    write.gsd._flush_open_gsd_writers()
     _default_excepthook(type, value, traceback)
     sys.stderr.flush()
     _hoomd.abort_mpi(communicator._current_communicator.cpp_mpi_conf, 1)

--- a/hoomd/write/gsd.py
+++ b/hoomd/write/gsd.py
@@ -437,13 +437,8 @@ class GSD(Writer):
 
             gsd.flush()
         """
-        if not self._attached:
-            raise RuntimeError(
-                "The GSD file is unavailable until the"
-                "simulation runs for 0 or more steps."
-            )
-
-        self._cpp_obj.flush()
+        if self._attached:
+            self._cpp_obj.flush()
 
 
 def _iterable_is_incomplete(iterable):

--- a/hoomd/write/gsd.py
+++ b/hoomd/write/gsd.py
@@ -21,6 +21,7 @@ from hoomd.operation import Writer
 import numpy as np
 import json
 import inspect
+import weakref
 
 
 def _array_to_strings(value):
@@ -371,6 +372,7 @@ class GSD(Writer):
         )
 
         self._cpp_obj.log_writer = self.logger
+        self._finalizer = weakref.finalize(self, self.flush)
 
     @staticmethod
     def write(state, filename, filter=All(), mode="wb", logger=None):


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail. -->
Use `weakref.finalize` to flush GSD files on exit.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Apparently, it is a "feature" that Python does not always clean up objects when garbage collecting on exit. It does 95% of the time, but certain user scripts trigger cases where it does not. HOOMD-blue relies on C++ destructors to flush and close GSD files cleanly. Thus, we need to use `weakref.finalize` to ensure that all GSD files are flushed on exit.

<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves #2234 

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
The test case in #2234 passes.

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
- [x] I have summarized these changes in `CHANGELOG.rst` following the established format.
