### PR TITLE
Improve the sampling of rotation trial moves.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,7 +7,7 @@ Recent releases
 Next release
 ^^^^^^^^^^^^^^^^^^^^
 
-HOOMD-blue 7.0 changes the definition of the rotation trial move size `a`. You will need to
+HOOMD-blue 7.0 changes the definition of the rotation trial move size ``a``. You will need to
 retune any hard-coded or saved values. Here are the distributions of the trial move rotation
 angles in HOOMD-blue 2.0–6.x and in 7.0+ for comparison:
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,11 +7,18 @@ Recent releases
 Next release
 ^^^^^^^^^^^^^^^^^^^^
 
+HOOMD-blue 7.0 changes the definition of the rotation trial move size `a`. You will need to
+retune any hard-coded or saved values. Here are the distributions of the trial move rotation
+angles in HOOMD-blue 2.0--6.x and in 7.0+ for comparison:
+
+.. image:: https://github.com/user-attachments/assets/4a713aa9-2ec4-40dc-8363-aaf93e7eca2b
+
 *Added*
 
 *Changed*
 
 * Use tabs in binary installation documentation (#2246).
+* Improve the sampling of rotation trial moves (#2264).
 
 *Deprecated*
 
@@ -20,6 +27,7 @@ Next release
 *Fixed*
 
 * Fixed Helfrich equation in the docs (#2242)
+* Build with Eigen 5.x (#2261)
 
 6.1.1 (2026-02-19)
 ^^^^^^^^^^^^^^^^^^^^

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,7 +9,7 @@ Next release
 
 HOOMD-blue 7.0 changes the definition of the rotation trial move size `a`. You will need to
 retune any hard-coded or saved values. Here are the distributions of the trial move rotation
-angles in HOOMD-blue 2.0--6.x and in 7.0+ for comparison:
+angles in HOOMD-blue 2.0–6.x and in 7.0+ for comparison:
 
 .. image:: https://github.com/user-attachments/assets/4a713aa9-2ec4-40dc-8363-aaf93e7eca2b
 

--- a/hoomd/hpmc/Moves.h
+++ b/hoomd/hpmc/Moves.h
@@ -81,32 +81,36 @@ DEVICE void move_rotate(quat<Scalar>& orientation, RandomGenerator& rng, Scalar 
         }
     else
         {
-        hoomd::UniformDistribution<Scalar> uniform(Scalar(-1.0), Scalar(1.0));
+        // Based on Karney 2007: doi.org/10.1016/j.jmgm.2006.04.002
+        hoomd::NormalDistribution<Scalar> normal(a);
+        quat<Scalar> small_rotation = quat<Scalar>();
 
-        // Frenkel and Smit reference Allen and Tildesley, referencing Vesley(1982), referencing
-        // Marsaglia(1972). Generate a random unit quaternion. Scale it to a small rotation and
-        // apply.
-        quat<Scalar> q;
-        Scalar s1, s2, s3;
+        while(true) {
+            vec3<Scalar> s = vec3<Scalar>(normal(rng), normal(rng), normal(rng));
+            Scalar theta = fast::sqrt(dot(s,s));
 
-        do
-            {
-            q.s = uniform(rng);
-            q.v.x = uniform(rng);
-            } while ((s1 = q.s * q.s + q.v.x * q.v.x) >= Scalar(1.0));
+            // Reject moves with |s| > pi to ensure detailed balance. Otherwise, there
+            // is a shorter path between the proposed move and the start (theta - pi),
+            // which has a different rejection probability.
+            if (theta > M_PI) {
+                continue;
+            }
 
-        do
-            {
-            q.v.y = uniform(rng);
-            q.v.z = uniform(rng);
-            } while ((s2 = q.v.y * q.v.y + q.v.z * q.v.z) >= Scalar(1.0) || s2 == Scalar(0.0));
+            // Lift the normally distributed values to SO(3) with the exponential map
+            Scalar half_theta = 0.5 * theta;
+            Scalar w = fast::cos(half_theta);
 
-        s3 = fast::sqrt((Scalar(1.0) - s1) / s2);
-        q.v.y *= s3;
-        q.v.z *= s3;
+            Scalar v_factor = fast::sin(half_theta) / theta;
+            if (!isfinite(v_factor)) {
+                v_factor = 0.5;
+            }
 
-        // generate new trial orientation
-        orientation += a * q;
+            vec3<Scalar> v = s * v_factor;
+            small_rotation = quat<Scalar>(w, v);
+            break;
+            }
+
+        orientation = small_rotation * orientation;
 
         // renormalize
         orientation = orientation * (fast::rsqrt(norm2(orientation)));

--- a/hoomd/hpmc/Moves.h
+++ b/hoomd/hpmc/Moves.h
@@ -85,25 +85,28 @@ DEVICE void move_rotate(quat<Scalar>& orientation, RandomGenerator& rng, Scalar 
         hoomd::NormalDistribution<Scalar> normal(a);
         quat<Scalar> small_rotation = quat<Scalar>();
 
-        while(true) {
+        while (true)
+            {
             vec3<Scalar> s = vec3<Scalar>(normal(rng), normal(rng), normal(rng));
-            Scalar theta = fast::sqrt(dot(s,s));
+            Scalar theta = fast::sqrt(dot(s, s));
 
             // Reject moves with |s| > pi to ensure detailed balance. Otherwise, there
             // is a shorter path between the proposed move and the start (theta - pi),
             // which has a different rejection probability.
-            if (theta > M_PI) {
+            if (theta > M_PI)
+                {
                 continue;
-            }
+                }
 
             // Lift the normally distributed values to SO(3) with the exponential map
             Scalar half_theta = 0.5 * theta;
             Scalar w = fast::cos(half_theta);
 
             Scalar v_factor = fast::sin(half_theta) / theta;
-            if (!isfinite(v_factor)) {
+            if (!isfinite(v_factor))
+                {
                 v_factor = 0.5;
-            }
+                }
 
             vec3<Scalar> v = s * v_factor;
             small_rotation = quat<Scalar>(w, v);

--- a/hoomd/hpmc/test/test_moves.cc
+++ b/hoomd/hpmc/test/test_moves.cc
@@ -57,8 +57,8 @@ UP_TEST(rand_rotate_3d)
             // out << maximum_rotation << "," << theta << "," << "v7.x+" << endl;
 
             // check that all coordinates moved
-            // yes, it is possible that one of the random numbers is zero - if that is the case we can
-            // pick a different seed so that we do not sample that case
+            // yes, it is possible that one of the random numbers is zero - if that is the case we
+            // can pick a different seed so that we do not sample that case
             UP_ASSERT(fabs(delta.s) > 0);
             UP_ASSERT(fabs(delta.v.x) > 0);
             UP_ASSERT(fabs(delta.v.y) > 0);

--- a/hoomd/hpmc/test/test_moves.cc
+++ b/hoomd/hpmc/test/test_moves.cc
@@ -35,24 +35,38 @@ UP_TEST(rand_rotate_3d)
     {
     hoomd::RandomGenerator rng(hoomd::Seed(0, 1, 2), hoomd::Counter(4, 5, 6));
 
-    quat<Scalar> a(1, vec3<Scalar>(0, 0, 0));
-    for (int i = 0; i < 10000; i++)
+    // The commented code inspects the distribution of rotation move angles.
+    // ofstream out("rotate_move_angles.txt");
+    // out << "a,angle,branch" << endl;
+
+    for (Scalar maximum_rotation = 0.1; maximum_rotation < 1.0; maximum_rotation += 0.4)
         {
-        // move the shape
-        quat<Scalar> prev = a;
-        move_rotate<3>(a, rng, 1.0);
-        quat<Scalar> delta(prev.s - a.s, prev.v - a.v);
+        quat<Scalar> a(1, vec3<Scalar>(0, 0, 0));
+        for (int i = 0; i < 10000; i++)
+            {
+            // move the shape
+            quat<Scalar> prev = a;
+            move_rotate<3>(a, rng, maximum_rotation);
+            quat<Scalar> delta(prev.s - a.s, prev.v - a.v);
 
-        // check that all coordinates moved
-        // yes, it is possible that one of the random numbers is zero - if that is the case we can
-        // pick a different seed so that we do not sample that case
-        UP_ASSERT(fabs(delta.s) > 0);
-        UP_ASSERT(fabs(delta.v.x) > 0);
-        UP_ASSERT(fabs(delta.v.y) > 0);
-        UP_ASSERT(fabs(delta.v.z) > 0);
+            // compute the angle that the body rotated by
+            // quat<Scalar> q = conj(prev) * a;
+            // Scalar cos_alpha_over_2 = q.s;
+            // Scalar sin_alpha_over_2 = fast::sqrt(dot(q.v, q.v));
+            // Scalar theta = 2.0 * atan2(sin_alpha_over_2, cos_alpha_over_2);
+            // out << maximum_rotation << "," << theta << "," << "v7.x+" << endl;
 
-        // check that it is a valid rotation
-        MY_CHECK_CLOSE(norm2(a), 1, tol);
+            // check that all coordinates moved
+            // yes, it is possible that one of the random numbers is zero - if that is the case we can
+            // pick a different seed so that we do not sample that case
+            UP_ASSERT(fabs(delta.s) > 0);
+            UP_ASSERT(fabs(delta.v.x) > 0);
+            UP_ASSERT(fabs(delta.v.y) > 0);
+            UP_ASSERT(fabs(delta.v.z) > 0);
+
+            // check that it is a valid rotation
+            MY_CHECK_CLOSE(norm2(a), 1, tol);
+            }
         }
     }
 


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail. -->
Implement the rotation move algorithm from [10.1016/j.jmgm.2006.04.002](https://doi.org/10.1016/j.jmgm.2006.04.002). This is a breaking change because it redefines the the rotation trial move size `a`.

This code was originally written in Rust by @janbridley (https://github.com/glotzerlab/hoomd-rs/pull/131). I converted it to C++ for use with HOOMD-blue.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
The new distribution well-defined and behaves better than the old.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
This plot compares the distribution of rotation angles that result from the rotation moves.
![rotate-move-compare](https://github.com/user-attachments/assets/4a713aa9-2ec4-40dc-8363-aaf93e7eca2b)

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
- [x] I have summarized these changes in `CHANGELOG.rst` following the established format.
