### PR TITLE
RATTLE Langevin GPU fix

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,8 @@ Next release
 
 *Fixed*
 
+* Fixed incorrect reading of net_force instead of acceleration in RATTLELangevin GPU code (#2318)
+
 
 7.1.0 (2026-06-24)
 ^^^^^^^^^^^^^^^^^^^^

--- a/hoomd/md/TwoStepRATTLELangevinGPU.cuh
+++ b/hoomd/md/TwoStepRATTLELangevinGPU.cuh
@@ -194,7 +194,7 @@ __global__ void gpu_rattle_langevin_step_two_kernel(const Scalar4* d_pos,
 
         // read in the net force and calculate the acceleration MEM TRANSFER: 16 bytes
         Scalar4 net_force = d_net_force[idx];
-        Scalar3 accel = make_scalar3(net_force.x, net_force.y, net_force.z);
+        Scalar3 accel = d_accel[idx];
 
         Scalar3 pos = make_scalar3(d_pos[idx].x, d_pos[idx].y, d_pos[idx].z);
 
@@ -246,9 +246,9 @@ __global__ void gpu_rattle_langevin_step_two_kernel(const Scalar4* d_pos,
         // MEM TRANSFER: 4 bytes   FLOPS: 3
         Scalar mass = vel.w;
         Scalar minv = Scalar(1.0) / mass;
-        accel.x = (accel.x + bd_force.x) * minv;
-        accel.y = (accel.y + bd_force.y) * minv;
-        accel.z = (accel.z + bd_force.z) * minv;
+        accel.x = (net_force.x + bd_force.x) * minv;
+        accel.y = (net_force.y + bd_force.y) * minv;
+        accel.z = (net_force.z + bd_force.z) * minv;
 
         // v(t+deltaT) = v(t+deltaT/2) + 1/2 * a(t+deltaT)*deltaT
         // update the velocity (FLOPS: 6)


### PR DESCRIPTION
## Description

RATTLE Langevin had a bug in their GPU code that wrote in the net_force instead of acceleration. This will fix it!

<!-- Describe your changes in detail. -->

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves bug discussed in #2310 

## How has this been tested?

Provided simulation behaves as expected

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk/CONTRIBUTING.rst).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk/ContributorAgreement.md).
- [x] My name is on the list of contributors (`sphinx-doc/credits.rst`) in the pull request source branch.
- [x] I have summarized these changes in `CHANGELOG.rst` following the established format.
