### PR TITLE
Prevent rigid bodies from rotating out of the plane in 2D simulations.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,8 @@ Next release
 *Fixed*
 
 * Fixed incorrect smart default behavior for sequences and numpy arrays (#2292).
+* Prevent motion in the z direction on the first step after starting a simulation (#2303).
+* Prevent rigid bodies from rotating out of the plane in 2D simulations (#2303).
 
 Recent releases
 ---------------

--- a/hoomd/ParticleGroup.cc
+++ b/hoomd/ParticleGroup.cc
@@ -689,9 +689,9 @@ void ParticleGroup::thermalizeParticleMomenta(Scalar kT, uint64_t timestep)
 
         if (h_tag.data[j] == h_body.data[j] || h_body.data[j] >= MIN_FLOPPY)
             {
-            if (I.x > 0)
+            if (I.x > 0 && n_dimensions > 2)
                 p_vec.x = hoomd::NormalDistribution<Scalar>(slow::sqrt(kT * I.x))(rng);
-            if (I.y > 0)
+            if (I.y > 0 && n_dimensions > 2)
                 p_vec.y = hoomd::NormalDistribution<Scalar>(slow::sqrt(kT * I.y))(rng);
             if (I.z > 0)
                 p_vec.z = hoomd::NormalDistribution<Scalar>(slow::sqrt(kT * I.z))(rng);

--- a/hoomd/md/TwoStepBD.cc
+++ b/hoomd/md/TwoStepBD.cc
@@ -184,12 +184,12 @@ void TwoStepBD::integrateStepOne(uint64_t timestep)
                 bf_torque.y = NormalDistribution<Scalar>(sigma_r.y)(rng);
                 bf_torque.z = NormalDistribution<Scalar>(sigma_r.z)(rng);
 
-                if (x_zero)
+                if (x_zero || D == 2)
                     {
                     bf_torque.x = 0;
                     t.x = 0;
                     }
-                if (y_zero)
+                if (y_zero || D == 2)
                     {
                     bf_torque.y = 0;
                     t.y = 0;
@@ -206,13 +206,6 @@ void TwoStepBD::integrateStepOne(uint64_t timestep)
                 // different gamma_r and then rotate the "angular velocity" back to lab frame and
                 // integrate
                 bf_torque = rotate(q, bf_torque);
-                if (D < 3)
-                    {
-                    bf_torque.x = 0;
-                    bf_torque.y = 0;
-                    t.x = 0;
-                    t.y = 0;
-                    }
 
                 // do the integration for quaternion
                 q += Scalar(0.5) * m_deltaT * ((t + bf_torque) / vec3<Scalar>(gamma_r)) * q;
@@ -233,15 +226,12 @@ void TwoStepBD::integrateStepOne(uint64_t timestep)
                     p_vec.z = NormalDistribution<Scalar>(fast::sqrt(currentTemp * I.z))(rng);
                     }
 
-                if (x_zero)
+                if (x_zero || D == 2)
                     p_vec.x = 0;
-                if (y_zero)
+                if (y_zero || D == 2)
                     p_vec.y = 0;
                 if (z_zero)
                     p_vec.z = 0;
-
-                // !! Note this isn't well-behaving in 2D,
-                // !! because may have effective non-zero ang_mom in x,y
 
                 // store ang_mom quaternion
                 quat<Scalar> p = Scalar(2.0) * q * p_vec;

--- a/hoomd/md/TwoStepBDGPU.cu
+++ b/hoomd/md/TwoStepBDGPU.cu
@@ -233,12 +233,12 @@ __global__ void gpu_brownian_step_one_kernel(Scalar4* d_pos,
                 bf_torque.y = NormalDistribution<Scalar>(sigma_r.y)(rng);
                 bf_torque.z = NormalDistribution<Scalar>(sigma_r.z)(rng);
 
-                if (x_zero)
+                if (x_zero || D == 2)
                     {
                     bf_torque.x = 0;
                     t.x = 0;
                     }
-                if (y_zero)
+                if (y_zero || D == 2)
                     {
                     bf_torque.y = 0;
                     t.y = 0;
@@ -252,13 +252,6 @@ __global__ void gpu_brownian_step_one_kernel(Scalar4* d_pos,
                 // use the damping by gamma_r and rotate back to lab frame
                 // For Future Updates: take special care when have anisotropic gamma_r
                 bf_torque = rotate(q, bf_torque);
-                if (D < 3)
-                    {
-                    bf_torque.x = 0;
-                    bf_torque.y = 0;
-                    t.x = 0;
-                    t.y = 0;
-                    }
 
                 // do the integration for quaternion
                 q += Scalar(0.5) * deltaT * ((t + bf_torque) / vec3<Scalar>(gamma_r)) * q;
@@ -279,15 +272,12 @@ __global__ void gpu_brownian_step_one_kernel(Scalar4* d_pos,
                     p_vec.z = NormalDistribution<Scalar>(fast::sqrt(T * I.z))(rng);
                     }
 
-                if (x_zero)
+                if (x_zero || D == 2)
                     p_vec.x = 0;
-                if (y_zero)
+                if (y_zero || D == 2)
                     p_vec.y = 0;
                 if (z_zero)
                     p_vec.z = 0;
-
-                // !! Note this ang_mom isn't well-behaving in 2D,
-                // !! because may have effective non-zero ang_mom in x,y
 
                 // store ang_mom quaternion
                 quat<Scalar> p = Scalar(2.0) * q * p_vec;

--- a/hoomd/md/TwoStepConstantPressure.cc
+++ b/hoomd/md/TwoStepConstantPressure.cc
@@ -310,6 +310,11 @@ void TwoStepConstantPressure::integrateStepOne(uint64_t timestep)
             Scalar3 accel = h_accel.data[j];
             Scalar3 r = make_scalar3(h_pos.data[j].x, h_pos.data[j].y, h_pos.data[j].z);
 
+            if (m_sysdef->getNDimensions() == 2)
+                {
+                accel.z = Scalar(0.0);
+                }
+
             // advance velocity
             v += m_deltaT / Scalar(2.0) * accel;
 

--- a/hoomd/md/TwoStepConstantPressureGPU.cc
+++ b/hoomd/md/TwoStepConstantPressureGPU.cc
@@ -244,6 +244,7 @@ void TwoStepConstantPressureGPU::integrateStepOne(uint64_t timestep)
                                          d_index_array.data,
                                          m_group->getNumMembers(),
                                          m_deltaT,
+                                         m_sysdef->getNDimensions(),
                                          rescalingFactors[1],
                                          m_tuner_angular_one->getParam()[0]);
 
@@ -346,6 +347,7 @@ void TwoStepConstantPressureGPU::integrateStepTwo(uint64_t timestep)
                                          d_index_array.data,
                                          m_group->getNumMembers(),
                                          m_deltaT,
+                                         m_sysdef->getNDimensions(),
                                          rescalingFactors[1], // exp_thermo_fac_rot,
                                          m_tuner_angular_two->getParam()[0]);
 

--- a/hoomd/md/TwoStepConstantPressureGPU.cc
+++ b/hoomd/md/TwoStepConstantPressureGPU.cc
@@ -184,7 +184,8 @@ void TwoStepConstantPressureGPU::integrateStepOne(uint64_t timestep)
                                          m_mat_exp_r_int,
                                          m_deltaT,
                                          m_rescale_all,
-                                         m_tuner_one->getParam()[0]);
+                                         m_tuner_one->getParam()[0],
+                                         m_sysdef->getNDimensions());
 
         if (m_exec_conf->isCUDAErrorCheckingEnabled())
             CHECK_CUDA_ERROR();

--- a/hoomd/md/TwoStepConstantPressureGPU.cu
+++ b/hoomd/md/TwoStepConstantPressureGPU.cu
@@ -178,7 +178,7 @@ hipError_t gpu_npt_rescale_step_one(Scalar4* d_pos,
                        mat_exp_r_int[5],
                        deltaT,
                        rescale_all,
-                       unsigned int n_dimensions);
+                       n_dimensions);
 
     return hipSuccess;
     }

--- a/hoomd/md/TwoStepConstantPressureGPU.cu
+++ b/hoomd/md/TwoStepConstantPressureGPU.cu
@@ -47,7 +47,8 @@ __global__ void gpu_npt_mtk_step_one_kernel(Scalar4* d_pos,
                                             Scalar mat_exp_r_int_yz,
                                             Scalar mat_exp_r_int_zz,
                                             Scalar deltaT,
-                                            bool rescale_all)
+                                            bool rescale_all,
+                                            unsigned int n_dimensions)
     {
     // determine which particle this thread works on
     int work_idx = blockIdx.x * blockDim.x + threadIdx.x;
@@ -67,6 +68,11 @@ __global__ void gpu_npt_mtk_step_one_kernel(Scalar4* d_pos,
         Scalar3 accel = d_accel[idx];
         ;
         Scalar3 r = make_scalar3(pos.x, pos.y, pos.z);
+
+        if (n_dimensions == 2)
+            {
+            accel.z = Scalar(0.0);
+            }
 
         // advance velocity
         v += deltaT / Scalar(2.0) * accel;
@@ -124,7 +130,8 @@ hipError_t gpu_npt_rescale_step_one(Scalar4* d_pos,
                                     Scalar* mat_exp_r_int,
                                     Scalar deltaT,
                                     bool rescale_all,
-                                    const unsigned int block_size)
+                                    const unsigned int block_size,
+                                    unsigned int n_dimensions)
     {
     unsigned int max_block_size;
     hipFuncAttributes attr;
@@ -170,7 +177,8 @@ hipError_t gpu_npt_rescale_step_one(Scalar4* d_pos,
                        mat_exp_r_int[4],
                        mat_exp_r_int[5],
                        deltaT,
-                       rescale_all);
+                       rescale_all,
+                       unsigned int n_dimensions);
 
     return hipSuccess;
     }

--- a/hoomd/md/TwoStepConstantPressureGPU.cuh
+++ b/hoomd/md/TwoStepConstantPressureGPU.cuh
@@ -32,7 +32,8 @@ hipError_t gpu_npt_rescale_step_one(Scalar4* d_pos,
                                     Scalar* mat_exp_r_int,
                                     Scalar deltaT,
                                     bool rescale_all,
-                                    const unsigned int block_size);
+                                    const unsigned int block_size,
+                                    unsigned int n_dimensions);
 
 //! Kernel driver for wrapping particles back in the box (part of first step)
 hipError_t gpu_npt_rescale_wrap(const unsigned int N,

--- a/hoomd/md/TwoStepConstantVolume.cc
+++ b/hoomd/md/TwoStepConstantVolume.cc
@@ -37,6 +37,11 @@ void hoomd::md::TwoStepConstantVolume::integrateStepOne(uint64_t timestep)
             Scalar3 pos = make_scalar3(h_pos.data[j].x, h_pos.data[j].y, h_pos.data[j].z);
             Scalar3 accel = h_accel.data[j];
 
+            if (m_sysdef->getNDimensions() == 2)
+                {
+                accel.z = Scalar(0.0);
+                }
+
             // update velocity and position
             v = v + Scalar(1.0 / 2.0) * accel * m_deltaT;
 

--- a/hoomd/md/TwoStepConstantVolume.cc
+++ b/hoomd/md/TwoStepConstantVolume.cc
@@ -115,8 +115,8 @@ void hoomd::md::TwoStepConstantVolume::integrateStepOne(uint64_t timestep)
 
             // check for zero moment of inertia
             bool x_zero, y_zero, z_zero;
-            x_zero = (I.x == 0);
-            y_zero = (I.y == 0);
+            x_zero = (I.x == 0 || m_sysdef->getNDimensions() == 2);
+            y_zero = (I.y == 0 || m_sysdef->getNDimensions() == 2);
             z_zero = (I.z == 0);
 
             // ignore torque component along an axis for which the moment of inertia zero
@@ -300,8 +300,8 @@ void hoomd::md::TwoStepConstantVolume::integrateStepTwo(uint64_t timestep)
 
             // check for zero moment of inertia
             bool x_zero, y_zero, z_zero;
-            x_zero = (I.x == 0);
-            y_zero = (I.y == 0);
+            x_zero = (I.x == 0 || m_sysdef->getNDimensions() == 2);
+            y_zero = (I.y == 0 || m_sysdef->getNDimensions() == 2);
             z_zero = (I.z == 0);
 
             // ignore torque component along an axis for which the moment of inertia zero

--- a/hoomd/md/TwoStepConstantVolumeGPU.cc
+++ b/hoomd/md/TwoStepConstantVolumeGPU.cc
@@ -90,6 +90,7 @@ void TwoStepConstantVolumeGPU::integrateStepOne(uint64_t timestep)
                                          m_tuner_one->getParam()[0],
                                          rescalingFactors[0], // m_exp_thermo_fac,
                                          m_deltaT,
+                                         m_sysdef->getNDimensions(),
                                          limits.first,
                                          limits.second);
 

--- a/hoomd/md/TwoStepConstantVolumeGPU.cc
+++ b/hoomd/md/TwoStepConstantVolumeGPU.cc
@@ -126,6 +126,7 @@ void TwoStepConstantVolumeGPU::integrateStepOne(uint64_t timestep)
                                          d_index_array.data,
                                          m_group->getNumMembers(),
                                          m_deltaT,
+                                         m_sysdef->getNDimensions(),
                                          rescalingFactors[1],
                                          m_tuner_angular_one->getParam()[0]);
 
@@ -206,6 +207,7 @@ void TwoStepConstantVolumeGPU::integrateStepTwo(uint64_t timestep)
                                          d_index_array.data,
                                          m_group->getNumMembers(),
                                          m_deltaT,
+                                         m_sysdef->getNDimensions(),
                                          rescalingFactors[1],
                                          m_tuner_angular_two->getParam()[0]);
 

--- a/hoomd/md/TwoStepConstantVolumeGPU.cu
+++ b/hoomd/md/TwoStepConstantVolumeGPU.cu
@@ -40,6 +40,7 @@ __global__ void gpu_nvt_rescale_step_one_kernel(Scalar4* d_pos,
                                                 BoxDim box,
                                                 Scalar rescale_factor,
                                                 Scalar deltaT,
+                                                unsigned int n_dimensions,
                                                 bool limit = false,
                                                 Scalar maximum_displacement = Scalar(0.))
     {
@@ -57,6 +58,10 @@ __global__ void gpu_nvt_rescale_step_one_kernel(Scalar4* d_pos,
         Scalar4 velmass = d_vel[idx];
         Scalar3 vel = make_scalar3(velmass.x, velmass.y, velmass.z);
         Scalar3 accel = d_accel[idx];
+        if (n_dimensions == 2)
+            {
+            accel.z = Scalar(0.0);
+            }
 
         // velocity update
         vel = vel + Scalar(1.0 / 2.0) * accel * deltaT;
@@ -107,6 +112,7 @@ hipError_t gpu_nvt_rescale_step_one(Scalar4* d_pos,
                                     unsigned int block_size,
                                     Scalar rescale_factor,
                                     Scalar deltaT,
+                                    unsigned int n_dimensions,
                                     bool use_limit,
                                     Scalar maximum_displacement)
     {
@@ -138,6 +144,7 @@ hipError_t gpu_nvt_rescale_step_one(Scalar4* d_pos,
                        box,
                        rescale_factor,
                        deltaT,
+                       n_dimensions,
                        use_limit,
                        maximum_displacement);
 

--- a/hoomd/md/TwoStepConstantVolumeGPU.cuh
+++ b/hoomd/md/TwoStepConstantVolumeGPU.cuh
@@ -24,6 +24,7 @@ hipError_t gpu_nvt_rescale_step_one(Scalar4* d_pos,
                                     unsigned int block_size,
                                     Scalar rescale_factor,
                                     Scalar deltaT,
+                                    unsigned int n_dimensions,
                                     bool limit = false,
                                     Scalar limit_displacement = Scalar(0.));
 

--- a/hoomd/md/TwoStepLangevin.cc
+++ b/hoomd/md/TwoStepLangevin.cc
@@ -70,14 +70,20 @@ void TwoStepLangevin::integrateStepOne(uint64_t timestep)
 
         h_pos.data[j].x += dx;
         h_pos.data[j].y += dy;
-        h_pos.data[j].z += dz;
+        if (m_sysdef->getNDimensions() > 2)
+            {
+            h_pos.data[j].z += dz;
+            }
         // particles may have been moved slightly outside the box by the above steps, wrap them back
         // into place
         box.wrap(h_pos.data[j], h_image.data[j]);
 
         h_vel.data[j].x += Scalar(1.0 / 2.0) * h_accel.data[j].x * m_deltaT;
         h_vel.data[j].y += Scalar(1.0 / 2.0) * h_accel.data[j].y * m_deltaT;
-        h_vel.data[j].z += Scalar(1.0 / 2.0) * h_accel.data[j].z * m_deltaT;
+        if (m_sysdef->getNDimensions() > 2)
+            {
+            h_vel.data[j].z += Scalar(1.0 / 2.0) * h_accel.data[j].z * m_deltaT;
+            }
         }
 
     if (m_aniso)

--- a/hoomd/md/TwoStepLangevin.cc
+++ b/hoomd/md/TwoStepLangevin.cc
@@ -115,8 +115,8 @@ void TwoStepLangevin::integrateStepOne(uint64_t timestep)
 
             // check for zero moment of inertia
             bool x_zero, y_zero, z_zero;
-            x_zero = (I.x == 0);
-            y_zero = (I.y == 0);
+            x_zero = (I.x == 0 || m_sysdef->getNDimensions() == 2);
+            y_zero = (I.y == 0 || m_sysdef->getNDimensions() == 2);
             z_zero = (I.z == 0);
 
             // ignore torque component along an axis for which the moment of inertia zero
@@ -340,8 +340,8 @@ void TwoStepLangevin::integrateStepTwo(uint64_t timestep)
 
                 // check for degenerate moment of inertia
                 bool x_zero, y_zero, z_zero;
-                x_zero = (I.x == 0);
-                y_zero = (I.y == 0);
+                x_zero = (I.x == 0 || m_sysdef->getNDimensions() == 2);
+                y_zero = (I.y == 0 || m_sysdef->getNDimensions() == 2);
                 z_zero = (I.z == 0);
 
                 bf_torque.x = rand_x - gamma_r.x * (s.x / I.x);
@@ -388,8 +388,8 @@ void TwoStepLangevin::integrateStepTwo(uint64_t timestep)
 
             // check for zero moment of inertia
             bool x_zero, y_zero, z_zero;
-            x_zero = (I.x == 0);
-            y_zero = (I.y == 0);
+            x_zero = (I.x == 0 || m_sysdef->getNDimensions() == 2);
+            y_zero = (I.y == 0 || m_sysdef->getNDimensions() == 2);
             z_zero = (I.z == 0);
 
             // ignore torque component along an axis for which the moment of inertia zero

--- a/hoomd/md/TwoStepLangevinGPU.cc
+++ b/hoomd/md/TwoStepLangevinGPU.cc
@@ -126,6 +126,7 @@ void TwoStepLangevinGPU::integrateStepOne(uint64_t timestep)
                                          d_index_array.data,
                                          m_group->getNumMembers(),
                                          m_deltaT,
+                                         m_sysdef->getNDimensions(),
                                          1.0,
                                          m_tuner_angular_one->getParam()[0]);
 

--- a/hoomd/md/TwoStepLangevinGPU.cc
+++ b/hoomd/md/TwoStepLangevinGPU.cc
@@ -93,7 +93,8 @@ void TwoStepLangevinGPU::integrateStepOne(uint64_t timestep)
                              false,
                              0,
                              false,
-                             m_tuner_one->getParam()[0]);
+                             m_tuner_one->getParam()[0],
+                             m_sysdef->getNDimensions());
 
     if (m_exec_conf->isCUDAErrorCheckingEnabled())
         CHECK_CUDA_ERROR();

--- a/hoomd/md/TwoStepLangevinGPU.cu
+++ b/hoomd/md/TwoStepLangevinGPU.cu
@@ -331,8 +331,8 @@ __global__ void gpu_langevin_angular_step_two_kernel(const Scalar4* d_pos,
 
             // check for zero moment of inertia
             bool x_zero, y_zero, z_zero;
-            x_zero = (I.x == 0);
-            y_zero = (I.y == 0);
+            x_zero = (I.x == 0 || D == 2);
+            y_zero = (I.y == 0 || D == 2);
             z_zero = (I.z == 0);
 
             bf_torque.x = rand_x - gamma_r.x * (s.x / I.x);
@@ -372,8 +372,8 @@ __global__ void gpu_langevin_angular_step_two_kernel(const Scalar4* d_pos,
 
         // check for zero moment of inertia
         bool x_zero, y_zero, z_zero;
-        x_zero = (I.x == 0);
-        y_zero = (I.y == 0);
+        x_zero = (I.x == 0 || D == 2);
+        y_zero = (I.y == 0 || D == 2);
         z_zero = (I.z == 0);
 
         // ignore torque component along an axis for which the moment of inertia zero

--- a/hoomd/md/TwoStepNVEGPU.cu
+++ b/hoomd/md/TwoStepNVEGPU.cu
@@ -53,7 +53,8 @@ __global__ void gpu_nve_step_one_kernel(Scalar4* d_pos,
                                         Scalar deltaT,
                                         bool limit,
                                         Scalar limit_val,
-                                        bool zero_force)
+                                        bool zero_force,
+                                        unsigned int n_dimensions)
     {
     // determine which particle this thread works on (MEM TRANSFER: 4 bytes)
     int work_idx = blockIdx.x * blockDim.x + threadIdx.x;
@@ -78,6 +79,10 @@ __global__ void gpu_nve_step_one_kernel(Scalar4* d_pos,
         Scalar3 accel = make_scalar3(Scalar(0.0), Scalar(0.0), Scalar(0.0));
         if (!zero_force)
             accel = d_accel[idx];
+        if (n_dimensions == 2)
+            {
+            accel.z = Scalar(0.0);
+            }
 
         // update the position (FLOPS: 15)
         Scalar3 dx = vel * deltaT + (Scalar(1.0) / Scalar(2.0)) * accel * deltaT * deltaT;
@@ -135,7 +140,8 @@ hipError_t gpu_nve_step_one(Scalar4* d_pos,
                             bool limit,
                             Scalar limit_val,
                             bool zero_force,
-                            unsigned int block_size)
+                            unsigned int block_size,
+                            unsigned int n_dimensions)
     {
     unsigned int max_block_size;
     hipFuncAttributes attr;
@@ -166,7 +172,8 @@ hipError_t gpu_nve_step_one(Scalar4* d_pos,
                        deltaT,
                        limit,
                        limit_val,
-                       zero_force);
+                       zero_force,
+                       n_dimensions);
     return hipSuccess;
     }
 

--- a/hoomd/md/TwoStepNVEGPU.cu
+++ b/hoomd/md/TwoStepNVEGPU.cu
@@ -193,6 +193,7 @@ __global__ void gpu_nve_angular_step_one_kernel(Scalar4* d_orientation,
                                                 const unsigned int* d_group_members,
                                                 const unsigned int nwork,
                                                 Scalar deltaT,
+                                                unsigned int n_dimensions,
                                                 Scalar scale)
     {
     // determine which particle this thread works on (MEM TRANSFER: 4 bytes)
@@ -214,8 +215,8 @@ __global__ void gpu_nve_angular_step_one_kernel(Scalar4* d_orientation,
 
         // check for zero moment of inertia
         bool x_zero, y_zero, z_zero;
-        x_zero = (I.x == 0);
-        y_zero = (I.y == 0);
+        x_zero = (I.x == 0 || n_dimensions == 2);
+        y_zero = (I.y == 0 || n_dimensions == 2);
         z_zero = (I.z == 0);
 
         // ignore torque component along an axis for which the moment of inertia zero
@@ -320,6 +321,7 @@ hipError_t gpu_nve_angular_step_one(Scalar4* d_orientation,
                                     unsigned int* d_group_members,
                                     const unsigned int group_size,
                                     Scalar deltaT,
+                                    unsigned int n_dimensions,
                                     Scalar scale,
                                     const unsigned int block_size)
     {
@@ -349,6 +351,7 @@ hipError_t gpu_nve_angular_step_one(Scalar4* d_orientation,
                        d_group_members,
                        nwork,
                        deltaT,
+                       n_dimensions,
                        scale);
 
     return hipSuccess;
@@ -370,6 +373,7 @@ __global__ void gpu_nve_angular_step_two_kernel(const Scalar4* d_orientation,
                                                 unsigned int* d_group_members,
                                                 const unsigned int nwork,
                                                 Scalar deltaT,
+                                                unsigned int n_dimensions,
                                                 Scalar scale)
     {
     // determine which particle this thread works on (MEM TRANSFER: 4 bytes)
@@ -391,8 +395,8 @@ __global__ void gpu_nve_angular_step_two_kernel(const Scalar4* d_orientation,
 
         // check for zero moment of inertia
         bool x_zero, y_zero, z_zero;
-        x_zero = (I.x == 0);
-        y_zero = (I.y == 0);
+        x_zero = (I.x == 0 || n_dimensions == 2);
+        y_zero = (I.y == 0 || n_dimensions == 2);
         z_zero = (I.z == 0);
 
         // ignore torque component along an axis for which the moment of inertia zero
@@ -428,6 +432,7 @@ hipError_t gpu_nve_angular_step_two(const Scalar4* d_orientation,
                                     unsigned int* d_group_members,
                                     const unsigned int group_size,
                                     Scalar deltaT,
+                                    unsigned int n_dimensions,
                                     Scalar scale,
                                     const unsigned int block_size)
     {
@@ -457,6 +462,7 @@ hipError_t gpu_nve_angular_step_two(const Scalar4* d_orientation,
                        d_group_members,
                        nwork,
                        deltaT,
+                       n_dimensions,
                        scale);
 
     return hipSuccess;

--- a/hoomd/md/TwoStepNVEGPU.cuh
+++ b/hoomd/md/TwoStepNVEGPU.cuh
@@ -40,6 +40,7 @@ hipError_t gpu_nve_angular_step_one(Scalar4* d_orientation,
                                     unsigned int* d_group_members,
                                     const unsigned int group_size,
                                     Scalar deltaT,
+                                    unsigned int n_dimensions,
                                     Scalar scale,
                                     const unsigned int block_size);
 
@@ -51,6 +52,7 @@ hipError_t gpu_nve_angular_step_two(const Scalar4* d_orientation,
                                     unsigned int* d_group_members,
                                     const unsigned int group_size,
                                     Scalar deltaT,
+                                    unsigned int n_dimensions,
                                     Scalar scale,
                                     const unsigned int block_size);
 

--- a/hoomd/md/TwoStepNVEGPU.cuh
+++ b/hoomd/md/TwoStepNVEGPU.cuh
@@ -29,7 +29,8 @@ hipError_t gpu_nve_step_one(Scalar4* d_pos,
                             bool limit,
                             Scalar limit_val,
                             bool zero_force,
-                            unsigned int block_size);
+                            unsigned int block_size,
+                            unsigned int n_dimensions);
 
 //! Kernel driver for the first part of the angular NVE update (NO_SQUISH) by TwoStepNVEPU
 hipError_t gpu_nve_angular_step_one(Scalar4* d_orientation,

--- a/hoomd/md/pytest/CMakeLists.txt
+++ b/hoomd/md/pytest/CMakeLists.txt
@@ -1,6 +1,7 @@
 # copy python modules to the build directory to make it a working python package
 set(files __init__.py
     forces_and_energies.json
+    test_2d_rigid.py
     test_active.py
     test_active_rotational_diffusion.py
     test_alchemostat.py

--- a/hoomd/md/pytest/test_2d_rigid.py
+++ b/hoomd/md/pytest/test_2d_rigid.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2009-2026 The Regents of the University of Michigan.
+# Part of HOOMD-blue, released under the BSD 3-Clause License.
+
 import numpy
 import pytest
 
@@ -6,12 +9,32 @@ import hoomd
 rigid_centers_and_free = hoomd.filter.Rigid(("center", "free"))
 
 _methods = [
-    pytest.param(lambda: hoomd.md.methods.Brownian(rigid_centers_and_free, 1.5), id="Brownain"),
-    pytest.param(lambda: hoomd.md.methods.ConstantVolume(rigid_centers_and_free), id="ConstantVolume"),
-    pytest.param(lambda: hoomd.md.methods.ConstantPressure(rigid_centers_and_free, 0.1, 1.0, "xy"), id="ConstantPressure"),
-    pytest.param(lambda: hoomd.md.methods.DisplacementCapped(rigid_centers_and_free, 1.5), id="DisplacementCapped"),
-    pytest.param(lambda: hoomd.md.methods.Langevin(rigid_centers_and_free, 1.5), id="Langevin"),
-    pytest.param(lambda: hoomd.md.methods.OverdampedViscous(rigid_centers_and_free, default_gamma = 0.01, default_gamma_r = (0.1, 0.1, 0.1)), id="OverdampedViscous"),
+    pytest.param(
+        lambda: hoomd.md.methods.Brownian(rigid_centers_and_free, 1.5), id="Brownain"
+    ),
+    pytest.param(
+        lambda: hoomd.md.methods.ConstantVolume(rigid_centers_and_free),
+        id="ConstantVolume",
+    ),
+    pytest.param(
+        lambda: hoomd.md.methods.ConstantPressure(
+            rigid_centers_and_free, 0.1, 1.0, "xy"
+        ),
+        id="ConstantPressure",
+    ),
+    pytest.param(
+        lambda: hoomd.md.methods.DisplacementCapped(rigid_centers_and_free, 1.5),
+        id="DisplacementCapped",
+    ),
+    pytest.param(
+        lambda: hoomd.md.methods.Langevin(rigid_centers_and_free, 1.5), id="Langevin"
+    ),
+    pytest.param(
+        lambda: hoomd.md.methods.OverdampedViscous(
+            rigid_centers_and_free, default_gamma=0.01, default_gamma_r=(0.1, 0.1, 0.1)
+        ),
+        id="OverdampedViscous",
+    ),
 ]
 
 
@@ -24,9 +47,11 @@ def test_2d_rigid(simulation_factory, create_method):
     initial_snapshot = hoomd.Snapshot()
     initial_snapshot.particles.types = ["dimer", "A"]
     initial_snapshot.particles.N = 3
-    initial_snapshot.particles.position[:] =  [[-2.5, -2.5, 0],
-                     [-2.5, 2.5, 0],
-                     [2.5, 2.5, 0]]
+    initial_snapshot.particles.position[:] = [
+        [-2.5, -2.5, 0],
+        [-2.5, 2.5, 0],
+        [2.5, 2.5, 0],
+    ]
     initial_snapshot.configuration.box = [10, 10, 0, 0, 0, 0]
     initial_snapshot.particles.mass[:] = [2] * 3
     initial_snapshot.particles.moment_inertia[:] = [moment_of_inertia] * 3
@@ -42,30 +67,32 @@ def test_2d_rigid(simulation_factory, create_method):
 
     rigid_1.create_bodies(simulation_1.state)
 
-    integrator_1 = hoomd.md.Integrator(dt = 0.005, integrate_rotational_dof = True)
+    integrator_1 = hoomd.md.Integrator(dt=0.005, integrate_rotational_dof=True)
     simulation_1.operations.integrator = integrator_1
     integrator_1.rigid = rigid_1
 
     integrator_1.methods.append(create_method())
 
-    cell_1 = hoomd.md.nlist.Cell(buffer = 0, exclusions = ["body"])
-    lj_1 = hoomd.md.pair.LJ(nlist = cell_1)
-    lj_1.params[("A", "A")] = dict(epsilon=1, sigma = 2)
+    cell_1 = hoomd.md.nlist.Cell(buffer=0, exclusions=["body"])
+    lj_1 = hoomd.md.pair.LJ(nlist=cell_1)
+    lj_1.params[("A", "A")] = dict(epsilon=1, sigma=2)
     lj_1.r_cut[("A", "A")] = 2.5
-    lj_1.params[("dimer", "dimer"), ("dimer", "A")] = dict(epsilon = 0, sigma = 0)
+    lj_1.params[("dimer", "dimer"), ("dimer", "A")] = dict(epsilon=0, sigma=0)
     lj_1.r_cut[("dimer", "dimer"), ("dimer", "A")] = 0
     integrator_1.forces.append(lj_1)
 
     thermo = hoomd.md.compute.ThermodynamicQuantities(filter=hoomd.filter.All())
     simulation_1.operations.add(thermo)
 
-    simulation_1.state.thermalize_particle_momenta(filter = rigid_centers_and_free, kT = 1.5)
+    simulation_1.state.thermalize_particle_momenta(
+        filter=rigid_centers_and_free, kT=1.5
+    )
     simulation_1.run(1000)
 
     snapshot_1 = simulation_1.state.get_snapshot()
 
-    numpy.testing.assert_array_equal(snapshot_1.particles.position[:,2], [0.0]*9)
-    numpy.testing.assert_array_equal(snapshot_1.particles.velocity[:,2], [0.0]*9)
+    numpy.testing.assert_array_equal(snapshot_1.particles.position[:, 2], [0.0] * 9)
+    numpy.testing.assert_array_equal(snapshot_1.particles.velocity[:, 2], [0.0] * 9)
     assert thermo.rotational_degrees_of_freedom == 3.0
 
     simulation_2 = simulation_factory(snapshot_1)
@@ -77,23 +104,22 @@ def test_2d_rigid(simulation_factory, create_method):
         "orientations": [(1.0, 0.0, 0.0, 0.0), (1.0, 0.0, 0.0, 0.0)],
     }
 
-    integrator_2 = hoomd.md.Integrator(dt = 0.005, integrate_rotational_dof = True)
+    integrator_2 = hoomd.md.Integrator(dt=0.005, integrate_rotational_dof=True)
     simulation_2.operations.integrator = integrator_2
     integrator_2.rigid = rigid_2
 
     integrator_2.methods.append(create_method())
 
-    cell_2 = hoomd.md.nlist.Cell(buffer = 0, exclusions = ["body"])
-    lj_2 = hoomd.md.pair.LJ(nlist = cell_2)
-    lj_2.params[("A", "A")] = dict(epsilon=1, sigma = 2)
+    cell_2 = hoomd.md.nlist.Cell(buffer=0, exclusions=["body"])
+    lj_2 = hoomd.md.pair.LJ(nlist=cell_2)
+    lj_2.params[("A", "A")] = dict(epsilon=1, sigma=2)
     lj_2.r_cut[("A", "A")] = 2.5
-    lj_2.params[("dimer", "dimer"), ("dimer", "A")] = dict(epsilon = 0, sigma = 0)
+    lj_2.params[("dimer", "dimer"), ("dimer", "A")] = dict(epsilon=0, sigma=0)
     lj_2.r_cut[("dimer", "dimer"), ("dimer", "A")] = 0
     integrator_2.forces.append(lj_2)
 
     simulation_2.run(100)
     snapshot_2 = simulation_2.state.get_snapshot()
 
-    numpy.testing.assert_array_equal(snapshot_2.particles.position[:,2], [0.0]*9)
-    numpy.testing.assert_array_equal(snapshot_2.particles.velocity[:,2], [0.0]*9)
-    
+    numpy.testing.assert_array_equal(snapshot_2.particles.position[:, 2], [0.0] * 9)
+    numpy.testing.assert_array_equal(snapshot_2.particles.velocity[:, 2], [0.0] * 9)

--- a/hoomd/md/pytest/test_2d_rigid.py
+++ b/hoomd/md/pytest/test_2d_rigid.py
@@ -56,13 +56,17 @@ def test_2d_rigid(simulation_factory, create_method):
     lj_1.r_cut[("dimer", "dimer"), ("dimer", "A")] = 0
     integrator_1.forces.append(lj_1)
 
+    thermo = hoomd.md.compute.ThermodynamicQuantities(filter=hoomd.filter.All())
+    simulation_1.operations.add(thermo)
+
     simulation_1.state.thermalize_particle_momenta(filter = rigid_centers_and_free, kT = 1.5)
     simulation_1.run(1000)
 
     snapshot_1 = simulation_1.state.get_snapshot()
 
-    # TODO assert checks
-
+    numpy.testing.assert_array_equal(snapshot_1.particles.position[:,2], [0.0]*9)
+    numpy.testing.assert_array_equal(snapshot_1.particles.velocity[:,2], [0.0]*9)
+    assert thermo.rotational_degrees_of_freedom == 3.0
 
     simulation_2 = simulation_factory(snapshot_1)
 

--- a/hoomd/md/pytest/test_2d_rigid.py
+++ b/hoomd/md/pytest/test_2d_rigid.py
@@ -38,6 +38,7 @@ _methods = [
 ]
 
 
+@pytest.mark.serial
 @pytest.mark.parametrize("create_method", _methods)
 def test_2d_rigid(simulation_factory, create_method):
     # Test case from: https://github.com/glotzerlab/hoomd-blue/discussions/2299

--- a/hoomd/md/pytest/test_2d_rigid.py
+++ b/hoomd/md/pytest/test_2d_rigid.py
@@ -1,0 +1,95 @@
+import numpy
+import pytest
+
+import hoomd
+
+rigid_centers_and_free = hoomd.filter.Rigid(("center", "free"))
+
+_methods = [
+    pytest.param(lambda: hoomd.md.methods.Brownian(rigid_centers_and_free, 1.5), id="Brownain"),
+    pytest.param(lambda: hoomd.md.methods.ConstantVolume(rigid_centers_and_free), id="ConstantVolume"),
+    pytest.param(lambda: hoomd.md.methods.ConstantPressure(rigid_centers_and_free, 0.1, 1.0, "xy"), id="ConstantPressure"),
+    pytest.param(lambda: hoomd.md.methods.DisplacementCapped(rigid_centers_and_free, 1.5), id="DisplacementCapped"),
+    pytest.param(lambda: hoomd.md.methods.Langevin(rigid_centers_and_free, 1.5), id="Langevin"),
+    pytest.param(lambda: hoomd.md.methods.OverdampedViscous(rigid_centers_and_free, default_gamma = 0.01, default_gamma_r = (0.1, 0.1, 0.1)), id="OverdampedViscous"),
+]
+
+
+@pytest.mark.parametrize("create_method", _methods)
+def test_2d_rigid(simulation_factory, create_method):
+    # Test case from: https://github.com/glotzerlab/hoomd-blue/discussions/2299
+    dimer_positions = [[-1.2, 0, 0], [1.2, 0, 0]]
+    moment_of_inertia = [0, 2.8, 2.8]
+
+    initial_snapshot = hoomd.Snapshot()
+    initial_snapshot.particles.types = ["dimer", "A"]
+    initial_snapshot.particles.N = 3
+    initial_snapshot.particles.position[:] =  [[-2.5, -2.5, 0],
+                     [-2.5, 2.5, 0],
+                     [2.5, 2.5, 0]]
+    initial_snapshot.configuration.box = [10, 10, 0, 0, 0, 0]
+    initial_snapshot.particles.mass[:] = [2] * 3
+    initial_snapshot.particles.moment_inertia[:] = [moment_of_inertia] * 3
+
+    simulation_1 = simulation_factory(initial_snapshot)
+
+    rigid_1 = hoomd.md.constrain.Rigid()
+    rigid_1.body["dimer"] = {
+        "constituent_types": ["A", "A"],
+        "positions": dimer_positions,
+        "orientations": [(1.0, 0.0, 0.0, 0.0), (1.0, 0.0, 0.0, 0.0)],
+    }
+
+    rigid_1.create_bodies(simulation_1.state)
+
+    integrator_1 = hoomd.md.Integrator(dt = 0.005, integrate_rotational_dof = True)
+    simulation_1.operations.integrator = integrator_1
+    integrator_1.rigid = rigid_1
+
+    integrator_1.methods.append(create_method())
+
+    cell_1 = hoomd.md.nlist.Cell(buffer = 0, exclusions = ["body"])
+    lj_1 = hoomd.md.pair.LJ(nlist = cell_1)
+    lj_1.params[("A", "A")] = dict(epsilon=1, sigma = 2)
+    lj_1.r_cut[("A", "A")] = 2.5
+    lj_1.params[("dimer", "dimer"), ("dimer", "A")] = dict(epsilon = 0, sigma = 0)
+    lj_1.r_cut[("dimer", "dimer"), ("dimer", "A")] = 0
+    integrator_1.forces.append(lj_1)
+
+    simulation_1.state.thermalize_particle_momenta(filter = rigid_centers_and_free, kT = 1.5)
+    simulation_1.run(1000)
+
+    snapshot_1 = simulation_1.state.get_snapshot()
+
+    # TODO assert checks
+
+
+    simulation_2 = simulation_factory(snapshot_1)
+
+    rigid_2 = hoomd.md.constrain.Rigid()
+    rigid_2.body["dimer"] = {
+        "constituent_types": ["A", "A"],
+        "positions": dimer_positions,
+        "orientations": [(1.0, 0.0, 0.0, 0.0), (1.0, 0.0, 0.0, 0.0)],
+    }
+
+    integrator_2 = hoomd.md.Integrator(dt = 0.005, integrate_rotational_dof = True)
+    simulation_2.operations.integrator = integrator_2
+    integrator_2.rigid = rigid_2
+
+    integrator_2.methods.append(create_method())
+
+    cell_2 = hoomd.md.nlist.Cell(buffer = 0, exclusions = ["body"])
+    lj_2 = hoomd.md.pair.LJ(nlist = cell_2)
+    lj_2.params[("A", "A")] = dict(epsilon=1, sigma = 2)
+    lj_2.r_cut[("A", "A")] = 2.5
+    lj_2.params[("dimer", "dimer"), ("dimer", "A")] = dict(epsilon = 0, sigma = 0)
+    lj_2.r_cut[("dimer", "dimer"), ("dimer", "A")] = 0
+    integrator_2.forces.append(lj_2)
+
+    simulation_2.run(100)
+    snapshot_2 = simulation_2.state.get_snapshot()
+
+    numpy.testing.assert_array_equal(snapshot_2.particles.position[:,2], [0.0]*9)
+    numpy.testing.assert_array_equal(snapshot_2.particles.velocity[:,2], [0.0]*9)
+    


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail. -->
Prevent rigid bodies from rotating out of the plane in 2D simulations.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
See #2299.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
I added a unit test based on #2299. The unit test covers all integration methods and devices.

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
- [x] I have summarized these changes in `CHANGELOG.rst` following the established format.
